### PR TITLE
fix: keep reader font, size and theme across chapter changes (#33)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,19 @@ All notable changes to Tome are documented here. Format loosely follows
   or the web; each is filed under its author folder, matching Tome's library
   layout. Bumps the plugin to build 15 (1.2.2).
 
+## [1.3.2] — 2026-06-06
+
+### Fixed
+- **Reader font, size and theme no longer reset at every chapter** (#33). In the
+  EPUB reader, changing the font, font size or background theme worked on the
+  page you were on but was silently reverted the moment you turned into a new
+  chapter — snapping back to whatever settings were saved when you first opened
+  the book. The chapter-load handler was re-applying a stale snapshot of the
+  reader settings captured at open time; it now always applies your current
+  choices, so adjustments persist across chapters for the rest of the session.
+
+## [1.3.1] — 2026-06-06
+
 ### Fixed
 - **Shared libraries are now actually shared** (#31). Marking a library *public*
   had no effect: the library list only ever returned libraries you owned (plus

--- a/frontend/src/pages/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage.tsx
@@ -400,6 +400,10 @@ export default function ReaderPage() {
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const initialCfi = useRef<string | null>(null)
   const readyToSave = useRef(false)
+  // Holds the latest applyStyles so the foliate 'load' listener (registered
+  // once at init) always re-applies the CURRENT theme/font on each new
+  // chapter, instead of the stale values captured when the book opened.
+  const applyStylesRef = useRef<() => void>(() => {})
 
   // Persist comic reader preferences so they carry across chapters.
   useEffect(() => { localStorage.setItem('reader_comic_rtl', isRTL ? '1' : '0') }, [isRTL])
@@ -589,7 +593,7 @@ export default function ReaderPage() {
       viewRef.current = view
 
       view.addEventListener('load', () => {
-        applyStyles()
+        applyStylesRef.current()
         if (view.book?.toc) {
           setToc(flattenToc(view.book.toc))
         }
@@ -661,6 +665,7 @@ export default function ReaderPage() {
   }, [theme, fontSize, fontFamily])
 
   useEffect(() => {
+    applyStylesRef.current = applyStyles
     if (!isComic) applyStyles()
   }, [applyStyles, isComic])
 


### PR DESCRIPTION
Forward-ports the **v1.3.2** hotfix (already tagged off `v1.3.1`) onto `main`.

## The bug (#33)
In the EPUB reader, changing the font, font size or theme applied to the current page but was reverted the moment you turned into a new chapter — snapping back to whatever settings were saved when the book was first opened.

## Root cause
The foliate `load` listener (registered once at init) re-applied a **stale** `applyStyles` closure captured at open time, clobbering the live settings on every chapter (new spine section) load.

## Fix
Keep a ref pointed at the latest `applyStyles` and call it from the `load` listener, so the current theme/font/size are reapplied on every chapter.

## Verification
- Playwright A/B against a real multi-chapter EPUB: buggy build reverts to light/Times after a chapter jump; fixed build stays dark/serif.
- `tsc -b` clean, full backend suite green (459 passed).

Closes #33