### PR TITLE
KOReader plugin: download location & naming templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,21 @@ All notable changes to Tome are documented here. Format loosely follows
   default: with the toggle off the plugin behaves exactly as before. Only
   user-initiated actions reconnect; background tracking never wakes the radio.
   (build 18 / 1.3.0, #38)
+- **KOReader plugin: choose where downloads go.** A new **Settings → Download
+  location & naming** option controls how the plugin files series downloads,
+  inbox deliveries — everything. Three choices: the default layout
+  (book-type/series folders, standalones under their author), **Flat in home
+  folder** (every book lands directly in the home folder as
+  "Series - NN - Title", so nothing nests), or a **custom template** built
+  from tokens — `{book_type}` `{series}` `{volume}` `{volume:00}` `{title}`
+  `{author}`, with `{Lower(...)}`/`{Upper(...)}` case modifiers and `/`
+  starting a new folder, Sonarr-style. Empty tokens drop out cleanly (one
+  template serves series books and standalones), every path segment is
+  sanitized so a template can never escape the library folder, and templates
+  are validated when saved with a preview of the resulting filename. The
+  setting is per-device and stored in KOReader. Already-downloaded books are
+  remembered by ID, so changing layout doesn't re-download your library.
+  (build 19 / 1.4.0)
 
 ### Changed
 - **KOReader plugin: clearer menu.** The ambiguous in-book "Enabled (tap to

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -40,8 +40,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 18
-TOMESYNC_PLUGIN_SEMVER = "1.3.0"
+TOMESYNC_PLUGIN_BUILD = 19
+TOMESYNC_PLUGIN_SEMVER = "1.4.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1051,6 +1051,7 @@ local rapidjson        = require("rapidjson")
 local lfs              = require("libs/libkoreader-lfs")
 local util             = require("util")
 local Menu             = require("ui/widget/menu")
+local InputDialog      = require("ui/widget/inputdialog")
 local Dispatcher       = require("dispatcher")
 local Event            = require("ui/event")
 
@@ -1214,6 +1215,97 @@ local function downloadFile(book_id, file_id, dest_path)
 
     return true
 end
+
+-- ── Download path templates ──────────────────────────────────────────────────
+
+-- mkdir -p: create every missing directory level of an absolute path.
+local function mkdirp(path)
+    local acc = path:sub(1, 1) == "/" and "/" or ""
+    for seg in path:gmatch("[^/]+") do
+        acc = acc .. seg
+        lfs.mkdir(acc)
+        acc = acc .. "/"
+    end
+end
+
+-- TOMESYNC_TEMPLATE_BEGIN (kept dependency-free except util — extracted and
+-- unit-tested standalone by the backend test suite)
+-- Render a download path template into a relative path (no extension).
+-- Tokens: {{book_type}} {{series}} {{title}} {{author}} {{volume}} {{volume:00}}
+-- plus {{Lower(token)}} / {{Upper(token)}}. "/" separates folders. Empty tokens
+-- are dropped along with orphaned ASCII separators around them, so one
+-- template works for series books and standalones alike. Every segment is
+-- sanitized, so a template can never escape the base directory. Returns nil
+-- when a token is unknown or the whole template renders to nothing usable —
+-- callers fall back to the built-in layout.
+local function renderDownloadPath(template, ctx)
+    local function fmtVolume(spec)
+        local vol = ctx.volume
+        if type(vol) ~= "number" then return "" end
+        if vol == math.floor(vol) then
+            local pad = spec and spec:match("^:(0+)$")
+            if pad then return string.format("%0" .. #pad .. "d", vol) end
+            return tostring(math.floor(vol))
+        end
+        return tostring(vol)
+    end
+    local function tokenValue(name)
+        local case
+        local inner = name:match("^Lower%((.+)%)$")
+        if inner then case, name = "lower", inner end
+        if not case then
+            inner = name:match("^Upper%((.+)%)$")
+            if inner then case, name = "upper", inner end
+        end
+        local val
+        if name == "volume" or name:match("^volume:") then
+            val = fmtVolume(name:match("^volume(:.*)$"))
+        elseif name == "book_type" then val = ctx.book_type or ""
+        elseif name == "series" then val = ctx.series or ""
+        elseif name == "title" then val = ctx.title or ""
+        elseif name == "author" then val = ctx.author or ""
+        else return nil end
+        if case == "lower" then val = val:lower()
+        elseif case == "upper" then val = val:upper() end
+        -- A "/" inside a value must not create folders (only template
+        -- slashes separate segments).
+        return (val:gsub("/", "-"))
+    end
+    local unknown = false
+    local rendered = template:gsub("%{{(.-)%}}", function(name)
+        local v = tokenValue(name)
+        if v == nil then unknown = true; return "" end
+        return v
+    end)
+    if unknown then return nil end
+    local segments = {{}}
+    for seg in rendered:gmatch("[^/]+") do
+        seg = seg:gsub("%s+", " ")
+        -- Collapse separator runs left behind by empty tokens ("a - - b"),
+        -- then strip orphaned separators at the ends. ASCII-only on purpose:
+        -- multibyte chars in Lua pattern classes match stray bytes.
+        local prev
+        repeat
+            prev = seg
+            seg = seg:gsub("([%-_,])%s*[%-_,]", "%1")
+        until seg == prev
+        seg = seg:gsub("^[%s%-_,.]+", ""):gsub("[%s%-_,.]+$", "")
+        seg = util.getSafeFilename(seg)
+        if seg ~= "" and seg ~= "." and seg ~= ".." then
+            table.insert(segments, seg)
+        end
+    end
+    if #segments == 0 then return nil end
+    return table.concat(segments, "/")
+end
+-- TOMESYNC_TEMPLATE_END
+
+-- Preset for "Flat in home folder": no folders, series + volume in the
+-- filename so flat layouts cannot collide across series. Separator-only
+-- between tokens (no glued literals like "Vol."), so empty tokens collapse
+-- cleanly for standalones. ASCII separators only (see the cleanup note in
+-- renderDownloadPath).
+local FLAT_TEMPLATE = "{{series}} - {{volume:00}} - {{title}}"
 
 -- ── Connectivity (issue #38) ─────────────────────────────────────────────────
 -- Interactive entry points route through this instead of hitting the network
@@ -1815,14 +1907,23 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
         return {{ downloaded = 0, skipped = 0, failed = #books }}
     end
 
-    -- Organize by book-type subfolder. A real series shares one folder; the No
-    -- Series bucket files each book under its author (resolved per book below).
-    local type_dir = base_dir .. "/" .. (book_type or "book")
-    lfs.mkdir(type_dir)
-    local series_dir
-    if not is_no_series then
-        series_dir = type_dir .. "/" .. util.getSafeFilename(series_name)
-        lfs.mkdir(series_dir)
+    -- A user template (Settings → Download location & naming) replaces the
+    -- built-in layout below; empty/unset means built-in.
+    local template = G_reader_settings:readSetting("tomesync_download_template") or ""
+
+    -- Built-in layout: organize by book-type subfolder. A real series shares
+    -- one folder; the No Series bucket files each book under its author
+    -- (resolved per book below). Dirs are created lazily so a template run
+    -- doesn't leave empty default folders behind.
+    local type_dir, series_dir
+    local function ensureDefaultDirs()
+        if type_dir then return end
+        type_dir = base_dir .. "/" .. (book_type or "book")
+        lfs.mkdir(type_dir)
+        if not is_no_series then
+            series_dir = type_dir .. "/" .. util.getSafeFilename(series_name)
+            lfs.mkdir(series_dir)
+        end
     end
 
     -- Build reverse lookup: book_id → local path (to skip already-downloaded books)
@@ -1845,27 +1946,47 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
                 table.insert(queue, {{book = book, file = nil, dest = nil}})
             else
                 local ext = file.format or "epub"
-                local display_title
-                if type(book.series_index) == "number" then
-                    local vol = book.series_index
-                    if vol == math.floor(vol) then vol = math.floor(vol) end
-                    display_title = "Vol. " .. tostring(vol) .. " — " .. book.title
-                else
-                    display_title = book.title
-                end
-                local fname = util.getSafeFilename(display_title .. "." .. ext)
-                -- Real series → shared series_dir. No Series → per-author folder,
-                -- falling back to the type dir when the book has no author.
-                local dest_dir = series_dir
-                if is_no_series then
-                    if type(book.author) == "string" and book.author ~= "" then
-                        dest_dir = type_dir .. "/" .. util.getSafeFilename(book.author)
-                        lfs.mkdir(dest_dir)
-                    else
-                        dest_dir = type_dir
+                local dest
+                if template ~= "" then
+                    local rel = renderDownloadPath(template, {{
+                        book_type = book_type or "book",
+                        series    = (not is_no_series) and series_name or "",
+                        volume    = type(book.series_index) == "number"
+                                    and book.series_index or nil,
+                        title     = book.title or "",
+                        author    = type(book.author) == "string" and book.author or "",
+                    }})
+                    if rel then
+                        dest = base_dir .. "/" .. rel .. "." .. ext
+                        mkdirp(dest:match("^(.*)/[^/]+$"))
                     end
                 end
-                local dest = dest_dir .. "/" .. fname
+                if not dest then
+                    -- Built-in layout (also the fallback when a template
+                    -- renders to nothing usable for this book).
+                    ensureDefaultDirs()
+                    local display_title
+                    if type(book.series_index) == "number" then
+                        local vol = book.series_index
+                        if vol == math.floor(vol) then vol = math.floor(vol) end
+                        display_title = "Vol. " .. tostring(vol) .. " — " .. book.title
+                    else
+                        display_title = book.title
+                    end
+                    local fname = util.getSafeFilename(display_title .. "." .. ext)
+                    -- Real series → shared series_dir. No Series → per-author folder,
+                    -- falling back to the type dir when the book has no author.
+                    local dest_dir = series_dir
+                    if is_no_series then
+                        if type(book.author) == "string" and book.author ~= "" then
+                            dest_dir = type_dir .. "/" .. util.getSafeFilename(book.author)
+                            lfs.mkdir(dest_dir)
+                        else
+                            dest_dir = type_dir
+                        end
+                    end
+                    dest = dest_dir .. "/" .. fname
+                end
                 if lfs.attributes(dest) then
                     skipped = skipped + 1
                 else
@@ -2266,6 +2387,64 @@ function TomeSync:_inboxMenuImpl()
     UIManager:show(self._inbox_menu)
 end
 
+-- Edit the custom download-path template in an input dialog. Validates by
+-- rendering a sample book before saving, so an unknown token is rejected here
+-- rather than silently falling back to the default layout per download.
+function TomeSync:_editDownloadTemplate()
+    local current = G_reader_settings:readSetting("tomesync_download_template") or ""
+    local dialog
+    dialog = InputDialog:new{{
+        title       = "Download path template",
+        input       = current ~= "" and current
+                      or "{{book_type}}/{{series}}/{{volume:00}} - {{title}}",
+        description = "Tokens: {{book_type}} {{series}} {{volume}} {{volume:00}} "
+                      .. "{{title}} {{author}} \\u{{2014}} wrap in {{Lower(...)}} or "
+                      .. "{{Upper(...)}} to force case.\\n"
+                      .. "\\"/\\" starts a new folder. The file extension is "
+                      .. "appended automatically.\\n"
+                      .. "Leave empty to restore the default layout.",
+        buttons     = {{{{
+            {{
+                text     = "Cancel",
+                id       = "close",
+                callback = function() UIManager:close(dialog) end,
+            }},
+            {{
+                text             = "Save",
+                is_enter_default = true,
+                callback         = function()
+                    local tpl = dialog:getInputText()
+                    if tpl == "" then
+                        G_reader_settings:delSetting("tomesync_download_template")
+                        UIManager:close(dialog)
+                        return
+                    end
+                    local sample = renderDownloadPath(tpl, {{
+                        book_type = "novels", series = "Sample Series",
+                        volume = 3, title = "Sample Title", author = "Sample Author",
+                    }})
+                    if not sample then
+                        UIManager:show(InfoMessage:new{{
+                            text = "Template is invalid (unknown token or "
+                                   .. "renders empty) \\u{{2014}} not saved.",
+                            timeout = 4,
+                        }})
+                        return
+                    end
+                    G_reader_settings:saveSetting("tomesync_download_template", tpl)
+                    UIManager:close(dialog)
+                    UIManager:show(InfoMessage:new{{
+                        text    = "Downloads will be saved as:\\n" .. sample .. ".epub",
+                        timeout = 5,
+                    }})
+                end,
+            }},
+        }}}},
+    }}
+    UIManager:show(dialog)
+    dialog:onShowKeyboard()
+end
+
 function TomeSync:_menuItems()
     local in_book = self.ui and self.ui.document
 
@@ -2283,6 +2462,53 @@ function TomeSync:_menuItems()
             G_reader_settings:saveSetting("tomesync_auto_connect",
                 not G_reader_settings:isTrue("tomesync_auto_connect"))
         end,
+    }})
+    local function currentTemplate()
+        return G_reader_settings:readSetting("tomesync_download_template") or ""
+    end
+    table.insert(settings_items, {{
+        text           = "Download location & naming",
+        separator      = true,
+        sub_item_table = {{
+            {{
+                text         = "Default (type and series folders)",
+                help_text    = "Downloads land under the home folder as "
+                               .. "book-type/series/Vol. N \\u{{2014}} Title; "
+                               .. "standalones go under their author instead "
+                               .. "of a series folder.",
+                checked_func = function() return currentTemplate() == "" end,
+                callback     = function()
+                    G_reader_settings:delSetting("tomesync_download_template")
+                end,
+            }},
+            {{
+                text         = "Flat in home folder",
+                help_text    = "Every download lands directly in the home "
+                               .. "folder, named \\"Series - NN - Title\\". "
+                               .. "Series and volume are dropped for books "
+                               .. "that have none.",
+                checked_func = function() return currentTemplate() == FLAT_TEMPLATE end,
+                callback     = function()
+                    G_reader_settings:saveSetting("tomesync_download_template", FLAT_TEMPLATE)
+                end,
+            }},
+            {{
+                text         = "Custom template",
+                help_text    = "Build the path from tokens: {{book_type}} "
+                               .. "{{series}} {{volume}} {{volume:00}} {{title}} "
+                               .. "{{author}}, wrapped in {{Lower(...)}} or "
+                               .. "{{Upper(...)}} to force case. \\"/\\" starts a "
+                               .. "new folder; the file extension is appended "
+                               .. "automatically.",
+                checked_func = function()
+                    local t = currentTemplate()
+                    return t ~= "" and t ~= FLAT_TEMPLATE
+                end,
+                callback     = function()
+                    self:_editDownloadTemplate()
+                end,
+            }},
+        }},
     }})
 
     local sub_items = {{}}

--- a/docs/koreader-plugin.md
+++ b/docs/koreader-plugin.md
@@ -106,26 +106,66 @@ The plugin can browse and download entire series directly to your device.
 
 ### Download location & naming
 
-By default downloads are filed as described above (`<book_type>/<Series Name>/Vol. N — Title.ext`, standalones under their author). **Settings → Download location & naming** changes this — per device, stored in KOReader:
+By default downloads are filed as described above (`<book_type>/<Series Name>/Vol. N — Title.ext`, standalones under their author). **Settings → Download location & naming** changes this. The setting applies to *every* way books reach the device — the series browser, the in-book series downloads, and the Send-to-KOReader inbox all share one downloader. It is per-device and stored in KOReader's own settings, so your phone can use a different layout than your e-reader, and it survives plugin updates.
 
-- **Default (type and series folders)** — the layout above.
-- **Flat in home folder** — every book lands directly in the home folder, named `Series - NN - Title.ext` (series and volume are dropped for books that have none). For people who keep everything unsorted in one place.
-- **Custom template** — build the path yourself from tokens, Sonarr/Radarr-style:
+Three options:
 
-| Token | Renders as |
+- **Default (type and series folders)** — the layout above. This is also what runs when no template is set, on exactly the same code path as before the setting existed.
+- **Flat in home folder** — every book lands directly in the home folder, named `Series - NN - Title.ext`. Series and volume are dropped for books that have none, so a standalone is just `Title.ext`. For people who keep everything unsorted in one place.
+- **Custom template** — build the path yourself, Sonarr/Radarr-style.
+
+#### Custom templates
+
+A template is a **free-form string**: tokens, literal text, and `/` folder separators in any combination. The dialog pre-fills a suggestion (`{book_type}/{series}/{volume:00} - {title}`) purely as a starting point — delete it and write anything. Tokens can repeat, literals can appear anywhere, folders can nest as deep as you like.
+
+**Token reference** (the complete set — anything else is rejected):
+
+| Token | Renders as | Empty when |
+|---|---|---|
+| `{book_type}` | Tome book-type slug (`manga`, `light_novel`, `novel`, ...) | never (falls back to `book`) |
+| `{series}` | series name | book has no series |
+| `{volume}` | series index as-is (`3`, `12`, `1.5`) | book has no series index |
+| `{volume:00}` | zero-padded series index (`03`); pad width = number of zeros, so `{volume:000}` gives `003`. Fractional volumes (`1.5`) are never padded. | book has no series index |
+| `{title}` | book title | never |
+| `{author}` | author name | author unknown |
+
+**Case modifiers:** wrap a token *name* in `Lower(...)` or `Upper(...)` — `{Lower(series)}`, `{Upper(book_type)}`. No inner braces: `{Lower({series})}` is not valid syntax.
+
+**Rules:**
+
+- `/` starts a new folder. Everything between slashes becomes one folder (or, for the last part, the filename).
+- The file extension (`.epub`, `.cbz`, ...) is **appended automatically** — never write it in the template.
+- Anything that isn't a token is literal text and is kept verbatim.
+
+**Examples** (Berserk vol. 3, "The Egg of the King", Kentaro Miura, type `manga`):
+
+| Template | Result |
 |---|---|
-| `{book_type}` | Tome book-type slug (`manga`, `light_novel`, ...) |
-| `{series}` | series name, empty for standalones |
-| `{volume}` | series index (`3`, `1.5`) |
-| `{volume:00}` | zero-padded series index (`03`); pad width = number of zeros |
-| `{title}` | book title |
-| `{author}` | author, empty when unknown |
+| `{title}` | `The Egg of the King.epub` |
+| `{series} - {volume:00} - {title}` | `Berserk - 03 - The Egg of the King.epub` (this is the flat preset) |
+| `Tome/{series}/{title}` | `Tome/Berserk/The Egg of the King.epub` — literal folder name |
+| `{author}/{series} {volume:000} {title}` | `Kentaro Miura/Berserk 003 The Egg of the King.epub` |
+| `{Upper(series)}/vol{volume} - {Lower(title)}` | `BERSERK/vol3 - the egg of the king.epub` |
+| `{book_type}/{series}/{series} v{volume}` | `manga/Berserk/Berserk v3.epub` — tokens may repeat |
 
-  Wrap a token name in `{Lower(...)}` or `{Upper(...)}` to force case — `{Lower(series)}`, no inner braces. `/` starts a new folder; the file extension is appended automatically. Example: `{book_type}/{Lower(series)}/{volume:00} - {title}` → `manga/berserk/03 - The Egg of the King.epub`.
+**Books without a series (or volume, or author):** empty tokens disappear, *together with orphaned separators around them* — spaces, `-`, `_` and `,` left dangling by a vanished token are tidied up, and a folder segment that renders entirely empty is dropped. So one template serves series books and standalones:
 
-  Empty tokens drop out together with the separators around them, so one template works for series books and standalones alike. Every path segment is sanitized — a template can never place files outside the base folder. Templates are validated when saved, with a preview of the resulting filename.
+| Template | Series book | Standalone |
+|---|---|---|
+| `{series} - {volume:00} - {title}` | `Berserk - 03 - The Egg of the King.epub` | `Frankenstein.epub` |
+| `{book_type}/{series}/{volume:00} - {title}` | `manga/Berserk/03 - The Egg of the King.epub` | `novel/Frankenstein.epub` (series folder dropped) |
 
-Changing the setting only affects *future* downloads: books already on the device are remembered by book ID and stay skipped, and previously downloaded files are not moved.
+One caveat: the cleanup removes orphaned *separators*, not orphaned *words*. A literal glued to a token — `Vol. {volume}` — leaves `Vol` behind when the book has no volume (`Vol - Title.epub`). If your library mixes series books and standalones, keep bare separators around tokens that can be empty (`{volume:00} - {title}`), the way both presets do. There is no conditional syntax ("include this text only when the token exists") — if you need that, open an issue.
+
+**Validation and safety:**
+
+- Templates are validated when you tap **Save**: an unknown token (or a template that renders to nothing) is rejected on the spot with an error, and a valid template shows a preview of the resulting filename. A typo can't silently misfile your downloads.
+- Every path segment is sanitized for the filesystem, and `..` segments are discarded — a template can never place files outside the download base folder.
+- A `/` *inside* a metadata value (a title like `Fate/Zero`) becomes `-`; only slashes you write in the template create folders.
+- If a saved template somehow renders empty for a particular book (e.g. it only uses `{series}` and the book has none), that book falls back to the default layout rather than failing.
+- Leave the dialog's input empty and save to clear the template and restore the default layout.
+
+**Changing the setting later** only affects *future* downloads: books already on the device are remembered by book ID and stay skipped regardless of where they live, and previously downloaded files are not moved.
 
 ---
 

--- a/docs/koreader-plugin.md
+++ b/docs/koreader-plugin.md
@@ -104,6 +104,29 @@ The plugin can browse and download entire series directly to your device.
 - Downloaded books are automatically registered in the book map, so sync works immediately when you open them
 - A summary shows downloaded/skipped/failed counts when finished
 
+### Download location & naming
+
+By default downloads are filed as described above (`<book_type>/<Series Name>/Vol. N — Title.ext`, standalones under their author). **Settings → Download location & naming** changes this — per device, stored in KOReader:
+
+- **Default (type and series folders)** — the layout above.
+- **Flat in home folder** — every book lands directly in the home folder, named `Series - NN - Title.ext` (series and volume are dropped for books that have none). For people who keep everything unsorted in one place.
+- **Custom template** — build the path yourself from tokens, Sonarr/Radarr-style:
+
+| Token | Renders as |
+|---|---|
+| `{book_type}` | Tome book-type slug (`manga`, `light_novel`, ...) |
+| `{series}` | series name, empty for standalones |
+| `{volume}` | series index (`3`, `1.5`) |
+| `{volume:00}` | zero-padded series index (`03`); pad width = number of zeros |
+| `{title}` | book title |
+| `{author}` | author, empty when unknown |
+
+  Wrap a token name in `{Lower(...)}` or `{Upper(...)}` to force case — `{Lower(series)}`, no inner braces. `/` starts a new folder; the file extension is appended automatically. Example: `{book_type}/{Lower(series)}/{volume:00} - {title}` → `manga/berserk/03 - The Egg of the King.epub`.
+
+  Empty tokens drop out together with the separators around them, so one template works for series books and standalones alike. Every path segment is sanitized — a template can never place files outside the base folder. Templates are validated when saved, with a preview of the resulting filename.
+
+Changing the setting only affects *future* downloads: books already on the device are remembered by book ID and stay skipped, and previously downloaded files are not moved.
+
 ---
 
 ## Offline and Unreachable Server
@@ -161,6 +184,7 @@ The plugin menu is context-aware. It self-registers in the **wrench menu** (afte
 | Option | Description |
 |---|---|
 | **Auto-connect WiFi when needed** | Opt-in toggle, off by default. When a TomeSync action needs the server and WiFi is down, KOReader re-establishes the connection first (honouring your KOReader WiFi prompt/auto-enable setting), then runs the action. Helps devices that aggressively sleep WiFi, e.g. PocketBook. Only user-initiated actions reconnect — background tracking never turns the radio on. |
+| **Download location & naming** | Where downloads (series, inbox) are filed: the default type/series layout, flat in the home folder, or a custom token template. Per-device. See [Download location & naming](#download-location--naming). |
 | **Test connection** | Verifies the server is reachable. Also resets the backoff counter if the server was previously unreachable. |
 | **Re-resolve all books** | Wipes the local filename-to-book-ID cache. Use if a book matched incorrectly. |
 | **Check for updates** | Fetches the latest plugin build from your server and installs it if newer (then prompts to restart). |

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -144,7 +144,7 @@ def test_zip_download_bakes_https_with_forwarded_proto(app_client):
 def test_build_bumped_for_rebake():
     # Must exceed every build already live (v1.2.0 shipped 10; main reached 12),
     # so all existing installs re-download and re-bake the corrected URL.
-    # 1.3.0 / build 18 adds the opt-in "Auto-connect WiFi" reconnect behaviour
-    # (#38), the Settings submenu, and the clearer tracking pause toggle.
-    assert TOMESYNC_PLUGIN_BUILD >= 18
-    assert TOMESYNC_PLUGIN_SEMVER == "1.3.0"
+    # 1.4.0 / build 19 adds the download location & naming templates (presets
+    # + custom token template) on top of 18's auto-connect and Settings menu.
+    assert TOMESYNC_PLUGIN_BUILD >= 19
+    assert TOMESYNC_PLUGIN_SEMVER == "1.4.0"

--- a/tests/test_tomesync_selfupdate.py
+++ b/tests/test_tomesync_selfupdate.py
@@ -166,6 +166,90 @@ def test_impl_menu_has_settings_submenu_and_renamed_tracking_toggle():
     assert "sub_item_table = settings_items" in impl
 
 
+def _luajit_or_skip():
+    import shutil
+
+    luajit = shutil.which("luajit")
+    if luajit is None:
+        pytest.skip("luajit not installed")
+    return luajit
+
+
+def test_download_template_renderer_behaviour(tmp_path):
+    """Extracts the marked renderDownloadPath block from the generated impl
+    and exercises it standalone — token rendering, padding, case modifiers,
+    empty-token cleanup, and path-safety guarantees."""
+    import subprocess
+
+    luajit = _luajit_or_skip()
+    impl = _main_impl_lua("https://tome.example", "tome_secret_key", "alice")
+    start = impl.index("-- TOMESYNC_TEMPLATE_BEGIN")
+    end = impl.index("-- TOMESYNC_TEMPLATE_END")
+    block = impl[start:end]
+
+    script = """
+local util = { getSafeFilename = function(s)
+    return (s:gsub('[\\\\:%*%?"<>|]', '_'))
+end }
+""" + block + """
+local function eq(got, want, label)
+    if got ~= want then
+        io.stderr:write(string.format("FAIL %s: got %q want %q\\n",
+            label, tostring(got), tostring(want)))
+        os.exit(1)
+    end
+end
+local series = { book_type = "manga", series = "Berserk", volume = 3,
+                 title = "The Egg of the King", author = "Kentaro Miura" }
+local standalone = { book_type = "novels", series = "", volume = nil,
+                     title = "Standalone", author = "Some Author" }
+
+-- flat preset: collision-safe for series, clean for standalones
+local FLAT = "{series} - {volume:00} - {title}"
+eq(renderDownloadPath(FLAT, series), "Berserk - 03 - The Egg of the King", "flat series")
+eq(renderDownloadPath(FLAT, standalone), "Standalone", "flat standalone")
+
+-- folders, zero-pad, fractional volumes
+eq(renderDownloadPath("{book_type}/{series}/{volume:00} - {title}", series),
+   "manga/Berserk/03 - The Egg of the King", "nested")
+eq(renderDownloadPath("{book_type}/{series}/{volume:00} - {title}", standalone),
+   "novels/Standalone", "nested standalone drops empty segment")
+eq(renderDownloadPath("{volume}", { volume = 1.5, title = "t" }), "1.5", "fractional volume")
+
+-- case modifiers
+eq(renderDownloadPath("{Lower(series)}/{title}", series),
+   "berserk/The Egg of the King", "Lower")
+eq(renderDownloadPath("{Upper(book_type)}/{title}", series),
+   "MANGA/The Egg of the King", "Upper")
+
+-- safety: unknown token rejects, traversal and slashes cannot escape
+eq(renderDownloadPath("{nope}/{title}", series), nil, "unknown token")
+eq(renderDownloadPath("../{title}", series), "The Egg of the King", "dotdot dropped")
+eq(renderDownloadPath("{series}/../../{title}", series),
+   "Berserk/The Egg of the King", "dotdot segments dropped")
+eq(renderDownloadPath("{title}", { title = "A/B" }), "A-B", "slash in value")
+eq(renderDownloadPath("{series}", standalone), nil, "renders empty -> nil")
+print("ALL OK")
+"""
+    path = tmp_path / "template_spec.lua"
+    path.write_text(script)
+    proc = subprocess.run([luajit, str(path)], capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    assert "ALL OK" in proc.stdout
+
+
+def test_impl_download_template_invariants():
+    impl = _main_impl_lua("https://tome.example", "tome_secret_key", "alice")
+    # Setting key, menu entry, presets and dialog are all present.
+    assert "tomesync_download_template" in impl
+    assert "Download location & naming" in impl
+    assert "Flat in home folder" in impl
+    assert 'local FLAT_TEMPLATE = "{series} - {volume:00} - {title}"' in impl
+    # Unset template must keep the built-in layout code path.
+    assert "ensureDefaultDirs" in impl
+    assert 'display_title = "Vol. " .. tostring(vol)' in impl
+
+
 def test_impl_compiles_under_luajit(tmp_path):
     """Guards the f-string brace escaping: a stray single brace renders broken
     Lua that validateImpl would reject on-device."""


### PR DESCRIPTION
Successor to #48 (closed by the base-branch deletion when #47 merged). Builds on the Settings submenu from #47, now in main.

## What

Each device can now choose where TomeSync files its downloads. **Settings → Download location & naming**, applying to every download path (series browser, in-book series downloads, Send-to-KOReader inbox — one shared downloader):

- **Default (type and series folders)** — when no template is set, the *exact* pre-existing code path runs. Zero change for everyone who doesn't touch the setting.
- **Flat in home folder** — everything lands at the home folder root as `Series - NN - Title.ext`; series + volume in the filename so flat layouts can't collide across series, and both drop out cleanly for standalones. (Requested by a Send-to-KOReader user on Discord who keeps all epubs unsorted in Home.)
- **Custom template** — free-form, Sonarr-style: `{book_type} {series} {volume} {volume:00} {title} {author}`, `{Lower(...)}`/`{Upper(...)}` case modifiers, `/` creates folders, literals anywhere, extension auto-appended. (Requested by u/imscrewed153 in the r/koreader launch thread.)

The setting is per-device, stored in `G_reader_settings`. **No web UI, API, or DB changes** — the only touched backend file is `tome_sync.py` because it generates the plugin Lua.

## Renderer guarantees

- Empty tokens drop out together with orphaned separators, so one template serves series books and standalones (documented caveat: separators are tidied, glued literal *words* are not — the presets and docs model the safe style).
- Unknown tokens reject the template — at save time in the dialog (with a filename preview on success), and at render time by falling back to the built-in layout per book.
- Path safety: every segment sanitized, `..` segments discarded, `/` inside metadata values becomes `-`. A template can never escape the download base folder.
- Built-in dirs are now created lazily, so template runs and all-skipped runs no longer leave empty default folders.
- Already-downloaded books are skipped by book ID, so changing layout never re-downloads a library.

Ships as **build 19 / semver 1.4.0** via self-update. Full user documentation in `docs/koreader-plugin.md` (token reference, examples, caveats).

## Verification

- 488 backend tests pass. The renderer sits between `TOMESYNC_TEMPLATE_BEGIN/END` markers and is extracted + spec-tested standalone under luajit: 12 behavioral cases covering padding (`{volume:00}`/`{volume:000}`), fractional volumes, case modifiers, empty-token cleanup, unknown-token rejection, `..` traversal, and slash-in-value handling. Plus impl-compiles-under-luajit and menu/setting invariants.
- Emulator round-trip against a live server: flat preset downloaded a real book to the home folder root (no stray type folder created); switching back to default skipped the same book by ID without re-downloading; clearing the mapping re-downloaded into the correct `type/Author/` default path; preset radio menu and template dialog render in both the wrench menu and the gesture popup.
- Template dialog Save driven live in the emulator (via the dialog's button callbacks, the same functions a tap invokes): an unknown-token template is rejected with the error toast and the setting stays unchanged (dialog stays open for correction); a valid template saves, closes the dialog, and shows the filename preview; reopening prefills the saved template; saving empty clears back to the default layout.

