### PR TITLE
fix: serve OPDS feeds with default Atom namespace (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ All notable changes to Tome are documented here. Format loosely follows
   instead of a full-width grid.
 
 ### Fixed
+- OPDS feeds are now served with the standard default Atom namespace
+  (`<feed xmlns="http://www.w3.org/2005/Atom">`) instead of prefixed
+  `ns0:` elements, so strict OPDS clients such as KOReader parse them and the
+  catalog is no longer empty. The feed builder shared a process-global XML
+  namespace map with the download metadata embedder; whichever module was
+  imported last claimed the default prefix and silently broke the other.
+  Namespace prefixes are now re-asserted, under a lock, at serialization time so
+  they no longer depend on import order. The Content-Type was already
+  `application/atom+xml`. (#15)
 - Adding or editing a book type in admin settings no longer fails with a 422
   error. The create/edit form never sends a `slug` (it is derived from the
   label), but the API required one, so every save was rejected before it

--- a/backend/services/metadata_embed.py
+++ b/backend/services/metadata_embed.py
@@ -20,6 +20,7 @@ from xml.etree import ElementTree as ET
 
 from backend.core.config import settings
 from backend.models.book import Book, BookFile
+from backend.services.xml_ns import namespaces
 
 log = logging.getLogger(__name__)
 
@@ -27,9 +28,13 @@ OPF_NS = "http://www.idpf.org/2007/opf"
 DC_NS = "http://purl.org/dc/elements/1.1/"
 CONTAINER_NS = "urn:oasis:names:tc:opendocument:xmlns:container"
 
-ET.register_namespace("", OPF_NS)
-ET.register_namespace("dc", DC_NS)
-ET.register_namespace("opf", OPF_NS)
+# Re-asserted at serialization time rather than relying on global,
+# import-order-dependent state — see ``backend/services/xml_ns.py`` (GH #15).
+_NS_REGISTRATIONS = (
+    ("", OPF_NS),
+    ("dc", DC_NS),
+    ("opf", OPF_NS),
+)
 
 
 # ── Cache plumbing ────────────────────────────────────────────────────────────
@@ -239,7 +244,8 @@ def _rewrite_opf(
         cover_href = _find_cover_href(root)
 
     out = io.BytesIO()
-    tree.write(out, encoding="utf-8", xml_declaration=True)
+    with namespaces(_NS_REGISTRATIONS):
+        tree.write(out, encoding="utf-8", xml_declaration=True)
     return out.getvalue(), cover_href
 
 

--- a/backend/services/opds.py
+++ b/backend/services/opds.py
@@ -4,17 +4,25 @@ from datetime import datetime
 
 from fastapi.responses import Response
 
+from backend.services.xml_ns import namespaces
+
 ATOM_NS = "http://www.w3.org/2005/Atom"
 DC_NS = "http://purl.org/dc/terms/"
 OPDS_NS = "http://opds-spec.org/2010/catalog"
 OPENSEARCH_NS = "http://a9.com/-/spec/opensearch/1.1/"
 TOME_NS = "https://tome.app/ns/1.0"
 
-ET.register_namespace("", ATOM_NS)
-ET.register_namespace("dc", DC_NS)
-ET.register_namespace("opds", OPDS_NS)
-ET.register_namespace("opensearch", OPENSEARCH_NS)
-ET.register_namespace("tome", TOME_NS)
+# The Atom namespace must serialize as the default ('') prefix so strict OPDS
+# clients (e.g. KOReader) accept the feed. These registrations are re-asserted
+# at serialization time in ``feed_response`` rather than relying on global,
+# import-order-dependent state — see ``backend/services/xml_ns.py`` (GH #15).
+_NS_REGISTRATIONS = (
+    ("", ATOM_NS),
+    ("dc", DC_NS),
+    ("opds", OPDS_NS),
+    ("opensearch", OPENSEARCH_NS),
+    ("tome", TOME_NS),
+)
 
 ACQUISITION_TYPE = "application/atom+xml;profile=opds-catalog;kind=acquisition"
 NAVIGATION_TYPE = "application/atom+xml;profile=opds-catalog;kind=navigation"
@@ -159,5 +167,7 @@ def add_pagination(
 
 
 def feed_response(feed: ET.Element) -> Response:
-    xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(feed, encoding="unicode")
+    with namespaces(_NS_REGISTRATIONS):
+        body = ET.tostring(feed, encoding="unicode")
+    xml = '<?xml version="1.0" encoding="UTF-8"?>\n' + body
     return Response(content=xml, media_type="application/atom+xml;charset=utf-8")

--- a/backend/services/xml_ns.py
+++ b/backend/services/xml_ns.py
@@ -1,0 +1,42 @@
+"""Thread-safe namespace handling for ElementTree serialization.
+
+ElementTree keeps a single *process-global* namespace→prefix map
+(``xml.etree.ElementTree._namespace_map``) that ``register_namespace`` mutates.
+Worse, ``register_namespace`` deletes any existing entry whose prefix equals the
+new one — so two modules that both want the default ('') prefix collide:
+
+* OPDS (``services/opds.py``) wants ''  → Atom namespace
+* the download embedder (``services/metadata_embed.py``) wants '' → OPF namespace
+
+Whichever module is imported *last* steals '' for its own namespace and silently
+breaks the other. In practice the OPDS feed ended up serialized with ``ns0:``
+prefixes (``<ns0:feed xmlns:ns0="http://www.w3.org/2005/Atom">``) which KOReader
+and other strict OPDS clients can't parse, so the catalog showed up empty
+(GH #15).
+
+This module provides a lock-guarded context manager that re-asserts the caller's
+own registrations immediately before it serializes, so each serialization gets
+the prefixes it asked for regardless of import order or concurrent callers
+(FastAPI runs sync handlers on a thread pool).
+"""
+from __future__ import annotations
+
+import threading
+import xml.etree.ElementTree as ET
+from contextlib import contextmanager
+from typing import Iterable, Tuple
+
+_LOCK = threading.RLock()
+
+
+@contextmanager
+def namespaces(registrations: Iterable[Tuple[str, str]]):
+    """Re-assert ``(prefix, uri)`` registrations, then yield, under a lock.
+
+    Serialize inside the ``with`` block so the global namespace map can't be
+    clobbered by another thread between registration and serialization.
+    """
+    with _LOCK:
+        for prefix, uri in registrations:
+            ET.register_namespace(prefix, uri)
+        yield

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1,0 +1,74 @@
+"""Regression tests for OPDS feed serialization (GH #15).
+
+The Atom feed must serialize with the *default* namespace
+(``<feed xmlns="http://www.w3.org/2005/Atom">``) and the
+``application/atom+xml`` content type. Strict OPDS clients such as KOReader
+silently reject prefixed namespaces (``<ns0:feed xmlns:ns0=...>``) and show an
+empty catalog.
+
+The historical failure mode was a process-global ``register_namespace`` collision
+between ``services/opds.py`` and ``services/metadata_embed.py`` — both wanted the
+empty ('') prefix, and whichever was imported last won, breaking the other.
+"""
+import xml.etree.ElementTree as ET
+
+from backend.core.security import get_current_user_basic
+from backend.services.opds import make_feed, add_navigation_entry, feed_response
+
+
+def _first_tag(body: str) -> str:
+    # body is "<?xml ...?>\n<feed ...>..."
+    return body.split("\n", 1)[1]
+
+
+def test_feed_uses_default_atom_namespace():
+    feed = make_feed("urn:tome:root", "Tome", "http://x/opds", kind="navigation")
+    add_navigation_entry(feed, "urn:tome:all", "All Books", "http://x/opds/all")
+    body = feed_response(feed).body.decode()
+
+    assert '<feed xmlns="http://www.w3.org/2005/Atom">' in body
+    assert "ns0:" not in body
+    assert "<ns0:feed" not in body
+
+
+def test_feed_content_type_is_atom_xml():
+    feed = make_feed("urn:tome:root", "Tome", "http://x/opds")
+    resp = feed_response(feed)
+    assert "application/atom+xml" in resp.media_type
+    assert "json" not in resp.media_type
+
+
+def test_feed_robust_against_global_namespace_clobber():
+    """Even if another module steals the '' prefix for a foreign namespace,
+    the OPDS feed must still serialize Atom as the default namespace."""
+    # Simulate metadata_embed (or any other module) winning the '' prefix.
+    ET.register_namespace("", "http://www.idpf.org/2007/opf")
+    try:
+        feed = make_feed("urn:tome:root", "Tome", "http://x/opds")
+        body = feed_response(feed).body.decode()
+        assert '<feed xmlns="http://www.w3.org/2005/Atom">' in body
+        assert "ns0:" not in body
+    finally:
+        # Restore the Atom default so we don't leak clobbered state to other tests.
+        ET.register_namespace("", "http://www.w3.org/2005/Atom")
+
+
+def test_opds_root_endpoint_serves_default_namespace(client):
+    """End-to-end: the live /opds endpoint returns atom+xml with a default ns."""
+
+    class _U:
+        id = 1
+        is_admin = True
+        role = "admin"
+        username = "t"
+
+    client.app.dependency_overrides[get_current_user_basic] = lambda: _U()
+    try:
+        resp = client.get("/opds")
+        assert resp.status_code == 200
+        assert "application/atom+xml" in resp.headers["content-type"]
+        body = _first_tag(resp.text)
+        assert body.startswith('<feed xmlns="http://www.w3.org/2005/Atom">')
+        assert "ns0:" not in resp.text
+    finally:
+        client.app.dependency_overrides.pop(get_current_user_basic, None)


### PR DESCRIPTION
Fixes #15.

## Problem
KOReader (and other strict OPDS clients) showed an empty Tome catalog. The feed was serialized with prefixed namespaces — `<ns0:feed xmlns:ns0="http://www.w3.org/2005/Atom">` — instead of the default `<feed xmlns="...">`, which those parsers reject.

## Cause
`ElementTree.register_namespace()` mutates a **process-global** namespace map and deletes any existing entry whose prefix matches the new one. Two modules both registered the default `""` prefix at import time:

- `backend/services/opds.py` → `("", ATOM_NS)`
- `backend/services/metadata_embed.py` → `("", OPF_NS)`

Whichever imported last claimed `""` for the whole process. At real app boot the embedder won, so the Atom feed lost its default prefix and fell back to `ns0:`. This regressed when download metadata-embedding was added; OPDS was correct before that.

## Fix
New `backend/services/xml_ns.py` exposes a lock-guarded `namespaces()` context manager that re-asserts a module's `(prefix, uri)` registrations immediately before serialization. `opds.py` and `metadata_embed.py` now serialize inside it instead of registering globally at import, so output no longer depends on import order or thread interleaving. OPF output is byte-identical to before.

## Verification
- Full suite: 401 passed
- New `tests/test_opds.py` (4 tests), incl. one that deliberately clobbers the global map and asserts OPDS still serializes the default namespace
- Full-boot `/opds` now returns `<feed xmlns="http://www.w3.org/2005/Atom">` with `Content-Type: application/atom+xml`

## Note
The reporter also saw `Content-Type: application/json`; that isn't reproducible — the authenticated `/opds` response returns `application/atom+xml`. It was likely the 401 Basic-auth challenge (JSON) or a reverse proxy. The namespace fix is what was breaking KOReader.