### PR TITLE
docs: flag unreleased features (SSO) as not-yet-in-:latest

### DIFF
--- a/website/src/components/UnreleasedNote.astro
+++ b/website/src/components/UnreleasedNote.astro
@@ -1,0 +1,12 @@
+---
+// Marks a docs page/section whose feature is on the rolling `:main` image but
+// not yet in a tagged release (`:latest`). The docs site deploys from `main`,
+// which can run ahead of `:latest` — drop this on a page that documents an
+// unreleased feature, and remove it when the feature ships in a release.
+import Callout from './Callout.astro'
+---
+<Callout variant="warning" title="Not in the latest release yet">
+  This documents a feature on the rolling <code>:main</code> image. It reaches the
+  <code>:latest</code> tag at the next tagged release — if you run <code>:latest</code>,
+  it won't appear until then.
+</Callout>

--- a/website/src/pages/docs/sso.astro
+++ b/website/src/pages/docs/sso.astro
@@ -4,6 +4,7 @@ import SectionHero from '../../components/SectionHero.astro'
 import DocsMeta from '../../components/DocsMeta.astro'
 import Callout from '../../components/Callout.astro'
 import Steps from '../../components/Steps.astro'
+import UnreleasedNote from '../../components/UnreleasedNote.astro'
 
 const envSnippet = `TOME_OIDC_ENABLED=true
 TOME_OIDC_ISSUER=https://auth.example.com
@@ -26,6 +27,7 @@ TOME_PUBLIC_URL=https://tome.example.com`
     Authelia, Authentik, Keycloak, Zitadel, Google, and more. The examples below use Pocket ID, but
     the Tome side is standard OIDC.
   </p>
+  <UnreleasedNote />
   <DocsMeta />
 
   <Callout variant="info" title="SSO is additive and off by default">


### PR DESCRIPTION
Adds a reusable `UnreleasedNote` callout and places it on the SSO docs page. The docs site deploys from `main`, which can run ahead of `:latest`, so this signals to `:latest` users that a documented feature isn't in their release yet. Remove the note when the feature ships in a tagged release. Docs-only.