### PR TITLE
fix: sticky book completion + correct web→KOReader progress scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,21 @@ All notable changes to Tome are documented here. Format loosely follows
   instead of a full-width grid.
 
 ### Fixed
+- Finishing a book on KOReader is now permanent. Previously, opening a finished
+  book again (even briefly) could push a lower position percentage and silently
+  un-finish it — dropping the status back to "reading" and erasing the 100%
+  mark. Completion is now sticky: once a book reaches "read", any later position
+  update from the device leaves the status and progress untouched. The device's
+  resume position (used to reopen the book at the right place) still updates as
+  normal, so returning to a finished book still opens at the last page. The same
+  fix applies to reading sessions flushed from the plugin's offline queue.
+  Finishing always normalizes progress to exactly 100%.
+- Web reading progress now syncs to KOReader at the correct scale. Progress
+  fractions are 0–1 throughout the stack, but the web reader was mistakenly
+  dividing an already-fractional value by 100 before writing to the sync
+  position table — so marking a book finished on the web synced as ~1% to
+  KOReader, and mid-read positions appeared near the start of the book.
+  Web and device positions now match.
 - TomeSync (KOReader) sync silently failing on HTTPS deployments behind a
   reverse proxy (also released as the 1.2.1 hotfix). The plugin baked its server
   URL from the scheme the app server saw, which is `http` when TLS is terminated

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -210,27 +210,37 @@ def put_position(
         )
         db.add(pos)
 
-    # Keep UserBookStatus in sync
+    # Keep UserBookStatus in sync.
+    # Completion is sticky: a "read" book stays read/100% regardless of what the
+    # device reports next (e.g. opening the book again from page 1).
+    # Resume position always tracks the device (last-write-wins) — that is
+    # handled above on the TomeSyncPosition row, not here.
     status_row = (
         db.query(UserBookStatus)
         .filter(UserBookStatus.user_id == user.id, UserBookStatus.book_id == book_id)
         .first()
     )
     if status_row:
-        status_row.progress_pct = pct
+        # Resume CFI tracks the device unconditionally (last-write-wins).
         if body.progress:
             status_row.cfi = body.progress
-        if status_row.status == "unread" and pct > 0:
-            status_row.status = "reading"
-        elif pct >= 0.99:
-            status_row.status = "read"
+        if status_row.status == "read":
+            # Sticky: leave status and progress_pct alone once finished.
+            pass
+        else:
+            status_row.progress_pct = pct
+            if status_row.status == "unread" and pct > 0:
+                status_row.status = "reading"
+            elif pct >= 0.99:
+                status_row.status = "read"
+                status_row.progress_pct = 1.0
     else:
         new_status = "read" if pct >= 0.99 else ("reading" if pct > 0 else "unread")
         db.add(UserBookStatus(
             user_id=user.id,
             book_id=book_id,
             status=new_status,
-            progress_pct=pct,
+            progress_pct=1.0 if new_status == "read" else pct,
             cfi=body.progress,
         ))
 
