### PR TITLE
fix(deps): bump react-router-dom to 7.17.0 (clears 4 react-router CVEs)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,7 +16,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-is": "^19.2.4",
-        "react-router-dom": "^7.13.2",
+        "react-router-dom": "^7.17.0",
         "recharts": "^3.8.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
@@ -6649,9 +6649,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.2.tgz",
-      "integrity": "sha512-tX1Aee+ArlKQP+NIUd7SE6Li+CiGKwQtbS+FfRxPX6Pe4vHOo6nr9d++u5cwg+Z8K/x8tP+7qLmujDtfrAoUJA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -6671,12 +6671,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.2.tgz",
-      "integrity": "sha512-aR7SUORwTqAW0JDeiWF07e9SBE9qGpByR9I8kJT5h/FrBKxPMS6TiC7rmVO+gC0q52Bx7JnjWe8Z1sR9faN4YA==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.2"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-is": "^19.2.4",
-    "react-router-dom": "^7.13.2",
+    "react-router-dom": "^7.17.0",
     "recharts": "^3.8.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",


### PR DESCRIPTION
Closes four Dependabot alerts, all on `react-router` in the frontend, all fixed by a single bump to `react-router-dom@^7.17.0` (resolves `react-router` 7.17.0, within 7.x — no breaking change).

| # | Severity | Summary |
|---|----------|---------|
| #17 | High | RCE via vendored turbo-stream `TYPE_ERROR` deserialization |
| #19 | High | DoS via unbounded path expansion in `__manifest` endpoint |
| #20 | High | DoS via reflected user input in single-fetch |
| #18 | Medium | Open redirect via protocol-relative `//` path reinterpretation |

## Exploitability in Tome

None are practically exploitable in Tome's current usage: it's a static Vite SPA using `react-router` in declarative mode (`BrowserRouter` + `Routes`/`Route`) — no SSR/framework mode, no data loaders, no `createBrowserRouter`, and redirects only target hardcoded paths. Three CVEs require the framework/SSR server Tome doesn't run; the open-redirect needs attacker-controlled redirect targets Tome doesn't expose. This is dependency hygiene, not an active exploit — so no hotfix release; it rides to the next feature release.

## Changes

- `frontend/package.json`: `react-router-dom` `^7.13.2` → `^7.17.0`
- `frontend/package-lock.json`: regenerated with `--legacy-peer-deps` (matches `Dockerfile`'s `npm ci --legacy-peer-deps`)
- Frontend build (`tsc -b` + vite) passes clean