### PR TITLE
fix: name Send-to-Device files the KOReader way so TomeSync resolves them (#25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,13 @@ All notable changes to Tome are documented here. Format loosely follows
   instead of a full-width grid.
 
 ### Fixed
+- Books sent with **Send to Device** now sync their reading position back from
+  KOReader. They were emailed as a bare `Title.ext`, which the TomeSync resolver
+  couldn't reliably match to a library book (it failed with "Book not resolved").
+  Sent files are now named the same way KOReader names its OPDS downloads —
+  `Author - Vol. X — Title.ext` — so they resolve through the path that already
+  works for OPDS. No change for books already on a device; re-send to pick up the
+  new name (#25).
 - You can no longer lock yourself out by removing the last admin. Demoting,
   deactivating, or deleting a user is now refused with "Cannot remove the last
   admin" when they are the only remaining active admin — previously a single-user

--- a/backend/api/send_to_device.py
+++ b/backend/api/send_to_device.py
@@ -27,6 +27,7 @@ from backend.services.email import (
     send_test_email,
 )
 from backend.services.metadata_embed import get_baked_path
+from backend.services.organizer import koreader_style_name
 
 log = logging.getLogger(__name__)
 
@@ -229,7 +230,10 @@ def send_to_device(
         raise HTTPException(404, "Book file not found on disk")
 
     try:
-        send_book_to_device(device.email, book.title, baked, book_file.format)
+        attachment_name = koreader_style_name(
+            book.author, book.title, book.series_index, book_file.format
+        )
+        send_book_to_device(device.email, book.title, attachment_name, baked, book_file.format)
         status_str = "ok"
         error_str = None
     except FileTooLargeError as exc:
@@ -284,7 +288,7 @@ def bulk_send_to_device(
     if not device or device.user_id != user.id:
         raise HTTPException(404, "Device not found")
 
-    to_send: list[tuple[str, Path, str, Book]] = []
+    to_send: list[tuple[str, str, Path, str, Book]] = []
     errors: list[dict] = []
 
     for bid in body.book_ids:
@@ -300,15 +304,16 @@ def bulk_send_to_device(
         if not baked.exists():
             errors.append({"book_id": bid, "error": "File not found on disk"})
             continue
-        to_send.append((book.title, baked, bf.format, book))
+        name = koreader_style_name(book.author, book.title, book.series_index, bf.format)
+        to_send.append((book.title, name, baked, bf.format, book))
 
     sent = 0
     if to_send:
         results = send_books_bulk(
             device.email,
-            [(title, path, fmt) for title, path, fmt, _ in to_send],
+            [(title, name, path, fmt) for title, name, path, fmt, _ in to_send],
         )
-        for (title, error), (_, _, fmt, book) in zip(results, to_send):
+        for (title, error), (_, _, _, fmt, book) in zip(results, to_send):
             status_str = "ok" if error is None else "failed"
             audit(
                 db,

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -7,7 +7,6 @@ from email.mime.text import MIMEText
 from pathlib import Path
 
 from backend.core.config import settings
-from backend.services.organizer import sanitize_name
 
 log = logging.getLogger(__name__)
 
@@ -58,10 +57,15 @@ def _connect() -> smtplib.SMTP:
 def _build_book_message(
     to_email: str,
     book_title: str,
+    attachment_name: str,
     file_path: Path,
     file_format: str,
 ) -> MIMEMultipart:
-    """Build a MIME message with the book file attached."""
+    """Build a MIME message with the book file attached.
+
+    ``book_title`` is the human subject line; ``attachment_name`` is the on-disk
+    filename the device saves (KOReader-style, so TomeSync can resolve it).
+    """
     file_size = file_path.stat().st_size
     if file_size > MAX_ATTACHMENT_BYTES:
         size_mb = file_size / (1024 * 1024)
@@ -76,7 +80,7 @@ def _build_book_message(
     mime_type = MIME_TYPES.get(file_format, "application/octet-stream")
     maintype, subtype = mime_type.split("/", 1)
 
-    filename = f"{sanitize_name(book_title)}.{file_format}"
+    filename = attachment_name
     with open(file_path, "rb") as f:
         attachment = MIMEApplication(f.read(), _subtype=subtype)
     attachment.add_header("Content-Disposition", "attachment", filename=filename)
@@ -88,11 +92,12 @@ def _build_book_message(
 def send_book_to_device(
     to_email: str,
     book_title: str,
+    attachment_name: str,
     file_path: Path,
     file_format: str,
 ) -> None:
     """Send a single book to a device email address."""
-    msg = _build_book_message(to_email, book_title, file_path, file_format)
+    msg = _build_book_message(to_email, book_title, attachment_name, file_path, file_format)
     conn = _connect()
     try:
         conn.sendmail(settings.smtp_from_address, [to_email], msg.as_string())
@@ -105,13 +110,13 @@ def send_book_to_device(
 
 def send_books_bulk(
     to_email: str,
-    books: list[tuple[str, Path, str]],
+    books: list[tuple[str, str, Path, str]],
 ) -> list[tuple[str, str | None]]:
     """Send multiple books over a single SMTP connection.
 
     Args:
         to_email: device email address
-        books: list of (book_title, file_path, file_format) tuples
+        books: list of (book_title, attachment_name, file_path, file_format) tuples
 
     Returns:
         list of (book_title, error_or_none) — None means success
@@ -119,9 +124,9 @@ def send_books_bulk(
     conn = _connect()
     results: list[tuple[str, str | None]] = []
     try:
-        for title, path, fmt in books:
+        for title, attachment_name, path, fmt in books:
             try:
-                msg = _build_book_message(to_email, title, path, fmt)
+                msg = _build_book_message(to_email, title, attachment_name, path, fmt)
                 conn.sendmail(settings.smtp_from_address, [to_email], msg.as_string())
                 results.append((title, None))
                 log.info("Bulk send: sent '%s' to %s", title, to_email)

--- a/backend/services/organizer.py
+++ b/backend/services/organizer.py
@@ -26,6 +26,31 @@ def sanitize_name(s: str) -> str:
     return s or 'Unknown'
 
 
+def koreader_style_name(
+    author: str | None,
+    title: str | None,
+    series_index: float | None,
+    file_format: str,
+) -> str:
+    """Name a book the way KOReader names its OPDS downloads.
+
+    KOReader saves OPDS files as ``Author - Vol. X — Title.ext`` (em dash before
+    the title), and TomeSync's ``/tome-sync/resolve`` is built around exactly that
+    shape. Naming Send-to-Device files the same way lets them resolve through the
+    path that already works for OPDS, rather than the bare ``Title.ext`` that only
+    reaches the fragile substring fallback. The volume number, when present, lets
+    resolve anchor on ``series_index`` independent of how the title is sanitized.
+    """
+    author_s = sanitize_name(author or "Unknown")
+    title_s = sanitize_name(title or "Unknown")
+    if series_index is not None:
+        vol = int(series_index) if series_index == int(series_index) else series_index
+        stem = f"{author_s} - Vol. {vol} — {title_s}"
+    else:
+        stem = f"{author_s} - {title_s}"
+    return f"{stem}.{file_format}"
+
+
 _VOL_IN_TITLE = re.compile(r',?\s*\b(?:vol\.?|volume|v)\s*\d+(?:\.\d+)?', re.IGNORECASE)
 
 

--- a/tests/test_send_to_device_naming.py
+++ b/tests/test_send_to_device_naming.py
@@ -1,0 +1,85 @@
+"""Send-to-Device names files the KOReader/OPDS way so TomeSync resolves them.
+
+The bug: Send-to emailed files as a bare ``<title>.ext``, which `/tome-sync/resolve`
+(built for KOReader's ``Author - Vol. X — Title.ext`` OPDS naming) couldn't reliably
+match. Fix is server-only: name the attachment the KOReader way. The resolver is
+unchanged — these tests drive the real endpoint to prove the new names resolve.
+"""
+import tempfile
+from pathlib import Path
+
+from backend.models.tome_sync import ApiKey
+from backend.services.organizer import koreader_style_name
+from backend.services.email import _build_book_message
+
+
+def _api_key_for(db, user_id: int) -> str:
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(user_id=user_id, key_hash=ApiKey.hash_key(plaintext),
+                  key_prefix=plaintext[:11], label="test"))
+    db.flush()
+    return plaintext
+
+
+def _resolve(client, key, filename):
+    return client.get(
+        "/api/tome-sync/resolve",
+        params={"filename": filename},
+        headers={"Authorization": f"Bearer {key}"},
+    )
+
+
+# ── helper formatting ─────────────────────────────────────────────────────────
+
+def test_name_series_uses_author_volume_title():
+    assert koreader_style_name("Isuna Hasekura", "Spice and Wolf", 1, "epub") == \
+        "Isuna Hasekura - Vol. 1 — Spice and Wolf.epub"
+
+
+def test_name_standalone_is_author_title():
+    assert koreader_style_name("Frank Herbert", "Dune", None, "epub") == \
+        "Frank Herbert - Dune.epub"
+
+
+def test_name_decimal_volume_and_missing_author():
+    assert koreader_style_name("A", "B", 10.5, "cbz") == "A - Vol. 10.5 — B.cbz"
+    assert koreader_style_name(None, "Lonely", None, "epub") == "Unknown - Lonely.epub"
+
+
+# ── resolve end-to-end (resolver unchanged) ───────────────────────────────────
+
+def test_series_style_name_resolves(client, db, admin_user, make_book):
+    user, _ = admin_user
+    key = _api_key_for(db, user.id)
+    book = make_book(title="Spice and Wolf", author="Isuna Hasekura",
+                     series="Spice and Wolf", series_index=1)
+    name = koreader_style_name(book.author, book.title, book.series_index, "epub")
+
+    r = _resolve(client, key, name)
+    assert r.status_code == 200
+    assert r.json()["book_id"] == book.id
+
+
+def test_standalone_style_name_resolves(client, db, admin_user, make_book):
+    user, _ = admin_user
+    key = _api_key_for(db, user.id)
+    book = make_book(title="Dune", author="Frank Herbert")
+    name = koreader_style_name(book.author, book.title, None, "epub")
+
+    r = _resolve(client, key, name)
+    assert r.status_code == 200
+    assert r.json()["book_id"] == book.id
+
+
+# ── send side wiring ──────────────────────────────────────────────────────────
+
+def test_sent_attachment_uses_koreader_name():
+    name = koreader_style_name("Frank Herbert", "Dune", None, "epub")
+    with tempfile.NamedTemporaryFile(suffix=".epub") as tmp:
+        tmp.write(b"enough bytes to be a file")
+        tmp.flush()
+        msg = _build_book_message("reader@example.com", "Dune", name, Path(tmp.name), "epub")
+
+    # Subject stays the human title; the attachment carries the resolvable name.
+    assert msg["Subject"] == "Dune"
+    assert msg.get_payload()[1].get_filename() == "Frank Herbert - Dune.epub"


### PR DESCRIPTION
Closes the reported half of #25: books delivered via **Send to Device** don't sync their reading position back from KOReader — "Sync now" fails with *"Book not resolved"* — while OPDS-downloaded books sync fine.

## Root cause

`/tome-sync/resolve` maps a device filename to a library book, and it was built around KOReader's OPDS naming: `Author - Vol. X — Title.ext`. But **Send to Device** emailed the file as a bare `sanitize_name(title).ext`, which only reaches resolve's weak title-substring fallback — and that breaks whenever `sanitize_name` strips a character that's in the title (`:`, `?`, `/`, …). OPDS works precisely because KOReader composes the richer `Author - Vol. X — Title` name, which resolve handles.

## Fix (server-only)

Name the emailed attachment the same way KOReader names OPDS downloads, via a new `organizer.koreader_style_name()` helper, so sent files resolve through the path that already works for OPDS. For series books the `Vol. X` token lets resolve anchor on `series_index` regardless of how the title is sanitized.

- `backend/services/organizer.py` — `koreader_style_name(author, title, series_index, fmt)`
- `backend/services/email.py` — attachment name passed in (the email subject stays the human title)
- `backend/api/send_to_device.py` — compute the name at the single + bulk send sites

The resolver is **unchanged** — the tests drive the real endpoint to prove the new names resolve. Only the emailed copy's filename changes; the on-disk library file and its `content_hash` are untouched. Books already on a device are unaffected — re-send to pick up the new name.

## Scope / caveats

This brings Send-to to **parity with OPDS**, not perfection: series books resolve robustly (volume-anchored); a standalone book with a stripped-char title is exactly as reliable as it'd be via OPDS. Exact-identity resolution (embedding the book id) was considered and deliberately deferred — it requires a plugin change and isn't warranted for this bug.

## Tests

`tests/test_send_to_device_naming.py` — helper formatting (series / standalone / decimal volume / missing author), end-to-end resolve of both name shapes through the unchanged resolver, and that the sent attachment carries the resolvable name while the subject stays the title. Full backend suite: 454 passed.

## Not yet verified

Whether a real device's mail pipeline (e.g. PocketBook) preserves the filename end to end — worth an emulator/real-device round-trip before relying on it. The OPDS-parity fallback means nothing regresses if it doesn't.