@@ -293,7 +303,9 @@ def post_session(
     db.add(session)
 
     # Keep UserBookStatus in sync — catches up when position PUTs failed
-    # but queued sessions flush later
+    # but queued sessions flush later.
+    # Completion is sticky: once a book is "read", a later session (e.g. a
+    # re-read) cannot drag it back to "reading" or lower its progress.
     if body.progress_end is not None:
         pct = body.progress_end
         status_row = (
@@ -302,19 +314,24 @@ def post_session(
             .first()
         )
         if status_row:
-            if pct > (status_row.progress_pct or 0):
-                status_row.progress_pct = pct
-            if status_row.status == "unread" and pct > 0:
-                status_row.status = "reading"
-            elif pct >= 0.99:
-                status_row.status = "read"
+            if status_row.status == "read":
+                # Sticky: a later session never un-finishes a completed book.
+                pass
+            else:
+                if pct > (status_row.progress_pct or 0):
+                    status_row.progress_pct = pct
+                if status_row.status == "unread" and pct > 0:
+                    status_row.status = "reading"
+                elif pct >= 0.99:
+                    status_row.status = "read"
+                    status_row.progress_pct = 1.0
         else:
             new_status = "read" if pct >= 0.99 else ("reading" if pct > 0 else "unread")
             db.add(UserBookStatus(
                 user_id=user.id,
                 book_id=body.book_id,
                 status=new_status,
-                progress_pct=pct,
+                progress_pct=1.0 if new_status == "read" else pct,
             ))
 
     db.commit()

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -95,6 +95,8 @@ def set_book_status(
     db.refresh(row)
 
     # ── Sync position to TomeSyncPosition (for KOReader pickup) ─────────────
+    # progress_pct is a 0–1 fraction end-to-end (API field, UserBookStatus.progress_pct,
+    # and TomeSyncPosition.percentage), so no scaling is needed.
     if body.progress_pct is not None or body.cfi is not None:
         pos = db.query(TomeSyncPosition).filter(
             TomeSyncPosition.user_id == current_user.id,
@@ -102,7 +104,7 @@ def set_book_status(
         ).first()
         if pos:
             if body.progress_pct is not None:
-                pos.percentage = body.progress_pct / 100.0
+                pos.percentage = body.progress_pct
             if body.cfi is not None:
                 pos.progress = body.cfi
             pos.device = "web"
@@ -111,7 +113,7 @@ def set_book_status(
             db.add(TomeSyncPosition(
                 user_id=current_user.id,
                 book_id=book_id,
-                percentage=(body.progress_pct or 0) / 100.0,
+                percentage=(body.progress_pct or 0),
                 progress=body.cfi,
                 device="web",
             ))
@@ -154,7 +156,7 @@ def _track_web_reading_session(
     cutoff: datetime = now - timedelta(minutes=5)
 
     if status == "reading" and progress_pct is not None:
-        progress_fraction: float = progress_pct / 100.0
+        progress_fraction: float = progress_pct
 
         # Look for a recent open session to extend
         recent: Optional[ReadingSession] = (

--- a/tests/test_reading_progress.py
+++ b/tests/test_reading_progress.py
@@ -1,0 +1,315 @@
+"""Tests for reading progress sync correctness.
+
+Covers:
+- Completion stickiness in put_position (KOReader/TomeSync)
+- Completion stickiness in post_session (KOReader/TomeSync)
+- Web progress sync scale bug (/ 100.0 removed)
+
+Note: tome-sync endpoints use _get_api_key_user (API key only, not JWT).
+The JWT `client` fixture cannot authenticate against them. We create an API
+key row directly and use a `tome_*` bearer — mirroring test_tomesync_selfupdate.py.
+"""
+from datetime import datetime
+
+import pytest
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from backend.core.database import get_db
+from backend.core.security import hash_password, create_access_token
+from backend.models.user import User, UserPermission
+from backend.models.user_book_status import UserBookStatus
+from backend.models.tome_sync import ApiKey, ReadingSession, TomeSyncPosition
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_user(db: Session, username: str, role: str = "member") -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password=hash_password("pass"),
+        is_active=True,
+        is_admin=(role == "admin"),
+        role=role,
+        must_change_password=False,
+    )
+    db.add(user)
+    db.flush()
+    db.add(UserPermission(
+        user_id=user.id,
+        can_upload=True,
+        can_download=True,
+        can_use_kosync=True,
+    ))
+    db.flush()
+    return user, create_access_token(subject=user.id)
+
+
+def _create_api_key(db: Session, user: User) -> str:
+    """Insert an ApiKey row and return the plaintext key."""
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(
+        user_id=user.id,
+        key_hash=ApiKey.hash_key(plaintext),
+        key_prefix=plaintext[:11],
+        label="test",
+    ))
+    db.flush()
+    return plaintext
+
+
+# ── shared fixture ────────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def ts_client(db: Session):
+    """Yield (TestClient, db, user, jwt_token, api_key_plaintext).
+
+    The client has NO default Authorization header so we can set it per-call.
+    App dependency is overridden to use the test db.
+    """
+    from backend.main import create_app
+    app = create_app()
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    user, jwt_token = _make_user(db, "tsuser", "member")
+    api_key = _create_api_key(db, user)
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        # Yield order: client, db, user, jwt_token, api_key
+        yield c, db, user, jwt_token, api_key
+
+    app.dependency_overrides.clear()
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+# 1. put_position lower pct on a "read" book — status stays read/1.0, BUT
+#    TomeSyncPosition.percentage DOES update to the pushed (lower) value.
+def test_put_position_does_not_unfinish_read_book(ts_client, make_book):
+    c, db, user, _jwt, api_key = ts_client
+    book = make_book(title="Already Finished")
+
+    # Seed a completed status
+    status = UserBookStatus(
+        user_id=user.id, book_id=book.id,
+        status="read", progress_pct=1.0,
+    )
+    db.add(status)
+    db.flush()
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    r = c.put(
+        f"/api/tome-sync/position/{book.id}",
+        json={"percentage": 0.42, "progress": "epubcfi(/6/8!/4/2/4:0)", "device": "kindle"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+
+    db.expire_all()
+    ubs = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).first()
+    assert ubs is not None
+    assert ubs.status == "read"
+    assert ubs.progress_pct == pytest.approx(1.0)
+
+    # TomeSyncPosition DOES track the device (resume position)
+    pos = db.query(TomeSyncPosition).filter_by(user_id=user.id, book_id=book.id).first()
+    assert pos is not None
+    assert pos.percentage == pytest.approx(0.42)
+
+
+# 2. put_position with pct >= 0.99 on a fresh book → status "read", progress_pct == 1.0
+def test_put_position_finish_sets_status_read_and_normalizes(ts_client, make_book):
+    c, db, user, _jwt, api_key = ts_client
+    book = make_book(title="About To Finish")
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    r = c.put(
+        f"/api/tome-sync/position/{book.id}",
+        json={"percentage": 0.995, "device": "kindle"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+
+    db.expire_all()
+    ubs = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).first()
+    assert ubs is not None
+    assert ubs.status == "read"
+    assert ubs.progress_pct == pytest.approx(1.0)
+
+
+# 3. put_position while "reading" with a lower pct than current → progress follows device
+def test_put_position_reading_tracks_device_unconditionally(ts_client, make_book):
+    c, db, user, _jwt, api_key = ts_client
+    book = make_book(title="In Progress")
+
+    status = UserBookStatus(
+        user_id=user.id, book_id=book.id,
+        status="reading", progress_pct=0.8,
+    )
+    db.add(status)
+    db.flush()
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    r = c.put(
+        f"/api/tome-sync/position/{book.id}",
+        json={"percentage": 0.3, "device": "kindle"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+
+    db.expire_all()
+    ubs = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).first()
+    assert ubs is not None
+    assert ubs.status == "reading"
+    assert ubs.progress_pct == pytest.approx(0.3)
+
+
+# 4. Regression (book 40 scenario): read/1.0, push 0.78 → stays read/1.0;
+#    TomeSyncPosition.percentage == 0.78.
+def test_regression_book40_read_book_position_update(ts_client, make_book):
+    c, db, user, _jwt, api_key = ts_client
+    book = make_book(title="Book 40")
+
+    db.add(UserBookStatus(
+        user_id=user.id, book_id=book.id,
+        status="read", progress_pct=1.0,
+    ))
+    db.flush()
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    r = c.put(
+        f"/api/tome-sync/position/{book.id}",
+        json={"percentage": 0.78, "device": "kindle"},
+        headers=headers,
+    )
+    assert r.status_code == 200
+
+    db.expire_all()
+    ubs = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).first()
+    assert ubs.status == "read"
+    assert ubs.progress_pct == pytest.approx(1.0)
+
+    pos = db.query(TomeSyncPosition).filter_by(user_id=user.id, book_id=book.id).first()
+    assert pos.percentage == pytest.approx(0.78)
+
+
+# 5. Web finish: PUT /api/books/{id}/status {status:"read", progress_pct:1}
+#    → TomeSyncPosition.percentage == 1.0 (NOT 0.01) and UserBookStatus.progress_pct == 1.0
+def test_web_finish_syncs_position_at_correct_scale(ts_client, make_book):
+    c, db, user, jwt_token, _api_key = ts_client
+    book = make_book(title="Web Finished Book")
+
+    # Use JWT auth for the web endpoint
+    r = c.put(
+        f"/api/books/{book.id}/status",
+        json={"status": "read", "progress_pct": 1.0},
+        headers={"Authorization": f"Bearer {jwt_token}"},
+    )
+    assert r.status_code == 200
+
+    db.expire_all()
+    ubs = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).first()
+    assert ubs is not None
+    assert ubs.progress_pct == pytest.approx(1.0)
+
+    pos = db.query(TomeSyncPosition).filter_by(user_id=user.id, book_id=book.id).first()
+    assert pos is not None
+    assert pos.percentage == pytest.approx(1.0), (
+        f"Expected 1.0 but got {pos.percentage} — / 100 scale bug still present"
+    )
+
+
+# 6. Web mid-read: PUT /api/books/{id}/status {status:"reading", progress_pct:0.5}
+#    → TomeSyncPosition.percentage == 0.5
+def test_web_reading_syncs_position_at_correct_scale(ts_client, make_book):
+    c, db, user, jwt_token, _api_key = ts_client
+    book = make_book(title="Web Mid-Read Book")
+
+    r = c.put(
+        f"/api/books/{book.id}/status",
+        json={"status": "reading", "progress_pct": 0.5},
+        headers={"Authorization": f"Bearer {jwt_token}"},
+    )
+    assert r.status_code == 200
+
+    db.expire_all()
+    pos = db.query(TomeSyncPosition).filter_by(user_id=user.id, book_id=book.id).first()
+    assert pos is not None
+    assert pos.percentage == pytest.approx(0.5), (
+        f"Expected 0.5 but got {pos.percentage} — / 100 scale bug still present"
+    )
+
+
+# 7. post_session promoting unread→read with progress_end 0.995 → read/1.0;
+#    a later session with lower progress_end leaves it read/1.0.
+def test_post_session_finish_and_later_session_sticky(ts_client, make_book):
+    c, db, user, _jwt, api_key = ts_client
+    book = make_book(title="Session Finisher")
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    # First session — finishes the book
+    r = c.post("/api/tome-sync/session", json={
+        "book_id": book.id,
+        "started_at": "2026-01-01T10:00:00Z",
+        "ended_at": "2026-01-01T11:00:00Z",
+        "duration_seconds": 3600,
+        "progress_start": 0.8,
+        "progress_end": 0.995,
+        "device": "kindle",
+    }, headers=headers)
+    assert r.status_code == 201
+
+    db.expire_all()
+    ubs = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).first()
+    assert ubs is not None
+    assert ubs.status == "read"
+    assert ubs.progress_pct == pytest.approx(1.0)
+
+    # Second session — lower progress_end (re-read from the start)
+    r = c.post("/api/tome-sync/session", json={
+        "book_id": book.id,
+        "started_at": "2026-02-01T10:00:00Z",
+        "ended_at": "2026-02-01T10:30:00Z",
+        "duration_seconds": 1800,
+        "progress_start": 0.0,
+        "progress_end": 0.2,
+        "device": "kindle",
+    }, headers=headers)
+    assert r.status_code == 201
+
+    db.expire_all()
+    ubs = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).first()
+    assert ubs.status == "read", "Completion must be sticky after a later session"
+    assert ubs.progress_pct == pytest.approx(1.0)
+
+
+# 8. Web reading session scale: PUT /api/books/{id}/status {status:"reading", progress_pct:0.5}
+#    → created ReadingSession.progress_end == 0.5 (NOT 0.005).
+def test_web_reading_session_scale(ts_client, make_book):
+    c, db, user, jwt_token, _api_key = ts_client
+    book = make_book(title="Session Scale Book")
+
+    r = c.put(
+        f"/api/books/{book.id}/status",
+        json={"status": "reading", "progress_pct": 0.5},
+        headers={"Authorization": f"Bearer {jwt_token}"},
+    )
+    assert r.status_code == 200
+
+    db.expire_all()
+    session = (
+        db.query(ReadingSession)
+        .filter_by(user_id=user.id, book_id=book.id, device="web")
+        .first()
+    )
+    assert session is not None
+    assert session.progress_end == pytest.approx(0.5), (
+        f"Expected progress_end=0.5 but got {session.progress_end} — / 100 scale bug still present"
+    )
+    assert session.progress_start == pytest.approx(0.5)


### PR DESCRIPTION
## Summary

Hardens two latent reading-progress sync bugs found while diagnosing the "read but 78%" incident (id 40). Server-side only — **no plugin change**, so no `TOMESYNC_PLUGIN_BUILD` bump. Folds into the current `[Unreleased]` / next minor; not a separate hotfix release.

### Bug 1 — completion could be silently un-finished
`PUT /api/tome-sync/position/{book_id}` overwrote `UserBookStatus.progress_pct` unconditionally and never protected `status == "read"`. A stale or lower device position (reopening a finished book at the cover, a jump-back) dragged a completed book backward and could demote it to `reading`.

**Fix:** completion is sticky — once a book is `read`, its status and `progress_pct` are left alone. The device's **resume position** (`TomeSyncPosition`) still tracks last-write-wins, so reopening still lands at the right place. Promotion to `read` normalizes `progress_pct = 1.0`. The same sticky/normalize treatment is applied to `post_session` (offline-queue flush path) for consistency.

A genuine re-read is started by the user explicitly setting the book back to `reading`/`unread` in the web UI, after which device positions track normally again.

### Bug 2 — web reads synced to KOReader at 1/100th scale
`progress_pct` is a 0–1 fraction end-to-end, but `set_book_status` divided it by 100 before writing `TomeSyncPosition.percentage` (and the web `ReadingSession`). Finishing on the web synced as ~1% to KOReader; mid-read positions landed near the start. Three `/100.0` sites removed; the 0–1 invariant is now documented inline. (Also corrects the admin sync-status page, which displayed those web rows at 1/100th.)

## Tests
New `tests/test_reading_progress.py` (8 tests): sticky completion + resume-still-moves, finish→1.0 normalization, reading tracks device (decrease allowed), book-40 regression, web finish/mid-read at correct scale, web reading-session scale, post_session sticky/normalize.

Full backend suite: **421 passed**.

## Follow-up (optional, deferred)
Existing `TomeSyncPosition` rows written by the old web path may hold `/100` values. A one-off reconcile could find rows where `UserBookStatus.progress_pct` ≫ `TomeSyncPosition.percentage` for the same user+book. Not required for the fix; deferred per plan unless users report web→device positions landing near 0.