### PR TITLE
fix: book type create/edit returns 422 (#12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to Tome are documented here. Format loosely follows
   now logs a clear warning instead of failing silently. (#10)
 
 ### Fixed
+- Adding or editing a book type in admin settings no longer fails with a 422
+  error. The create/edit form never sends a `slug` (it is derived from the
+  label), but the API required one, so every save was rejected before it
+  reached the handler. The slug is now optional and auto-derived from the label
+  on create. (#12)
 - Series metadata embedded by Calibre (`calibre:series`) and EPUB3 collections
   (`belongs-to-collection`) is now read correctly on import. It was previously
   dropped — ingest fell back to parsing the title, which mis-grouped or failed

--- a/backend/api/book_types.py
+++ b/backend/api/book_types.py
@@ -13,7 +13,7 @@ router = APIRouter(tags=["book-types"])
 
 
 class BookTypeIn(BaseModel):
-    slug: str
+    slug: Optional[str] = None
     label: str
     icon: str = "BookOpen"
     color: str = "blue"
@@ -44,7 +44,8 @@ def create_book_type(
     current_user: User = Depends(get_current_user),
 ):
     require_role(current_user, "admin")
-    slug = body.slug.strip().lower().replace(" ", "_")
+    raw_slug = body.slug or body.label
+    slug = raw_slug.strip().lower().replace(" ", "_")
     if db.query(BookType).filter(BookType.slug == slug).first():
         raise HTTPException(status_code=400, detail="Slug already exists")
     bt = BookType(slug=slug, label=body.label.strip(), icon=body.icon, color=body.color, sort_order=body.sort_order)

--- a/tests/test_book_types.py
+++ b/tests/test_book_types.py
@@ -1,0 +1,85 @@
+"""Regression tests for the book-types API.
+
+Covers:
+- POST /api/book-types — slug auto-derived from label when not supplied
+- POST /api/book-types — explicit slug is accepted and used verbatim
+- POST /api/book-types — duplicate slug returns 400
+- PUT  /api/book-types/{id} — update succeeds without slug in body
+- DELETE /api/book-types/{id} — admin can delete an unused type
+"""
+import pytest
+from starlette.testclient import TestClient
+
+
+def test_create_book_type_no_slug_derives_from_label(client: TestClient):
+    """POST without a slug must succeed and derive the slug from the label."""
+    resp = client.post("/api/book-types", json={
+        "label": "Light Novel",
+        "icon": "BookOpen",
+        "color": "blue",
+        "sort_order": 10,
+    })
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["label"] == "Light Novel"
+    assert data["slug"] == "light_novel"
+
+
+def test_create_book_type_explicit_slug(client: TestClient):
+    """POST with an explicit slug must use that slug (lowercased/underscored)."""
+    resp = client.post("/api/book-types", json={
+        "slug": "My Manga",
+        "label": "Manga",
+        "icon": "BookOpen",
+        "color": "pink",
+        "sort_order": 20,
+    })
+    assert resp.status_code == 201, resp.text
+    data = resp.json()
+    assert data["slug"] == "my_manga"
+    assert data["label"] == "Manga"
+
+
+def test_create_book_type_duplicate_slug_returns_400(client: TestClient):
+    """POST with a duplicate slug must return 400."""
+    client.post("/api/book-types", json={"label": "Comics", "sort_order": 1})
+    resp = client.post("/api/book-types", json={"label": "Comics", "sort_order": 2})
+    assert resp.status_code == 400, resp.text
+
+
+def test_update_book_type_without_slug(client: TestClient):
+    """PUT without a slug field must succeed (slug is Optional in BookTypeIn)."""
+    create_resp = client.post("/api/book-types", json={
+        "label": "Novel",
+        "icon": "BookOpen",
+        "color": "green",
+        "sort_order": 5,
+    })
+    assert create_resp.status_code == 201, create_resp.text
+    bt_id = create_resp.json()["id"]
+
+    put_resp = client.put(f"/api/book-types/{bt_id}", json={
+        "label": "Novel (Updated)",
+        "icon": "Book",
+        "color": "teal",
+        "sort_order": 6,
+    })
+    assert put_resp.status_code == 200, put_resp.text
+    data = put_resp.json()
+    assert data["label"] == "Novel (Updated)"
+    # Slug is NOT updated by PUT — it should still equal the original derived slug
+    assert data["slug"] == "novel"
+
+
+def test_delete_unused_book_type(client: TestClient):
+    """Admin can delete a book type that has no associated books."""
+    create_resp = client.post("/api/book-types", json={"label": "Temporary", "sort_order": 99})
+    assert create_resp.status_code == 201, create_resp.text
+    bt_id = create_resp.json()["id"]
+
+    del_resp = client.delete(f"/api/book-types/{bt_id}")
+    assert del_resp.status_code == 204, del_resp.text
+
+    # Should no longer appear in list
+    list_resp = client.get("/api/book-types")
+    assert all(bt["id"] != bt_id for bt in list_resp.json())


### PR DESCRIPTION
Fixes #12.

## Problem
Adding or editing a book type in admin settings always failed with **422 Unprocessable Entity**.

The admin Types form (`AdminPage.tsx`) sends `{ label, icon, color, sort_order }` and never a `slug` — the slug is meant to be auto-derived from the label, and there is no slug input in the UI. But `BookTypeIn` declared `slug: str` as **required**, so FastAPI rejected the body before the handler ran. This broke both **Add type** and **Edit type** (PUT uses the same schema).

## Fix
Backend-only (`backend/api/book_types.py`):
- `slug` is now `Optional[str] = None`
- `create_book_type` derives the slug from `slug or label` before normalizing
- `update_book_type` already ignored slug, so edit is fixed by the optional field

No frontend change — the UI intentionally has no slug field.

## Tests
- New `tests/test_book_types.py`: slug auto-derivation, explicit slug, duplicate-slug 400, slugless PUT, delete-unused
- Full backend suite: **370 passed**