### PR TITLE
KOReader plugin: opt-in WiFi auto-connect, Settings submenu, clearer tracking toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,25 @@ All notable changes to Tome are documented here. Format loosely follows
   stacks: if a filter matches only 2 of 15 volumes the badge shows 2, and
   series with no matching volumes disappear. The toggle is off by default and
   remembered per device. (#43)
+- **KOReader plugin: opt-in WiFi auto-connect.** Some devices (notably
+  PocketBook) sleep WiFi so aggressively that every TomeSync action just failed
+  with "offline". A new **Settings → Auto-connect WiFi when needed** toggle
+  lets KOReader re-establish the connection first (honouring your KOReader
+  network prompt/auto setting) and then runs the action — browsing series,
+  downloads, Sync now, Test connection, update checks, and the Inbox. Off by
+  default: with the toggle off the plugin behaves exactly as before. Only
+  user-initiated actions reconnect; background tracking never wakes the radio.
+  (build 18 / 1.3.0, #38)
 
 ### Changed
+- **KOReader plugin: clearer menu.** The ambiguous in-book "Enabled (tap to
+  disable)" entry is now "Tracking: on (tap to pause)" — it pauses automatic
+  session tracking and syncing for the current KOReader run (it was never a
+  permanent setting, and now says so). Persistent options and diagnostics
+  (auto-connect, update checks, Test connection, Re-resolve all books) moved
+  into a **Settings** submenu, so the in-book menu no longer spills onto a
+  second page. The gesture-opened popup menu now shows toggle states and opens
+  submenus instead of silently ignoring them. (build 18 / 1.3.0)
 - **Reading Stats is now a fully customisable dashboard.** The page looks the
   same on day one — the default boards replicate the old layout one-to-one —
   but everything is now a tile on a drag-and-resize grid: hit **Edit** to

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -40,8 +40,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 17
-TOMESYNC_PLUGIN_SEMVER = "1.2.4"
+TOMESYNC_PLUGIN_BUILD = 18
+TOMESYNC_PLUGIN_SEMVER = "1.3.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1215,6 +1215,22 @@ local function downloadFile(book_id, file_id, dest_path)
     return true
 end
 
+-- ── Connectivity (issue #38) ─────────────────────────────────────────────────
+-- Interactive entry points route through this instead of hitting the network
+-- directly. Default: run the action as-is, so the existing isConnected guards
+-- behave exactly as before. With "Auto-connect WiFi" enabled, KOReader brings
+-- the connection back up first (per the user's wifi_enable_action setting) and
+-- runs the action once connected — devices like PocketBook aggressively sleep
+-- the radio, which otherwise leaves every action failing with "offline".
+local function whenConnected(fn)
+    if G_reader_settings:isTrue("tomesync_auto_connect")
+            and not NetworkMgr:isConnected() then
+        NetworkMgr:runWhenConnected(fn)
+        return
+    end
+    fn()
+end
+
 -- ── Self-update helpers ──────────────────────────────────────────────────────
 
 local function implDir()
@@ -1352,13 +1368,15 @@ function TomeSync:onTomeSyncAnnotations()
         UIManager:show(InfoMessage:new{{ text = "No book resolved. Open a book first.", timeout = 3 }})
         return true
     end
-    local resp = self:_syncAnnotations()
-    if resp == nil and not NetworkMgr:isConnected() then
-        UIManager:show(InfoMessage:new{{ text = "Offline — highlights will sync later.", timeout = 3 }})
-    else
-        local n = (resp and resp.annotations) and #resp.annotations or 0
-        UIManager:show(InfoMessage:new{{ text = "Highlights synced (" .. n .. " on this book).", timeout = 3 }})
-    end
+    whenConnected(function()
+        local resp = self:_syncAnnotations()
+        if resp == nil and not NetworkMgr:isConnected() then
+            UIManager:show(InfoMessage:new{{ text = "Offline — highlights will sync later.", timeout = 3 }})
+        else
+            local n = (resp and resp.annotations) and #resp.annotations or 0
+            UIManager:show(InfoMessage:new{{ text = "Highlights synced (" .. n .. " on this book).", timeout = 3 }})
+        end
+    end)
     return true
 end
 
@@ -1958,6 +1976,10 @@ function TomeSync:_seriesBooksMenu(data)
 end
 
 function TomeSync:_browseSeriesMenu()
+    whenConnected(function() self:_browseSeriesMenuImpl() end)
+end
+
+function TomeSync:_browseSeriesMenuImpl()
     if not NetworkMgr:isConnected() then
         UIManager:show(InfoMessage:new{{
             text = "WiFi not connected.",
@@ -2023,6 +2045,10 @@ function TomeSync:_downloadCurrentBookSeries(rest_only)
         return
     end
 
+    whenConnected(function() self:_downloadCurrentBookSeriesImpl(rest_only) end)
+end
+
+function TomeSync:_downloadCurrentBookSeriesImpl(rest_only)
     local ok, data, code = pcall(apiRequest, "GET",
         "/tome-sync/series/" .. self.book_id)
     if not ok or not data or not data.books then
@@ -2189,6 +2215,10 @@ end
 
 -- Inbox drill-down: a "Download all" row plus one row per queued book.
 function TomeSync:_inboxMenu()
+    whenConnected(function() self:_inboxMenuImpl() end)
+end
+
+function TomeSync:_inboxMenuImpl()
     if not NetworkMgr:isConnected() then
         UIManager:show(InfoMessage:new{{ text = "WiFi not connected.", timeout = 3 }})
         return
@@ -2239,6 +2269,22 @@ end
 function TomeSync:_menuItems()
     local in_book = self.ui and self.ui.document
 
+    -- Settings submenu: persistent toggles and diagnostics, set once and
+    -- forgotten — kept out of the top level so frequent actions stay reachable.
+    local settings_items = {{}}
+    table.insert(settings_items, {{
+        text         = "Auto-connect WiFi when needed",
+        help_text    = "When a TomeSync action needs the server and WiFi is down, "
+                       .. "let KOReader re-establish the connection instead of "
+                       .. "failing with \\"offline\\". Helps devices that "
+                       .. "aggressively sleep WiFi (e.g. PocketBook).",
+        checked_func = function() return G_reader_settings:isTrue("tomesync_auto_connect") end,
+        callback     = function()
+            G_reader_settings:saveSetting("tomesync_auto_connect",
+                not G_reader_settings:isTrue("tomesync_auto_connect"))
+        end,
+    }})
+
     local sub_items = {{}}
 
     -- Always-visible items
@@ -2254,28 +2300,31 @@ function TomeSync:_menuItems()
             callback  = function() self:_inboxMenu() end,
         }})
     end
-    table.insert(sub_items, {{
+    table.insert(settings_items, {{
         text     = "Test connection",
         callback = function()
-            local ok, result, code = pcall(apiRequest, "GET", "/health")
-            if ok and type(code) == "number" and code >= 200 and code < 300 then
-                UIManager:show(InfoMessage:new{{
-                    text = "Connected to " .. SERVER_URL
-                           .. "\\nUser: " .. USERNAME,
-                    timeout = 4,
-                }})
-            else
-                local err = tostring(result or "unknown error")
-                UIManager:show(InfoMessage:new{{
-                    text = "Connection failed!\\n" .. SERVER_URL
-                           .. "\\nError: " .. err,
-                    timeout = 6,
-                }})
-            end
+            whenConnected(function()
+                local ok, result, code = pcall(apiRequest, "GET", "/health")
+                if ok and type(code) == "number" and code >= 200 and code < 300 then
+                    UIManager:show(InfoMessage:new{{
+                        text = "Connected to " .. SERVER_URL
+                               .. "\\nUser: " .. USERNAME,
+                        timeout = 4,
+                    }})
+                else
+                    local err = tostring(result or "unknown error")
+                    UIManager:show(InfoMessage:new{{
+                        text = "Connection failed!\\n" .. SERVER_URL
+                               .. "\\nError: " .. err,
+                        timeout = 6,
+                    }})
+                end
+            end)
         end,
     }})
-    table.insert(sub_items, {{
+    table.insert(settings_items, {{
         text     = "Re-resolve all books",
+        separator = true,
         callback = function()
             self.book_map = {{}}
             self.book_id = nil
@@ -2286,43 +2335,34 @@ function TomeSync:_menuItems()
             }})
         end,
     }})
-    table.insert(sub_items, {{
+    table.insert(settings_items, {{
         text     = "Check for updates",
         callback = function()
-            self:checkForUpdate(function(avail, err)
-                if avail then
-                    self:_promptUpdate(avail)
-                elseif avail == false then
-                    UIManager:show(InfoMessage:new{{
-                        text = "TomeSync is up to date (build " .. BUILD .. ").",
-                        timeout = 4,
-                    }})
-                else
-                    UIManager:show(InfoMessage:new{{
-                        text = err or "Update check failed.",
-                        timeout = 5,
-                    }})
-                end
+            whenConnected(function()
+                self:checkForUpdate(function(avail, err)
+                    if avail then
+                        self:_promptUpdate(avail)
+                    elseif avail == false then
+                        UIManager:show(InfoMessage:new{{
+                            text = "TomeSync is up to date (build " .. BUILD .. ").",
+                            timeout = 4,
+                        }})
+                    else
+                        UIManager:show(InfoMessage:new{{
+                            text = err or "Update check failed.",
+                            timeout = 5,
+                        }})
+                    end
+                end)
             end)
         end,
     }})
-    table.insert(sub_items, {{
-        text         = "Auto-check on launch",
+    table.insert(settings_items, {{
+        text         = "Auto-check for updates on launch",
         checked_func = function() return G_reader_settings:isTrue("tomesync_auto_check") end,
         callback     = function()
             G_reader_settings:saveSetting("tomesync_auto_check",
                 not G_reader_settings:isTrue("tomesync_auto_check"))
-        end,
-    }})
-    table.insert(sub_items, {{
-        text     = "About",
-        separator = in_book,
-        callback = function()
-            UIManager:show(InfoMessage:new{{
-                text    = "TomeSync " .. SEMVER .. " (build " .. BUILD .. ")"
-                          .. "\\nSyncs with your Tome library.",
-                timeout = 4,
-            }})
         end,
     }})
 
@@ -2339,39 +2379,47 @@ function TomeSync:_menuItems()
         table.insert(sub_items, {{
             text         = "Sync now",
             callback     = function()
-                if self.book_id then
-                    self:_pushPosition()
-                    self:_syncAnnotations()
-                end
-                self:_flushPendingSessions()
-                local pending = #self.pending_sessions
-                local msg
-                if self.book_id then
-                    local pct = self:_getCurrentPercentage()
-                    msg = string.format("Synced: %.1f%%", pct * 100)
-                else
-                    msg = "Book not resolved (position not synced)"
-                end
-                if pending > 0 then
-                    msg = msg .. string.format("\\n%d session(s) still pending", pending)
-                end
-                UIManager:show(InfoMessage:new{{
-                    text = msg,
-                    timeout = 4,
-                }})
+                whenConnected(function()
+                    if self.book_id then
+                        self:_pushPosition()
+                        self:_syncAnnotations()
+                    end
+                    self:_flushPendingSessions()
+                    local pending = #self.pending_sessions
+                    local msg
+                    if self.book_id then
+                        local pct = self:_getCurrentPercentage()
+                        msg = string.format("Synced: %.1f%%", pct * 100)
+                    else
+                        msg = "Book not resolved (position not synced)"
+                    end
+                    if pending > 0 then
+                        msg = msg .. string.format("\\n%d session(s) still pending", pending)
+                    end
+                    UIManager:show(InfoMessage:new{{
+                        text = msg,
+                        timeout = 4,
+                    }})
+                end)
             end,
         }})
         table.insert(sub_items, {{
-            text = self.enabled and "Enabled (tap to disable)" or "Disabled (tap to enable)",
+            text = self.enabled and "Tracking: on (tap to pause)"
+                or "Tracking: paused (tap to resume)",
+            help_text = "Pauses all automatic tracking and syncing — sessions, "
+                        .. "position, highlights — until resumed. Resets to on "
+                        .. "when KOReader restarts.",
             callback = function()
                 self.enabled = not self.enabled
                 UIManager:show(InfoMessage:new{{
-                    text    = "TomeSync " .. (self.enabled and "enabled" or "disabled"),
-                    timeout = 2,
+                    text    = self.enabled and "TomeSync tracking resumed."
+                        or "Tracking paused for this session.\\nTurns back on at next KOReader start.",
+                    timeout = 3,
                 }})
             end,
         }})
         table.insert(sub_items, {{
+            separator = true,
             text_func = function()
                 local n = #self.pending_sessions
                 if n > 0 then
@@ -2402,6 +2450,21 @@ function TomeSync:_menuItems()
         }})
     end
 
+    table.insert(sub_items, {{
+        text           = "Settings",
+        sub_item_table = settings_items,
+    }})
+    table.insert(sub_items, {{
+        text     = "About",
+        callback = function()
+            UIManager:show(InfoMessage:new{{
+                text    = "TomeSync " .. SEMVER .. " (build " .. BUILD .. ")"
+                          .. "\\nSyncs with your Tome library.",
+                timeout = 4,
+            }})
+        end,
+    }})
+
     return sub_items
 end
 
@@ -2416,22 +2479,42 @@ end
 
 -- Show the full TomeSync menu as a standalone popup (used by the "Open menu"
 -- gesture). Reuses _menuItems() so it always matches the wrench-menu contents.
+-- The plain Menu widget has no checkboxes or nested tables (TouchMenu-only),
+-- so toggles get their state appended to the label and submenus open as
+-- another popup.
 function TomeSync:_openMenu()
-    local raw = self:_menuItems()
+    self:_showPopupMenu("TomeSync", self:_menuItems())
+end
+
+function TomeSync:_showPopupMenu(title, raw)
     local items = {{}}
     for _, it in ipairs(raw) do
-        local orig = it.callback
+        local orig      = it.callback
+        local sub       = it.sub_item_table
+        local text_func = it.text_func
+        if it.checked_func and not text_func then
+            local base, checked_func = it.text, it.checked_func
+            text_func = function()
+                return base .. (checked_func() and ": on" or ": off")
+            end
+        elseif sub and not text_func then
+            text_func = function() return it.text .. " \\u{{25B8}}" end
+        end
         table.insert(items, {{
             text      = it.text,
-            text_func = it.text_func,
+            text_func = text_func,
             callback  = function()
                 if self._gesture_menu then UIManager:close(self._gesture_menu) end
-                if orig then orig() end
+                if sub then
+                    self:_showPopupMenu(it.text, sub)
+                elseif orig then
+                    orig()
+                end
             end,
         }})
     end
     self._gesture_menu = Menu:new{{
-        title       = "TomeSync",
+        title       = title,
         item_table  = items,
         width       = Device.screen:getWidth() - 20,
         height      = Device.screen:getHeight() - 20,

--- a/docs/koreader-plugin.md
+++ b/docs/koreader-plugin.md
@@ -130,7 +130,7 @@ Sessions also flush when you tap "Sync now" in the menu, or when WiFi reconnects
 
 - Up to 50 sessions can be saved locally. If you go offline for an extremely long time, the oldest sessions are dropped to prevent unbounded storage use.
 - Sessions saved locally survive KOReader restarts -- they are stored in KOReader's settings file.
-- The backoff counter (3 failures before giving up) resets automatically on the next successful request. You can also reset it manually via **Test connection** in the plugin menu.
+- The backoff counter (3 failures before giving up) resets automatically on the next successful request. You can also reset it manually via **Settings → Test connection** in the plugin menu.
 
 ---
 
@@ -143,10 +143,7 @@ The plugin menu is context-aware. It self-registers in the **wrench menu** (afte
 | Option | Description |
 |---|---|
 | **Browse series** | Opens the series browser. Lists all series with book count and author. Tap to download. |
-| **Test connection** | Verifies the server is reachable. Also resets the backoff counter if the server was previously unreachable. |
-| **Re-resolve all books** | Wipes the local filename-to-book-ID cache. Use if a book matched incorrectly. |
-| **Check for updates** | Fetches the latest plugin build from your server and installs it if newer (then prompts to restart). |
-| **Auto-check on launch** | Opt-in toggle. When on, TomeSync checks for updates shortly after startup and prompts only when one is available. |
+| **Settings** | Submenu with persistent options and diagnostics (see below). |
 | **About** | Version info (semver + build). |
 
 ### Only when a book is open
@@ -156,8 +153,18 @@ The plugin menu is context-aware. It self-registers in the **wrench menu** (afte
 | **Download full series** | Downloads all books in the current book's series. |
 | **Download rest of series** | Downloads books after the current volume only. |
 | **Sync now** | Pushes current position, highlights/notes, and flushes any pending offline sessions. |
-| **Enabled / Disabled** | Toggle sync on or off. |
+| **Tracking: on / paused** | Pauses automatic session tracking and syncing for the current KOReader run. Resets to on at the next start — it is not a permanent setting. Manual actions (Sync now, downloads) still work while paused. |
 | **Pending sessions (N)** | Shows how many sessions are queued for sync. Tap for details. |
+
+### Settings submenu
+
+| Option | Description |
+|---|---|
+| **Auto-connect WiFi when needed** | Opt-in toggle, off by default. When a TomeSync action needs the server and WiFi is down, KOReader re-establishes the connection first (honouring your KOReader WiFi prompt/auto-enable setting), then runs the action. Helps devices that aggressively sleep WiFi, e.g. PocketBook. Only user-initiated actions reconnect — background tracking never turns the radio on. |
+| **Test connection** | Verifies the server is reachable. Also resets the backoff counter if the server was previously unreachable. |
+| **Re-resolve all books** | Wipes the local filename-to-book-ID cache. Use if a book matched incorrectly. |
+| **Check for updates** | Fetches the latest plugin build from your server and installs it if newer (then prompts to restart). |
+| **Auto-check for updates on launch** | Opt-in toggle. When on, TomeSync checks for updates shortly after startup and prompts only when one is available. |
 
 ### Gestures
 
@@ -204,7 +211,7 @@ The plugin authenticates with an API key (`Authorization: Bearer tk_...`), not y
 
 ## Updating the Plugin
 
-Once the plugin is installed, it updates itself — open the **TomeSync** menu and tap **Check for updates** (or enable **Auto-check on launch**). It downloads the latest build from your server, swaps it in atomically, and asks you to restart. Your server URL, API key, and reading history carry over automatically.
+Once the plugin is installed, it updates itself — open the **TomeSync** menu and tap **Settings → Check for updates** (or enable **Auto-check for updates on launch**). It downloads the latest build from your server, swaps it in atomically, and asks you to restart. Your server URL, API key, and reading history carry over automatically.
 
 The plugin version is shown on the Settings page next to "TomeSync Plugin" (`v<semver> (build N)`); the build integer is what drives update comparisons.
 

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -144,7 +144,7 @@ def test_zip_download_bakes_https_with_forwarded_proto(app_client):
 def test_build_bumped_for_rebake():
     # Must exceed every build already live (v1.2.0 shipped 10; main reached 12),
     # so all existing installs re-download and re-bake the corrected URL.
-    # 1.2.4 / build 17 fixes the book-open sync toast swallowing Profiles
-    # auto-exec actions (plus web-CFI goto + duplicate session init).
-    assert TOMESYNC_PLUGIN_BUILD >= 17
-    assert TOMESYNC_PLUGIN_SEMVER == "1.2.4"
+    # 1.3.0 / build 18 adds the opt-in "Auto-connect WiFi" reconnect behaviour
+    # (#38), the Settings submenu, and the clearer tracking pause toggle.
+    assert TOMESYNC_PLUGIN_BUILD >= 18
+    assert TOMESYNC_PLUGIN_SEMVER == "1.3.0"

--- a/tests/test_tomesync_selfupdate.py
+++ b/tests/test_tomesync_selfupdate.py
@@ -136,3 +136,51 @@ def test_shim_is_config_free_and_loads_impl():
     assert "tome_secret_key" in impl
     assert f"local BUILD           = {TOMESYNC_PLUGIN_BUILD}" in impl
     assert f'local SEMVER          = "{TOMESYNC_PLUGIN_SEMVER}"' in impl
+
+
+def test_impl_auto_connect_is_opt_in_and_wraps_interactive_paths():
+    """#38: the WiFi reconnect path is gated on the persisted opt-in setting,
+    and only interactive entry points route through it — background tracking
+    (page heartbeat, suspend/resume) must never wake the radio."""
+    impl = _main_impl_lua("https://tome.example", "tome_secret_key", "alice")
+    # runWhenConnected is called in exactly one place: the gated helper.
+    assert impl.count("NetworkMgr:runWhenConnected") == 1
+    assert 'G_reader_settings:isTrue("tomesync_auto_connect")' in impl
+    # Interactive entry points route through the gate.
+    assert "whenConnected(function() self:_browseSeriesMenuImpl() end)" in impl
+    assert "whenConnected(function() self:_inboxMenuImpl() end)" in impl
+    assert (
+        "whenConnected(function() self:_downloadCurrentBookSeriesImpl(rest_only) end)"
+        in impl
+    )
+
+
+def test_impl_menu_has_settings_submenu_and_renamed_tracking_toggle():
+    impl = _main_impl_lua("https://tome.example", "tome_secret_key", "alice")
+    # The ambiguous "Enabled" label is gone in favour of an explicit one.
+    assert "Enabled (tap to disable)" not in impl
+    assert "Tracking: on (tap to pause)" in impl
+    assert "Tracking: paused (tap to resume)" in impl
+    # Persistent settings live in a nested submenu.
+    assert "Auto-connect WiFi when needed" in impl
+    assert "sub_item_table = settings_items" in impl
+
+
+def test_impl_compiles_under_luajit(tmp_path):
+    """Guards the f-string brace escaping: a stray single brace renders broken
+    Lua that validateImpl would reject on-device."""
+    import shutil
+    import subprocess
+
+    luajit = shutil.which("luajit")
+    if luajit is None:
+        pytest.skip("luajit not installed")
+    impl = _main_impl_lua("https://tome.example", "tome_secret_key", "alice")
+    path = tmp_path / "main_impl.lua"
+    path.write_text(impl)
+    proc = subprocess.run(
+        [luajit, "-e", f"assert(loadfile({str(path)!r}))"],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr


### PR DESCRIPTION
Closes #38.

## WiFi auto-connect (opt-in)

Devices that aggressively sleep WiFi (notably PocketBook) left every TomeSync action failing with "offline" even though the radio was nominally on. A new **Settings → Auto-connect WiFi when needed** toggle (off by default) routes all interactive entry points — series browser, series downloads, Sync now, Test connection, update checks, the Inbox, and the highlight-sync gesture — through `NetworkMgr:runWhenConnected`, so KOReader re-establishes the connection first (honouring the user's KOReader WiFi prompt/auto-enable setting) and then runs the action.

Safety properties:
- **Toggle off (default): the code path is unchanged** — the gate runs the action directly and the existing `isConnected()` guards behave exactly as before. Existing users see zero behaviour change.
- **Background tracking never reconnects** in either state. Page heartbeats, suspend/resume session recording, and close-document pushes keep their silent `isConnected()` guards, so the plugin never wakes the radio or pops a WiFi prompt on its own. Sessions queue offline and flush later, as today.

This follows the shape proposed and tested by @BartoszCichecki in #38 (thanks!), rebased onto the current plugin and gated behind the toggle.

## Menu cleanup

- The ambiguous in-book **"Enabled (tap to disable)"** entry is now **"Tracking: on (tap to pause)"**, with help text and a toast clarifying that it pauses automatic tracking/sync for the current KOReader run and resets at the next start. Manual actions still work while paused.
- Persistent options and diagnostics (auto-connect, Test connection, Re-resolve all books, Check for updates, Auto-check on launch) moved into a **Settings** submenu — the in-book menu fits on one page again.
- The gesture-opened popup menu now opens submenus and shows toggle state; previously it silently dropped both.

Ships as **build 18 / semver 1.3.0** via the normal self-update path.

## Verification

- 486 backend tests pass; 3 new ones: the auto-connect gate is opt-in and wraps only interactive paths (`runWhenConnected` appears exactly once, in the gated helper), menu invariants (old label gone, submenu present), and the generated impl compiles under luajit (guards the f-string brace escaping).
- KOReader emulator round-trip against a live server: wrench menu + gesture popup rendering in and out of a book, tracking pause/resume, "up to date (build 18)" update check, and the gate exercised with the radio stubbed offline in both setting states — ON fires exactly one `runWhenConnected` then runs the action; OFF shows the legacy "WiFi not connected." with no reconnect attempt.

**Caveat:** the emulator cannot reproduce PocketBook's real radio-sleep behaviour, so confirmation on actual hardware (offered by the reporters in #38) is the last step after release.

