### PR TITLE
fix: series progress no longer reads as complete when starting the last book

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ All notable changes to Tome are documented here. Format loosely follows
   or the web; each is filed under its author folder, matching Tome's library
   layout. Bumps the plugin to build 15 (1.2.2).
 
+### Fixed
+- **Series progress no longer shows as complete the moment you start the last
+  book** (#36). The dashboard's "Series Progress" bar measured progress by the
+  index of the book you were currently reading, so beginning book 2 of a 2-book
+  series filled the bar to 100% before you'd finished it. It now reflects the
+  number of volumes you've actually read, so the series only reads as complete
+  once the last book is marked read.
+
 ## [1.3.2] — 2026-06-06
 
 ### Fixed

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1094,7 +1094,11 @@ export function DashboardPage() {
                         const seriesData = seriesList.find(s => s.name === book.series)
                         const total = seriesData?.book_count ?? null
                         const current = book.series_index!
-                        const pct = total ? Math.min(100, (current / total) * 100) : null
+                        // Progress reflects *completed* (read) volumes, not the index of the
+                        // book you're currently reading — otherwise starting the last book
+                        // would show the series as 100% before you've finished it.
+                        const readCount = seriesData?.read_count ?? 0
+                        const pct = total ? Math.min(100, (readCount / total) * 100) : null
                         return (
                           <div key={book.id} className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-muted/50 border border-border">
                             <div className="min-w-0 flex-1">


### PR DESCRIPTION
Closes #36.

### Problem
The dashboard's **Series Progress** widget measured how far through a series you were by the *index of the book you were currently reading*:

```ts
const current = book.series_index!
const pct = (current / total) * 100
```

So beginning the last volume of a series (e.g. starting book 2 of a 2-book series) immediately filled the bar to 100% — the series read as "complete" before you'd actually finished it. Reported against v1.3.1.

### Fix
Base the bar on the number of volumes actually **read** (`read_count`, already returned per series by the API and already used by the series grid bar) rather than the current book's index:

```ts
const readCount = seriesData?.read_count ?? 0
const pct = total ? (readCount / total) * 100 : null
```

Reading book 2 of 2 with book 1 finished now shows 50%; the series only reaches 100% once the last book is marked read. The "Book X of Y" label is unchanged (it correctly reflects the book you're on).

### Testing
- `tsc -b` clean.
- Manual: a 2-book series with book 1 read + book 2 in progress now shows 50%, not 100%.