### PR TITLE
Library view: "Group by series" toggle that stacks volumes into one card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- **Group by series in the library view.** A new toggle in the All Books
+  toolbar collapses each series into a single stacked card — first volume's
+  cover, a volume-count badge, and a subtle stacked-paper look — so one long
+  manga run no longer drowns out the rest of the grid. Standalone books render
+  as normal cards. Clicking a stack opens the series detail view (status badge,
+  arcs, Continue Reading and all); clicking the series name on an individual
+  book card still filters the grid as before. Active filters apply inside the
+  stacks: if a filter matches only 2 of 15 volumes the badge shows 2, and
+  series with no matching volumes disappear. The toggle is off by default and
+  remembered per device. (#43)
+
 ### Changed
 - **Reading Stats is now a fully customisable dashboard.** The page looks the
   same on day one — the default boards replicate the old layout one-to-one —

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -125,6 +125,7 @@ def list_books(
     content_type: Optional[str] = Query(None, description="Filter by content type: volume, chapter"),
     added_by: Optional[int] = Query(None, description="Filter by uploader user ID (admin only)"),
     ownership: Optional[str] = Query(None, description="Ownership filter: 'mine' or 'shared' (member only)"),
+    group_by_series: Optional[bool] = Query(None, description="Collapse series into one representative book each, annotated with series_count"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -253,6 +254,42 @@ def list_books(
             )
         )
 
+    # ── Group by series ──────────────────────────────────────────────────────
+    # Collapse each series to one representative volume (lowest series_index)
+    # annotated with how many volumes matched the active filters; standalone
+    # books pass through with a count of 1.
+    if group_by_series:
+        from sqlalchemy import func as _func, select as _select
+
+        # Joins above (tags, files, libraries) can duplicate book rows —
+        # collapse to distinct IDs first so the window count isn't inflated.
+        id_sq = query.with_entities(Book.id).distinct().subquery()
+        partition = _func.coalesce(Book.series, _func.printf("__solo__%d", Book.id))
+        win_sq = (
+            db.query(
+                Book.id.label("book_id"),
+                partition.label("grp"),
+                _func.row_number()
+                .over(
+                    partition_by=partition,
+                    order_by=(Book.series_index.asc().nullslast(), Book.title.asc()),
+                )
+                .label("rn"),
+                _func.count().over(partition_by=partition).label("series_count"),
+            )
+            .filter(Book.id.in_(_select(id_sq.c.id)))
+            .subquery()
+        )
+        query = (
+            db.query(Book, win_sq.c.series_count)
+            .join(win_sq, Book.id == win_sq.c.book_id)
+            .filter(win_sq.c.rn == 1)
+        )
+        if sort == "status_updated":
+            # status_updated needs the UserBookStatus join the grouped query
+            # doesn't carry — fall back to a sane default.
+            sort = "added_at"
+
     # When filtering by a specific series, always sort by series_index
     if series:
         query = query.order_by(Book.series_index.asc().nullslast(), Book.title.asc())
@@ -296,7 +333,7 @@ def list_books(
     # Eager-load the relationships BookOut serializes (files, tags, libraries
     # via the library_ids property) so a page is a few queries, not ~3 per row.
     from sqlalchemy.orm import selectinload
-    return (
+    rows = (
         query.options(
             selectinload(Book.files),
             selectinload(Book.tags),
@@ -307,6 +344,34 @@ def list_books(
         .limit(limit)
         .all()
     )
+    if group_by_series:
+        # For the stacked-card fan effect, fetch the next two volumes per
+        # series on this page that actually have a cover (ID-only query).
+        series_names = [b.series for b, _ in rows if b.series]
+        fan_map: dict[str, list[int]] = {}
+        if series_names:
+            fan_rows = (
+                db.query(win_sq.c.grp, win_sq.c.book_id)
+                .join(Book, Book.id == win_sq.c.book_id)
+                .filter(
+                    win_sq.c.grp.in_(series_names),
+                    win_sq.c.rn > 1,
+                    Book.cover_path.isnot(None),
+                )
+                .order_by(win_sq.c.grp, win_sq.c.rn)
+                .all()
+            )
+            for grp, bid in fan_rows:
+                ids = fan_map.setdefault(grp, [])
+                if len(ids) < 2:
+                    ids.append(bid)
+        books = []
+        for book, series_count in rows:
+            book.series_count = int(series_count)
+            book.stack_cover_ids = fan_map.get(book.series or "", [])
+            books.append(book)
+        return books
+    return rows
 
 
 # ── Facets (for filter dropdowns) ────────────────────────────────────────────

--- a/backend/schemas/book.py
+++ b/backend/schemas/book.py
@@ -40,6 +40,11 @@ class BookOut(BaseModel):
     tags: list[BookTagOut] = []
     library_ids: list[int] = []
     book_type_id: Optional[int] = None
+    # Only populated by GET /books?group_by_series=true — number of volumes
+    # in this book's series that matched the active filters, and the IDs of
+    # the next volumes with covers (for the stacked-card fan effect).
+    series_count: Optional[int] = None
+    stack_cover_ids: Optional[list[int]] = None
 
     @classmethod
     def from_orm_with_libraries(cls, book):

--- a/frontend/src/components/SeriesStackCard.tsx
+++ b/frontend/src/components/SeriesStackCard.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useRef } from 'react'
+import { Layers } from 'lucide-react'
+import type { Book } from '@/lib/books'
+import type { ViewMode } from '@/components/BookCard'
+import { cn } from '@/lib/utils'
+import { CoverImage } from '@/components/CoverImage'
+
+interface SeriesStackCardProps {
+  book: Book
+  count: number
+  view: ViewMode
+  focused?: boolean
+  index?: number
+  onOpen: () => void
+}
+
+// Stacked card for the "Group by series" library view: the first volume's
+// cover sits on top of the next volumes' real covers, which fan out on hover.
+// Clicking anywhere opens the series detail view.
+export function SeriesStackCard({ book, count, view, focused, index = 0, onOpen }: SeriesStackCardProps) {
+  const cardRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (focused && cardRef.current) {
+      cardRef.current.scrollIntoView({ block: 'nearest' })
+    }
+  }, [focused])
+
+  const coverUrl = book.cover_path ? `/api/books/${book.id}/cover` : null
+  const seriesName = book.series ?? book.title
+  // Real covers of the next volumes, deepest last in the array
+  const fanIds = (book.stack_cover_ids ?? []).slice(0, 2)
+
+  // ── List view ────────────────────────────────────────────────────────────
+  if (view === 'list') {
+    return (
+      <div
+        ref={cardRef}
+        onClick={onOpen}
+        className={cn(
+          'group flex items-center gap-3 px-3 py-2.5 rounded-lg border bg-card cursor-pointer transition-all duration-150 touch-feedback',
+          'border-border hover:bg-accent hover:border-primary/20',
+          focused && 'ring-2 ring-blue-500 ring-offset-1 ring-offset-background',
+        )}
+      >
+        <div className="relative w-9 h-12 shrink-0">
+          <div className="absolute inset-0 translate-x-1 -translate-y-0.5 rounded overflow-hidden bg-muted border border-border transition-transform duration-200 group-hover:translate-x-2 group-hover:-translate-y-1">
+            {fanIds[0] && (
+              <CoverImage src={`/api/books/${fanIds[0]}/cover`} alt="" iconClassName="w-3 h-3" />
+            )}
+          </div>
+          <div className="relative w-full h-full rounded overflow-hidden bg-muted border border-border">
+            <CoverImage src={coverUrl} alt={seriesName} iconClassName="w-4 h-4" />
+          </div>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-foreground truncate group-hover:text-primary transition-colors">
+            {seriesName}
+          </p>
+          {book.author && (
+            <p className="text-xs text-muted-foreground truncate">{book.author}</p>
+          )}
+        </div>
+        <span className="shrink-0 flex items-center gap-1 text-[10px] font-medium px-1.5 py-0.5 rounded bg-muted border border-border text-muted-foreground">
+          <Layers className="w-3 h-3" />
+          {count} {count === 1 ? 'volume' : 'volumes'}
+        </span>
+      </div>
+    )
+  }
+
+  // ── Cover grid (large / small) ────────────────────────────────────────────
+  // The pile sits bottom-left in its cell; the cell reserves top/right padding
+  // so the back covers (and the hover fan) stay inside the cell instead of
+  // overlapping neighbouring cards. Small view halves the offsets — its grid
+  // gap is tighter.
+  const lg = view === 'large'
+  const deepLayerCls = lg
+    ? 'translate-x-2 -translate-y-2 group-hover:translate-x-3 group-hover:-translate-y-3.5 group-hover:rotate-2'
+    : 'translate-x-1 -translate-y-1 group-hover:translate-x-1.5 group-hover:-translate-y-2 group-hover:rotate-2'
+  const nearLayerCls = lg
+    ? 'translate-x-1 -translate-y-1 group-hover:translate-x-1.5 group-hover:-translate-y-2 group-hover:rotate-1'
+    : 'translate-x-0.5 -translate-y-0.5 group-hover:translate-x-1 group-hover:-translate-y-1 group-hover:rotate-1'
+  const layerBaseCls = 'absolute inset-0 rounded-xl overflow-hidden border border-border bg-muted transition-transform duration-300 ease-out'
+
+  return (
+    <div
+      ref={cardRef}
+      onClick={onOpen}
+      className="group flex flex-col cursor-pointer animate-card-appear touch-feedback"
+      style={{ animationDelay: `${Math.min(index * 30, 400)}ms` }}
+    >
+      {/* Reserved bleed area for the stack layers */}
+      <div className={cn('relative', lg ? 'pt-2 pr-2' : 'pt-1 pr-1')}>
+        <div className="relative">
+          {/* Volumes behind the top cover — real covers when available, fanning out on hover */}
+          {fanIds.length > 0 ? (
+            <>
+              {fanIds[1] && (
+                <div className={cn(layerBaseCls, deepLayerCls)}>
+                  <CoverImage src={`/api/books/${fanIds[1]}/cover`} alt="" imgClassName="brightness-[0.7]" />
+                </div>
+              )}
+              {fanIds[0] && (
+                <div className={cn(layerBaseCls, nearLayerCls)}>
+                  <CoverImage src={`/api/books/${fanIds[0]}/cover`} alt="" imgClassName="brightness-[0.85]" />
+                </div>
+              )}
+            </>
+          ) : (
+            /* Fallback when no other volume has a cover: subtle paper layers */
+            <>
+              <div className={cn(layerBaseCls, deepLayerCls)} />
+              <div className={cn(layerBaseCls, nearLayerCls, 'bg-card')} />
+            </>
+          )}
+          <div
+            className={cn(
+              'relative aspect-[2/3] bg-muted overflow-hidden rounded-xl shadow-sm border border-border',
+              'transition-transform duration-300 ease-out group-hover:shadow-lg group-hover:shadow-accent-soft group-hover:-translate-y-0.5',
+              focused && 'ring-2 ring-blue-500 ring-offset-2 ring-offset-background',
+            )}
+          >
+            <CoverImage
+              src={coverUrl}
+              alt={seriesName}
+              iconClassName={lg ? 'w-12 h-12' : 'w-8 h-8'}
+            />
+            {/* Volume count badge — top right */}
+            <span className="absolute top-1.5 right-1.5 flex items-center gap-1 px-1.5 py-0.5 rounded text-[9px] font-semibold bg-background/70 backdrop-blur-sm text-foreground/90 border border-border/50">
+              <Layers className="w-2.5 h-2.5" />
+              {count}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-0.5 pt-2 px-0.5">
+        <p
+          className={cn(
+            'font-medium text-foreground line-clamp-2 leading-snug transition-colors duration-150 group-hover:text-primary',
+            view === 'large' ? 'text-[13px]' : 'text-xs',
+          )}
+        >
+          {seriesName}
+        </p>
+        <p className={cn('text-muted-foreground line-clamp-1', view === 'large' ? 'text-xs' : 'text-[10px]')}>
+          {count} {count === 1 ? 'volume' : 'volumes'}
+          {book.author ? ` · ${book.author}` : ''}
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/books.ts
+++ b/frontend/src/lib/books.ts
@@ -29,6 +29,10 @@ export interface Book {
   tags: BookTag[]
   library_ids: number[]
   book_type_id: number | null
+  // Only set by GET /books?group_by_series=true — matching volumes in this
+  // series, and IDs of the next covered volumes for the stack fan effect
+  series_count?: number | null
+  stack_cover_ids?: number[] | null
 }
 
 export interface BookDetail extends Book {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,12 +5,13 @@ import {
   LayoutGrid, List,
   ChevronUp, ChevronDown, SlidersHorizontal, LayoutList, Loader2,
   Library as LibraryIcon, CheckSquare, XSquare, Download, Pencil, Menu,
-  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2,
+  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers,
 } from 'lucide-react'
 import { TomeMark } from '@/components/TomeMark'
 import { useAuth, isMember, isAdmin } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
 import { BookCard, type ViewMode } from '@/components/BookCard'
+import { SeriesStackCard } from '@/components/SeriesStackCard'
 import { CoverImage } from '@/components/CoverImage'
 import { Sidebar } from '@/components/Sidebar'
 import { SaveFilterButton } from '@/components/SaveFilterButton'
@@ -97,6 +98,7 @@ const SORT_LABELS: Record<SortField, string> = {
 const VIEW_KEY = 'tome_view'
 const SORT_KEY = 'tome_sort'
 const ORDER_KEY = 'tome_order'
+const GROUP_KEY = 'tome_group_series'
 
 // ── Bulk Delete Modal ──────────────────────────────────────────────────────────
 interface BulkDeleteModalProps {
@@ -264,6 +266,14 @@ export function DashboardPage() {
   function persistView(v: ViewMode) { setView(v); localStorage.setItem(VIEW_KEY, v) }
   function persistSort(s: SortField) { setSort(s); localStorage.setItem(SORT_KEY, s) }
   function persistOrder(o: SortOrder) { setOrder(o); localStorage.setItem(ORDER_KEY, o) }
+
+  // ── Group by series (persisted) ───────────────────────────────────────────
+  const [groupBySeries, setGroupBySeries] = useState(() => localStorage.getItem(GROUP_KEY) === 'true')
+  function persistGroup(v: boolean) {
+    setGroupBySeries(v)
+    localStorage.setItem(GROUP_KEY, String(v))
+    if (v) exitSelectionMode()
+  }
 
   // ── Tab (Home / Books / Series) — derived from URL ───────────────────────
   const tab = (searchParams.get('tab') || 'home') as 'home' | 'books' | 'series'
@@ -476,6 +486,10 @@ export function DashboardPage() {
 
   const hasFilters = !!(search || filterSeries || filterNoSeries || filterAuthor || filterTag || filterFormat || filterReadingStatus || filterMissing || filterOwnership || filterAddedBy)
 
+  // Grouping is bypassed while drilling into a specific series — the user
+  // explicitly asked for that series' volumes, so a single stack is useless.
+  const groupActive = groupBySeries && !filterSeries
+
   // ── Debounced search ──────────────────────────────────────────────────────
   const [searchInput, setSearchInput] = useState(search)
   const searchDebounce = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
@@ -684,6 +698,7 @@ export function DashboardPage() {
     if (contentType) params.set('content_type', contentType)
     if (filterOwnership) params.set('ownership', filterOwnership)
     if (filterAddedBy) params.set('added_by', String(filterAddedBy))
+    if (groupActive) params.set('group_by_series', 'true')
     api.getWithHeaders<Book[]>(`/books?${params}`, signal)
       .then(({ data: newBooks, headers }) => {
         if (signal?.aborted) return
@@ -717,7 +732,7 @@ export function DashboardPage() {
         if (reset) { setLoading(false); setRefreshing(false) }
         else setLoadingMore(false)
       })
-  }, [sort, order, search, filterSeries, filterNoSeries, filterAuthor, filterTag, filterFormat, filterLibrary, filterReadingStatus, filterMissing, contentType, filterOwnership, filterAddedBy])
+  }, [sort, order, search, filterSeries, filterNoSeries, filterAuthor, filterTag, filterFormat, filterLibrary, filterReadingStatus, filterMissing, contentType, filterOwnership, filterAddedBy, groupActive])
 
   useEffect(() => { loadBooks() }, [loadBooks])
 
@@ -750,6 +765,10 @@ export function DashboardPage() {
 
   function loadFacets() { api.get<Facets>('/books/facets').then(setFacets).catch(() => {}) }
   useEffect(() => { loadFacets() }, [])
+
+  // Mirror groupActive into a ref so the keydown handler (bound once) sees it
+  const groupActiveRef = useRef(false)
+  useEffect(() => { groupActiveRef.current = groupActive }, [groupActive])
 
 
   useEffect(() => {
@@ -786,7 +805,12 @@ export function DashboardPage() {
       if (e.key === 'Enter') {
         setFocusedIndex(prev => {
           if (prev !== null && booksRef.current[prev]) {
-            navigate(`/books/${booksRef.current[prev].id}`)
+            const b = booksRef.current[prev]
+            if (groupActiveRef.current && b.series) {
+              navigate(`/?tab=series&series_detail=${encodeURIComponent(b.series)}`)
+            } else {
+              navigate(`/books/${b.id}`)
+            }
           }
           return prev
         })
@@ -1530,13 +1554,33 @@ export function DashboardPage() {
             <span className="text-xs text-muted-foreground hidden sm:block">
               {loading
                 ? '…'
-                : totalCount !== null && totalCount > books.length
-                  ? `${books.length} of ${totalCount} books`
-                  : `${books.length} book${books.length !== 1 ? 's' : ''}`}
+                : (() => {
+                    const noun = (n: number) => groupActive ? (n === 1 ? 'entry' : 'entries') : (n === 1 ? 'book' : 'books')
+                    return totalCount !== null && totalCount > books.length
+                      ? `${books.length} of ${totalCount} ${noun(totalCount)}`
+                      : `${books.length} ${noun(books.length)}`
+                  })()}
             </span>
 
-            {/* Select mode toggle */}
-            {books.length > 0 && (
+            {/* Group by series toggle */}
+            <button
+              onClick={() => persistGroup(!groupBySeries)}
+              title={groupBySeries ? 'Show individual volumes' : 'Group volumes by series'}
+              aria-label="Group by series"
+              aria-pressed={groupBySeries}
+              className={cn(
+                'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-all',
+                groupBySeries
+                  ? 'border-primary/40 bg-primary/10 text-primary'
+                  : 'border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted'
+              )}
+            >
+              <Layers className="w-3.5 h-3.5" />
+              <span className="hidden sm:inline">Group series</span>
+            </button>
+
+            {/* Select mode toggle — selection operates on individual books, hidden while grouped */}
+            {books.length > 0 && !groupActive && (
               <div className="flex items-center gap-1">
                 <button
                   onClick={() => {
@@ -1826,6 +1870,17 @@ export function DashboardPage() {
           ) : (
             <div className={cn(gridClass, refreshing && 'opacity-50 transition-opacity duration-150')}>
               {books.map((book, i) => (
+                groupActive && book.series ? (
+                  <SeriesStackCard
+                    key={`${view}-stack-${book.id}`}
+                    book={book}
+                    count={book.series_count ?? 1}
+                    view={view}
+                    index={i}
+                    focused={focusedIndex === i}
+                    onOpen={() => navigate(`/?tab=series&series_detail=${encodeURIComponent(book.series!)}`)}
+                  />
+                ) : (
                 <BookCard
                   key={`${view}-${book.id}`}
                   book={book}
@@ -1840,6 +1895,7 @@ export function DashboardPage() {
                   readingStatus={readingStatuses[book.id]?.status}
                   progressPct={readingStatuses[book.id]?.progress_pct}
                 />
+                )
               ))}
             </div>
           )}

--- a/tests/test_book_filters.py
+++ b/tests/test_book_filters.py
@@ -213,3 +213,103 @@ def test_sort_by_title(client: TestClient, make_book):
     # The slice containing our three books should already be sorted; verify the
     # full returned list is sorted ascending.
     assert titles == sorted(titles)
+
+
+# ── Group by series ───────────────────────────────────────────────────────────
+
+def test_group_by_series_collapses_volumes(client: TestClient, make_book):
+    """group_by_series=true returns one representative per series (lowest
+    series_index) with a series_count, and standalones pass through."""
+    v2 = make_book(title="Saga Vol 2", series="Saga", series_index=2.0)
+    v1 = make_book(title="Saga Vol 1", series="Saga", series_index=1.0)
+    v3 = make_book(title="Saga Vol 3", series="Saga", series_index=3.0)
+    solo = make_book(title="Standalone Novel")
+
+    resp = client.get("/api/books", params={"group_by_series": "true"})
+    assert resp.status_code == 200
+
+    books = resp.json()
+    ids = [b["id"] for b in books]
+    assert v1.id in ids
+    assert v2.id not in ids
+    assert v3.id not in ids
+    assert solo.id in ids
+    assert _total(resp) == 2
+
+    by_id = {b["id"]: b for b in books}
+    assert by_id[v1.id]["series_count"] == 3
+    assert by_id[solo.id]["series_count"] == 1
+
+
+def test_group_by_series_counts_respect_filters(client: TestClient, make_book):
+    """Filters apply inside the stacks: the count reflects matching volumes
+    only, and series with no matching volumes disappear."""
+    make_book(title="Saga Vol 1", series="Saga", series_index=1.0, file_format="epub")
+    v2 = make_book(title="Saga Vol 2", series="Saga", series_index=2.0, file_format="cbz")
+    make_book(title="Saga Vol 3", series="Saga", series_index=3.0, file_format="cbz")
+    make_book(title="Other Vol 1", series="Other", series_index=1.0, file_format="epub")
+
+    resp = client.get("/api/books", params={"group_by_series": "true", "format": "cbz"})
+    assert resp.status_code == 200
+
+    books = resp.json()
+    assert _total(resp) == 1
+    # Representative is the lowest-index *matching* volume
+    assert books[0]["id"] == v2.id
+    assert books[0]["series_count"] == 2
+
+
+def test_group_by_series_pagination(client: TestClient, make_book):
+    """Pagination operates over groups, not raw volumes."""
+    for i in range(1, 4):
+        make_book(title=f"Alpha Vol {i}", series="Alpha", series_index=float(i))
+    for i in range(1, 3):
+        make_book(title=f"Beta Vol {i}", series="Beta", series_index=float(i))
+    make_book(title="Gamma Standalone")
+
+    resp = client.get("/api/books", params={
+        "group_by_series": "true", "sort": "title", "order": "asc",
+        "skip": 0, "limit": 2,
+    })
+    assert resp.status_code == 200
+    assert _total(resp) == 3
+    assert len(resp.json()) == 2
+
+    resp2 = client.get("/api/books", params={
+        "group_by_series": "true", "sort": "title", "order": "asc",
+        "skip": 2, "limit": 2,
+    })
+    assert len(resp2.json()) == 1
+    assert set(_ids(resp)).isdisjoint(set(_ids(resp2)))
+
+
+def test_ungrouped_has_no_series_count(client: TestClient, make_book):
+    """Without the flag, series_count stays null and all volumes are returned."""
+    make_book(title="Saga Vol 1", series="Saga", series_index=1.0)
+    make_book(title="Saga Vol 2", series="Saga", series_index=2.0)
+
+    resp = client.get("/api/books")
+    assert resp.status_code == 200
+    books = resp.json()
+    assert _total(resp) == 2
+    assert all(b["series_count"] is None for b in books)
+
+
+def test_group_by_series_stack_cover_ids(client: TestClient, make_book):
+    """Grouped reps carry the IDs of the next two volumes that have a cover
+    (for the stacked-card fan), skipping coverless volumes."""
+    v1 = make_book(title="Saga Vol 1", series="Saga", series_index=1.0, cover_path="/c/1.jpg")
+    _v2 = make_book(title="Saga Vol 2", series="Saga", series_index=2.0, cover_path=None)
+    v3 = make_book(title="Saga Vol 3", series="Saga", series_index=3.0, cover_path="/c/3.jpg")
+    v4 = make_book(title="Saga Vol 4", series="Saga", series_index=4.0, cover_path="/c/4.jpg")
+    _v5 = make_book(title="Saga Vol 5", series="Saga", series_index=5.0, cover_path="/c/5.jpg")
+    solo = make_book(title="Standalone Novel")
+
+    resp = client.get("/api/books", params={"group_by_series": "true"})
+    assert resp.status_code == 200
+    by_id = {b["id"]: b for b in resp.json()}
+
+    assert v1.id in by_id
+    # Coverless vol 2 is skipped; capped at two covers
+    assert by_id[v1.id]["stack_cover_ids"] == [v3.id, v4.id]
+    assert by_id[solo.id]["stack_cover_ids"] == []


### PR DESCRIPTION
Closes #43 — thanks @emmur0 for the suggestion (over in #41)! This will ship with the next release.

## What

A new **Group series** toggle in the All Books toolbar. When on, books that share a series collapse into a single stacked card — the first volume's cover sitting on a pile of the next volumes' real covers, with a volume-count badge. Standalone books render as normal cards. Off by default, remembered per device.

- Clicking a stack (or pressing Enter with keyboard nav) opens the existing **series detail view** — status badge, arcs, read counts, Continue Reading. Clicking the series name on an individual book card keeps its current behaviour (filters the grid).
- **Filters apply inside the stacks**: if a filter matches only 2 of 15 volumes, the badge shows 2, and series with no matching volumes don't appear.
- Hovering a stack fans the covers out — contained within the grid cell, so neighbouring cards are never overlapped.
- Grouping is bypassed while filtering by a specific series (you asked for those volumes), and selection mode stays volume-level (the Select control hides while grouped).
- Works in all three views (large covers, small covers, list).

## How

- `GET /books` gains a `group_by_series` flag: a window function collapses each series to its lowest-index volume, annotated with a filter-aware `series_count` plus the next two covered volumes' IDs (`stack_cover_ids`) for the fan effect. Pagination and `X-Total-Count` operate over groups.
- New `SeriesStackCard` component; the toggle is persisted like the existing view/sort prefs.

## Testing

- 5 new API tests (collapse + representative choice, filter-aware counts, pagination over groups, fan IDs skipping coverless volumes, ungrouped unchanged); full suite passes.
- Verified against a real 270-book library: collapses to 108 entries, counts and fan covers correct.