### PR TITLE
fix: forward-port plugin HTTPS sync fix to main (build 14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,17 @@ All notable changes to Tome are documented here. Format loosely follows
   instead of a full-width grid.
 
 ### Fixed
+- TomeSync (KOReader) sync silently failing on HTTPS deployments behind a
+  reverse proxy (also released as the 1.2.1 hotfix). The plugin baked its server
+  URL from the scheme the app server saw, which is `http` when TLS is terminated
+  upstream — and if the proxy then redirected HTTP→HTTPS, KOReader could not
+  follow the 307 on POST/PUT, so every reading session and position update failed
+  (sessions piled up as "pending" and nothing reached the library). The server
+  now honours `X-Forwarded-Proto` when baking the plugin's `SERVER_URL`, and a
+  new optional `TOME_PUBLIC_URL` setting pins the canonical public origin
+  explicitly. The plugin build was bumped so existing installs re-bake the
+  corrected URL on **TomeSync → Check for updates**. Plain HTTP, LAN, and
+  localhost deployments are unaffected.
 - OPDS feeds are now served with the standard default Atom namespace
   (`<feed xmlns="http://www.w3.org/2005/Atom">`) instead of prefixed
   `ns0:` elements, so strict OPDS clients such as KOReader parse them and the

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Did click? **Don't run it on your laptop long-term.** Move `~/Tome` to an always
 | `TOME_LIBRARY_DIR` | No | `/books` | Library root |
 | `TOME_INCOMING_DIR` | No | `/bindery` | Bindery folder |
 | `TOME_PORT` | No | `8080` | HTTP port |
+| `TOME_PUBLIC_URL` | No | -- | Canonical public origin (e.g. `https://tome.example.org`). Pin this behind a reverse proxy so the KOReader plugin is baked with the correct `https://` URL |
 | `TOME_HARDCOVER_TOKEN` | No | -- | [Hardcover](https://hardcover.app) API token for metadata |
 | `TOME_AUTO_IMPORT` | No | `false` | Auto-import files from the bindery on a schedule |
 | `TOME_AUTO_IMPORT_INTERVAL` | No | `300` | Seconds between auto-import scans |

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from typing import Optional
 
 from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import FileResponse, StreamingResponse
@@ -17,6 +18,7 @@ from pydantic import BaseModel as PydanticBaseModel, field_validator
 from sqlalchemy import func
 from sqlalchemy.orm import Session, joinedload
 
+from backend.core.config import settings
 from backend.core.database import get_db
 from backend.core.permissions import user_can_see_book
 from backend.core.security import get_current_user
@@ -32,8 +34,13 @@ logger = logging.getLogger(__name__)
 # integer — bump on every plugin code change). SEMVER is human-facing display.
 # VERSION is kept as a back-compat alias (= str(BUILD)) for old plugins and the
 # web UI, which read `version` from /plugin/version.
-TOMESYNC_PLUGIN_BUILD = 12
-TOMESYNC_PLUGIN_SEMVER = "1.2.0"
+# BUILD 14: the HTTPS-sync fix also shipped as 1.2.1 (BUILD 13, cut from the
+# v1.2.0 tag). main's impl carries more than 1.2.1's, so it must take a *higher*
+# build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
+# later points at a main/1.3.0 server (also 13) would not re-download main's
+# richer impl. Hence 14.
+TOMESYNC_PLUGIN_BUILD = 14
+TOMESYNC_PLUGIN_SEMVER = "1.2.1"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -689,6 +696,40 @@ def plugin_version() -> dict:
 
 # ── Plugin download ───────────────────────────────────────────────────────────
 
+def _baked_server_url(request: Request, explicit: str | None) -> str:
+    """Resolve the origin baked into the plugin's SERVER_URL.
+
+    Priority:
+      1. an explicit ``?server_url=`` (the web UI passes this to dodge the Vite
+         dev proxy);
+      2. ``TOME_PUBLIC_URL`` config — the authoritative public origin;
+      3. the request origin, but with the scheme taken from ``X-Forwarded-Proto``
+         when a proxy sent it.
+
+    (3) is the fix for HTTPS-behind-a-proxy deployments: a TLS-terminating proxy
+    makes the app server see ``http``, so ``request.base_url`` would bake an
+    ``http://`` URL; if the proxy then redirects HTTP→HTTPS, KOReader can't
+    follow the 307 on POST/PUT and every session/position sync fails. Honouring
+    the forwarded scheme bakes ``https`` instead. When the header is absent
+    (plain HTTP / LAN / localhost) the scheme is left untouched, so those
+    deployments bake exactly what they did before.
+    """
+    if explicit:
+        return explicit.rstrip("/")
+    if settings.public_url:
+        return settings.public_url.rstrip("/")
+    base = str(request.base_url).rstrip("/")
+    forwarded = request.headers.get("x-forwarded-proto")
+    if forwarded:
+        # May be a comma-separated chain (e.g. "https,http"); the client-facing
+        # scheme is the first hop.
+        proto = forwarded.split(",")[0].strip().lower()
+        if proto in ("http", "https"):
+            parts = urlsplit(base)
+            base = urlunsplit((proto, parts.netloc, parts.path, parts.query, parts.fragment))
+    return base.rstrip("/")
+
+
 @router.get("/plugin/koreader")
 def download_plugin(
     request: Request,
@@ -710,9 +751,7 @@ def download_plugin(
     ))
     db.commit()
 
-    # Use explicit server_url if provided (frontend passes it to avoid vite proxy issues)
-    if not server_url:
-        server_url = str(request.base_url).rstrip("/")
+    server_url = _baked_server_url(request, server_url)
 
     # Build the ZIP in memory — shim + impl split for self-update:
     #   main.lua       frozen stable shim (no config; runs the rollback machine)
@@ -750,8 +789,7 @@ def download_main_impl(
     auth = request.headers.get("authorization", "")
     api_key_value = auth.removeprefix("Bearer ").strip()
 
-    if not server_url:
-        server_url = str(request.base_url).rstrip("/")
+    server_url = _baked_server_url(request, server_url)
 
     return StreamingResponse(
         io.BytesIO(_main_impl_lua(server_url, api_key_value, current_user.username).encode()),

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -18,6 +18,12 @@ class Settings(BaseSettings):
     incoming_dir: Path = Path("./bindery")
     port: int = 8080
     hardcover_token: str | None = None
+    # Canonical public origin (env TOME_PUBLIC_URL), e.g. "https://tome.example.org".
+    # When set, it is baked verbatim into the KOReader plugin's SERVER_URL — the
+    # authoritative way to pin the scheme/host behind a reverse proxy. When unset,
+    # the plugin URL is inferred from the request (honouring X-Forwarded-Proto), so
+    # plain HTTP / LAN / localhost deployments need not set it.
+    public_url: str | None = None
     # Optional Google Books API key (env TOME_GOOGLE_BOOKS_KEY). When set, Google
     # Books requests are charged against your own Cloud project quota instead of
     # the shared anonymous pool — fixes 429/quota failures, which hit hardest for

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -1,0 +1,148 @@
+"""Regression tests for the URL baked into the KOReader plugin's SERVER_URL.
+
+Background: on HTTPS deployments behind a TLS-terminating reverse proxy, the app
+server sees ``http``; if the proxy then redirects HTTP→HTTPS, KOReader can't
+follow the 307 on POST/PUT and every sync fails. The bake must honour
+``X-Forwarded-Proto`` (and an explicit ``TOME_PUBLIC_URL``) so it produces
+``https`` for those deployments — while leaving plain HTTP / LAN / localhost
+deployments baking exactly what they did before.
+"""
+import io
+import re
+import zipfile
+
+import pytest
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+import backend.api.tome_sync as tome_sync
+from backend.core.database import get_db
+from backend.core.security import hash_password, create_access_token
+from backend.models.user import User, UserPermission
+from backend.api.tome_sync import TOMESYNC_PLUGIN_BUILD, TOMESYNC_PLUGIN_SEMVER
+
+
+def _make_user(db: Session, username: str) -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password=hash_password("pass"),
+        is_active=True,
+        is_admin=False,
+        role="member",
+        must_change_password=False,
+    )
+    db.add(user)
+    db.flush()
+    db.add(UserPermission(user_id=user.id, can_upload=True, can_download=True))
+    db.flush()
+    return user, create_access_token(subject=user.id)
+
+
+@pytest.fixture()
+def app_client(db: Session):
+    from backend.main import create_app
+    app = create_app()
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c, db
+    app.dependency_overrides.clear()
+
+
+def _baked_url(impl_text: str) -> str:
+    m = re.search(r'local SERVER_URL\s*=\s*"([^"]+)"', impl_text)
+    assert m, "SERVER_URL not found in baked impl"
+    return m.group(1)
+
+
+def _impl_via_self_update(c: TestClient, token: str, **kwargs) -> str:
+    """Mint a key, hit /plugin/main-impl.lua, return the baked impl text."""
+    rk = c.post("/api/plugin/api-keys", json={"label": "KO"},
+                headers={"Authorization": f"Bearer {token}"})
+    key = rk.json()["key"]
+    r = c.get("/api/plugin/main-impl.lua",
+              headers={"Authorization": f"Bearer {key}", **kwargs.get("headers", {})},
+              params=kwargs.get("params"))
+    assert r.status_code == 200, r.text
+    return r.text
+
+
+# ── The fix ──────────────────────────────────────────────────────────────────
+
+def test_plain_request_bakes_http_unchanged(app_client):
+    """No forwarded header, no TOME_PUBLIC_URL → scheme is left as-is (http).
+
+    Proves LAN / localhost / plain-HTTP deployments are unaffected by the fix.
+    """
+    c, db = app_client
+    _, token = _make_user(db, "plain")
+    assert _baked_url(_impl_via_self_update(c, token)) == "http://testserver"
+
+
+def test_forwarded_proto_https_bakes_https(app_client):
+    """A proxy that terminates TLS sends X-Forwarded-Proto: https → bake https."""
+    c, db = app_client
+    _, token = _make_user(db, "fwd")
+    impl = _impl_via_self_update(c, token, headers={"X-Forwarded-Proto": "https"})
+    assert _baked_url(impl) == "https://testserver"
+
+
+def test_forwarded_proto_chain_takes_first_hop(app_client):
+    """X-Forwarded-Proto may be a comma chain; the client-facing scheme is first."""
+    c, db = app_client
+    _, token = _make_user(db, "chain")
+    impl = _impl_via_self_update(c, token, headers={"X-Forwarded-Proto": "https, http"})
+    assert _baked_url(impl) == "https://testserver"
+
+
+def test_public_url_overrides_everything(app_client, monkeypatch):
+    """TOME_PUBLIC_URL wins even against a (wrong) forwarded header."""
+    c, db = app_client
+    _, token = _make_user(db, "pub")
+    monkeypatch.setattr(tome_sync.settings, "public_url", "https://tome.example.org")
+    impl = _impl_via_self_update(c, token, headers={"X-Forwarded-Proto": "http"})
+    assert _baked_url(impl) == "https://tome.example.org"
+
+
+def test_public_url_trailing_slash_trimmed(app_client, monkeypatch):
+    c, db = app_client
+    _, token = _make_user(db, "pubslash")
+    monkeypatch.setattr(tome_sync.settings, "public_url", "https://tome.example.org/")
+    assert _baked_url(_impl_via_self_update(c, token)) == "https://tome.example.org"
+
+
+def test_explicit_server_url_param_wins(app_client):
+    c, db = app_client
+    _, token = _make_user(db, "explicit")
+    impl = _impl_via_self_update(
+        c, token,
+        params={"server_url": "https://pinned.example"},
+        headers={"X-Forwarded-Proto": "http"},
+    )
+    assert _baked_url(impl) == "https://pinned.example"
+
+
+# ── Same logic on the initial ZIP download ───────────────────────────────────
+
+def test_zip_download_bakes_https_with_forwarded_proto(app_client):
+    c, db = app_client
+    _, token = _make_user(db, "zipfwd")
+    r = c.get("/api/plugin/koreader",
+              headers={"Authorization": f"Bearer {token}", "X-Forwarded-Proto": "https"})
+    assert r.status_code == 200
+    zf = zipfile.ZipFile(io.BytesIO(r.content))
+    impl = zf.read("tomesync.koplugin/main_impl.lua").decode()
+    assert _baked_url(impl) == "https://testserver"
+
+
+# ── Release guard: the build MUST be bumped or devices won't re-bake ──────────
+
+def test_build_bumped_for_rebake():
+    # Must exceed every build already live (v1.2.0 shipped 10; main reached 12),
+    # so all existing installs re-download and re-bake the corrected URL.
+    assert TOMESYNC_PLUGIN_BUILD >= 13
+    assert TOMESYNC_PLUGIN_SEMVER == "1.2.1"

--- a/website/src/pages/docs/changelog.astro
+++ b/website/src/pages/docs/changelog.astro
@@ -27,6 +27,25 @@ import { withBase } from '../../lib/path'
     Nothing on <code>main</code> beyond the latest tagged release yet.
   </p>
 
+  <h2>v1.2.1</h2>
+  <p>
+    A hotfix for reading-sync over HTTPS. If you run Tome behind a TLS-terminating reverse proxy,
+    the KOReader plugin was baking an <code>http://</code> server URL; when the proxy redirected to
+    HTTPS, KOReader couldn't follow the redirect on uploads, so reading sessions and progress
+    silently failed to sync (they queued as "pending" on the device). Plain HTTP, LAN, and localhost
+    setups were unaffected.
+  </p>
+  <h3>Fixed</h3>
+  <ul>
+    <li>
+      The server now honours <code>X-Forwarded-Proto</code> when baking the plugin's server URL, and
+      a new optional <code>TOME_PUBLIC_URL</code> setting pins the public origin explicitly. The
+      plugin build was bumped, so existing installs re-bake the corrected URL via
+      <strong>TomeSync → Check for updates</strong> — pending sessions then flush automatically. No
+      reading data is lost.
+    </li>
+  </ul>
+
   <h2>v1.2.0 — "Press"</h2>
   <p>
     The release that gets out of its own way: the KOReader plugin now updates itself, and a single

--- a/website/src/pages/docs/configuration.astro
+++ b/website/src/pages/docs/configuration.astro
@@ -26,6 +26,7 @@ import { withBase } from '../../lib/path'
       <tr><td><code>TOME_LIBRARY_DIR</code></td><td><code>/books</code></td><td>Ebook library root</td></tr>
       <tr><td><code>TOME_INCOMING_DIR</code></td><td><code>/bindery</code></td><td>Inbox for new files</td></tr>
       <tr><td><code>TOME_PORT</code></td><td><code>8080</code></td><td>HTTP listen port</td></tr>
+      <tr><td><code>TOME_PUBLIC_URL</code></td><td>—</td><td>Canonical public origin (e.g. <code>https://tome.example.org</code>) — pin it behind a reverse proxy so the KOReader plugin bakes the correct <code>https://</code> URL</td></tr>
       <tr><td><code>TOME_HARDCOVER_TOKEN</code></td><td>—</td><td>Hardcover API token (optional)</td></tr>
       <tr><td><code>TOME_AUTO_IMPORT</code></td><td><code>false</code></td><td>Auto-ingest from Bindery</td></tr>
       <tr><td><code>TOME_AUTO_IMPORT_INTERVAL</code></td><td><code>300</code></td><td>Seconds between scans</td></tr>


### PR DESCRIPTION
Forward-ports the **1.2.1 hotfix** (released from the `v1.2.0` tag, see [release v1.2.1](https://github.com/bndct-devops/tome/releases/tag/v1.2.1)) onto `main`.

## Background
On HTTPS deployments behind a TLS-terminating reverse proxy, the KOReader plugin baked an `http://` `SERVER_URL` (the scheme the app server sees). When the proxy redirected HTTP→HTTPS, KOReader couldn't follow the 307 on `POST`/`PUT`, so every reading session and position update failed silently — they queued as "pending" on the device and never reached the library. ("Test connection" still passed because it's a `GET`, which follows the redirect.) Plain HTTP / LAN / localhost deployments were unaffected.

## Changes
- `_baked_server_url()` honours `X-Forwarded-Proto` when baking the plugin's `SERVER_URL`; scoped to the two plugin-bake endpoints, so nothing else in the app changes.
- New optional `TOME_PUBLIC_URL` setting pins the canonical public origin explicitly (priority: explicit `?server_url=` → `TOME_PUBLIC_URL` → request origin w/ forwarded scheme).
- Plugin `BUILD` → **14** so existing installs re-bake on **Check for updates**. (14, not 13: `main`'s impl carries more than 1.2.1's, so it must outrank 1.2.1's build-13 to force a re-bake for devices migrating off the 1.2.x line.)
- Docs: `TOME_PUBLIC_URL` in README + website config; v1.2.1 entry in the website changelog.

## Tests
- New `tests/test_tomesync_plugin_url.py` (8 tests): http unchanged with no forwarded header (LAN/localhost untouched), https with `X-Forwarded-Proto`, comma-chain first-hop, `TOME_PUBLIC_URL` override + trailing-slash trim, explicit param wins, the zip path, and a build-bump guard.
- Full suite: **413 passed**.
- Verified end-to-end in the KOReader emulator: build-13 plugin loaded clean, a real session + position synced and landed server-side.
