### PR TITLE
fix: stop the PWA service worker hijacking /api and /opds navigations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,13 @@ All notable changes to Tome are documented here. Format loosely follows
   instead of a full-width grid.
 
 ### Fixed
+- The PWA service worker no longer swallows full-page navigations to server
+  routes. Its SPA navigation fallback was serving the cached app shell for *any*
+  navigation, including `/api/*` and `/opds/*` — so on an installed/cached client
+  the SSO handshake silently failed (the redirect to `/api/auth/oidc/login` and
+  the provider's return to the callback both got the app shell, dropping you back
+  to the dashboard instead of completing sign-in). The navigation fallback now
+  excludes `/api` and `/opds`.
 - Finishing a book on KOReader is now permanent. Previously, opening a finished
   book again (even briefly) could push a lower position percentage and silently
   un-finish it — dropping the status back to "reading" and erasing the 100%

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -39,6 +39,13 @@ export default defineConfig({
         ],
       },
       workbox: {
+        // The SPA navigation fallback serves index.html for navigations — but it
+        // must NOT swallow full-page navigations to server routes, or the service
+        // worker returns the app shell instead of letting them reach the backend.
+        // This broke the OIDC handshake (window.location → /api/auth/oidc/login
+        // and the IdP's redirect to /callback both got the SPA shell), and would
+        // do the same to any /api or /opds navigation (downloads, plugin, feeds).
+        navigateFallbackDenylist: [/^\/api\//, /^\/opds\//],
         // Cache static assets; skip large book files
         globPatterns: ['**/*.{js,css,html,svg,png,woff2}'],
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024, // 5 MB


### PR DESCRIPTION
## Symptom

On the deployed (PWA-cached) instance, **Link SSO / Sign in with SSO** ends back on the dashboard instead of completing. Server logs show `POST /api/auth/oidc/link/start → 200` but **no `GET /api/auth/oidc/login` and no `/callback` ever reach the backend**. Works fine in local dev.

## Cause

The generated service worker registers a navigation fallback for the SPA with **no denylist**:

```js
registerRoute(new NavigationRoute(createHandlerBoundToURL("index.html")))
```

So every top-level **navigation** is served the cached app shell — including `window.location → /api/auth/oidc/login` and the provider's redirect back to `/api/auth/oidc/callback`. Those never reach the server, the SPA loads, and an already-authed user lands on the dashboard. The `link/start` XHR works because it's a `fetch`, not a navigation. Local dev has no active service worker, which is why it only showed up in prod — the exact class of issue the behind-a-proxy test exists to catch.

This also affected any other full-page `/api` or `/opds` navigation (file downloads, plugin download, OPDS feeds).

## Fix

```js
workbox: {
  navigateFallbackDenylist: [/^\/api\//, /^\/opds\//],
  ...
}
```

Verified in the built `dist/sw.js`: `NavigationRoute(...,{denylist:[/^\/api\//,/^\/opds\//]})`.

## After deploy

`registerType: 'autoUpdate'`, so the new service worker installs and activates on next load(s); the old cached SW keeps the old behavior until it updates, so a reload (or two) may be needed on already-open clients.