### PR TITLE
fix: import and round-trip embedded EPUB genre/subject tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to Tome are documented here. Format loosely follows
   (`belongs-to-collection`) is now read correctly on import. It was previously
   dropped — ingest fell back to parsing the title, which mis-grouped or failed
   to group same-series books whose titles lacked a "Vol. N".
+- Genre/category tags embedded in EPUBs (`dc:subject` — what Calibre stores as
+  "tags") are now imported as book tags. They were previously read only from CBZ
+  `ComicInfo.xml`, so EPUB tags were silently dropped and shelf filters showed
+  none. Tags also now round-trip back out on download — embedded as `dc:subject`
+  in EPUBs and `<Genre>` in CBZ `ComicInfo.xml`. Applies to newly imported books;
+  existing books are not retroactively re-tagged.
 
 ## [1.2.0] — 2026-06-02 — "Press"
 

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1877,16 +1877,17 @@ def upload_book(
         content_hash=content_hash,
     ))
 
-    # Create genre tags from ComicInfo.xml
+    # Create genre tags from embedded metadata (epub dc:subject / CBZ ComicInfo)
     if meta.get("_genres"):
         from backend.models.book import BookTag
+        source = meta.get("_genre_source", "comic_info")
         for genre in meta["_genres"]:
             existing = db.query(BookTag).filter(
                 BookTag.book_id == book.id,
                 BookTag.tag == genre,
             ).first()
             if not existing:
-                db.add(BookTag(book_id=book.id, tag=genre, source="comic_info"))
+                db.add(BookTag(book_id=book.id, tag=genre, source=source))
 
     db.flush()
     from backend.services.fts import index_book

--- a/backend/services/metadata.py
+++ b/backend/services/metadata.py
@@ -122,6 +122,21 @@ def extract_epub(path: Path, covers_dir: Path) -> dict:
             if m:
                 meta["year"] = int(m.group(1))
 
+        # Genre/category tags. Calibre and most tools store these as
+        # <dc:subject> elements — one per tag.
+        subjects = book.get_metadata("DC", "subject")
+        if subjects:
+            genres: list[str] = []
+            seen: set[str] = set()
+            for s in subjects:
+                val = (s[0] or "").strip()
+                if val and val.lower() not in seen:
+                    seen.add(val.lower())
+                    genres.append(val)
+            if genres:
+                meta["_genres"] = genres
+                meta["_genre_source"] = "embedded"
+
         # Series from embedded metadata. Calibre writes OPF2
         # <meta name="calibre:series" .../>; EPUB3 uses belongs-to-collection.
         series = _opf_meta_by_name(book, "calibre:series")
@@ -264,6 +279,7 @@ def _parse_comic_info_xml(xml_bytes: bytes) -> dict:
         el = root.find("Genre")
         if el is not None and el.text:
             meta["_genres"] = [g.strip() for g in el.text.split(",") if g.strip()]
+            meta["_genre_source"] = "comic_info"
 
         # Manga detection
         el = root.find("Manga")

