### PR TITLE
fix(tomesync): stop the book-open sync message swallowing layout profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ All notable changes to Tome are documented here. Format loosely follows
   layout. Bumps the plugin to build 15 (1.2.2).
 
 ### Fixed
+- **The TomeSync plugin no longer breaks layout profiles that auto-execute on
+  book open.** The "TomeSync: Server at X% (device: Y%)" message shown when
+  another device had read ahead was a modal window, and KOReader delivers
+  profile actions only to the topmost non-modal window — so a profile applying
+  your layout (font size, margins, columns) on book open was silently swallowed
+  exactly on those opens, leaving the book with default or stale layout
+  settings. The message is now a passive toast that lets profile actions
+  through. Also fixes two more issues in the same path: a position saved by the
+  web reader no longer throws KOReader to page 1 (the plugin now recognises it
+  isn't a KOReader-native position and jumps by percentage instead), and the
+  book-open sync no longer runs twice per open. Bumps the plugin to build 17
+  (1.2.4).
 - **Series progress no longer shows as complete the moment you start the last
   book** (#36). The dashboard's "Series Progress" bar measured progress by the
   index of the book you were currently reading, so beginning book 2 of a 2-book

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -40,8 +40,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 16
-TOMESYNC_PLUGIN_SEMVER = "1.2.3"
+TOMESYNC_PLUGIN_BUILD = 17
+TOMESYNC_PLUGIN_SEMVER = "1.2.4"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1041,6 +1041,7 @@ logger.info("TomeSync: main_impl.lua loading...")
 
 local WidgetContainer = require("ui/widget/container/widgetcontainer")
 local InfoMessage      = require("ui/widget/infomessage")
+local Notification     = require("ui/widget/notification")
 local UIManager        = require("ui/uimanager")
 local Device           = require("device")
 local NetworkMgr       = require("ui/network/manager")
@@ -1088,6 +1089,11 @@ http.TIMEOUT = 5
 -- Track consecutive failures for backoff
 local consecutive_failures = 0
 local MAX_BACKOFF_FAILURES = 3
+
+-- Chunk-local (shared across plugin instances): dedupes _initSession when the
+-- ReaderReady event reaches more than one live TomeSync instance for the same
+-- open. Cleared in onCloseDocument so an immediate reopen still inits.
+local last_session_init = {{ book_id = nil, at = 0 }}
 
 -- ── HTTP client ──────────────────────────────────────────────────────────────
 
@@ -1518,6 +1524,7 @@ function TomeSync:onCloseDocument()
     self.page_count     = 0
     self.progress_start = nil
     self.last_progress  = nil
+    last_session_init.book_id = nil
 end
 
 -- ── Helpers ──────────────────────────────────────────────────────────────────
@@ -1540,6 +1547,14 @@ function TomeSync:_tryResolve()
 end
 
 function TomeSync:_initSession()
+    if self.book_id == last_session_init.book_id
+            and (os.time() - last_session_init.at) < 5 then
+        logger.dbg("TomeSync: duplicate session init skipped, id =", self.book_id)
+        return
+    end
+    last_session_init.book_id = self.book_id
+    last_session_init.at = os.time()
+
     logger.dbg("TomeSync: book opened, id =", self.book_id)
     self.session_start = os.time()
     self.page_count    = 0
@@ -1550,17 +1565,31 @@ function TomeSync:_initSession()
         local local_pct  = self:_getCurrentPercentage()
         if server_pct > (local_pct + 0.01) and server_pct < 0.99 then
             self.progress_start = server_pct
-            UIManager:show(InfoMessage:new{{
+            -- Must be a toast (Notification), not an InfoMessage: this shows
+            -- right when Profiles auto-exec ("on book opening") dispatches its
+            -- actions, and UIManager:sendEvent drops events at the topmost
+            -- non-toast window — an InfoMessage here silently eats the user's
+            -- layout profile (font size, margins, columns).
+            UIManager:show(Notification:new{{
                 text = string.format(
                     "TomeSync: Server at %.0f%% (device: %.0f%%).",
                     server_pct * 100, local_pct * 100
                 ),
                 timeout = 3,
             }})
-            if pos.progress and self.ui and self.ui.rolling then
-                pcall(function()
-                    self.ui.rolling:onGotoXPointer(pos.progress, pos.progress)
-                end)
+            if self.ui and self.ui.rolling then
+                if type(pos.progress) == "string" and pos.progress:sub(1, 1) == "/" then
+                    pcall(function()
+                        self.ui.rolling:onGotoXPointer(pos.progress, pos.progress)
+                    end)
+                else
+                    -- Not a crengine xpointer (e.g. the web reader stores a
+                    -- foliate epubcfi here) — onGotoXPointer with it lands on
+                    -- page 1, so jump by percentage instead.
+                    pcall(function()
+                        self.ui.rolling:onGotoPercent(server_pct * 100)
+                    end)
+                end
             end
         else
             self.progress_start = local_pct

--- a/tests/test_tomesync_initsession.py
+++ b/tests/test_tomesync_initsession.py
@@ -1,0 +1,72 @@
+"""Regression tests for the plugin's book-open sync (`_initSession`).
+
+Background (reported on Reddit against v1.3.2): the "TomeSync: Server at X%
+(device: Y%)" message was an ``InfoMessage`` — a modal window. KOReader's
+Profiles plugin auto-executes "on book opening" profiles right after
+ReaderReady via ``UIManager:sendEvent``, which delivers events only to the
+topmost *non-toast* window. The modal swallowed every profile action (font
+size, margins, columns) exactly on opens where another device had read ahead,
+so users' layout profiles silently failed to apply. Two more bugs lived in the
+same function: a web-reader position (foliate ``epubcfi(...)``) fed to
+``onGotoXPointer`` lands on page 1, and ``_initSession`` could run twice per
+open.
+
+These are tripwires on the generated Lua: they can't execute KOReader, but
+they pin the load-bearing properties of the fix so a refactor can't silently
+revert them.
+"""
+import re
+
+from backend.api.tome_sync import _main_impl_lua
+
+
+def _impl() -> str:
+    return _main_impl_lua("http://localhost:8080", "tk_test", "tester")
+
+
+def _init_session_body(lua: str) -> str:
+    match = re.search(r"function TomeSync:_initSession\(\).*?\nend\n", lua, re.S)
+    assert match, "_initSession not found in generated impl"
+    return match.group(0)
+
+
+def test_open_sync_message_is_a_toast_not_a_modal():
+    # Must be a Notification (toast=true: never blocks UIManager:sendEvent
+    # propagation), NOT an InfoMessage, or Profiles auto-exec actions are
+    # swallowed while it is on screen.
+    body = _init_session_body(_impl())
+    assert "Notification:new" in body
+    assert "InfoMessage:new" not in body
+
+
+def test_notification_widget_is_required():
+    assert 'require("ui/widget/notification")' in _impl()
+
+
+def test_goto_guards_against_non_crengine_xpointers():
+    # The web reader stores a foliate epubcfi in TomeSyncPosition.progress;
+    # crengine xpointers always start with "/". Anything else must fall back
+    # to a percentage jump instead of onGotoXPointer (which lands on page 1).
+    body = _init_session_body(_impl())
+    guard = body.find('pos.progress:sub(1, 1) == "/"')
+    goto_xp = body.find("onGotoXPointer")
+    goto_pct = body.find("onGotoPercent")
+    assert guard != -1, "missing xpointer-shape guard"
+    assert goto_xp != -1 and guard < goto_xp, "goto must be behind the guard"
+    assert goto_pct != -1, "missing percentage fallback for web positions"
+
+
+def test_session_init_is_deduped_per_open():
+    lua = _impl()
+    body = _init_session_body(lua)
+    assert "last_session_init" in body, "missing duplicate-init guard"
+    # The guard must be declared before onCloseDocument references it,
+    # or that reference resolves to a nil global at runtime.
+    decl = lua.find("local last_session_init")
+    close_doc = lua.find("function TomeSync:onCloseDocument")
+    assert decl != -1 and close_doc != -1 and decl < close_doc
+    # And onCloseDocument must clear it so an immediate reopen still inits.
+    close_body = re.search(
+        r"function TomeSync:onCloseDocument\(\).*?\nend\n", lua, re.S
+    ).group(0)
+    assert "last_session_init.book_id = nil" in close_body

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -144,6 +144,7 @@ def test_zip_download_bakes_https_with_forwarded_proto(app_client):
 def test_build_bumped_for_rebake():
     # Must exceed every build already live (v1.2.0 shipped 10; main reached 12),
     # so all existing installs re-download and re-bake the corrected URL.
-    # 1.2.3 / build 16 adds the Send-to-KOReader inbox (beta).
-    assert TOMESYNC_PLUGIN_BUILD >= 16
-    assert TOMESYNC_PLUGIN_SEMVER == "1.2.3"
+    # 1.2.4 / build 17 fixes the book-open sync toast swallowing Profiles
+    # auto-exec actions (plus web-CFI goto + duplicate session init).
+    assert TOMESYNC_PLUGIN_BUILD >= 17
+    assert TOMESYNC_PLUGIN_SEMVER == "1.2.4"


### PR DESCRIPTION
## What

Fixes the "TomeSync keeps resetting my layout" report from the r/koreader thread (against v1.3.2). Three bugs, all in the plugin's book-open sync (`_initSession`):

1. **The sync message ate layout profiles.** "TomeSync: Server at X% (device: Y%)" was an `InfoMessage` — a modal window. KOReader's Profiles plugin auto-executes "on book opening" profiles right after ReaderReady via `UIManager:sendEvent`, which only delivers to the topmost **non-toast** window. So on exactly the opens where another device had read ahead (the toast condition), the user's layout profile (font size, margins, columns) was silently dropped — leaving default/stale layout that then got saved to the sidecar. The message is now a `Notification` (toast, never blocks event propagation).
2. **Web-reader positions threw devices to page 1.** The web reader stores a foliate `epubcfi(...)` in `TomeSyncPosition.progress`; feeding that to `onGotoXPointer` lands on page 1. Non-crengine xpointers (anything not starting with `/`) now fall back to a percentage jump.
3. **`_initSession` ran twice per book open** — duplicate position fetch and a doubled message. Now deduped per open via a chunk-local guard, cleared on close so immediate reopens still init.

Plugin build **16 → 17** (1.2.4) — ships to devices via self-update.

## Verification

- Emulator repro of the report: auto-exec layout profile + server-ahead position. Before: profile logged "auto executing" but zero ConfigChange calls, layout stuck at defaults. After: `set font size 51` / `set visible page count 2` land with the toast on screen, position syncs to the server xpointer.
- `epubcfi(...)` at 85%: goto page 205/242 (≈85%), not page 1.
- "duplicate session init skipped" logged on the double delivery; every close→reopen cycle still inits.
- New tripwire tests (`tests/test_tomesync_initsession.py`) pin the toast-not-modal choice, the xpointer-shape guard + percent fallback, and the dedupe declaration order.
- Full suite: 470 passed.

Compat: `Notification` and `onGotoPercent` have existed in KOReader since ~2014; both call sites are pcall-wrapped; a failed impl load is covered by the shim's anti-brick rollback.