### PR TITLE
fix: prevent locking out the last admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,11 @@ All notable changes to Tome are documented here. Format loosely follows
   instead of a full-width grid.
 
 ### Fixed
+- You can no longer lock yourself out by removing the last admin. Demoting,
+  deactivating, or deleting a user is now refused with "Cannot remove the last
+  admin" when they are the only remaining active admin — previously a single-user
+  instance that changed its own role to member (or guest) had no way back through
+  the UI and needed a manual database edit to recover.
 - The PWA service worker no longer swallows full-page navigations to server
   routes. Its SPA navigation fallback was serving the cached app shell for *any*
   navigation, including `/api/*` and `/opds/*` — so on an installed/cached client

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -481,6 +481,24 @@ def create_user(body: UserCreate, db: Session = Depends(get_db), admin: User = D
     )
 
 
+def _active_admin_count(db: Session, *, exclude_id: Optional[int] = None) -> int:
+    """Number of users who can currently log in and act as admin."""
+    q = db.query(User).filter(User.is_admin == True, User.is_active == True)  # noqa: E712
+    if exclude_id is not None:
+        q = q.filter(User.id != exclude_id)
+    return q.count()
+
+
+def _guard_last_admin(db: Session, user: User, *, demote: bool, deactivate: bool) -> None:
+    """Refuse a change that would leave the instance with no usable admin."""
+    if not (user.is_admin and user.is_active):
+        return
+    if not (demote or deactivate):
+        return
+    if _active_admin_count(db, exclude_id=user.id) == 0:
+        raise HTTPException(400, "Cannot remove the last admin")
+
+
 @router.put("/users/{user_id}", response_model=UserOut)
 def update_user(
     user_id: int,
@@ -497,6 +515,20 @@ def update_user(
         user.email = body.email
     if body.password is not None:
         user.hashed_password = bcrypt.hashpw(body.password.encode(), bcrypt.gensalt()).decode()
+    # Work out the prospective admin/active state, then refuse if it would
+    # leave the instance with no usable admin (single-user self-demotion footgun).
+    if body.role is not None and body.is_admin is None:
+        would_be_admin = body.role == "admin"
+    elif body.is_admin is not None:
+        would_be_admin = body.is_admin or body.role == "admin"
+    else:
+        would_be_admin = user.is_admin
+    would_be_active = body.is_active if body.is_active is not None else user.is_active
+    _guard_last_admin(
+        db, user,
+        demote=not would_be_admin,
+        deactivate=not would_be_active,
+    )
     if body.is_active is not None:
         user.is_active = body.is_active
     # Keep is_admin and role in sync
@@ -560,6 +592,7 @@ def delete_user(
     user = db.get(User, user_id)
     if not user:
         raise HTTPException(404, "User not found")
+    _guard_last_admin(db, user, demote=True, deactivate=True)
     audit(db, "users.deleted", user_id=admin.id, username=admin.username,
           resource_type="user", resource_id=user.id, resource_title=user.username)
     db.delete(user)

--- a/tests/test_last_admin_guard.py
+++ b/tests/test_last_admin_guard.py
@@ -1,0 +1,94 @@
+"""The instance must never be left without a usable admin.
+
+A single-user instance that demotes (or deactivates) its only admin would
+otherwise lock itself out of every admin-gated endpoint. These tests cover the
+guard in `update_user` / `delete_user`.
+"""
+from sqlalchemy.orm import Session
+
+from backend.core.security import hash_password
+from backend.models.user import User
+
+
+def _add_admin(db: Session, username: str) -> User:
+    u = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password=hash_password("password123"),
+        is_active=True,
+        is_admin=True,
+        role="admin",
+        must_change_password=False,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def test_demoting_the_last_admin_is_refused(client, admin_user, db):
+    user, _ = admin_user  # the only admin
+    resp = client.put(f"/api/users/{user.id}", json={"role": "member"})
+    assert resp.status_code == 400
+    assert "last admin" in resp.json()["detail"].lower()
+
+    db.refresh(user)
+    assert user.is_admin is True
+
+
+def test_deactivating_the_last_admin_is_refused(client, admin_user, db):
+    user, _ = admin_user
+    resp = client.put(f"/api/users/{user.id}", json={"is_active": False})
+    assert resp.status_code == 400
+
+    db.refresh(user)
+    assert user.is_active is True
+
+
+def test_deleting_via_is_admin_false_on_last_admin_is_refused(client, admin_user, db):
+    user, _ = admin_user
+    resp = client.put(f"/api/users/{user.id}", json={"is_admin": False})
+    assert resp.status_code == 400
+
+    db.refresh(user)
+    assert user.is_admin is True
+
+
+def test_demoting_an_admin_is_allowed_when_another_admin_remains(client, admin_user, db):
+    user, _ = admin_user
+    other = _add_admin(db, "secondadmin")
+
+    # Demoting the *other* admin is fine — `user` is still an admin.
+    resp = client.put(f"/api/users/{other.id}", json={"role": "member"})
+    assert resp.status_code == 200
+    assert resp.json()["role"] == "member"
+
+
+def test_promoting_a_member_back_to_admin_still_works(client, admin_user, db):
+    # The recovery direction must never be blocked.
+    member = User(
+        username="lockedout",
+        email="lockedout@example.com",
+        hashed_password=hash_password("password123"),
+        is_active=True,
+        is_admin=False,
+        role="member",
+        must_change_password=False,
+    )
+    db.add(member)
+    db.flush()
+
+    resp = client.put(f"/api/users/{member.id}", json={"role": "admin"})
+    assert resp.status_code == 200
+    assert resp.json()["is_admin"] is True
+
+
+def test_an_inactive_admin_does_not_count_as_usable(client, admin_user, db):
+    """A disabled admin can't log in, so it must not satisfy the guard."""
+    user, _ = admin_user
+    inactive = _add_admin(db, "disabledadmin")
+    inactive.is_active = False
+    db.flush()
+
+    # `user` is still the only *active* admin, so demoting it must fail.
+    resp = client.put(f"/api/users/{user.id}", json={"role": "member"})
+    assert resp.status_code == 400

--- a/website/src/pages/docs/troubleshooting.astro
+++ b/website/src/pages/docs/troubleshooting.astro
@@ -76,12 +76,28 @@ import { withBase } from '../../lib/path'
 
   <h2>Forgot admin password</h2>
   <p>
-    Shell into the container and run the reset CLI:
+    Shell into the container and rewrite the password hash using Tome's own hashing, so it's
+    guaranteed compatible:
   </p>
-  <pre><code>docker exec -it tome python -m backend.cli reset-password &lt;username&gt;</code></pre>
+  <pre><code>docker exec -it tome python -c "from backend.core.security import hash_password; import sqlite3; c=sqlite3.connect('/data/tome.db'); c.execute('UPDATE users SET hashed_password=? WHERE username=?', (hash_password('NEW_PASSWORD'), 'USERNAME')); c.commit()"</code></pre>
   <p>
-    You'll be prompted for a new password. Existing JWTs survive (only the hash changed), so
-    other devices stay signed in.
+    Replace <code>NEW_PASSWORD</code> and <code>USERNAME</code>. Existing JWTs survive (only the
+    hash changed), so other devices stay signed in. Log in with the new password and change it
+    from <strong>Settings</strong>.
+  </p>
+
+  <h2>Locked out — no admin left</h2>
+  <p>
+    If the only admin on the instance was demoted to member/guest, deactivated, or deleted, every
+    admin-gated page is now unreachable and there's no admin left to undo it from the UI. Recent
+    versions refuse the change that would cause this, but if you're already locked out, promote an
+    account back to admin directly in the database:
+  </p>
+  <pre><code>docker exec -it tome sqlite3 /data/tome.db "UPDATE users SET role='admin', is_admin=1 WHERE username='&lt;username&gt;';"</code></pre>
+  <p>
+    Refresh the page — no restart or re-login needed, since the role is read from the database on
+    every request. Not on Docker? Point <code>sqlite3</code> at <code>tome.db</code> under your
+    <code>TOME_DATA_DIR</code> instead.
   </p>
 
   <h2>Reverse proxy 502 / 504</h2>


### PR DESCRIPTION
## Problem

A single-user instance can lock itself out: demoting the only admin to member/guest — or deactivating/deleting it — leaves no admin to undo the change, and every admin-gated endpoint is `require_admin`. The only recovery was a manual `sqlite3` edit of the database.

## Fix

Adds `_guard_last_admin` in `backend/api/users.py`, wired into both lockout paths:

- `update_user` — refuses a role/`is_admin` demotion **or** a deactivation that would remove the last admin
- `delete_user` — same guard before deletion

All return `400 "Cannot remove the last admin"`. Only **active** admins count toward the total (a disabled admin can't log in). The recovery direction (member → admin) and demoting a non-last admin stay unblocked.

## Tests

`tests/test_last_admin_guard.py` — 6 cases: last-admin demote / deactivate / `is_admin=false` refused; demote allowed when a second admin remains; promotion back to admin still works; an inactive admin doesn't satisfy the guard. Full backend suite: 448 passed.

## Docs

`docs/troubleshooting` gains a **"Locked out — no admin left"** section with the manual `sqlite3` recovery command for anyone already stuck on an older build. Also fixes the pre-existing **"Forgot admin password"** section, which referenced a `backend.cli reset-password` command that does not exist — replaced with a runnable container one-liner that reuses Tome's own `hash_password`.