--- a/backend/services/metadata_embed.py
+++ b/backend/services/metadata_embed.py
@@ -224,6 +224,14 @@ def _rewrite_opf(
         idx_s = str(int(idx)) if idx == int(idx) else str(idx)
         ET.SubElement(meta, f"{{{OPF_NS}}}meta", {"name": "calibre:series_index", "content": idx_s})
 
+    # Genre/category tags — one <dc:subject> per tag (Calibre convention).
+    _clear("subject")
+    for t in book.tags:
+        tag_val = (t.tag or "").strip()
+        if tag_val:
+            el = ET.SubElement(meta, f"{{{DC_NS}}}subject")
+            el.text = tag_val
+
     # Cover reference — return the in-zip path of the current cover image so
     # the caller can overwrite its bytes. Resolved relative to the OPF.
     cover_href: Optional[str] = None
@@ -331,6 +339,9 @@ def _build_comic_info(book: Book) -> bytes:
         _add("Year", book.year)
     if book.language:
         _add("LanguageISO", book.language)
+    tags = [t.tag.strip() for t in book.tags if t.tag and t.tag.strip()]
+    if tags:
+        _add("Genre", ", ".join(tags))
 
     buf = io.BytesIO()
     ET.ElementTree(root).write(buf, encoding="utf-8", xml_declaration=True)

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -326,12 +326,13 @@ def _create_book_entry(
     # A freshly-created book has no library associations yet, so the old
     # `book.libraries` check here only ever fired an empty lazy-load per book.)
 
-    # Create genre tags from ComicInfo.xml
+    # Create genre tags from embedded metadata (epub dc:subject / CBZ ComicInfo)
     genres = meta.get("_genres") or []
     if genres:
         from backend.models.book import BookTag
+        source = meta.get("_genre_source", "comic_info")
         for genre in genres:
-            db.add(BookTag(book_id=book.id, tag=genre, source="comic_info"))
+            db.add(BookTag(book_id=book.id, tag=genre, source=source))
 
     # Keep the FTS index in sync inline. Pass tags explicitly so a bulk scan
     # doesn't lazy-load book.tags per book (book.id is already set by the flush

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -76,6 +76,64 @@ class TestSeriesExtraction:
         assert meta.get("series_index") == 7.0
 
 
+class TestSubjectExtraction:
+    """Regression: embedded <dc:subject> tags must be imported as genres.
+    Previously extract_epub never read them, so 'nonfiction'/genre tags were
+    silently dropped on import. Reported on the r/selfhosted + r/koreader launch."""
+
+    def test_dc_subject_tags_imported(self, tmp_path):
+        opf = '''<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>A Book</dc:title>
+    <dc:identifier id="uid">urn:uuid:test-sub</dc:identifier>
+    <dc:subject>Nonfiction</dc:subject>
+    <dc:subject>Science</dc:subject>
+    <dc:subject>History</dc:subject>
+  </metadata>
+  <manifest><item id="t" href="t.xhtml" media-type="application/xhtml+xml"/></manifest>
+  <spine><itemref idref="t"/></spine>
+</package>'''
+        epub = tmp_path / "subj.epub"
+        _write_epub(epub, opf)
+        meta = extract_metadata(epub, tmp_path / "covers")
+        assert meta.get("_genres") == ["Nonfiction", "Science", "History"]
+        assert meta.get("_genre_source") == "embedded"
+
+    def test_dc_subject_deduped_case_insensitive(self, tmp_path):
+        opf = '''<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>A Book</dc:title>
+    <dc:identifier id="uid">urn:uuid:test-dup</dc:identifier>
+    <dc:subject>Fantasy</dc:subject>
+    <dc:subject>fantasy</dc:subject>
+    <dc:subject></dc:subject>
+  </metadata>
+  <manifest><item id="t" href="t.xhtml" media-type="application/xhtml+xml"/></manifest>
+  <spine><itemref idref="t"/></spine>
+</package>'''
+        epub = tmp_path / "dup.epub"
+        _write_epub(epub, opf)
+        meta = extract_metadata(epub, tmp_path / "covers")
+        assert meta.get("_genres") == ["Fantasy"]
+
+    def test_no_subject_no_genres(self, tmp_path):
+        opf = '''<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="uid">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>A Book</dc:title>
+    <dc:identifier id="uid">urn:uuid:test-none</dc:identifier>
+  </metadata>
+  <manifest><item id="t" href="t.xhtml" media-type="application/xhtml+xml"/></manifest>
+  <spine><itemref idref="t"/></spine>
+</package>'''
+        epub = tmp_path / "none.epub"
+        _write_epub(epub, opf)
+        meta = extract_metadata(epub, tmp_path / "covers")
+        assert "_genres" not in meta
+
+
 # ── normalise_author ──────────────────────────────────────────────────────────
 
 class TestNormaliseAuthor:

--- a/tests/test_metadata_embed.py
+++ b/tests/test_metadata_embed.py
@@ -1,0 +1,73 @@
+"""Tests for metadata embedding on download (backend/services/metadata_embed.py).
+
+Regression: genre/category tags (book.tags) must be written back into
+downloaded files — <dc:subject> for EPUB, <Genre> for CBZ ComicInfo — so the
+import→edit→download round-trip preserves tags. Previously neither was written.
+"""
+import xml.etree.ElementTree as ET
+from types import SimpleNamespace
+
+from backend.services.metadata_embed import _rewrite_opf, _build_comic_info, DC_NS
+
+
+def _tag(name: str) -> SimpleNamespace:
+    return SimpleNamespace(tag=name)
+
+
+def _book(**overrides) -> SimpleNamespace:
+    base = dict(
+        title="A Book", subtitle=None, author="An Author", publisher=None,
+        description=None, language=None, year=None, isbn=None,
+        series=None, series_index=None, tags=[],
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+MINIMAL_OPF = (
+    '<?xml version="1.0" encoding="utf-8"?>'
+    '<package xmlns="http://www.idpf.org/2007/opf" version="2.0" unique-identifier="uid">'
+    '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/" '
+    'xmlns:opf="http://www.idpf.org/2007/opf">'
+    '<dc:title>Old</dc:title>'
+    '<dc:subject>StaleTag</dc:subject>'
+    '</metadata>'
+    '<manifest><item id="t" href="t.xhtml" media-type="application/xhtml+xml"/></manifest>'
+    '<spine><itemref idref="t"/></spine></package>'
+).encode()
+
+
+def _subjects(opf_bytes: bytes) -> list[str]:
+    root = ET.fromstring(opf_bytes)
+    return [el.text for el in root.iter(f"{{{DC_NS}}}subject")]
+
+
+class TestEpubSubjectWrite:
+    def test_tags_written_as_dc_subject(self):
+        book = _book(tags=[_tag("Nonfiction"), _tag("Science")])
+        out, _ = _rewrite_opf(MINIMAL_OPF, book, "content.opf", [], have_cover=False)
+        assert _subjects(out) == ["Nonfiction", "Science"]
+
+    def test_stale_subjects_replaced(self):
+        # The pre-existing <dc:subject>StaleTag</dc:subject> must be cleared.
+        book = _book(tags=[_tag("Fresh")])
+        out, _ = _rewrite_opf(MINIMAL_OPF, book, "content.opf", [], have_cover=False)
+        assert _subjects(out) == ["Fresh"]
+
+    def test_no_tags_clears_subjects(self):
+        book = _book(tags=[])
+        out, _ = _rewrite_opf(MINIMAL_OPF, book, "content.opf", [], have_cover=False)
+        assert _subjects(out) == []
+
+
+class TestComicInfoGenreWrite:
+    def test_tags_written_as_genre(self):
+        book = _book(tags=[_tag("Action"), _tag("Adventure")])
+        root = ET.fromstring(_build_comic_info(book))
+        genre = root.find("Genre")
+        assert genre is not None and genre.text == "Action, Adventure"
+
+    def test_no_tags_no_genre(self):
+        book = _book(tags=[])
+        root = ET.fromstring(_build_comic_info(book))
+        assert root.find("Genre") is None


### PR DESCRIPTION
## What

EPUB genre/category tags (`<dc:subject>` — what Calibre stores as "tags", e.g. *nonfiction*) were silently dropped on import. `extract_epub` never read `dc:subject`; only CBZ `ComicInfo.xml` `<Genre>` was imported. Two redditors hit this on the launch (r/koreader and r/selfhosted) — shelf filters showed "any tags" because there genuinely were none in the DB.

## Changes

**Read (import):**
- `extract_epub` now reads `<dc:subject>`, dedupes case-insensitively, and tags provenance (`embedded` vs `comic_info`).
- The two embedded-extraction import paths (folder scan, upload) use the source label instead of hardcoding `comic_info`.

**Write (download):**
- Tags now round-trip back out: `<dc:subject>` per tag in EPUB downloads, and `<Genre>` in CBZ `ComicInfo.xml` (the CBZ side read Genre but never wrote it — fixed for symmetry).

## Scope

- New imports only. Existing books are **not** retroactively re-tagged (no backfill — intentional; library was launched yesterday so nobody has a large pre-existing collection affected).
- Scribe `ingest` path untouched (caller-authoritative).
- No schema change, no migration, no frontend work.

## Testing

- Unit: `TestSubjectExtraction` (3) + new `tests/test_metadata_embed.py` (5 write-side). Full backend suite green.
- End-to-end on the dev server: built a real EPUB with `dc:subject` tags, uploaded via `/api/books/upload`, confirmed tags read back on the book, downloaded the baked file and confirmed `dc:subject` embedded, cleaned up. read=PASS write=PASS.