### PR TITLE
ci: publish :latest only on release tags, not every main push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -66,7 +66,11 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
+            # :latest tracks the newest RELEASE (vX.Y.Z tag), not main HEAD.
+            # main keeps publishing the rolling :main tag (type=ref,event=branch
+            # above) — point a dogfood/staging deploy at :main to run ahead of
+            # what :latest users receive.
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## What

Change one tag rule in `docker.yml`: `:latest` is now applied **only on `vX.Y.Z` release tags** instead of on every push to `main`.

```diff
- type=raw,value=latest,enable={{is_default_branch}}
+ type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
```

## Why

Today `:latest` and `:main` are duplicates — both rebuild on every push to `main`, so anyone pulling `ghcr.io/.../tome` (→ `:latest`) is silently on main HEAD (unreleased, unversioned). This gives users a real stable channel.

## Resulting tags

| Trigger | Tags produced |
|---|---|
| push to `main` | `:main`, `:<sha>` |
| push tag `vX.Y.Z` | `:latest`, `:X.Y.Z`, `:X.Y`, `:<sha>` |

- **Users** pull `:latest` → newest release only.
- **Dogfood/prod** can pull `:main` → every merge as it lands, ahead of release.

## Note

After this, `:latest` only advances when a `vX.Y.Z` tag is pushed — so cutting releases becomes the way users receive updates (semver + changelog already in place). No new branches or workflow changes.