### PR TITLE
TomeSync self-update with anti-brick rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- TomeSync self-update: the KOReader plugin can now update itself from the
+  server — **TomeSync → Check for updates** (manual) plus an opt-in
+  **Auto-check on launch** toggle — replacing the SSH-into-every-device
+  workflow. A bad update cannot brick: the plugin is split into a frozen
+  stable shim (`main.lua`) and a replaceable implementation (`main_impl.lua`),
+  and the shim runs an anti-brick rollback state machine — a syntax-broken
+  update rolls back on the same boot, an init-crashing update rolls back on the
+  next, and a corrupt download is rejected before it is ever swapped in.
+  Reading progress, book mappings, and pending sessions live in KOReader
+  settings, so updates never touch them. Adds a `tome_browse_series` gesture
+  action.
+
+### Changed
+- TomeSync plugin versioning: a hidden monotonic **build** integer (now `8`)
+  drives update comparisons, with an independent human-facing **semver**
+  (`1.0.0`). `GET /plugin/version` now returns `build` and `semver` alongside
+  the existing `version` field (kept as `str(build)` for back-compat). New
+  authenticated `GET /plugin/main-impl.lua` serves the config-baked
+  implementation for self-update. The first shim+impl build must be installed
+  manually once (the last SSH deploy); every update after is in-app.
+
 ## [1.1.0] — 2026-05-31 — "Vellum"
 
 ### Added

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -28,7 +28,13 @@ from backend.models.tome_sync import ApiKey, ReadingSession, TomeSyncPosition
 router = APIRouter(tags=["tome-sync"])
 logger = logging.getLogger(__name__)
 
-TOMESYNC_PLUGIN_VERSION = "6"  # bump when plugin code changes
+# Plugin versioning. BUILD is the ONLY value compared for self-update (monotonic
+# integer — bump on every plugin code change). SEMVER is human-facing display.
+# VERSION is kept as a back-compat alias (= str(BUILD)) for old plugins and the
+# web UI, which read `version` from /plugin/version.
+TOMESYNC_PLUGIN_BUILD = 8
+TOMESYNC_PLUGIN_SEMVER = "1.0.0"
+TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
 # ── API key auth ──────────────────────────────────────────────────────────────
