### PR TITLE
fix: make public/shared libraries actually visible to other users (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+- **Shared libraries are now actually shared** (#31). Marking a library *public*
+  had no effect: the library list only ever returned libraries you owned (plus
+  the built-in global ones), so a library created by one user was invisible to
+  everyone else regardless of its public/private flag. Public libraries are now
+  visible to all users, and their books show up for members too (previously only
+  guests saw public-library books). Private libraries can be shared with
+  individual people: the library editor gained a **Share with users** picker, and
+  library owners — not just admins — can grant and revoke access to their own
+  libraries. The rename/delete/add-to-library controls now appear only on
+  libraries you can actually manage (your own, or any library if you're an admin),
+  so you no longer see edit buttons that error out on libraries owned by someone
+  else.
+
 ## [1.3.0] — 2026-06-05 — "Diary"
 
 ### Added

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -155,6 +155,7 @@ def list_books(
                 Book.added_by.in_(admin_ids),
                 Book.added_by.is_(None),        # legacy books without uploader = shared
                 Book.added_by == current_user.id,
+                Book.libraries.any(Library.is_public == True),  # public = shared with all
             ]
             if assigned_lib_ids:
                 visibility_conditions.append(
@@ -1016,7 +1017,8 @@ def get_book(
             }
             book_lib_ids = {lib.id for lib in book.libraries}
             in_assigned_library = bool(assigned_lib_ids & book_lib_ids)
-            if not (is_admin_book or is_own_book or in_assigned_library):
+            in_public_library = any(lib.is_public for lib in book.libraries)
+            if not (is_admin_book or is_own_book or in_assigned_library or in_public_library):
                 raise HTTPException(status_code=404, detail="Book not found")
         else:
             # Guest

--- a/backend/api/libraries.py
+++ b/backend/api/libraries.py
@@ -2,6 +2,7 @@ import json
 from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
+from sqlalchemy import or_
 from sqlalchemy.orm import Session
 
 from backend.core.database import get_db
@@ -34,6 +35,7 @@ class LibraryOut(BaseModel):
     sort_order: int
     book_count: int
     assigned_user_ids: list[int] = []
+    can_edit: bool = False  # may the current user rename/delete/share this library
 
     class Config:
         from_attributes = True
@@ -59,11 +61,15 @@ class ReorderIn(BaseModel):
 
 # ── Libraries ─────────────────────────────────────────────────────────────────
 
-def _lib_out(lib: Library) -> LibraryOut:
+def _lib_out(lib: Library, user: User) -> LibraryOut:
+    # Mirrors the mutation guard in _get_library: admins can edit anything,
+    # owners can edit their own; global libraries (owner_id IS NULL) are admin-only.
+    can_edit = _is_admin(user) or (lib.owner_id is not None and lib.owner_id == user.id)
     return LibraryOut(
         id=lib.id, name=lib.name, icon=lib.icon, is_public=lib.is_public,
         sort_order=lib.sort_order, book_count=len(lib.books or []),
         assigned_user_ids=[u.id for u in (lib.assigned_users or [])],
+        can_edit=can_edit,
     )
 
 
@@ -74,10 +80,30 @@ def list_libraries(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    libs = db.query(Library).filter(
-        (Library.owner_id == current_user.id) | (Library.owner_id.is_(None))
-    ).order_by(Library.sort_order, Library.name).all()
-    return [_lib_out(l) for l in libs]
+    if _is_admin(current_user):
+        libs = db.query(Library).order_by(Library.sort_order, Library.name).all()
+    else:
+        from backend.models.library import library_users_table
+        # Libraries this user has been individually assigned to (private sharing)
+        assigned_lib_ids = [
+            row[1] for row in db.execute(
+                library_users_table.select().where(
+                    library_users_table.c.user_id == current_user.id
+                )
+            ).fetchall()
+        ]
+        # Visible: own + global + public (shared with everyone) + privately assigned
+        conditions = [
+            Library.owner_id == current_user.id,
+            Library.owner_id.is_(None),
+            Library.is_public == True,  # noqa: E712
+        ]
+        if assigned_lib_ids:
+            conditions.append(Library.id.in_(assigned_lib_ids))
+        libs = db.query(Library).filter(or_(*conditions)).order_by(
+            Library.sort_order, Library.name
+        ).all()
+    return [_lib_out(l, current_user) for l in libs]
 
 
 @router.post("/libraries", response_model=LibraryOut, status_code=status.HTTP_201_CREATED)
@@ -93,7 +119,7 @@ def create_library(
     db.refresh(lib)
     audit(db, "libraries.created", user_id=current_user.id, username=current_user.username,
           resource_type="library", resource_id=lib.id, resource_title=lib.name)
-    return _lib_out(lib)
+    return _lib_out(lib, current_user)
 
 
 @router.put("/libraries/{lib_id}", response_model=LibraryOut)
@@ -111,7 +137,7 @@ def update_library(
     db.refresh(lib)
     audit(db, "libraries.updated", user_id=current_user.id, username=current_user.username,
           resource_type="library", resource_id=lib.id, resource_title=lib.name)
-    return _lib_out(lib)
+    return _lib_out(lib, current_user)
 
 
 @router.delete("/libraries/{lib_id}", status_code=status.HTTP_204_NO_CONTENT)
@@ -187,7 +213,7 @@ def assign_user_to_library(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, "admin")
+    # _get_library enforces owner-or-admin, so library owners can share their own.
     lib = _get_library(lib_id, current_user, db)
     user = db.query(User).filter(User.id == body.user_id).first()
     if not user:
@@ -204,7 +230,7 @@ def remove_user_from_library(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    require_role(current_user, "admin")
+    # _get_library enforces owner-or-admin, so library owners can manage their own.
     lib = _get_library(lib_id, current_user, db)
     user = db.query(User).filter(User.id == user_id).first()
     if user and user in lib.assigned_users:

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -408,8 +408,12 @@ def list_users_simple(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Return minimal user list for filter dropdowns. Admin only."""
-    require_role(current_user, "admin")
+    """Return minimal user list for filter dropdowns and library sharing.
+
+    Members need this to share their private libraries with individual users;
+    it exposes only id/username/role, no sensitive fields.
+    """
+    require_role(current_user, "member")
     users = db.query(User).filter(User.is_active == True).all()
     return [
         {

--- a/backend/core/permissions.py
+++ b/backend/core/permissions.py
@@ -62,6 +62,7 @@ def book_visibility_filter(db: Session, user: User):
             Book.added_by.in_(admin_ids),
             Book.added_by.is_(None),
             Book.added_by == user.id,
+            Book.libraries.any(Library.is_public == True),  # noqa: E712
         ]
         if assigned_lib_ids:
             conditions.append(Book.libraries.any(Library.id.in_(assigned_lib_ids)))

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import {
   BookOpen, Plus, Pencil, Trash2,
   ChevronLeft, ChevronRight, Bookmark, Library as LibraryIcon, Layers, Home, BarChart3,
   Settings, Shield, LogOut, ChevronsUpDown, Lock, X, BookPlus, ExternalLink,
-  Sun, Moon, Flame, Check, Sparkles,
+  Sun, Moon, Flame, Check, Sparkles, Users,
   type LucideIcon,
 } from 'lucide-react'
 import { api } from '@/lib/api'
@@ -136,6 +136,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
   const [libModalInitialName, setLibModalInitialName] = useState('')
   const [libModalInitialIcon, setLibModalInitialIcon] = useState('Library')
   const [libModalInitialPublic, setLibModalInitialPublic] = useState(true)
+  const [libModalLibraryId, setLibModalLibraryId] = useState<number | null>(null)
+  const [libModalAssignedIds, setLibModalAssignedIds] = useState<number[]>([])
 
   const location = useLocation()
 
@@ -200,6 +202,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
     setLibModalInitialName('')
     setLibModalInitialIcon('Library')
     setLibModalInitialPublic(true)
+    setLibModalLibraryId(null)
+    setLibModalAssignedIds([])
     setLibModalOnSave(() => async (name: string, icon: string, isPublic: boolean) => {
       await api.post('/libraries', { name, icon, is_public: isPublic })
       onLibrariesChange()
@@ -212,6 +216,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
     setLibModalInitialName(lib.name)
     setLibModalInitialIcon(lib.icon ?? 'Library')
     setLibModalInitialPublic(lib.is_public ?? true)
+    setLibModalLibraryId(lib.id)
+    setLibModalAssignedIds(lib.assigned_user_ids ?? [])
     setLibModalOnSave(() => async (name: string, icon: string, isPublic: boolean) => {
       await api.put(`/libraries/${lib.id}`, { name, icon, is_public: isPublic })
       onLibrariesChange()
@@ -266,7 +272,11 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
           initialName={libModalInitialName}
           initialIcon={libModalInitialIcon}
           initialIsPublic={libModalInitialPublic}
+          libraryId={libModalLibraryId}
+          initialAssignedIds={libModalAssignedIds}
+          currentUserId={user?.id ?? null}
           onSave={libModalOnSave}
+          onChanged={onLibrariesChange}
           onClose={() => setLibModalOpen(false)}
         />
       )}
@@ -518,12 +528,12 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   active={activeLibrary === lib.id}
                   isPrivate={lib.is_public === false}
                   onClick={() => selectLibrary(lib.id)}
-                  onEdit={() => openEditLibModal(lib)}
-                  onDelete={async () => {
+                  onEdit={lib.can_edit ? () => openEditLibModal(lib) : undefined}
+                  onDelete={lib.can_edit ? async () => {
                     await api.delete(`/libraries/${lib.id}`)
                     if (activeLibrary === lib.id) selectAllBooks()
                     onLibrariesChange()
-                  }}
+                  } : undefined}
                 />
               ))}
             </Section>
@@ -675,12 +685,12 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                     active={activeLibrary === lib.id}
                     isPrivate={lib.is_public === false}
                     onClick={() => selectLibrary(lib.id)}
-                    onEdit={() => openEditLibModal(lib)}
-                    onDelete={async () => {
+                    onEdit={lib.can_edit ? () => openEditLibModal(lib) : undefined}
+                    onDelete={lib.can_edit ? async () => {
                       await api.delete(`/libraries/${lib.id}`)
                       if (activeLibrary === lib.id) selectAllBooks()
                       onLibrariesChange()
-                    }}
+                    } : undefined}
                   />
                 ))}
               </Section>
@@ -1002,12 +1012,18 @@ function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdi
   )
 }
 
-function LibraryModal({ title, initialName, initialIcon, initialIsPublic, onSave, onClose }: {
+type ShareUser = { id: number; username: string; role: string }
+
+function LibraryModal({ title, initialName, initialIcon, initialIsPublic, libraryId, initialAssignedIds, currentUserId, onSave, onChanged, onClose }: {
   title: string
   initialName?: string
   initialIcon?: string
   initialIsPublic?: boolean
+  libraryId?: number | null
+  initialAssignedIds?: number[]
+  currentUserId?: number | null
   onSave: (name: string, icon: string, isPublic: boolean) => Promise<void>
+  onChanged?: () => void
   onClose: () => void
 }) {
   const [name, setName] = useState(initialName ?? '')
@@ -1016,6 +1032,39 @@ function LibraryModal({ title, initialName, initialIcon, initialIsPublic, onSave
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
+
+  // Share-with-users state (only meaningful when editing an existing, private library)
+  const [users, setUsers] = useState<ShareUser[]>([])
+  const [assignedIds, setAssignedIds] = useState<Set<number>>(new Set(initialAssignedIds ?? []))
+  const [busyUserId, setBusyUserId] = useState<number | null>(null)
+  const canShare = libraryId != null && !isPublic
+
+  useEffect(() => {
+    if (libraryId == null) return
+    api.get<ShareUser[]>('/users/list')
+      .then(list => setUsers(list.filter(u => u.id !== currentUserId)))
+      .catch(() => {})
+  }, [libraryId, currentUserId])
+
+  async function toggleUser(userId: number) {
+    if (libraryId == null || busyUserId != null) return
+    setBusyUserId(userId)
+    const isAssigned = assignedIds.has(userId)
+    try {
+      if (isAssigned) {
+        await api.delete(`/libraries/${libraryId}/users/${userId}`)
+        setAssignedIds(prev => { const next = new Set(prev); next.delete(userId); return next })
+      } else {
+        await api.post(`/libraries/${libraryId}/users`, { user_id: userId })
+        setAssignedIds(prev => new Set(prev).add(userId))
+      }
+      onChanged?.()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update sharing')
+    } finally {
+      setBusyUserId(null)
+    }
+  }
 
   useEffect(() => { inputRef.current?.focus() }, [])
   useEffect(() => {
@@ -1077,6 +1126,42 @@ function LibraryModal({ title, initialName, initialIcon, initialIsPublic, onSave
           <p className="text-xs text-muted-foreground flex items-center gap-1">
             <Lock className="w-3 h-3" /> Private — only assigned users can access
           </p>
+        )}
+        {canShare && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
+              <Users className="w-3.5 h-3.5" /> Share with users
+            </div>
+            {users.length === 0 ? (
+              <p className="text-xs text-muted-foreground">No other users to share with.</p>
+            ) : (
+              <div className="max-h-40 overflow-y-auto rounded-lg border border-border divide-y divide-border">
+                {users.map(u => {
+                  const assigned = assignedIds.has(u.id)
+                  return (
+                    <button
+                      key={u.id}
+                      type="button"
+                      onClick={() => toggleUser(u.id)}
+                      disabled={busyUserId === u.id}
+                      className="w-full flex items-center justify-between px-3 py-2 text-sm hover:bg-muted transition-colors disabled:opacity-50"
+                    >
+                      <span className="truncate">{u.username}</span>
+                      <span className={cn(
+                        'flex items-center justify-center w-5 h-5 rounded border flex-shrink-0',
+                        assigned ? 'bg-primary border-primary text-primary-foreground' : 'border-border'
+                      )}>
+                        {assigned && <Check className="w-3.5 h-3.5" />}
+                      </span>
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        )}
+        {!isPublic && libraryId == null && (
+          <p className="text-xs text-muted-foreground">Save the library first, then reopen it to share with users.</p>
         )}
         {error && <p className="text-xs text-destructive">{error}</p>}
         <div className="flex items-center justify-end gap-2 pt-1">

--- a/frontend/src/lib/books.ts
+++ b/frontend/src/lib/books.ts
@@ -91,6 +91,7 @@ export interface Library {
   book_count: number
   is_public: boolean
   assigned_user_ids: number[]
+  can_edit: boolean
 }
 
 export interface SavedFilter {

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -849,7 +849,7 @@ export function BookDetailPage() {
             {canEdit && !editing && (
               <>
                 {/* Add to Library dropdown */}
-                {libraries.length > 0 && (
+                {libraries.some(l => l.can_edit) && (
                   <div className="relative" ref={libMenuRef}>
                     <button
                       onClick={() => setLibMenuOpen(o => !o)}
@@ -873,7 +873,7 @@ export function BookDetailPage() {
                         <p className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground border-b border-border mb-1">
                           Add to library
                         </p>
-                        {libraries.map(lib => {
+                        {libraries.filter(l => l.can_edit).map(lib => {
                           const inLib = localLibIds.includes(lib.id)
                           const pending = libPending.has(lib.id)
                           return (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1733,7 +1733,7 @@ export function DashboardPage() {
                 <Pencil className="w-3.5 h-3.5" />
                 Edit Metadata
               </button>
-              {libraries.length > 0 && (
+              {libraries.some(l => l.can_edit) && (
                 <div className="relative">
                   <button
                     onClick={() => setBulkLibMenu(o => !o)}
@@ -1747,7 +1747,7 @@ export function DashboardPage() {
                     <>
                       <div className="fixed inset-0 z-10" onClick={() => setBulkLibMenu(false)} />
                       <div className="absolute right-0 top-full mt-1 z-20 bg-card border border-border rounded-xl shadow-xl py-1 min-w-44">
-                        {libraries.map(lib => (
+                        {libraries.filter(l => l.can_edit).map(lib => (
                           <button
                             key={lib.id}
                             onClick={() => bulkAddToLibrary(lib.id)}

--- a/tests/test_library_visibility.py
+++ b/tests/test_library_visibility.py
@@ -1,0 +1,135 @@
+"""Regression tests for library visibility & sharing (issue #31).
+
+Before the fix, GET /api/libraries only returned libraries the caller *owned*
+or global ones (owner_id IS NULL). A public library created by another user, or
+a private library shared with the caller, was never returned — so the
+``is_public`` flag and individual sharing did nothing.
+"""
+from sqlalchemy.orm import Session
+
+from backend.core.security import hash_password, create_access_token
+from backend.models.user import User
+from backend.models.library import Library
+
+
+def _make_user(db: Session, username: str, role: str) -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password=hash_password("password123"),
+        is_active=True,
+        is_admin=(role == "admin"),
+        role=role,
+        must_change_password=False,
+    )
+    db.add(user)
+    db.flush()
+    return user, create_access_token(subject=user.id)
+
+
+def _lib_ids(client, token: str) -> set[int]:
+    r = client.get("/api/libraries", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    return {lib["id"] for lib in r.json()}
+
+
+def _libs(client, token: str) -> list[dict]:
+    r = client.get("/api/libraries", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_public_library_visible_to_other_user(client, db: Session):
+    """A public library owned by user A is visible to an unrelated user B."""
+    user_a, token_a = _make_user(db, "owner_a", "member")
+    _user_b, token_b = _make_user(db, "viewer_b", "member")
+
+    pub = Library(name="Shared Public", is_public=True, owner_id=user_a.id)
+    priv = Library(name="A's Private", is_public=False, owner_id=user_a.id)
+    db.add_all([pub, priv])
+    db.flush()
+
+    visible = _lib_ids(client, token_b)
+    assert pub.id in visible           # public → shared with everyone
+    assert priv.id not in visible      # private & unshared → hidden
+
+    # can_edit: owner may edit, an unrelated viewer may not (so the UI hides
+    # the edit/delete/add controls instead of letting them 403).
+    b_pub = next(l for l in _libs(client, token_b) if l["id"] == pub.id)
+    assert b_pub["can_edit"] is False
+    a_pub = next(l for l in _libs(client, token_a) if l["id"] == pub.id)
+    assert a_pub["can_edit"] is True
+
+
+def test_admin_can_edit_everything(client, db: Session, admin_user):
+    """Admins get can_edit=True for any library, including private/global ones."""
+    _admin, admin_token = admin_user
+    member, _ = _make_user(db, "owner_m", "member")
+    priv = Library(name="Member Private", is_public=False, owner_id=member.id)
+    glob = Library(name="Global Lib", is_public=True, owner_id=None)
+    db.add_all([priv, glob])
+    db.flush()
+
+    libs = {l["id"]: l for l in _libs(client, admin_token)}
+    assert libs[priv.id]["can_edit"] is True
+    assert libs[glob.id]["can_edit"] is True
+
+    # A member never gets can_edit on a global library (admin-only mutation)
+    _m2, m2_token = _make_user(db, "viewer_m2", "member")
+    m2_libs = {l["id"]: l for l in _libs(client, m2_token)}
+    assert m2_libs[glob.id]["can_edit"] is False
+
+
+def test_private_library_visible_after_sharing(client, db: Session):
+    """A private library becomes visible to user B once the owner assigns them."""
+    user_a, token_a = _make_user(db, "owner_a2", "member")
+    user_b, token_b = _make_user(db, "viewer_b2", "member")
+
+    priv = Library(name="Shared Private", is_public=False, owner_id=user_a.id)
+    db.add(priv)
+    db.flush()
+
+    assert priv.id not in _lib_ids(client, token_b)
+
+    # Owner (not admin) shares it with user B
+    r = client.post(
+        f"/api/libraries/{priv.id}/users",
+        json={"user_id": user_b.id},
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    assert r.status_code == 204, r.text
+
+    assert priv.id in _lib_ids(client, token_b)
+
+    # Un-sharing hides it again
+    r = client.delete(
+        f"/api/libraries/{priv.id}/users/{user_b.id}",
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    assert r.status_code == 204, r.text
+    assert priv.id not in _lib_ids(client, token_b)
+
+
+def test_owner_cannot_share_another_users_library(client, db: Session):
+    """A member may only share libraries they own (not someone else's)."""
+    user_a, _ = _make_user(db, "owner_a3", "member")
+    user_b, token_b = _make_user(db, "stranger_b3", "member")
+
+    priv = Library(name="A's Private 3", is_public=False, owner_id=user_a.id)
+    db.add(priv)
+    db.flush()
+
+    r = client.post(
+        f"/api/libraries/{priv.id}/users",
+        json={"user_id": user_b.id},
+        headers={"Authorization": f"Bearer {token_b}"},
+    )
+    assert r.status_code == 403, r.text
+
+
+def test_member_can_list_users_for_sharing(client, db: Session):
+    """Members need /users/list to populate the share picker."""
+    _member, token = _make_user(db, "member_share", "member")
+    r = client.get("/api/users/list", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200, r.text
+    assert isinstance(r.json(), list)


### PR DESCRIPTION
Fixes #31. Intended as the **v1.3.1 hotfix** — branched off the `v1.3.0` tag, so it can be released without pulling in the unreleased `#30` work currently on `main`.

## The bug

A library marked **public** was invisible to everyone but its owner. `GET /libraries` only ever returned libraries you owned plus the built-in global (book-type) ones — it never looked at `is_public` or the `library_users` assignment table. So the public/private flag did nothing, and there was no UI to share a private library with individuals (despite the "share individually" copy in the editor).

The reporter was correct on both counts; there was also a third gap (even an admin-assigned private share wouldn't appear, since the list query ignored assignments too).

## The fix

- `list_libraries` now returns **own + global + public + privately-assigned** libraries (admins still see all).
- `book_visibility_filter` (and the two inline copies in `books.py`) now let **members** see books in public libraries too, so a now-visible public library actually shows its contents. The change is purely additive and, because everything routes through the shared filter, propagates consistently to downloads, OPDS, stats, send-to-device and TomeSync.
- **Library owners** (not just admins) can assign/revoke individual users on their own libraries; `/users/list` relaxed to `member` (returns only id/username/role) so the picker can be populated.
- New **"Share with users"** picker in the library editor.
- `LibraryOut` gains a server-computed **`can_edit`** flag; the frontend hides rename/delete/add-to-library controls on libraries you can't manage. This also cleans up a pre-existing wart where members saw dead edit/delete buttons on the global book-type libraries.

All library *mutations* remain owner/admin-gated (`_get_library`), so the widened list can't be used to modify others' libraries — those still 403. No data-loss path.

## Testing

- Full backend suite: **459 passed** (incl. new `tests/test_library_visibility.py`).
- Frontend `tsc -b`: clean.
- Headless-browser (Playwright) end-to-end against a clean two-member instance:
  - a second user sees another user's public library but **not** their private one;
  - the owner's editor shows the **Share with users** picker; after sharing, the second user sees the private library;
  - the second user gets **no** edit/delete controls on a library they don't own, while the owner does.