### PR TITLE
fix: guard null author/series_index in TomeSync series browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,13 +23,21 @@ All notable changes to Tome are documented here. Format loosely follows
   reader and the file manager.
 
 ### Changed
-- TomeSync plugin versioning: a hidden monotonic **build** integer (now `9`)
+- TomeSync plugin versioning: a hidden monotonic **build** integer (now `10`)
   drives update comparisons, with an independent human-facing **semver**
-  (`1.0.0`). `GET /plugin/version` now returns `build` and `semver` alongside
+  (`1.0.1`). `GET /plugin/version` now returns `build` and `semver` alongside
   the existing `version` field (kept as `str(build)` for back-compat). New
   authenticated `GET /plugin/main-impl.lua` serves the config-baked
   implementation for self-update. The first shim+impl build must be installed
   manually once (the last SSH deploy); every update after is in-app.
+
+### Fixed
+- TomeSync series browser crashed (`attempt to concatenate field 'author'`)
+  when a series' first book had no author. The server emitted JSON `null`,
+  which rapidjson decodes to a truthy userdata sentinel, so the plugin's guard
+  passed and then failed concatenating it. The server now omits the author when
+  absent, and the plugin type-checks the field; the same hardening covers a
+  null `series_index` in the series-download paths. Plugin build `10`.
 
 ## [1.1.0] — 2026-05-31 — "Vellum"
 

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -32,8 +32,8 @@ logger = logging.getLogger(__name__)
 # integer — bump on every plugin code change). SEMVER is human-facing display.
 # VERSION is kept as a back-compat alias (= str(BUILD)) for old plugins and the
 # web UI, which read `version` from /plugin/version.
-TOMESYNC_PLUGIN_BUILD = 9
-TOMESYNC_PLUGIN_SEMVER = "1.0.0"
+TOMESYNC_PLUGIN_BUILD = 10
+TOMESYNC_PLUGIN_SEMVER = "1.0.1"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -339,12 +339,17 @@ def list_series(
             .order_by(Book.series_index.asc().nullslast(), Book.title.asc())
             .first()
         )
-        result.append({
+        entry = {
             "name": series_name,
             "book_count": book_count,
-            "author": first_book.author if first_book else None,
             "first_book_id": first_book.id if first_book else None,
-        })
+        }
+        # Only include author when it's a real string. Emitting JSON null here
+        # crashes the KOReader series browser, because rapidjson decodes null to
+        # a (truthy) userdata sentinel that the plugin then tries to concatenate.
+        if first_book and first_book.author:
+            entry["author"] = first_book.author
+        result.append(entry)
 
     return result
 
@@ -1274,7 +1279,7 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type)
     local queue = {{}}
     local skipped = 0
     for _, book in ipairs(books) do
-        if min_index and book.series_index and book.series_index <= min_index then
+        if min_index and type(book.series_index) == "number" and book.series_index <= min_index then
             skipped = skipped + 1
         elseif id_to_path[book.id] and lfs.attributes(id_to_path[book.id]) then
             skipped = skipped + 1
@@ -1285,7 +1290,7 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type)
             else
                 local ext = file.format or "epub"
                 local display_title
-                if book.series_index then
+                if type(book.series_index) == "number" then
                     local vol = book.series_index
                     if vol == math.floor(vol) then vol = math.floor(vol) end
                     display_title = "Vol. " .. tostring(vol) .. " — " .. book.title
@@ -1378,7 +1383,9 @@ function TomeSync:_browseSeriesMenu()
     local items = {{}}
     for _, s in ipairs(series_list) do
         local text = s.name .. " (" .. s.book_count .. ")"
-        if s.author then
+        -- type-check guards against JSON null, which rapidjson decodes to a
+        -- truthy userdata sentinel rather than nil.
+        if type(s.author) == "string" and s.author ~= "" then
             text = text .. " - " .. s.author
         end
         table.insert(items, {{
@@ -1433,7 +1440,9 @@ function TomeSync:_downloadCurrentBookSeries(rest_only)
         -- Find current book's series_index
         for _, b in ipairs(data.books) do
             if b.id == self.book_id then
-                min_index = b.series_index
+                if type(b.series_index) == "number" then
+                    min_index = b.series_index
+                end
                 break
             end
         end


### PR DESCRIPTION
## Problem

Opening **Browse Series** in the KOReader TomeSync plugin crashes with:

```
main_impl.lua:675: attempt to concatenate field 'author' (a userdata value)
```

The `/tome-sync/series` endpoint emitted JSON `null` for the author when a series' first book has none. rapidjson decodes `null` to a truthy userdata sentinel (not `nil`), so the plugin's `if s.author then` guard passed and then crashed concatenating the sentinel onto the menu label.

## Fix

- **Backend:** `list_series` omits the `author` key entirely when there's no author, instead of sending `null`. This resolves the crash for already-deployed build-9 plugins as soon as the server updates.
- **Plugin:** type-check the field (`type(s.author) == "string"`) before using it.
- **Latent sibling bug:** same hardening for `series_index` in the series-download paths, where a null index would have crashed the "download rest of series" comparison / volume formatting.
- Plugin build 9 -> 10, semver 1.0.0 -> 1.0.1, so devices self-update.

## Testing

- Rendered impl byte-compiles clean under luajit (no self-update brick) and passes the plugin's own `validateImpl` gate.
- `92 passed` across the `tome_sync`/`series` test selection; all 5 `test_tomesync_selfupdate.py` tests green after the build bump.

Fixes #6