@@ -488,7 +494,14 @@ def revoke_api_key(
 
 @router.get("/plugin/version")
 def plugin_version() -> dict:
-    return {"version": TOMESYNC_PLUGIN_VERSION}
+    # `version` stays a build-int-as-string for back-compat (existing plugins +
+    # web UI read it). `build` (int) is what the self-updater compares; `semver`
+    # is display-only.
+    return {
+        "version": TOMESYNC_PLUGIN_VERSION,
+        "build": TOMESYNC_PLUGIN_BUILD,
+        "semver": TOMESYNC_PLUGIN_SEMVER,
+    }
 
 
 # ── Plugin download ───────────────────────────────────────────────────────────
@@ -518,17 +531,48 @@ def download_plugin(
     if not server_url:
         server_url = str(request.base_url).rstrip("/")
 
-    # Build the ZIP in memory — single-file plugin (meta + main only)
+    # Build the ZIP in memory — shim + impl split for self-update:
+    #   main.lua       frozen stable shim (no config; runs the rollback machine)
+    #   main_impl.lua  the real plugin + baked config; the only file updates replace
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr("tomesync.koplugin/_meta.lua", _meta_lua())
-        zf.writestr("tomesync.koplugin/main.lua", _main_lua(server_url, api_key_value, current_user.username))
+        zf.writestr("tomesync.koplugin/main.lua", _main_shim_lua())
+        zf.writestr("tomesync.koplugin/main_impl.lua",
+                    _main_impl_lua(server_url, api_key_value, current_user.username))
     buf.seek(0)
 
     return StreamingResponse(
         buf,
         media_type="application/zip",
         headers={"Content-Disposition": "attachment; filename=tomesync.koplugin.zip"},
+    )
+
+
+# ── Plugin self-update (impl only) ────────────────────────────────────────────
+
+@router.get("/plugin/main-impl.lua")
+def download_main_impl(
+    request: Request,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(_get_api_key_user),
+    server_url: str | None = None,
+):
+    """Serve the current main_impl.lua for self-update, with the caller's config
+    baked in. Authenticated by the plugin's own API key, so config (server URL,
+    key, username) survives every update. The shim (main.lua) is frozen and never
+    served here."""
+    # Reuse the API key the plugin authenticated with, so the refreshed impl keeps
+    # the same baked credentials. Recover the plaintext from the request header.
+    auth = request.headers.get("authorization", "")
+    api_key_value = auth.removeprefix("Bearer ").strip()
+
+    if not server_url:
+        server_url = str(request.base_url).rstrip("/")
+
+    return StreamingResponse(
+        io.BytesIO(_main_impl_lua(server_url, api_key_value, current_user.username).encode()),
+        media_type="text/plain; charset=utf-8",
     )
 
 
@@ -547,17 +591,130 @@ Tracks reading sessions and syncs position across devices.]]),
 '''
 
 
-def _main_lua(server_url: str, api_key: str, username: str) -> str:
-    return f'''--[[
-TomeSync KOReader Plugin — single-file build
-Syncs reading progress and sessions with a Tome library server.
-Browse and download series. Tracks reading sessions and syncs position across devices.
-
-Installation: copy tomesync.koplugin/ into koreader/plugins/ and restart.
+def _main_shim_lua() -> str:
+    # Frozen stable shim. Deployed once, never replaced by self-update. No config,
+    # no network. Its only jobs: find its own dir, run the anti-brick rollback
+    # state machine, dofile main_impl.lua, and return the plugin class (or a valid
+    # inert stub if even the backup can't load). Keep this minimal so it never
+    # needs to change — if it ever must, that's a manual redeploy.
+    return r'''--[[
+TomeSync KOReader Plugin — stable shim (frozen; do not edit on-device).
+Loads main_impl.lua with same-boot + next-boot rollback so a bad self-update
+can never leave TomeSync unloadable.
 ]]
 
 local logger = require("logger")
-logger.info("TomeSync: main.lua loading...")
+logger.info("TomeSync: shim loading...")
+
+local function selfDir()
+    local source = debug.getinfo(1, "S").source
+    return source:match("^@(.*)/[^/]+$") or "."
+end
+
+local DIR      = selfDir()
+local IMPL     = DIR .. "/main_impl.lua"
+local IMPL_BAK = DIR .. "/main_impl.lua.bak"
+
+local function readFile(path)
+    local f = io.open(path, "rb"); if not f then return nil end
+    local d = f:read("*a"); f:close(); return d
+end
+
+local function writeFile(path, data)
+    local f = io.open(path, "wb"); if not f then return false end
+    f:write(data); f:close(); return true
+end
+
+local function restoreBackup()
+    local bak = readFile(IMPL_BAK)
+    if not bak then return false end
+    return writeFile(IMPL, bak)
+end
+
+local function getState()
+    local ok, s = pcall(function() return G_reader_settings:readSetting("tomesync_update") end)
+    return ok and s or nil
+end
+
+local function setState(s)
+    pcall(function()
+        G_reader_settings:saveSetting("tomesync_update", s)
+        G_reader_settings:flush()
+    end)
+end
+
+local function notify(text)
+    pcall(function()
+        local InfoMessage = require("ui/widget/infomessage")
+        local UIManager   = require("ui/uimanager")
+        UIManager:show(InfoMessage:new{ text = text, timeout = 5 })
+    end)
+end
+
+local function stubPlugin()
+    local WidgetContainer = require("ui/widget/container/widgetcontainer")
+    local Stub = WidgetContainer:extend{ name = "tomesync", is_doc_only = false }
+    function Stub:init() pcall(function() self.ui.menu:registerToMainMenu(self) end) end
+    function Stub:addToMainMenu(menu_items)
+        menu_items.tomesync = {
+            text = "TomeSync (failed to load)",
+            callback = function() notify("TomeSync failed to load and could not roll back.\nPlease reinstall the plugin.") end,
+        }
+    end
+    return Stub
+end
+
+-- ── Next-boot rollback: an unconfirmed build that never confirmed crashed at init ──
+local state = getState()
+if state and not state.confirmed then
+    state.boots = (state.boots or 0) + 1
+    if state.boots >= 2 then
+        if restoreBackup() then
+            logger.warn("TomeSync: build", state.build, "never confirmed — rolling back")
+            setState({ build = state.prev_build, confirmed = true })
+            notify("TomeSync update failed — rolled back to previous version.")
+        else
+            setState(state)  -- no backup to restore; keep the bumped count
+        end
+    else
+        setState(state)
+    end
+end
+
+-- ── Load impl; same-boot rollback on a load/syntax failure ────────────────────
+local ok, plugin = pcall(dofile, IMPL)
+if not ok then
+    logger.warn("TomeSync: impl failed to load:", tostring(plugin))
+    local cur = getState()
+    if restoreBackup() then
+        setState({ build = (cur and cur.prev_build) or 0, confirmed = true })
+        notify("TomeSync update failed — rolled back to previous version.")
+        ok, plugin = pcall(dofile, IMPL)
+    end
+end
+
+if not ok or type(plugin) ~= "table" then
+    logger.warn("TomeSync: returning inert stub plugin")
+    local sok, stub = pcall(stubPlugin)
+    return sok and stub or nil
+end
+
+logger.info("TomeSync: shim loaded impl successfully")
+return plugin
+'''
+
+
+def _main_impl_lua(server_url: str, api_key: str, username: str) -> str:
+    return f'''--[[
+TomeSync KOReader Plugin — implementation (replaced in place by self-update).
+Syncs reading progress and sessions with a Tome library server.
+Browse and download series. Tracks reading sessions and syncs position across devices.
+
+Loaded by the frozen shim (main.lua). Contains the baked config; the shim does not.
+]]
+
+local logger = require("logger")
+logger.info("TomeSync: main_impl.lua loading...")
 
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local InfoMessage      = require("ui/widget/infomessage")
@@ -570,6 +727,7 @@ local rapidjson        = require("rapidjson")
 local lfs              = require("libs/libkoreader-lfs")
 local util             = require("util")
 local Menu             = require("ui/widget/menu")
+local Dispatcher       = require("dispatcher")
 
 -- ── Register in wrench menu (tools tab, after calibre) ──────────────────────
 -- Runs once per KOReader process via require() caching.
@@ -611,6 +769,8 @@ local MAX_BACKOFF_FAILURES = 3
 
 local HEARTBEAT_PAGES = 50
 local PLUGIN_VERSION  = "{TOMESYNC_PLUGIN_VERSION}"
+local BUILD           = {TOMESYNC_PLUGIN_BUILD}      -- monotonic; the only thing compared
+local SEMVER          = "{TOMESYNC_PLUGIN_SEMVER}"   -- human-facing display only
 
 local function urlEncode(s)
     return s:gsub("([^%w%-%.%_%~])", function(c)
@@ -725,6 +885,53 @@ local function downloadFile(book_id, file_id, dest_path)
     return true
 end
 
+-- ── Self-update helpers ──────────────────────────────────────────────────────
+
+local function implDir()
+    local source = debug.getinfo(1, "S").source
+    return source:match("^@(.*)/[^/]+$") or "."
+end
+
+local IMPL_PATH = implDir() .. "/main_impl.lua"
+local IMPL_BAK  = IMPL_PATH .. ".bak"
+
+local function readWhole(path)
+    local f = io.open(path, "rb"); if not f then return nil end
+    local d = f:read("*a"); f:close(); return d
+end
+
+local function writeWhole(path, data)
+    local f = io.open(path, "wb"); if not f then return false end
+    f:write(data); f:close(); return true
+end
+
+-- Raw (non-JSON) authenticated GET, used to fetch the new impl text.
+local function fetchText(path)
+    if not NetworkMgr:isConnected() then return nil, "offline" end
+    local chunks = {{}}
+    local saved_timeout = http.TIMEOUT
+    http.TIMEOUT = 30
+    local ok, code = http.request({{
+        url     = SERVER_URL .. "/api" .. path,
+        method  = "GET",
+        headers = {{ ["Authorization"] = "Bearer " .. API_KEY }},
+        sink    = ltn12.sink.table(chunks),
+    }})
+    http.TIMEOUT = saved_timeout
+    if not ok then return nil, code end
+    if type(code) == "number" and code >= 300 then return nil, code end
+    return table.concat(chunks), code
+end
+
+-- Reject anything that isn't a plausible, compilable impl before swapping it in.
+local function validateImpl(body)
+    if not body or #body < 15000 then return false, "too small" end
+    if not load(body) then return false, "does not compile" end
+    if not body:find("function TomeSync:init", 1, true) then return false, "missing init" end
+    if not body:find("return TomeSync", 1, true) then return false, "missing return" end
+    return true
+end
+
 -- ── Plugin widget ────────────────────────────────────────────────────────────
 
 local TomeSync = WidgetContainer:extend{{
@@ -741,9 +948,43 @@ function TomeSync:init()
     self.enabled        = true
     self.book_map       = G_reader_settings:readSetting("tomesync_book_map") or {{}}
     self.pending_sessions = G_reader_settings:readSetting("tomesync_pending_sessions") or {{}}
+    self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
     logger.info("TomeSync: init complete, menu registered,",
                 #self.pending_sessions, "pending sessions")
+
+    -- Anti-brick confirm (§3): init() reached the end, so this build is good.
+    -- Mark it confirmed now (and flush) so the shim never rolls it back.
+    local ustate = G_reader_settings:readSetting("tomesync_update")
+    if ustate and ustate.build == BUILD and not ustate.confirmed then
+        ustate.confirmed = true
+        G_reader_settings:saveSetting("tomesync_update", ustate)
+        G_reader_settings:flush()
+        logger.info("TomeSync: confirmed build", BUILD)
+    end
+
+    -- Opt-in: a deferred, non-blocking update check shortly after startup.
+    if G_reader_settings:isTrue("tomesync_auto_check") then
+        UIManager:scheduleIn(8, function()
+            self:checkForUpdate(function(avail)
+                if avail then self:_promptUpdate(avail) end
+            end)
+        end)
+    end
+end
+
+function TomeSync:onDispatcherRegisterActions()
+    Dispatcher:registerAction("tome_browse_series", {{
+        category = "none",
+        event    = "TomeBrowseSeries",
+        title    = "TomeSync: Browse series",
+        general  = true,
+    }})
+end
+
+function TomeSync:onTomeBrowseSeries()
+    self:_browseSeriesMenu()
+    return true
 end
 
 function TomeSync:onReaderReady()
@@ -1190,6 +1431,85 @@ function TomeSync:_downloadCurrentBookSeries(rest_only)
     self:_downloadSeriesBooks(data.series_name, data.books, min_index, data.book_type)
 end
 
+-- ── Self-update ──────────────────────────────────────────────────────────────
+
+-- on_result(avail) where avail is a {{build, semver}} table if newer, false if
+-- up to date, or nil + err message on failure.
+function TomeSync:checkForUpdate(on_result)
+    local ok, info, code = pcall(apiRequest, "GET", "/plugin/version")
+    if not ok or not info or (type(code) == "number" and code >= 300) then
+        on_result(nil, "Could not reach server.")
+        return
+    end
+    local server_build = tonumber(info.build or info.version)
+    if not server_build then
+        on_result(nil, "Server did not report a build.")
+        return
+    end
+    if server_build > BUILD then
+        on_result({{ build = server_build, semver = info.semver }})
+    else
+        on_result(false)
+    end
+end
+
+function TomeSync:installUpdate(new_build)
+    local body, code = fetchText("/plugin/main-impl.lua")
+    if not body then
+        UIManager:show(InfoMessage:new{{
+            text = "Download failed (" .. tostring(code) .. ").\\nNothing changed.",
+            timeout = 5,
+        }})
+        return
+    end
+    local valid, why = validateImpl(body)
+    if not valid then
+        UIManager:show(InfoMessage:new{{
+            text = "Update rejected: " .. tostring(why) .. ".\\nNothing changed.",
+            timeout = 6,
+        }})
+        return
+    end
+    -- Back up the current (known-good) impl, then atomically swap in the new one.
+    local current = readWhole(IMPL_PATH)
+    if current and not writeWhole(IMPL_BAK, current) then
+        UIManager:show(InfoMessage:new{{ text = "Could not write backup.", timeout = 5 }})
+        return
+    end
+    if not writeWhole(IMPL_PATH .. ".new", body) then
+        UIManager:show(InfoMessage:new{{ text = "Could not write update.", timeout = 5 }})
+        return
+    end
+    if not os.rename(IMPL_PATH .. ".new", IMPL_PATH) then
+        os.remove(IMPL_PATH .. ".new")
+        UIManager:show(InfoMessage:new{{ text = "Could not install update.", timeout = 5 }})
+        return
+    end
+    -- Arm the rollback state machine: unconfirmed until the new impl's init() runs.
+    local cur_state = G_reader_settings:readSetting("tomesync_update") or {{}}
+    G_reader_settings:saveSetting("tomesync_update", {{
+        build      = new_build,
+        confirmed  = false,
+        boots      = 0,
+        prev_build = cur_state.build or BUILD,
+    }})
+    G_reader_settings:flush()
+    UIManager:show(InfoMessage:new{{
+        text = "TomeSync updated to build " .. new_build .. ".\\nRestart KOReader to apply.",
+        timeout = 8,
+    }})
+end
+
+function TomeSync:_promptUpdate(avail)
+    local ConfirmBox = require("ui/widget/confirmbox")
+    UIManager:show(ConfirmBox:new{{
+        text = string.format("TomeSync update available: %s (build %d).\\nInstall now?",
+            avail.semver or "?", avail.build),
+        ok_text = "Install",
+        ok_callback = function() self:installUpdate(avail.build) end,
+    }})
+end
+
 -- ── Menu ─────────────────────────────────────────────────────────────────────
 
 function TomeSync:addToMainMenu(menu_items)
@@ -1235,11 +1555,39 @@ function TomeSync:addToMainMenu(menu_items)
         end,
     }})
     table.insert(sub_items, {{
+        text     = "Check for updates",
+        callback = function()
+            self:checkForUpdate(function(avail, err)
+                if avail then
+                    self:_promptUpdate(avail)
+                elseif avail == false then
+                    UIManager:show(InfoMessage:new{{
+                        text = "TomeSync is up to date (build " .. BUILD .. ").",
+                        timeout = 4,
+                    }})
+                else
+                    UIManager:show(InfoMessage:new{{
+                        text = err or "Update check failed.",
+                        timeout = 5,
+                    }})
+                end
+            end)
+        end,
+    }})
+    table.insert(sub_items, {{
+        text         = "Auto-check on launch",
+        checked_func = function() return G_reader_settings:isTrue("tomesync_auto_check") end,
+        callback     = function()
+            G_reader_settings:saveSetting("tomesync_auto_check",
+                not G_reader_settings:isTrue("tomesync_auto_check"))
+        end,
+    }})
+    table.insert(sub_items, {{
         text     = "About",
         separator = in_book,
         callback = function()
             UIManager:show(InfoMessage:new{{
-                text    = "TomeSync v" .. PLUGIN_VERSION
+                text    = "TomeSync " .. SEMVER .. " (build " .. BUILD .. ")"
                           .. "\\nSyncs with your Tome library.",
                 timeout = 4,
             }})

--- a/docs/koreader-plugin.md
+++ b/docs/koreader-plugin.md
@@ -145,7 +145,9 @@ The plugin menu is context-aware. It self-registers in the **wrench menu** (afte
 | **Browse series** | Opens the series browser. Lists all series with book count and author. Tap to download. |
 | **Test connection** | Verifies the server is reachable. Also resets the backoff counter if the server was previously unreachable. |
 | **Re-resolve all books** | Wipes the local filename-to-book-ID cache. Use if a book matched incorrectly. |
-| **About** | Version info. |
+| **Check for updates** | Fetches the latest plugin build from your server and installs it if newer (then prompts to restart). |
+| **Auto-check on launch** | Opt-in toggle. When on, TomeSync checks for updates shortly after startup and prompts only when one is available. |
+| **About** | Version info (semver + build). |
 
 ### Only when a book is open
 
@@ -171,9 +173,24 @@ The plugin authenticates with an API key (`Authorization: Bearer tk_...`), not y
 
 ## Updating the Plugin
 
-The current plugin version is shown on the Settings page next to "TomeSync Plugin". Re-download when it changes, or when your server address changes.
+Once the plugin is installed, it updates itself — open the **TomeSync** menu and tap **Check for updates** (or enable **Auto-check on launch**). It downloads the latest build from your server, swaps it in atomically, and asks you to restart. Your server URL, API key, and reading history carry over automatically.
 
-### Via SSH (recommended for Kindle)
+The plugin version is shown on the Settings page next to "TomeSync Plugin" (`v<semver> (build N)`); the build integer is what drives update comparisons.
+
+### How self-update can't brick the plugin
+
+The plugin is split into a frozen **shim** (`main.lua`, never replaced) and a replaceable **implementation** (`main_impl.lua`). On every load the shim runs a rollback state machine backed by `main_impl.lua.bak`:
+
+- A **download that fails validation** (too small, doesn't compile, missing sentinels) is rejected before anything is swapped — files untouched.
+- A **syntax-broken** update fails to load and is rolled back on the **same launch**.
+- An **init-crashing** update doesn't confirm itself, so the shim rolls it back on the **next launch**.
+- If even the backup is unusable, the shim loads a valid inert stub ("TomeSync failed to load — reinstall"); KOReader itself is never affected.
+
+### Manual install (first deploy / recovery)
+
+The **first** build carrying the shim+impl must be installed by hand once (every update after that is in-app). This is also the fallback if you ever need to force a clean reinstall.
+
+#### Via SSH (recommended for Kindle)
 
 ```bash
 # 1. Download plugin ZIP from Tome Settings page, unzip it
@@ -185,7 +202,7 @@ scp -r tomesync.koplugin root@<kindle-ip>:/mnt/us/koreader/plugins/
 
 No cable or USB mode needed. Requires SSH enabled on KOReader (Settings > Network > SSH server).
 
-### Via USB
+#### Via USB
 
 1. Exit KOReader
 2. Connect via USB cable
@@ -227,9 +244,11 @@ The downloaded plugin has your server URL and API key baked in, so there is noth
 
 ## Files
 
-The plugin consists of two files:
+The plugin consists of three files (plus a backup created on first update):
 
 | File | Purpose |
 |---|---|
 | `_meta.lua` | Plugin metadata (name, description) |
-| `main.lua` | All plugin logic, HTTP client, and config (server URL, API key baked in at download time) |
+| `main.lua` | Frozen stable shim — loads the implementation and runs the anti-brick rollback state machine. No config; never replaced by self-update. |
+| `main_impl.lua` | All plugin logic, HTTP client, and config (server URL, API key baked in at download time). The only file self-update replaces. |
+| `main_impl.lua.bak` | Last confirmed-good implementation, written automatically before each update so the shim can roll back. |

--- a/docs/tomesync-self-update-plan.md
+++ b/docs/tomesync-self-update-plan.md
@@ -1,0 +1,225 @@
+# TomeSync Self-Update — Implementation Plan
+
+> Status: **CODE COMPLETE — pending on-device testing + first manual deploy.**
+> In-app "Check for updates" + self-update for the TomeSync KOReader plugin,
+> replacing the SSH-into-every-device workflow. Built so a bad update **cannot
+> brick** — it self-heals on the next launch. Backend + shim + impl all
+> implemented on branch `tomesync-self-update`; §8 device tests and the §7
+> one-time manual bootstrap remain.
+
+Decisions locked with the user:
+- **Anti-brick:** stable shim + auto-rollback (not just validate+backup).
+- **Compat:** protect existing installs **and** keep `/plugin/version` back-compatible.
+- **Versioning:** independent plugin **semver** for humans + hidden monotonic
+  **build integer** for the actual comparison.
+- **Trigger:** a manual "Check for updates" item **plus** an opt-in auto-check on launch.
+
+---
+
+## 1. The brick problem, stated precisely
+
+A KOReader plugin can only "brick" by failing at **load/init** time. KOReader
+itself is resilient — `PluginLoader` `pcall`s both the module load and the
+instance creation, so a broken plugin is *skipped*, not fatal. So:
+
+- **KOReader never bricks.** Worst realistic case = "TomeSync is missing this session."
+- The job is to make even *that* self-recover, automatically, without SSH.
+
+Failure modes to defend against:
+
+| # | Failure | When | Defense |
+|---|---|---|---|
+| 1 | Truncated / corrupt download; server returns an HTML error page or empty body, written over the plugin | install | **Validate before swap** (status 200, size floor, `load()` compiles, sentinel strings) |
+| 2 | New code has a **syntax error** | next load | Shim `pcall(dofile)` fails → **same-boot rollback** |
+| 3 | New code loads but **throws at `init()`** | next instance creation | **Confirm-counter**: unproven build that doesn't confirm within one boot → **next-boot rollback** |
+| 4 | Even the backup is broken | rollback | Shim returns a **stub plugin** (valid, inert) so KOReader still gets a module |
+| 5 | Logic bug in an event handler (e.g. `onPageUpdate`) | runtime | Out of scope for bricking — KOReader `pcall`s event dispatch; it's a normal bug fixed by a later update |
+
+---
+
+## 2. Architecture — frozen shim + replaceable impl
+
+Split the single `main.lua` into two files:
+
+```
+tomesync.koplugin/
+  _meta.lua              static
+  main.lua               STABLE SHIM — deployed once, never touched by self-update
+  main_impl.lua          the real plugin (code + baked config) — what updates replace
+  main_impl.lua.bak      last confirmed-good impl
+```
+
+- **`main.lua` (shim):** ~50 lines, defensively `pcall`-wrapped end-to-end, contains
+  **no config**. Its only jobs: locate its own dir, run the rollback state-machine,
+  `dofile` the impl, return the plugin class. It is generated once and **frozen** —
+  the updater never overwrites it. (If it ever must change: rare, manual redeploy.)
+- **`main_impl.lua` (impl):** everything else — the full plugin code **and** the
+  baked `SERVER_URL` / `API_KEY` / `USERNAME`. This is the only file the updater swaps.
+- **State** (`book_map`, `pending_sessions`, settings) lives in `G_reader_settings`,
+  *not* in the files — so updates never touch reading progress / mappings.
+
+The shim finds its own directory with `debug.getinfo(1,"S").source` (strip `@` +
+filename) — self-contained, no dependency on how KOReader loaded it.
+
+---
+
+## 3. Anti-brick state machine (the centerpiece)
+
+State (in `G_reader_settings`, key `tomesync_update`):
+`{ build = <installed build>, confirmed = <bool>, boots = <int>, prev_build = <int> }`
+
+### Updater (in impl) — install build N
+1. Fetch new impl text; **validate** (see §5). Abort untouched on any failure.
+2. `cp main_impl.lua → main_impl.lua.bak` (current is known-good).
+3. Write text → `main_impl.lua.new`; `os.rename` → `main_impl.lua` (atomic; no
+   partial file ever in place).
+4. Set state `{ build=N, confirmed=false, boots=0, prev_build=<old build> }`; **flush**.
+5. Notify: "Update vX installed — restart KOReader."
+
+### Shim — every load, before `dofile`
+```
+state = read()
+if state and not state.confirmed then
+    state.boots = (state.boots or 0) + 1
+    if state.boots >= 2 then
+        -- a prior boot installed this build but it never confirmed -> it crashed at init
+        restore main_impl.lua.bak -> main_impl.lua
+        state = { build = state.prev_build, confirmed = true }   -- backup is known-good
+        notify("TomeSync update failed — rolled back")
+    end
+    write(state); flush()
+end
+
+ok, plugin = pcall(dofile, main_impl.lua)
+if not ok then
+    -- syntax / load-time throw: roll back immediately, same boot
+    restore main_impl.lua.bak -> main_impl.lua
+    set state confirmed=true, build=prev_build; flush()
+    ok, plugin = pcall(dofile, main_impl.lua)
+end
+if not ok then return stub_plugin() end   -- last resort: valid inert module
+return plugin
+```
+
+### Impl — on successful `init()`
+```
+if state.build == THIS_BUILD and not state.confirmed then
+    state.confirmed = true
+    G_reader_settings:flush()    -- force the write now, not just on exit
+end
+```
+
+### Walkthrough
+- **Good update:** install N (confirmed=false). Boot1: shim boots=1, `dofile` OK,
+  `init()` reaches the end → confirmed=true (+flush). Boot2+: confirmed → normal.
+- **Syntax-broken update:** Boot1: `pcall(dofile)` fails → restore `.bak`, reload →
+  working version **this same launch**. One notification, zero downtime.
+- **Init-crashing update:** Boot1: `dofile` OK, `init()` throws (KOReader skips the
+  instance, TomeSync absent this session), confirmed stays false. Boot2: shim sees
+  unconfirmed + boots≥2 → restore `.bak` → working version. Recovers within one relaunch.
+- **Backup also broken** (shouldn't happen — backup was confirmed-good): stub plugin
+  returned; KOReader fine; menu says "TomeSync failed to load — reinstall."
+
+False rollbacks (e.g. battery died mid-first-boot) only ever land you on the
+previous **known-good** version — harmless; just re-run the update.
+
+---
+
+## 4. Versioning
+
+- New constants (replace `TOMESYNC_PLUGIN_VERSION`):
+  - `TOMESYNC_PLUGIN_BUILD: int` — monotonic, the **only** thing compared. Current
+    "7" → continue at **8**.
+  - `TOMESYNC_PLUGIN_SEMVER: str` — independent plugin track, human-facing. Start **"1.0.0"**.
+- Comparison stays a trivial `tonumber(server_build) > local_build` — no semver
+  parsing in Lua (zero bug surface, which also means the *version logic* can't cause
+  a bad install; and even if it did, §3 catches it).
+- Semver is display-only ("TomeSync 1.0.0 (build 8)").
+
+---
+
+## 5. Server changes (`backend/api/tome_sync.py`)
+
+- `GET /plugin/version` — **back-compatible**: keep `version` = build int as a string
+  (unchanged for any existing reader, incl. the web UI), **add** `build` (int) and
+  `semver` (str):
+  `{"version": "8", "build": 8, "semver": "1.0.0"}`
+- New `GET /plugin/main-impl.lua` — **authenticated** (`_get_api_key_user`), returns
+  `_main_impl_lua(server_url, caller_api_key, caller_username)` as `text/plain`. Bakes
+  the caller's config, so config survives every update. *(Verify nothing else needs the
+  shim text; the shim is config-free and frozen, so it isn't served for updates.)*
+- Refactor `_main_lua` → `_main_shim_lua()` (static) + `_main_impl_lua(...)` (config).
+  The plugin-zip download endpoint now writes `_meta.lua`, `main.lua` (shim),
+  `main_impl.lua` (impl).
+- Confirm the web UI's reading of `/plugin/version` still works (it reads `version`
+  → same format); optionally switch its display to `semver`.
+
+---
+
+## 6. Plugin (Lua) changes
+
+**Shim (`main.lua`)** — frozen, ~50 lines: self-dir, the §3 state machine, `pcall`
+loader with same-boot rollback, `stub_plugin()` fallback. No config, no network.
+
+**Impl (`main_impl.lua`)** — current code plus:
+- The gesture action already drafted (`tome_browse_series` → `_browseSeriesMenu`).
+- `BUILD` / `SEMVER` constants.
+- `checkForUpdate()` — GET `/plugin/version`, compare `build`, return availability.
+- Menu: **"Check for updates"** (manual) and a **"Auto-check on launch"** toggle.
+- `installUpdate(build)` — fetch + validate + backup + atomic swap + arm state (§3).
+- Validation helper: HTTP 200, body non-empty, `#body > 15000`, `load(body)` compiles,
+  body contains `"function TomeSync:init"` **and** ends near `"return TomeSync"`.
+- In `init()`: the confirm step (§3); if auto-check enabled, a **deferred**
+  (`UIManager:scheduleIn`) non-blocking check that only notifies when newer.
+
+---
+
+## 7. Bootstrapping (the last manual deploy)
+
+Chicken-and-egg: the first version carrying the shim+updater is installed **by hand**
+(the final SSH push). It places `main.lua` (shim) **and** `main_impl.lua`, replacing
+the old single-file plugin. Every update after that is "Check for updates → restart"
+and only ever rewrites `main_impl.lua`.
+
+This same first deploy also ships the `tome_browse_series` gesture action.
+
+---
+
+## 8. Testing (must pass before we trust it on the real device)
+
+On a throwaway KOReader (or the showcase device) drive each §3 branch:
+1. **Happy path:** bump build on server → Check for updates → install → restart →
+   new version loads, confirms, `.bak` retained.
+2. **Syntax-broken impl** (inject a deliberate error into the served impl) → install →
+   restart → shim rolls back same boot; TomeSync still present; notification shown.
+3. **Init-crashing impl** (`error()` early in `init`) → install → restart (TomeSync
+   absent) → restart again → auto-rolled back to working version.
+4. **Garbage download** (server returns HTML/empty) → install **aborts**, files untouched.
+5. **Backup-also-broken** (manually corrupt `.bak` + impl) → stub plugin; KOReader fine.
+6. Config + state survive an update (token, `book_map`, `pending_sessions` intact).
+
+Keep the manual SSH restore (`mv .bak`) documented as the ultimate fallback.
+
+---
+
+## 9. Definition of Done
+- [x] `_main_lua` split into `_main_shim_lua()` + `_main_impl_lua()`; zip writes all three files
+- [x] `/plugin/version` returns `version`(compat) + `build` + `semver`
+- [x] `GET /plugin/main-impl.lua` (authenticated, config-baked)
+- [x] `TOMESYNC_PLUGIN_BUILD=8`, `TOMESYNC_PLUGIN_SEMVER="1.0.0"`
+- [x] Shim: state machine, pcall loader, same-boot + next-boot rollback, stub fallback
+- [x] Impl: check/install/validate, "Check for updates" + "Auto-check" menu, confirm-on-init, gesture action
+- [ ] All §8 test branches pass on a test device
+- [ ] First version deployed manually (shim + impl); `.bak` retained
+- [x] Web UI `/plugin/version` consumer verified (reads `version`; now displays `semver` + build); `TOMESYNC_PLUGIN_VERSION` kept as compat alias
+- [x] CHANGELOG + CLAUDE.md note the TomeSync versioning change
+
+---
+
+## 10. Open considerations
+- **`_meta.lua` changes:** rare; if ever needed, the updater would refresh it too.
+  For v1, impl-only updates (the shim and `_meta` are static).
+- **Shim immutability:** keep the shim deliberately minimal so it never needs an
+  update; if it ever does, that's a manual redeploy (documented).
+- **Multi-device:** each device self-updates independently against the same server;
+  no coordination needed.

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1543,14 +1543,16 @@ function PasswordField({
 }
 
 function PluginVersion() {
-  const [version, setVersion] = useState<string | null>(null)
+  const [label, setLabel] = useState<string | null>(null)
   useEffect(() => {
-    api.get<{ version: string }>('/plugin/version').then(r => setVersion(r.version)).catch(() => {})
+    api.get<{ version: string; build?: number; semver?: string }>('/plugin/version')
+      .then(r => setLabel(r.semver ? `v${r.semver} (build ${r.build ?? r.version})` : `v${r.version}`))
+      .catch(() => {})
   }, [])
-  if (!version) return null
+  if (!label) return null
   return (
     <span className="text-[10px] font-mono text-muted-foreground bg-muted px-1.5 py-0.5 rounded shrink-0">
-      v{version}
+      {label}
     </span>
   )
 }

--- a/tests/test_tomesync_selfupdate.py
+++ b/tests/test_tomesync_selfupdate.py
@@ -1,0 +1,138 @@
+"""Tests for the TomeSync self-update surface (shim/impl split + endpoints).
+
+See docs/tomesync-self-update-plan.md.
+"""
+import io
+import zipfile
+
+import pytest
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from backend.core.database import get_db
+from backend.core.security import hash_password, create_access_token
+from backend.models.user import User, UserPermission
+from backend.api.tome_sync import (
+    TOMESYNC_PLUGIN_BUILD,
+    TOMESYNC_PLUGIN_SEMVER,
+    _main_shim_lua,
+    _main_impl_lua,
+)
+
+
+def _make_user(db: Session, username: str, role: str = "member") -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password=hash_password("pass"),
+        is_active=True,
+        is_admin=(role == "admin"),
+        role=role,
+        must_change_password=False,
+    )
+    db.add(user)
+    db.flush()
+    db.add(UserPermission(user_id=user.id, can_upload=True, can_download=True))
+    db.flush()
+    return user, create_access_token(subject=user.id)
+
+
+@pytest.fixture()
+def app_client(db: Session):
+    from backend.main import create_app
+    app = create_app()
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c, db
+    app.dependency_overrides.clear()
+
+
+# ── /plugin/version: back-compat + new fields ────────────────────────────────
+
+def test_plugin_version_returns_build_and_semver(app_client):
+    c, _ = app_client
+    r = c.get("/api/plugin/version")
+    assert r.status_code == 200
+    body = r.json()
+    # back-compat: version stays a build-int-as-string
+    assert body["version"] == str(TOMESYNC_PLUGIN_BUILD)
+    assert body["build"] == TOMESYNC_PLUGIN_BUILD
+    assert isinstance(body["build"], int)
+    assert body["semver"] == TOMESYNC_PLUGIN_SEMVER
+
+
+# ── Plugin zip: three files, config only in impl ─────────────────────────────
+
+def test_plugin_zip_has_shim_and_impl(app_client):
+    c, db = app_client
+    _, token = _make_user(db, "zipuser", "member")
+    r = c.get("/api/plugin/koreader", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    names = set(zf.namelist())
+    assert "tomesync.koplugin/_meta.lua" in names
+    assert "tomesync.koplugin/main.lua" in names
+    assert "tomesync.koplugin/main_impl.lua" in names
+
+    shim = zf.read("tomesync.koplugin/main.lua").decode()
+    impl = zf.read("tomesync.koplugin/main_impl.lua").decode()
+    # Config is baked into the impl, never the frozen shim.
+    assert "local API_KEY" in impl and "local SERVER_URL" in impl
+    assert "API_KEY" not in shim or "local API_KEY" not in shim
+    assert "main_impl.lua" in shim  # shim loads the impl
+
+
+# ── /plugin/main-impl.lua: authenticated, config-baked, self-validating ──────
+
+def test_main_impl_requires_auth(app_client):
+    c, _ = app_client
+    # No Authorization header → dependency rejects with 422/401, never 200.
+    r = c.get("/api/plugin/main-impl.lua")
+    assert r.status_code in (401, 422)
+
+
+def test_main_impl_served_with_baked_config(app_client):
+    c, db = app_client
+    _, token = _make_user(db, "impluser", "member")
+    # Mint an API key for this user.
+    rk = c.post(
+        "/api/plugin/api-keys",
+        json={"label": "KO"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    key = rk.json()["key"]
+
+    r = c.get("/api/plugin/main-impl.lua", headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/plain")
+    body = r.text
+    # The caller's key is baked in so config survives the update.
+    assert key in body
+    assert "impluser" in body
+    # Passes the same sentinels the plugin checks before swapping.
+    assert len(body) > 15000
+    assert "function TomeSync:init" in body
+    assert "return TomeSync" in body
+
+
+# ── Generated Lua invariants ─────────────────────────────────────────────────
+
+def test_shim_is_config_free_and_loads_impl():
+    shim = _main_shim_lua()
+    impl = _main_impl_lua("https://tome.example", "tome_secret_key", "alice")
+    # Shim carries no secrets and no per-user config.
+    assert "tome_secret_key" not in shim
+    assert "https://tome.example" not in shim
+    assert "alice" not in shim
+    # Shim runs the rollback machine and loads the impl.
+    assert "main_impl.lua" in shim
+    assert "dofile" in shim
+    assert "tomesync_update" in shim
+    # Impl bakes config and carries the build/semver constants.
+    assert "tome_secret_key" in impl
+    assert f"local BUILD           = {TOMESYNC_PLUGIN_BUILD}" in impl
+    assert f'local SEMVER          = "{TOMESYNC_PLUGIN_SEMVER}"' in impl

--- a/website/src/pages/docs/koreader.astro
+++ b/website/src/pages/docs/koreader.astro
@@ -107,6 +107,26 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
   </ul>
   <p>Sessions shorter than 10 seconds are filtered out.</p>
 
+  <h2>Keeping the plugin updated</h2>
+  <p>
+    Once installed, TomeSync updates itself from your server — no re-download, no file copying.
+    In KOReader's <strong>TomeSync</strong> menu:
+  </p>
+  <ul>
+    <li><strong>Check for updates</strong> — pulls the latest plugin from your server. If a newer
+      build exists, it installs and asks you to restart KOReader.</li>
+    <li><strong>Auto-check on launch</strong> — opt-in toggle. When on, TomeSync quietly checks
+      shortly after startup and prompts only when an update is available.</li>
+  </ul>
+  <p>Your server URL, API key, and reading history carry over automatically — updates never touch them.</p>
+
+  <Callout variant="info" title="A bad update can't brick TomeSync">
+    The plugin is split into a tiny frozen loader and a replaceable implementation. If an update
+    fails to load, the loader automatically rolls back to the last working version on the next
+    launch (or even the same launch), so TomeSync always comes back on its own. Worst case, it
+    shows a "failed to load — reinstall" note; KOReader itself is never affected.
+  </Callout>
+
   <h2>Stable book IDs (vs KOSync hashes)</h2>
   <p>
     KOSync identifies books by the MD5 of the file. Edit metadata, re-save, redownload — the


### PR DESCRIPTION
In-app self-update for the TomeSync KOReader plugin, replacing the SSH-into-every-device workflow. Built so a bad update **cannot brick** — it self-heals on the next launch. Implements `docs/tomesync-self-update-plan.md`.

## Architecture
Splits the single-file plugin into:
- **`main.lua`** — frozen, config-free **stable shim** (~3 KB). Deployed once, never replaced by self-update.
- **`main_impl.lua`** — the real plugin + baked config. The only file updates swap.

State (`book_map`, `pending_sessions`, settings, update bookkeeping) lives in `G_reader_settings`, so updates never touch reading progress.

## Anti-brick rollback (in the shim)
- **Syntax-broken update** → `pcall(dofile)` fails → restore `.bak` and reload, **same boot**.
- **Init-crashing update** → unconfirmed build with `boots ≥ 2` → restore `.bak`, **next boot**.
- **Corrupt/garbage download** → rejected by validation before the swap (status, 15 KB floor, `load()` compiles, sentinel strings).
- **Backup also broken** → valid inert **stub plugin** so KOReader stays happy.

## Versioning
- `TOMESYNC_PLUGIN_BUILD = 8` (monotonic int — the only thing compared) + `TOMESYNC_PLUGIN_SEMVER = "1.0.0"` (display only).
- `GET /plugin/version` now returns `build` + `semver` alongside `version` (kept as `str(build)` for back-compat with existing readers and the web UI).
- New authenticated `GET /plugin/main-impl.lua` serves the config-baked impl for self-update.

## UI
- KOReader: **Check for updates** (manual) + **Auto-check on launch** (opt-in, deferred non-blocking). Adds the `tome_browse_series` gesture action.
- Web: Settings shows `v1.0.0 (build 8)`, falling back to `version`.

## Tests
`tests/test_tomesync_selfupdate.py` — `/plugin/version` fields, the three-file zip, `main-impl` auth + config baking + self-validation, and shim/impl Lua invariants. Full suite: 355 passing locally. Generated Lua validated with a Lua parser.

## Not in this PR (needs a device)
- §8 on-device test matrix (happy / syntax-broken / init-crashing / garbage / backup-broken / state survival).
- §7 one-time manual bootstrap: the first shim+impl build is hand-installed once per device; every update after is in-app.