### PR TITLE
TomeSync: "Open menu" gesture + build 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,14 @@ All notable changes to Tome are documented here. Format loosely follows
   update rolls back on the same boot, an init-crashing update rolls back on the
   next, and a corrupt download is rejected before it is ever swapped in.
   Reading progress, book mappings, and pending sessions live in KOReader
-  settings, so updates never touch them. Adds a `tome_browse_series` gesture
-  action.
+  settings, so updates never touch them.
+- TomeSync gesture actions: **TomeSync: Open menu** (pops the full context-aware
+  TomeSync menu) and **TomeSync: Browse series** (jumps straight to the series
+  browser). Bindable from KOReader's Gesture manager, available in both the
+  reader and the file manager.
 
 ### Changed
-- TomeSync plugin versioning: a hidden monotonic **build** integer (now `8`)
+- TomeSync plugin versioning: a hidden monotonic **build** integer (now `9`)
   drives update comparisons, with an independent human-facing **semver**
   (`1.0.0`). `GET /plugin/version` now returns `build` and `semver` alongside
   the existing `version` field (kept as `str(build)` for back-compat). New

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 # integer — bump on every plugin code change). SEMVER is human-facing display.
 # VERSION is kept as a back-compat alias (= str(BUILD)) for old plugins and the
 # web UI, which read `version` from /plugin/version.
-TOMESYNC_PLUGIN_BUILD = 8
+TOMESYNC_PLUGIN_BUILD = 9
 TOMESYNC_PLUGIN_SEMVER = "1.0.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
@@ -974,12 +974,23 @@ function TomeSync:init()
 end
 
 function TomeSync:onDispatcherRegisterActions()
+    Dispatcher:registerAction("tome_open_menu", {{
+        category = "none",
+        event    = "TomeOpenMenu",
+        title    = "TomeSync: Open menu",
+        general  = true,
+    }})
     Dispatcher:registerAction("tome_browse_series", {{
         category = "none",
         event    = "TomeBrowseSeries",
         title    = "TomeSync: Browse series",
         general  = true,
     }})
+end
+
+function TomeSync:onTomeOpenMenu()
+    self:_openMenu()
+    return true
 end
 
 function TomeSync:onTomeBrowseSeries()
@@ -1512,7 +1523,7 @@ end
 
 -- ── Menu ─────────────────────────────────────────────────────────────────────
 
-function TomeSync:addToMainMenu(menu_items)
+function TomeSync:_menuItems()
     local in_book = self.ui and self.ui.document
 
     local sub_items = {{}}
@@ -1669,12 +1680,42 @@ function TomeSync:addToMainMenu(menu_items)
         }})
     end
 
+    return sub_items
+end
+
+function TomeSync:addToMainMenu(menu_items)
     menu_items.tomesync = {{
-        text         = "TomeSync",
-        sub_item_table = sub_items,
+        text           = "TomeSync",
+        sub_item_table = self:_menuItems(),
     }}
 end
 
-logger.info("TomeSync: main.lua loaded successfully, returning plugin class")
+-- Show the full TomeSync menu as a standalone popup (used by the "Open menu"
+-- gesture). Reuses _menuItems() so it always matches the wrench-menu contents.
+function TomeSync:_openMenu()
+    local raw = self:_menuItems()
+    local items = {{}}
+    for _, it in ipairs(raw) do
+        local orig = it.callback
+        table.insert(items, {{
+            text      = it.text,
+            text_func = it.text_func,
+            callback  = function()
+                if self._gesture_menu then UIManager:close(self._gesture_menu) end
+                if orig then orig() end
+            end,
+        }})
+    end
+    self._gesture_menu = Menu:new{{
+        title       = "TomeSync",
+        item_table  = items,
+        width       = Device.screen:getWidth() - 20,
+        height      = Device.screen:getHeight() - 20,
+        show_parent = self.ui or UIManager,
+    }}
+    UIManager:show(self._gesture_menu)
+end
+
+logger.info("TomeSync: main_impl.lua loaded successfully, returning plugin class")
 return TomeSync
 '''

--- a/docs/koreader-plugin.md
+++ b/docs/koreader-plugin.md
@@ -159,6 +159,15 @@ The plugin menu is context-aware. It self-registers in the **wrench menu** (afte
 | **Enabled / Disabled** | Toggle sync on or off. |
 | **Pending sessions (N)** | Shows how many sessions are queued for sync. Tap for details. |
 
+### Gestures
+
+TomeSync registers two bindable gesture actions (KOReader **Settings → Taps and gestures → Gesture manager**, listed under *General* — available in both the reader and the file manager):
+
+| Action | Does |
+|---|---|
+| **TomeSync: Open menu** | Pops the full context-aware TomeSync menu as a standalone popup. |
+| **TomeSync: Browse series** | Jumps straight to the series browser/downloader. |
+
 ---
 
 ## API Keys


### PR DESCRIPTION
Follow-up to the self-update bootstrap (build 8 is now live on-device). This is also the payload for the first **real** in-app self-update test (build 8 → build 9).

## What's new
- **`TomeSync: Open menu`** gesture action — pops the full context-aware TomeSync menu (Browse series, Test connection, Check for updates, Sync now, etc.) as a standalone popup. The previous `TomeSync: Browse series` shortcut stays. Both are bindable from KOReader's Gesture manager (General group; reader + file manager).
- Menu builder extracted into `_menuItems()` so the gesture popup always mirrors the wrench-menu contents; each popup action closes the popup before running.
- `TOMESYNC_PLUGIN_BUILD` → **9**.
- Cosmetic: the impl's final log line said "main.lua loaded successfully" — it lives in `main_impl.lua` now; fixed.

## Tests
`tests/test_tomesync_selfupdate.py` green (build assertions track the constant). Rendered Lua parses; both gesture actions + the open-menu method present.

## Test plan (on prod, after merge)
1. Merge → CI builds `latest` with build 9.
2. Redeploy prod → `/plugin/version` reports build 9.
3. On the Kindle (currently build 8): **Check for updates → Install → restart** → should come back on build 9 and self-confirm. Then bind a gesture to **TomeSync: Open menu** and verify it opens the full menu.