### PR TITLE
feat: support user-defined Google Books API key (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- `TOME_GOOGLE_BOOKS_KEY`: optionally supply your own Google Books API key.
+  Without it, Google Books is queried anonymously against a shared global quota
+  that is exhausted almost immediately, making the fallback silently return zero
+  results — felt most acutely for non-English (e.g. traditional Chinese)
+  catalogues that depend on Google for coverage. With a key set, requests are
+  charged against your own Cloud project quota instead. Public-volume search
+  only — no OAuth, no access to user data. A configured key that hits its quota
+  now logs a clear warning instead of failing silently. (#10)
+
 ### Fixed
 - Series metadata embedded by Calibre (`calibre:series`) and EPUB3 collections
   (`belongs-to-collection`) is now read correctly on import. It was previously

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -18,6 +18,11 @@ class Settings(BaseSettings):
     incoming_dir: Path = Path("./bindery")
     port: int = 8080
     hardcover_token: str | None = None
+    # Optional Google Books API key (env TOME_GOOGLE_BOOKS_KEY). When set, Google
+    # Books requests are charged against your own Cloud project quota instead of
+    # the shared anonymous pool — fixes 429/quota failures, which hit hardest for
+    # non-English (e.g. zh-TW) catalogues that lean on Google as the fallback.
+    google_books_key: str | None = None
 
     # SMTP (send-to-device)
     smtp_host: str | None = None

--- a/backend/services/metadata_fetch.py
+++ b/backend/services/metadata_fetch.py
@@ -557,13 +557,28 @@ async def _google_books(
     query: str,
     isbn: str | None = None,
 ) -> list[MetadataCandidate]:
+    params: dict[str, str | int] = {
+        "q": query,
+        "maxResults": _MAX_RESULTS,
+        "printType": "books",
+    }
+    if settings.google_books_key:
+        params["key"] = settings.google_books_key
     try:
-        resp = await client.get(
-            GOOGLE_BOOKS_URL,
-            params={"q": query, "maxResults": _MAX_RESULTS, "printType": "books"},
-        )
-        if resp.status_code == 429:
-            logger.warning("Google Books rate limited")
+        resp = await client.get(GOOGLE_BOOKS_URL, params=params)
+        if resp.status_code in (400, 429):
+            # 400 is how Google reports an exhausted key quota ("Quota Exceeded");
+            # 429 is the anonymous shared-pool limit. Either way there's nothing
+            # more to fetch — log loudly when a key is configured so the operator
+            # knows it's *their* project quota that's drained, not a code bug.
+            if settings.google_books_key:
+                logger.warning(
+                    "Google Books quota exhausted for the configured API key "
+                    "(HTTP %s)", resp.status_code,
+                )
+            else:
+                logger.warning("Google Books rate limited (HTTP %s) — no API key "
+                               "configured; set TOME_GOOGLE_BOOKS_KEY", resp.status_code)
             return []
         resp.raise_for_status()
         data = resp.json()

--- a/docs/bindery-deployment.md
+++ b/docs/bindery-deployment.md
@@ -58,6 +58,7 @@ Environment variables:
 ```
 TOME_SECRET_KEY=<your-secret>
 TOME_HARDCOVER_TOKEN=<your-token>       # optional but recommended
+TOME_GOOGLE_BOOKS_KEY=<your-key>        # optional: use your own Google Books quota (fixes 429/400 quota errors)
 TOME_AUTO_IMPORT=true                   # optional: auto-ingest new files
 TOME_AUTO_IMPORT_INTERVAL=300           # optional: scan interval in seconds (default 300)
 ```

--- a/docs/examples/docker-compose.unraid.yml
+++ b/docs/examples/docker-compose.unraid.yml
@@ -17,4 +17,7 @@ services:
       # first start and save it to /data/secret.key.
       # - TOME_SECRET_KEY=
       # - TOME_HARDCOVER_TOKEN=
+      # Use your own Google Books quota instead of the shared anonymous pool
+      # (fixes 429/400 "Quota Exceeded", esp. for non-English catalogues):
+      # - TOME_GOOGLE_BOOKS_KEY=
     restart: unless-stopped

--- a/docs/features.md
+++ b/docs/features.md
@@ -102,6 +102,8 @@ Multi-select books on the dashboard to:
 
 Search Google Books, OpenLibrary, and Hardcover for metadata. Results are shown in a side-by-side diff UI so you can see exactly what will change before applying. Hardcover results are prioritized when a `TOME_HARDCOVER_TOKEN` is configured.
 
+By default Google Books is queried anonymously against a shared quota, which can hit `429`/`400` "Quota Exceeded" errors — most noticeable for non-English (e.g. traditional Chinese) catalogues that lean on Google as the fallback. Set `TOME_GOOGLE_BOOKS_KEY` to a free [Google Books API key](https://developers.google.com/books/docs/v1/using) and requests are charged against your own Cloud project quota instead. It's a plain public-search API key — no OAuth and no access to any user's private data.
+
 ---
 
 ## Cover Picker


### PR DESCRIPTION
Closes #10.

## Problem

`_google_books()` queries the Google Books API anonymously, against Google's shared global quota. That pool is exhausted almost constantly, so the call returns `429`/`400` "Quota Exceeded" and the metadata fallback silently yields zero results. As the reporter (a Tome user in Taiwan) notes, this is most painful for non-English — e.g. traditional Chinese — catalogues, where Hardcover coverage is sparse and Google is the realistic fallback.

## Change

- **`TOME_GOOGLE_BOOKS_KEY`** — new optional setting (mirrors `TOME_HARDCOVER_TOKEN`). When set, a `key=` param is added to the Google Books request so it is charged against the operator's own Cloud project quota instead of the shared anonymous pool.
- **Quota failures no longer fail silently.** `400` (how Google reports an exhausted *keyed* quota) is now handled alongside `429`, and the warning distinguishes "your key's quota is drained" from "no key set, hitting the shared pool" — previously a `400` was swallowed as a generic request failure.

Public-volume search only — **no OAuth, no access to any user's private data**. Behaviour with no key set is byte-for-byte unchanged.

## Scope notes

- Server-wide env var, not per-user — matches `hardcover_token` and suits a self-hosted single-admin deployment.
- A free Books API key raises the ceiling to your project quota (~1k req/day); it is not unlimited, so very large bulk fetches can still hit it — hence the clearer logging.
- Surfacing quota state to the frontend UI is intentionally left out of this PR as a separate follow-up.

## Testing

- Plumbing: `key` absent when unset, present and correct when set.
- Quota branch: `400`/`429` return `[]` with the correct keyed-vs-anonymous warning.
- **Live before/after:** the same query returned `429` + 0 results anonymously, then full results with a real key — including correct native-script metadata + covers for traditional-Chinese queries (the reporter's use case).
- Existing suite: 98/98 metadata tests pass.

## Docs

CHANGELOG, `docs/bindery-deployment.md`, the Unraid compose example, and `docs/features.md` all updated.