### PR TITLE
feat(stats): reading goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Reading goals.** Set yourself a target — books per year or month, minutes
+  or pages per day or week — and watch a progress ring fill as you read. Goals
+  live on the stats dashboard in a new **Reading Goals** tile — one card per
+  goal, all managed in place (add, edit and delete each goal right on its
+  card; preset chips like the classic 12/24/52-books year challenge get you
+  started) — and compact read-only rings appear on the Home tab. A goal can
+  be scoped to a single book type, so "20 books this year" and "20 manga this
+  year" count separately — no padding the year challenge with
+  one-sitting volumes. Progress is computed from reading you already track
+  (sessions from KOReader and the web reader, finished books), year and month
+  goals show whether you're ahead of or behind pace, and reaching one drops a
+  notification in the bell. Goals are per-user; nothing is shared.
 - **Group by series in the library view.** A new toggle in the All Books
   toolbar collapses each series into a single stacked card — first volume's
   cover, a volume-count badge, and a subtle stacked-paper look — so one long

--- a/backend/api/goals.py
+++ b/backend/api/goals.py
@@ -1,0 +1,463 @@
+"""Reading goals API — generalized metric × period model.
+
+Supported kinds (ALLOWED_KINDS):
+  books_per_year, books_per_month,
+  minutes_per_day, minutes_per_week,
+  pages_per_day, pages_per_week
+
+Each kind is parsed as {metric}_per_{period}:
+  metric ∈ books | minutes | pages
+  period ∈ day | week | month | year
+
+A goal may be scoped to a book type (book_type_id) so "20 books this year"
+and "20 manga this year" coexist as separate goals. Uniqueness per
+(user, kind, book_type_id) is enforced here, not in the DB (NULL semantics).
+
+Window semantics: day/month/year are local calendar windows; week is the
+last 7 local days inclusive of today (matches the stats heatmap/streak
+windows). goal_reached notifications are created lazily when progress is
+read, and only for month/year goals — day/week windows roll too often and
+would flood the bell.
+"""
+from datetime import datetime, timedelta
+from typing import Literal, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, field_validator
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from backend.core.database import get_db
+from backend.core.security import get_current_user
+from backend.models.book import Book
+from backend.models.library import BookType
+from backend.models.notification import Notification
+from backend.models.reading_goal import ReadingGoal
+from backend.models.tome_sync import ReadingSession
+from backend.models.user import User
+from backend.models.user_book_status import UserBookStatus
+
+router = APIRouter(tags=["goals"])
+
+ALLOWED_KINDS: set[str] = {
+    "books_per_year",
+    "books_per_month",
+    "minutes_per_day",
+    "minutes_per_week",
+    "pages_per_day",
+    "pages_per_week",
+}
+
+Metric = Literal["books", "minutes", "pages"]
+Period = Literal["day", "week", "month", "year"]
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+
+class GoalCreate(BaseModel):
+    kind: str
+    target: int
+    book_type_id: Optional[int] = None
+
+    @field_validator("target")
+    @classmethod
+    def target_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("target must be greater than 0")
+        return v
+
+    @field_validator("kind")
+    @classmethod
+    def kind_allowed(cls, v: str) -> str:
+        if v not in ALLOWED_KINDS:
+            raise ValueError(f"Invalid goal kind {v!r}. Allowed: {sorted(ALLOWED_KINDS)}")
+        return v
+
+
+class GoalUpdate(BaseModel):
+    target: int
+
+    @field_validator("target")
+    @classmethod
+    def target_positive(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError("target must be greater than 0")
+        return v
+
+
+# ── Kind parser ───────────────────────────────────────────────────────────────
+
+def _parse_kind(kind: str) -> tuple[Metric, Period]:
+    """Parse 'metric_per_period' into (metric, period). Raises ValueError on malformed kind."""
+    parts = kind.split("_per_", 1)
+    if len(parts) != 2:
+        raise ValueError(f"Cannot parse goal kind: {kind!r}")
+    metric, period = parts[0], parts[1]
+    if metric not in ("books", "minutes", "pages"):
+        raise ValueError(f"Unknown metric: {metric!r}")
+    if period not in ("day", "week", "month", "year"):
+        raise ValueError(f"Unknown period: {period!r}")
+    return metric, period  # type: ignore[return-value]
+
+
+# ── Window helpers ────────────────────────────────────────────────────────────
+
+def _local_now(tz_offset: int) -> datetime:
+    """Current local time. tz_offset is JS getTimezoneOffset (positive = west of UTC)."""
+    return datetime.utcnow() + timedelta(minutes=-tz_offset)
+
+
+def _tz_modifier(tz_offset: int) -> str:
+    """Convert JS getTimezoneOffset (positive=west) to SQLite datetime modifier."""
+    offset_hours = -(tz_offset // 60)
+    return f"{offset_hours:+d} hours"
+
+
+def _window_bounds(period: Period, tz_offset: int) -> tuple[datetime, datetime]:
+    """Return (start, end) of the current local period window, both as UTC datetimes."""
+    local_offset = timedelta(minutes=-tz_offset)
+    now_local = _local_now(tz_offset)
+    today_local = datetime(now_local.year, now_local.month, now_local.day)
+
+    if period == "day":
+        start_local = today_local
+        end_local = start_local + timedelta(days=1)
+    elif period == "week":
+        # last 7 local days inclusive of today — match existing days_hit_this_week window
+        start_local = today_local - timedelta(days=6)
+        end_local = today_local + timedelta(days=1)
+    elif period == "month":
+        start_local = datetime(now_local.year, now_local.month, 1)
+        end_local = (
+            datetime(now_local.year + 1, 1, 1)
+            if now_local.month == 12
+            else datetime(now_local.year, now_local.month + 1, 1)
+        )
+    else:  # year
+        start_local = datetime(now_local.year, 1, 1)
+        end_local = datetime(now_local.year + 1, 1, 1)
+
+    return start_local - local_offset, end_local - local_offset
+
+
+def _window_start(period: Period, tz_offset: int) -> datetime:
+    return _window_bounds(period, tz_offset)[0]
+
+
+def _expected_now(period: Period, target: int, tz_offset: int) -> Optional[float]:
+    """Target prorated to the elapsed fraction of the window — the "on pace" line.
+
+    Only meaningful for calendar windows that fill up over time (month/year);
+    day is too short to pace and week is a rolling window (always "full").
+    """
+    if period not in ("month", "year"):
+        return None
+    start, end = _window_bounds(period, tz_offset)
+    elapsed = (datetime.utcnow() - start).total_seconds()
+    total = (end - start).total_seconds()
+    return round(target * max(0.0, min(elapsed / total, 1.0)), 1)
+
+
+# ── Progress helpers ──────────────────────────────────────────────────────────
+
+def _compute_books_current(
+    db: Session, user_id: int, period: Period, tz_offset: int, book_type_id: Optional[int]
+) -> int:
+    """Count UserBookStatus rows with status='read' and updated_at in the current period window."""
+    start = _window_start(period, tz_offset)
+    q = db.query(UserBookStatus).filter(
+        UserBookStatus.user_id == user_id,
+        UserBookStatus.status == "read",
+        UserBookStatus.updated_at >= start,
+    )
+    if book_type_id is not None:
+        q = q.join(Book, Book.id == UserBookStatus.book_id).filter(
+            Book.book_type_id == book_type_id
+        )
+    return q.count()
+
+
+def _session_sum(
+    db: Session,
+    user_id: int,
+    column,
+    period: Period,
+    tz_offset: int,
+    book_type_id: Optional[int],
+) -> int:
+    """Sum a ReadingSession column over the current period window."""
+    start = _window_start(period, tz_offset)
+    q = db.query(func.coalesce(func.sum(column), 0)).filter(
+        ReadingSession.user_id == user_id,
+        ReadingSession.started_at >= start,
+    )
+    if book_type_id is not None:
+        q = q.join(Book, Book.id == ReadingSession.book_id).filter(
+            Book.book_type_id == book_type_id
+        )
+    return int(q.scalar() or 0)
+
+
+def _compute_current(
+    db: Session, user_id: int, metric: Metric, period: Period, tz_offset: int,
+    book_type_id: Optional[int],
+) -> float:
+    if metric == "books":
+        return _compute_books_current(db, user_id, period, tz_offset, book_type_id)
+    if metric == "minutes":
+        seconds = _session_sum(
+            db, user_id, ReadingSession.duration_seconds, period, tz_offset, book_type_id
+        )
+        return round(seconds / 60, 1)
+    return _session_sum(
+        db, user_id, ReadingSession.pages_turned, period, tz_offset, book_type_id
+    )
+
+
+def _compute_days_hit(
+    db: Session,
+    user_id: int,
+    metric: Metric,
+    target: int,
+    tz_offset: int,
+    book_type_id: Optional[int],
+) -> int:
+    """
+    For daily goals: count days in the last 7 local days (including today)
+    where the user's total for the metric >= target.
+    """
+    modifier = _tz_modifier(tz_offset)
+    week_cutoff = datetime.utcnow() - timedelta(days=7)
+
+    if metric == "books":
+        q = db.query(
+            func.date(UserBookStatus.updated_at, modifier).label("day"),
+            func.count(UserBookStatus.id).label("total"),
+        ).filter(
+            UserBookStatus.user_id == user_id,
+            UserBookStatus.status == "read",
+            UserBookStatus.updated_at >= week_cutoff,
+        )
+        if book_type_id is not None:
+            q = q.join(Book, Book.id == UserBookStatus.book_id).filter(
+                Book.book_type_id == book_type_id
+            )
+        daily_rows = q.group_by(func.date(UserBookStatus.updated_at, modifier)).all()
+        daily_map = {row.day: int(row.total) for row in daily_rows}
+    else:
+        column = (
+            ReadingSession.duration_seconds
+            if metric == "minutes"
+            else ReadingSession.pages_turned
+        )
+        q = db.query(
+            func.date(ReadingSession.started_at, modifier).label("day"),
+            func.coalesce(func.sum(column), 0).label("total"),
+        ).filter(
+            ReadingSession.user_id == user_id,
+            ReadingSession.started_at >= week_cutoff,
+        )
+        if book_type_id is not None:
+            q = q.join(Book, Book.id == ReadingSession.book_id).filter(
+                Book.book_type_id == book_type_id
+            )
+        daily_rows = q.group_by(func.date(ReadingSession.started_at, modifier)).all()
+        if metric == "minutes":
+            daily_map = {row.day: int(row.total) // 60 for row in daily_rows}
+        else:
+            daily_map = {row.day: int(row.total) for row in daily_rows}
+
+    return sum(1 for v in daily_map.values() if v >= target)
+
+
+# ── Notification ──────────────────────────────────────────────────────────────
+
+def _goal_phrase(metric: Metric, period: Period, target: int, type_label: Optional[str], tz_offset: int) -> str:
+    """Human phrase for a goal, e.g. '20 books in 2026' or '300 minutes this week (Manga)'."""
+    noun = {"books": "books" if target != 1 else "book", "minutes": "minutes", "pages": "pages"}[metric]
+    when = {
+        "day": "today",
+        "week": "this week",
+        "month": "this month",
+        "year": f"in {_local_now(tz_offset).year}",
+    }[period]
+    phrase = f"{target} {noun} {when}"
+    if type_label:
+        phrase += f" ({type_label})"
+    return phrase
+
+
+def _maybe_notify_reached(
+    db: Session,
+    goal: ReadingGoal,
+    metric: Metric,
+    period: Period,
+    current: float,
+    type_label: Optional[str],
+    tz_offset: int,
+) -> bool:
+    """Create a goal_reached notification once per month/year window. Returns True if created."""
+    if period not in ("month", "year") or current < goal.target:
+        return False
+    window_start = _window_start(period, tz_offset)
+    if goal.notified_window_start == window_start:
+        return False
+    db.add(
+        Notification(
+            user_id=goal.user_id,
+            kind="goal_reached",
+            title="Reading goal reached",
+            body=f"You hit your goal of {_goal_phrase(metric, period, goal.target, type_label, tz_offset)}.",
+            link="/stats",
+        )
+    )
+    goal.notified_window_start = window_start
+    return True
+
+
+# ── Response builder ──────────────────────────────────────────────────────────
+
+def _build_goal_response(db: Session, goal: ReadingGoal, tz_offset: int) -> dict:
+    metric, period = _parse_kind(goal.kind)
+
+    type_label: Optional[str] = None
+    if goal.book_type_id is not None:
+        bt = db.query(BookType).filter(BookType.id == goal.book_type_id).first()
+        type_label = bt.label if bt else None
+
+    current = _compute_current(db, goal.user_id, metric, period, tz_offset, goal.book_type_id)
+    pct = round(current / goal.target * 100, 1) if goal.target > 0 else 0.0
+
+    result: dict = {
+        "id": goal.id,
+        "kind": goal.kind,
+        "metric": metric,
+        "period": period,
+        "target": goal.target,
+        "book_type_id": goal.book_type_id,
+        "book_type_label": type_label,
+        "current": current,
+        "pct": pct,
+        "expected": _expected_now(period, goal.target, tz_offset),
+    }
+
+    if period == "day":
+        result["days_hit_this_week"] = _compute_days_hit(
+            db, goal.user_id, metric, goal.target, tz_offset, goal.book_type_id
+        )
+    if period == "year":
+        result["year"] = _local_now(tz_offset).year
+
+    _maybe_notify_reached(db, goal, metric, period, current, type_label, tz_offset)
+    return result
+
+
+def _user_goals(db: Session, user_id: int) -> list[ReadingGoal]:
+    return (
+        db.query(ReadingGoal)
+        .filter(ReadingGoal.user_id == user_id)
+        .order_by(ReadingGoal.created_at, ReadingGoal.id)
+        .all()
+    )
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.get("/goals")
+def list_goals(
+    tz_offset: int = Query(0, description="JS getTimezoneOffset() in minutes"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Return all goals for the current user with computed progress.
+
+    Also lazily creates goal_reached notifications — this endpoint is hit from
+    the Home tab and the stats dashboard, so it's the natural evaluation point.
+    """
+    goals = _user_goals(db, current_user.id)
+    payload = [_build_goal_response(db, g, tz_offset) for g in goals]
+    db.commit()  # persist any notifications / notified_window_start updates
+    return {"goals": payload}
+
+
+@router.post("/goals", status_code=201)
+def create_goal(
+    body: GoalCreate,
+    tz_offset: int = Query(0),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Create a goal. 409 if the same (kind, book type) goal already exists."""
+    if body.book_type_id is not None:
+        bt = db.query(BookType).filter(BookType.id == body.book_type_id).first()
+        if bt is None:
+            raise HTTPException(status_code=422, detail="Unknown book type")
+
+    existing = (
+        db.query(ReadingGoal)
+        .filter(
+            ReadingGoal.user_id == current_user.id,
+            ReadingGoal.kind == body.kind,
+            ReadingGoal.book_type_id == body.book_type_id,
+        )
+        .first()
+    )
+    if existing is not None:
+        raise HTTPException(status_code=409, detail="This goal already exists — edit it instead")
+
+    goal = ReadingGoal(
+        user_id=current_user.id,
+        kind=body.kind,
+        target=body.target,
+        book_type_id=body.book_type_id,
+    )
+    db.add(goal)
+    db.flush()
+    payload = _build_goal_response(db, goal, tz_offset)
+    db.commit()
+    return payload
+
+
+@router.put("/goals/{goal_id}")
+def update_goal(
+    goal_id: int,
+    body: GoalUpdate,
+    tz_offset: int = Query(0),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Update a goal's target. Clears the notified marker so a raised target can re-notify."""
+    goal = (
+        db.query(ReadingGoal)
+        .filter(ReadingGoal.id == goal_id, ReadingGoal.user_id == current_user.id)
+        .first()
+    )
+    if goal is None:
+        raise HTTPException(status_code=404, detail="Goal not found")
+
+    if body.target != goal.target:
+        goal.target = body.target
+        goal.notified_window_start = None
+        goal.updated_at = datetime.utcnow()
+
+    payload = _build_goal_response(db, goal, tz_offset)
+    db.commit()
+    return payload
+
+
+@router.delete("/goals/{goal_id}", status_code=204)
+def delete_goal(
+    goal_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    """Remove a goal. 404 if it doesn't exist or belongs to someone else."""
+    goal = (
+        db.query(ReadingGoal)
+        .filter(ReadingGoal.id == goal_id, ReadingGoal.user_id == current_user.id)
+        .first()
+    )
+    if goal is None:
+        raise HTTPException(status_code=404, detail="Goal not found")
+    db.delete(goal)
+    db.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,7 @@ from backend.api import send_to_device
 from backend.api import wishlist as wishlist_api
 from backend.api import notifications as notifications_api
 from backend.api import oidc as oidc_api
+from backend.api import goals as goals_api
 from backend.models.kosync import KOSyncUser, KOSyncProgress, OPDSPendingLink, ReadingHistory  # noqa: F401
 from backend.models.opds_pin import OpdsPin  # noqa: F401
 from backend.models.tome_sync import ApiKey, ReadingSession, TomeSyncPosition  # noqa: F401
@@ -42,6 +43,7 @@ from backend.models.series_meta import Arc, SeriesMeta  # noqa: F401
 from backend.models.user_device import UserDevice  # noqa: F401
 from backend.models.wish import Wish  # noqa: F401
 from backend.models.notification import Notification  # noqa: F401
+from backend.models.reading_goal import ReadingGoal  # noqa: F401
 
 
 @asynccontextmanager
@@ -130,6 +132,14 @@ async def lifespan(app: FastAPI):
         if "scope" not in at_cols:
             conn.execute(text("ALTER TABLE api_tokens ADD COLUMN scope VARCHAR(16) NOT NULL DEFAULT 'full'"))
             conn.commit()
+        # reading_goals from the parked feat/reading-goals WIP (never shipped) lacks
+        # book_type_id and carries a stale (user_id, kind) unique constraint that
+        # SQLite can't alter away — recreate the table on the current schema.
+        rg_cols = {r[1] for r in conn.execute(text("PRAGMA table_info(reading_goals)")).fetchall()}
+        if rg_cols and "book_type_id" not in rg_cols:
+            conn.execute(text("DROP TABLE reading_goals"))
+            conn.commit()
+    ReadingGoal.__table__.create(bind=engine, checkfirst=True)
     init_fts(engine)
     backfill_fts(engine)
     settings.ensure_dirs()
@@ -517,6 +527,7 @@ def create_app() -> FastAPI:
     app.include_router(wishlist_api.router, prefix="/api")
     app.include_router(notifications_api.router, prefix="/api")
     app.include_router(oidc_api.router, prefix="/api")
+    app.include_router(goals_api.router, prefix="/api")
 
     # Serve frontend static files in production (SPA fallback)
     frontend_dist = Path(__file__).parent.parent / "frontend" / "dist"

--- a/backend/models/reading_goal.py
+++ b/backend/models/reading_goal.py
@@ -1,0 +1,54 @@
+"""ReadingGoal model — per-user reading goals.
+
+Kinds follow the pattern {metric}_per_{period}:
+  metric ∈ books | minutes | pages
+  period ∈ day | week | month | year
+Curated set lives in backend/api/goals.py:ALLOWED_KINDS.
+
+A goal optionally targets a single book type (book_type_id), so "20 books
+this year" and "20 manga this year" can coexist. NULL means all books.
+Uniqueness per (user, kind, book_type_id) is enforced in the API — SQLite
+treats NULLs as distinct, so a DB unique constraint can't cover the
+all-books case.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.core.database import Base
+
+
+class ReadingGoal(Base):
+    __tablename__ = "reading_goals"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer,
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    kind: Mapped[str] = mapped_column(String(32), nullable=False)
+    target: Mapped[int] = mapped_column(Integer, nullable=False)
+    # NULL = all books; set = only books of this type count toward the goal.
+    book_type_id: Mapped[Optional[int]] = mapped_column(
+        Integer,
+        ForeignKey("book_types.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    # UTC start of the period window for which a goal_reached notification was
+    # already created. Resets naturally when the window rolls over; cleared on
+    # target change so a raised target can notify again.
+    notified_window_start: Mapped[Optional[datetime]] = mapped_column(
+        DateTime, nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Bell, Check, BookOpen } from 'lucide-react'
+import { Bell, Check, BookOpen, Target } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 import {
@@ -164,11 +164,11 @@ export function NotificationBell() {
                 >
                   <div className={cn(
                     'mt-0.5 flex items-center justify-center w-6 h-6 rounded-full shrink-0',
-                    n.kind === 'wish_fulfilled'
+                    n.kind === 'wish_fulfilled' || n.kind === 'goal_reached'
                       ? 'bg-success/10 text-success'
                       : 'bg-muted text-muted-foreground'
                   )}>
-                    <BookOpen className="w-3 h-3" />
+                    {n.kind === 'goal_reached' ? <Target className="w-3 h-3" /> : <BookOpen className="w-3 h-3" />}
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className={cn(

--- a/frontend/src/components/stats/GoalWidget.tsx
+++ b/frontend/src/components/stats/GoalWidget.tsx
@@ -1,0 +1,340 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useNavigate } from 'react-router-dom'
+import { Pencil, Plus, Target, Trash2, X } from 'lucide-react'
+import { ProgressRing } from '@/components/stats/ProgressRing'
+import {
+  ALLOWED_GOAL_KINDS,
+  createGoal,
+  deleteGoal,
+  goalMeta,
+  goalSubtext,
+  goalTitle,
+  listGoals,
+  updateGoal,
+  type Goal,
+  type GoalKind,
+} from '@/lib/goals'
+import { useBookTypes } from '@/lib/bookTypes'
+import { cn } from '@/lib/utils'
+
+// ── Ring card (shared by the dashboard tile and the Home strip) ───────────────
+
+function GoalRing({ goal, size, compact }: { goal: Goal; size: number; compact?: boolean }) {
+  const meta = goalMeta(goal.kind)
+  return (
+    <ProgressRing pct={goal.pct} size={size} stroke={compact ? 5 : 7}>
+      <div className="flex flex-col items-center leading-none">
+        <span className={cn('font-bold tabular-nums text-foreground', compact ? 'text-sm' : 'text-lg')}>
+          {Math.round(goal.current)}
+        </span>
+        <span className={cn('text-muted-foreground', compact ? 'text-[9px]' : 'text-[10px]')}>
+          /{goal.target}
+          {meta.unit}
+        </span>
+      </div>
+    </ProgressRing>
+  )
+}
+
+// ── Editor modal (create or edit) ─────────────────────────────────────────────
+
+/**
+ * Create mode: pick a kind (curated set), a preset or custom target, and an
+ * optional book type ("20 manga this year" alongside "20 books this year").
+ * Edit mode: the goal's identity (kind + type) is fixed; only the target moves.
+ */
+export function GoalEditorModal({
+  goal,
+  existing,
+  onSaved,
+  onClose,
+}: {
+  /** Set = edit this goal; unset = create a new one. */
+  goal?: Goal
+  /** Existing goals — used to grey out (kind, type) combos already taken. */
+  existing: Goal[]
+  onSaved: (saved: Goal) => void
+  onClose: () => void
+}) {
+  const bookTypes = useBookTypes()
+  const [kind, setKind] = useState<GoalKind>((goal?.kind as GoalKind) ?? 'books_per_year')
+  const [bookTypeId, setBookTypeId] = useState<number | null>(goal?.book_type_id ?? null)
+  const [target, setTarget] = useState<string>(goal ? String(goal.target) : '')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const meta = goalMeta(kind)
+  const taken = (k: GoalKind, typeId: number | null) =>
+    existing.some((g) => g.kind === k && g.book_type_id === typeId && g.id !== goal?.id)
+  const parsed = parseInt(target, 10)
+  const valid = Number.isFinite(parsed) && parsed > 0 && (goal != null || !taken(kind, bookTypeId))
+
+  async function save() {
+    if (!valid || saving) return
+    setSaving(true)
+    setError(null)
+    try {
+      const saved = goal ? await updateGoal(goal.id, parsed) : await createGoal(kind, parsed, bookTypeId)
+      onSaved(saved)
+      onClose()
+    } catch {
+      setError(goal ? 'Could not update the goal.' : 'Could not create the goal — it may already exist.')
+      setSaving(false)
+    }
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[70] flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-md rounded-2xl border border-border bg-card p-5 shadow-xl shadow-accent-soft">
+        <div className="mb-4 flex items-start justify-between">
+          <div>
+            <h2 className="text-base font-semibold">{goal ? 'Edit goal' : 'Set a reading goal'}</h2>
+            <p className="text-xs text-muted-foreground">
+              {goal ? goalTitle(goal) : 'Pick a rhythm — progress counts automatically.'}
+            </p>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close" className="rounded-md p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {!goal && (
+          <>
+            <p className="mb-1.5 text-xs font-medium text-muted-foreground">Goal</p>
+            <div className="mb-4 grid grid-cols-2 gap-1.5">
+              {ALLOWED_GOAL_KINDS.map((k) => (
+                <button
+                  key={k}
+                  type="button"
+                  onClick={() => setKind(k)}
+                  className={cn(
+                    'rounded-lg border px-2.5 py-1.5 text-left text-xs transition',
+                    kind === k ? 'border-primary bg-primary/10 text-primary' : 'border-border text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  {goalMeta(k).label}
+                </button>
+              ))}
+            </div>
+
+            {bookTypes.length > 0 && (
+              <>
+                <p className="mb-1.5 text-xs font-medium text-muted-foreground">Counts</p>
+                <select
+                  value={bookTypeId ?? ''}
+                  onChange={(e) => setBookTypeId(e.target.value === '' ? null : Number(e.target.value))}
+                  className="mb-4 w-full rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground focus:border-primary focus:outline-none"
+                >
+                  <option value="">All books</option>
+                  {bookTypes.map((t) => (
+                    <option key={t.id} value={t.id}>
+                      {t.label} only
+                    </option>
+                  ))}
+                </select>
+              </>
+            )}
+          </>
+        )}
+
+        <p className="mb-1.5 text-xs font-medium text-muted-foreground">Target</p>
+        <div className="mb-2 flex gap-1.5">
+          {meta.presets.map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => setTarget(String(p))}
+              className={cn(
+                'rounded-lg border px-2.5 py-1.5 text-xs tabular-nums transition',
+                target === String(p) ? 'border-primary bg-primary/10 text-primary' : 'border-border text-muted-foreground hover:text-foreground',
+              )}
+            >
+              {p}
+            </button>
+          ))}
+        </div>
+        <div className="mb-4 flex items-center gap-2">
+          <input
+            type="number"
+            min={1}
+            value={target}
+            onChange={(e) => setTarget(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && save()}
+            placeholder={String(meta.placeholder)}
+            className="w-24 rounded-lg border border-border bg-background px-2.5 py-1.5 text-sm tabular-nums text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none"
+          />
+          <span className="text-xs text-muted-foreground">{meta.inputUnit}</span>
+        </div>
+
+        {!goal && taken(kind, bookTypeId) && (
+          <p className="mb-3 text-xs text-muted-foreground">You already have this goal — edit it from its tile instead.</p>
+        )}
+        {error && <p className="mb-3 text-xs text-destructive">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={!valid || saving}
+            className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {goal ? 'Save' : 'Set goal'}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+// ── Dashboard tile body ───────────────────────────────────────────────────────
+
+/**
+ * The "Reading Goals" tile shows ALL of the user's goals — one card per goal,
+ * managed in place. One surface, local effects: the trash on a card deletes
+ * exactly that goal, the add-card creates one. No per-tile goal pointers.
+ */
+export function GoalWidgetBody({
+  goals,
+  onChanged,
+}: {
+  goals: Goal[] | null
+  onChanged: () => void
+}) {
+  const [editing, setEditing] = useState<Goal | null>(null)
+  const [creating, setCreating] = useState(false)
+
+  if (goals === null) {
+    return <div className="flex h-full items-center justify-center text-xs text-muted-foreground">Loading…</div>
+  }
+
+  if (goals.length === 0) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
+        <Target className="h-6 w-6 text-muted-foreground/40" />
+        <p className="text-xs text-muted-foreground">Set a target and watch the ring fill as you read.</p>
+        <button
+          type="button"
+          onClick={() => setCreating(true)}
+          className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:opacity-90"
+        >
+          Set a goal
+        </button>
+        {creating && <GoalEditorModal existing={[]} onSaved={onChanged} onClose={() => setCreating(false)} />}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      // Fixed equal columns (auto-fill) so cards are uniform and rows always
+      // line up — no ragged content-width wrapping. New-goal cell matches.
+      className="grid items-stretch gap-2.5"
+      style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(11.5rem, 1fr))' }}
+    >
+      {goals.map((goal) => {
+        const caption = goal.period === 'year' && goal.year ? `${goal.year} Challenge` : goalMeta(goal.kind).caption
+        const sub = goal.book_type_label ? `${goal.book_type_label} · ${goalSubtext(goal)}` : goalSubtext(goal)
+        return (
+          <div
+            key={goal.id}
+            className="group/goal relative flex items-center gap-2.5 overflow-hidden rounded-lg border border-border bg-muted/30 p-2.5"
+          >
+            <GoalRing goal={goal} size={48} compact />
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <p className="truncate text-xs font-medium leading-tight text-foreground">{caption}</p>
+              <p className="truncate text-[11px] leading-tight text-muted-foreground">{sub}</p>
+            </div>
+            {/* edit/delete reveal on hover — New goal is the always-visible action */}
+            <div className="absolute right-1 top-1 flex items-center gap-0.5 rounded-md bg-card/80 opacity-0 backdrop-blur-sm transition-opacity group-hover/goal:opacity-100">
+              <button
+                type="button"
+                onClick={() => setEditing(goal)}
+                title="Edit goal"
+                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                <Pencil className="h-3 w-3" />
+              </button>
+              <button
+                type="button"
+                onClick={() => deleteGoal(goal.id).then(onChanged).catch(() => {})}
+                title="Delete this goal"
+                className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
+              >
+                <Trash2 className="h-3 w-3" />
+              </button>
+            </div>
+          </div>
+        )
+      })}
+
+      {/* always-visible creation cell — matches a goal card's footprint */}
+      <button
+        type="button"
+        onClick={() => setCreating(true)}
+        className="flex min-h-[4.25rem] items-center justify-center gap-1.5 rounded-lg border border-dashed border-border text-xs text-muted-foreground transition hover:border-primary/50 hover:text-foreground"
+      >
+        <Plus className="h-3.5 w-3.5" />
+        New goal
+      </button>
+
+      {editing && (
+        <GoalEditorModal goal={editing} existing={goals} onSaved={onChanged} onClose={() => setEditing(null)} />
+      )}
+      {creating && <GoalEditorModal existing={goals} onSaved={onChanged} onClose={() => setCreating(false)} />}
+    </div>
+  )
+}
+
+// ── Home tab strip ────────────────────────────────────────────────────────────
+
+/**
+ * Read-only compact goal segments for the Home tab. Mirrors the quick-stats
+ * panel's visual language (label over value, hairline dividers, mini ring in
+ * the icon slot) so the two sit side by side as one summary zone.
+ * Renders nothing without goals. Pace details live in the title tooltip and
+ * on the stats dashboard tile — Home stays glanceable.
+ */
+export function HomeGoalRings() {
+  const navigate = useNavigate()
+  const [goals, setGoals] = useState<Goal[]>([])
+
+  useEffect(() => {
+    listGoals().then(setGoals).catch(() => {})
+  }, [])
+
+  if (goals.length === 0) return null
+
+  return (
+    <div className="grid w-full grid-cols-2 gap-y-3 rounded-xl border border-border bg-card px-5 py-4 sm:flex sm:w-fit">
+      {goals.map((goal, i) => (
+        <button
+          key={goal.id}
+          type="button"
+          onClick={() => navigate('/stats')}
+          title={goalSubtext(goal)}
+          className={cn(
+            'text-left sm:px-5 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-md',
+            i === 0 && 'sm:pl-0',
+            i > 0 && 'sm:border-l sm:border-border/60',
+          )}
+        >
+          <p className="text-xs text-muted-foreground/70">{goalTitle(goal)}</p>
+          <p className="flex items-center gap-2 text-xl font-semibold tabular-nums text-foreground leading-tight">
+            <ProgressRing pct={goal.pct} size={22} stroke={3.5} />
+            {Math.round(goal.current)}
+            <span className="text-base font-medium text-muted-foreground/70">
+              /{goal.target}
+              {goalMeta(goal.kind).unit}
+            </span>
+          </p>
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/stats/ProgressRing.tsx
+++ b/frontend/src/components/stats/ProgressRing.tsx
@@ -1,0 +1,67 @@
+import type { ReactNode } from 'react'
+import { useChartAccent } from '@/lib/useChartAccent'
+
+interface ProgressRingProps {
+  /** Progress percentage 0–100+. Arc is clamped at 100% visually. */
+  pct: number
+  /** Outer diameter in px (default 80) */
+  size?: number
+  /** Stroke width in px (default 7) */
+  stroke?: number
+  /** Content rendered in the centre of the ring */
+  children?: ReactNode
+}
+
+/**
+ * SVG circular progress ring.
+ * Track uses border color, arc uses the theme primary accent.
+ * linecap is round; arc is clamped at 100% even when pct > 100.
+ */
+export function ProgressRing({ pct, size = 80, stroke = 7, children }: ProgressRingProps) {
+  const accent = useChartAccent()
+  const radius = (size - stroke) / 2
+  const circumference = 2 * Math.PI * radius
+  const clamped = Math.min(Math.max(pct, 0), 100)
+  const dashOffset = circumference - (clamped / 100) * circumference
+
+  return (
+    <div className="relative flex items-center justify-center" style={{ width: size, height: size }}>
+      <svg
+        width={size}
+        height={size}
+        viewBox={`0 0 ${size} ${size}`}
+        style={{ transform: 'rotate(-90deg)' }}
+        aria-hidden="true"
+      >
+        {/* Track */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={stroke}
+          className="text-border"
+        />
+        {/* Progress arc */}
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          fill="none"
+          stroke={accent}
+          strokeWidth={stroke}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          style={{ transition: 'stroke-dashoffset 0.4s ease' }}
+        />
+      </svg>
+      {children && (
+        <div className="absolute inset-0 flex items-center justify-center">
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/goals.ts
+++ b/frontend/src/lib/goals.ts
@@ -1,0 +1,187 @@
+/**
+ * Reading goals — types, API calls, and per-kind display metadata.
+ * All per-kind display logic derives from the GOAL_META map; its preset
+ * chips are the curated on-ramp shown in the goal editor.
+ */
+import { api } from '@/lib/api'
+
+export type GoalKind =
+  | 'books_per_year'
+  | 'books_per_month'
+  | 'minutes_per_day'
+  | 'minutes_per_week'
+  | 'pages_per_day'
+  | 'pages_per_week'
+
+export type GoalMetric = 'books' | 'minutes' | 'pages'
+export type GoalPeriod = 'day' | 'week' | 'month' | 'year'
+
+/** Goal with computed progress, as returned by GET /api/goals. */
+export interface Goal {
+  id: number
+  kind: string
+  metric: GoalMetric
+  period: GoalPeriod
+  target: number
+  book_type_id: number | null
+  book_type_label: string | null
+  current: number
+  pct: number
+  /** Target prorated to the elapsed window — month/year only, null otherwise. */
+  expected: number | null
+  /** Present only for daily-period goals */
+  days_hit_this_week?: number
+  /** Present for year-period goals */
+  year?: number
+}
+
+interface GoalMeta {
+  label: string          // "Books this year"
+  caption: string        // ring caption below the number
+  unit: string           // suffix shown in ring center bottom ('' | 'm' | 'p')
+  inputUnit: string      // written-out unit for the input row (e.g. "books", "min", "pages")
+  placeholder: number    // default placeholder for the numeric input
+  presets: number[]      // quick-pick chips
+  metric: GoalMetric
+  period: GoalPeriod
+}
+
+const GOAL_META: Record<GoalKind, GoalMeta> = {
+  books_per_year: {
+    label: 'Books this year',
+    caption: 'Year Challenge',
+    unit: '',
+    inputUnit: 'books',
+    placeholder: 24,
+    presets: [12, 24, 52],
+    metric: 'books',
+    period: 'year',
+  },
+  books_per_month: {
+    label: 'Books this month',
+    caption: 'Monthly goal',
+    unit: '',
+    inputUnit: 'books',
+    placeholder: 2,
+    presets: [1, 2, 4],
+    metric: 'books',
+    period: 'month',
+  },
+  minutes_per_day: {
+    label: 'Minutes per day',
+    caption: 'Daily minutes',
+    unit: 'm',
+    inputUnit: 'min',
+    placeholder: 30,
+    presets: [15, 30, 60],
+    metric: 'minutes',
+    period: 'day',
+  },
+  minutes_per_week: {
+    label: 'Minutes per week',
+    caption: 'Weekly minutes',
+    unit: 'm',
+    inputUnit: 'min',
+    placeholder: 300,
+    presets: [120, 300, 600],
+    metric: 'minutes',
+    period: 'week',
+  },
+  pages_per_day: {
+    label: 'Pages per day',
+    caption: 'Daily pages',
+    unit: 'p',
+    inputUnit: 'pages',
+    placeholder: 50,
+    presets: [20, 50, 100],
+    metric: 'pages',
+    period: 'day',
+  },
+  pages_per_week: {
+    label: 'Pages per week',
+    caption: 'Weekly pages',
+    unit: 'p',
+    inputUnit: 'pages',
+    placeholder: 350,
+    presets: [150, 350, 700],
+    metric: 'pages',
+    period: 'week',
+  },
+}
+
+export function goalMeta(kind: string): GoalMeta {
+  return GOAL_META[kind as GoalKind] ?? {
+    label: kind,
+    caption: kind,
+    unit: '',
+    inputUnit: '',
+    placeholder: 10,
+    presets: [],
+    metric: 'books' as GoalMetric,
+    period: 'year' as GoalPeriod,
+  }
+}
+
+/** All 6 allowed kinds in display order */
+export const ALLOWED_GOAL_KINDS: GoalKind[] = [
+  'books_per_year',
+  'books_per_month',
+  'minutes_per_day',
+  'minutes_per_week',
+  'pages_per_day',
+  'pages_per_week',
+]
+
+/** Tile/card title, e.g. "Books this year · Manga" */
+export function goalTitle(goal: Goal): string {
+  const base = goalMeta(goal.kind).label
+  return goal.book_type_label ? `${base} · ${goal.book_type_label}` : base
+}
+
+/** Compute the subtext shown below a goal ring. Pace line for month/year. */
+export function goalSubtext(goal: Goal): string {
+  const { period } = goalMeta(goal.kind)
+  const reached = goal.current >= goal.target
+
+  if (period === 'day') {
+    if (reached) return 'Goal reached today'
+    return `${goal.days_hit_this_week ?? 0}/7 days this week`
+  }
+  if (period === 'week') {
+    return reached ? 'Goal reached' : 'this week'
+  }
+  // month/year: pace against the prorated target
+  if (reached) return 'Goal reached'
+  if (goal.expected != null) {
+    const diff = Math.round(goal.current - goal.expected)
+    if (diff >= 1) return `${diff} ahead of pace`
+    if (diff <= -1) return `${Math.abs(diff)} behind pace`
+    return 'on pace'
+  }
+  const toGo = Math.max(goal.target - Math.floor(goal.current), 0)
+  return `${toGo} to go`
+}
+
+// ── API ───────────────────────────────────────────────────────────────────────
+
+const tz = () => new Date().getTimezoneOffset()
+
+export function listGoals(): Promise<Goal[]> {
+  return api.get<{ goals: Goal[] }>(`/goals?tz_offset=${tz()}`).then((r) => r.goals)
+}
+
+export function createGoal(kind: GoalKind, target: number, bookTypeId: number | null): Promise<Goal> {
+  return api.post<Goal>(`/goals?tz_offset=${tz()}`, {
+    kind,
+    target,
+    book_type_id: bookTypeId,
+  })
+}
+
+export function updateGoal(id: number, target: number): Promise<Goal> {
+  return api.put<Goal>(`/goals/${id}?tz_offset=${tz()}`, { target })
+}
+
+export function deleteGoal(id: number): Promise<void> {
+  return api.delete<void>(`/goals/${id}`)
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -22,6 +22,7 @@ import { SendButton } from '@/components/SendButton'
 import { BookAnimation } from '@/components/BookAnimation'
 import { SyncStatusBadge } from '@/components/SyncStatusBadge'
 import { NotificationBell } from '@/components/NotificationBell'
+import { HomeGoalRings } from '@/components/stats/GoalWidget'
 import { api } from '@/lib/api'
 import type { Book, Library, SavedFilter, ReadingStatus, Arc, SeriesMeta, SeriesStatus } from '@/lib/books'
 import { formatBytes } from '@/lib/books'
@@ -1059,27 +1060,30 @@ export function DashboardPage() {
             /* ── Home tab ────────────────────────────────────────────────── */
             <div className="flex flex-col gap-8">
 
-              {/* ── Quick stats — flat hairline-divided panel ──────────────── */}
-              {homeStats && (
-                <div className="rounded-xl border border-border bg-card px-5 py-4 grid grid-cols-2 gap-y-3 sm:flex w-full sm:w-fit">
-                  {homeStatItems.map((s, i) => (
-                    <div
-                      key={s.label}
-                      className={cn(
-                        'sm:px-5',
-                        i === 0 && 'sm:pl-0',
-                        i > 0 && 'sm:border-l sm:border-border/60'
-                      )}
-                    >
-                      <p className="text-xs text-muted-foreground/70">{s.label}</p>
-                      <p className="flex items-center gap-2 text-xl font-semibold tabular-nums text-foreground leading-tight">
-                        <span className="text-primary/60">{s.icon}</span>
-                        {s.value}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-              )}
+              {/* ── Quick stats + goals — matching hairline-divided panels ── */}
+              <div className="flex flex-wrap items-stretch gap-3 empty:hidden">
+                {homeStats && (
+                  <div className="rounded-xl border border-border bg-card px-5 py-4 grid grid-cols-2 gap-y-3 sm:flex w-full sm:w-fit">
+                    {homeStatItems.map((s, i) => (
+                      <div
+                        key={s.label}
+                        className={cn(
+                          'sm:px-5',
+                          i === 0 && 'sm:pl-0',
+                          i > 0 && 'sm:border-l sm:border-border/60'
+                        )}
+                      >
+                        <p className="text-xs text-muted-foreground/70">{s.label}</p>
+                        <p className="flex items-center gap-2 text-xl font-semibold tabular-nums text-foreground leading-tight">
+                          <span className="text-primary/60">{s.icon}</span>
+                          {s.value}
+                        </p>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <HomeGoalRings />
+              </div>
 
               {/* ── Forgotten Books ───────────────────────────────────────── */}
               {(() => {

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -14,6 +14,8 @@ import { SyncStatusBadge } from '@/components/SyncStatusBadge'
 import { BookAnimation } from '@/components/BookAnimation'
 import { DOCS, docsLink } from '@/lib/docs'
 import { type StatsResponse, type CompletionEstimate } from '@/components/stats/shared'
+import { GoalWidgetBody } from '@/components/stats/GoalWidget'
+import { listGoals, type Goal } from '@/lib/goals'
 import {
   type ChartKind,
   HeadlineStatBody,
@@ -65,7 +67,12 @@ type TileConfig = { chartType: ChartKind; days: number; metric?: string; series?
 
 // ── Widget catalog (renders shared Stats components from live data) ─────────────
 
-type WidgetCtx = { stats: StatsResponse; estimates: CompletionEstimate[] | null }
+type WidgetCtx = {
+  stats: StatsResponse
+  estimates: CompletionEstimate[] | null
+  goals: Goal[] | null
+  reloadGoals: () => void
+}
 
 type WidgetDef = {
   id: string
@@ -203,6 +210,14 @@ const WIDGETS: WidgetDef[] = [
       const v = metricValue(stats, cfg.metric ?? 'avg-session')
       return <HeadlineStatBody value={v.value} sub={v.sub} />
     },
+  },
+  {
+    id: 'goal',
+    title: 'Reading Goals',
+    icon: Target,
+    size: { w: 6, h: 2, minW: 3, minH: 2 },
+    autoH: true,
+    render: ({ goals, reloadGoals }) => <GoalWidgetBody goals={goals} onChanged={reloadGoals} />,
   },
   {
     id: 'currently-reading',
@@ -416,6 +431,7 @@ const WIDGET_DESC: Record<string, string> = {
   'activity-365': 'A year of reading, heatmap',
   'session-log': 'Every session — paginated, deletable',
   'stat-metric': 'Pick your own metric — avg session, pages/day, best day…',
+  goal: 'All your reading goals — rings fill as you read, managed in place',
   'recently-finished': 'Latest finishes, newest first',
   'streak-calendar': 'This month, read days filled',
   'dow-bar': 'Which weekday you read most',
@@ -448,12 +464,13 @@ const NATURAL_PREVIEW = new Set(['stat-time', 'stat-sessions', 'stat-finished', 
 const SCROLL_IDS = new Set([
   'currently-reading', 'estimates', 'session-timeline', 'series-completion', 'per-book-table',
   'author-affinity', 'completion-by-type', 'pace-by-format', 'session-log', 'recently-finished',
+  'goal',
 ])
 
 const GALLERY_GROUPS: { label: string; ids: string[] }[] = [
   {
     label: 'Overview',
-    ids: ['stat-time', 'stat-sessions', 'stat-finished', 'stat-streak', 'stat-pages', 'stat-completion', 'stat-metric', 'currently-reading', 'recently-finished', 'streak-calendar', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log'],
+    ids: ['stat-time', 'stat-sessions', 'stat-finished', 'stat-streak', 'stat-pages', 'stat-completion', 'stat-metric', 'goal', 'currently-reading', 'recently-finished', 'streak-calendar', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log'],
   },
   {
     label: 'Habits',
@@ -482,6 +499,7 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
   'activity-365': { x: 0, y: 9, w: 12, h: 2 },
   'books-finished': { x: 0, y: 11, w: 12, h: 2 },
   'session-log': { x: 0, y: 13, w: 12, h: 7 },
+  goal: { x: 0, y: 20, w: 6, h: 3 },
   // Habits — all full width except the Pace | Pace-by-Format pair
   'hour-dow': { x: 0, y: 0, w: 12, h: 2 },
   'session-timeline': { x: 0, y: 2, w: 12, h: 3 },
@@ -506,7 +524,7 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
 type TabState = { id: string; label: string; tiles: Tile[]; layout: Layout }
 
 const TAB_DEFS: { id: string; label: string; ids: string[] }[] = [
-  { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log'] },
+  { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log', 'goal'] },
   { id: 'habits', label: 'Habits', ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
   { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
 ]
@@ -1139,7 +1157,7 @@ const PAD_LABEL: Record<PadWidth, string> = { none: 'None', bit: 'A bit', lot: '
 // boards saved under the old defaults so everyone starts from the replica.
 const LS_KEY = 'tome_stats_lab_v2'
 
-type Persisted = { tabs: TabState[]; activeTabId: string; pad: PadWidth; days: number }
+type Persisted = { tabs: TabState[]; activeTabId: string; pad: PadWidth; days: number; savedAt?: number }
 
 // Drop tiles whose widget no longer exists in the catalog, and orphaned layout
 // entries — saved state (localStorage or server) must never crash the page.
@@ -1337,6 +1355,7 @@ export function StatsPage() {
   const [custom, setCustom] = useState<CustomRange | null>(null)
   const [stats, setStats] = useState<StatsResponse | null>(null)
   const [estimates, setEstimates] = useState<CompletionEstimate[] | null>(null)
+  const [goals, setGoals] = useState<Goal[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [tabs, setTabs] = useState<TabState[]>(() => loadPersisted()?.tabs ?? buildTabs())
   const [activeTabId, setActiveTabId] = useState(() => loadPersisted()?.activeTabId ?? 'overview')
@@ -1393,6 +1412,11 @@ export function StatsPage() {
     api.get<CompletionEstimate[]>('/stats/completion-estimates').then(setEstimates).catch(() => {})
   }, [])
 
+  const reloadGoals = useCallback(() => {
+    listGoals().then(setGoals).catch(() => {})
+  }, [])
+  useEffect(reloadGoals, [reloadGoals])
+
   // Server is the source of truth across browsers/devices; localStorage is a
   // fast-boot cache. Apply the server copy once on mount, and only start
   // pushing local changes after that (so a slow GET can't be clobbered).
@@ -1401,15 +1425,23 @@ export function StatsPage() {
   const latest = useRef<Persisted>({ tabs, activeTabId, pad, days })
 
   useEffect(() => {
+    // Read the local cache's timestamp before the save effect below overwrites
+    // it with a fresh one (effects run in definition order, so this wins).
+    const localSavedAt = loadPersisted()?.savedAt ?? 0
     api
       .get<{ data: Persisted | null }>('/stats/dashboard')
       .then((res) => {
         const p = res.data ? sanitizePersisted(res.data) : null
-        if (p) {
+        if (p && (p.savedAt ?? 0) >= localSavedAt) {
           setTabs(p.tabs)
           setActiveTabId(p.activeTabId)
           if (p.pad) setPad(p.pad)
           if (p.days != null) setDays(p.days)
+        } else if (p) {
+          // The local cache is newer — a reload landed inside the 800ms save
+          // debounce, so the server missed the last edit. Keep local state and
+          // push it up instead of letting the stale copy clobber it.
+          api.put('/stats/dashboard', { data: latest.current }).catch(() => {})
         }
       })
       .catch(() => {})
@@ -1420,7 +1452,7 @@ export function StatsPage() {
 
   // Persist boards + view settings: localStorage immediately, server debounced.
   useEffect(() => {
-    const state: Persisted = { tabs, activeTabId, pad, days }
+    const state: Persisted = { tabs, activeTabId, pad, days, savedAt: Date.now() }
     latest.current = state
     try {
       localStorage.setItem(LS_KEY, JSON.stringify(state))
@@ -1942,7 +1974,7 @@ export function StatsPage() {
           </div>
         ) : (
           <div ref={boardRef}>
-            <FreeGrid tiles={active.tiles} layout={active.layout} ctx={{ stats, estimates }} editMode={editMode} onLayoutChange={setActiveLayout} onRemove={removeTile} onDuplicate={duplicateTile} onConfigChange={setConfig} />
+            <FreeGrid tiles={active.tiles} layout={active.layout} ctx={{ stats, estimates, goals, reloadGoals }} editMode={editMode} onLayoutChange={setActiveLayout} onRemove={removeTile} onDuplicate={duplicateTile} onConfigChange={setConfig} />
           </div>
         )
       ) : (
@@ -1951,7 +1983,7 @@ export function StatsPage() {
       </main>
 
       {addOpen && stats && (
-        <AddWidgetModal ctx={{ stats, estimates }} present={new Set(active.tiles.map((t) => t.defId))} onAdd={addWidget} onClose={() => setAddOpen(false)} />
+        <AddWidgetModal ctx={{ stats, estimates, goals, reloadGoals }} present={new Set(active.tiles.map((t) => t.defId))} onAdd={addWidget} onClose={() => setAddOpen(false)} />
       )}
 
       {/* undo bar — tile removal and board deletion are recoverable for ~6s */}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,6 +31,7 @@ from backend.core.database import Base, get_db
 from backend.core.security import hash_password, create_access_token
 from backend.models.user import User, UserPermission
 from backend.models.book import Book, BookFile, BookTag
+from backend.models.reading_goal import ReadingGoal  # noqa: F401 — registers table metadata
 
 
 # ── Global SMTP guard ─────────────────────────────────────────────────────────

--- a/tests/test_goals.py
+++ b/tests/test_goals.py
@@ -1,0 +1,669 @@
+"""Tests for the reading goals API — GET/POST/PUT/DELETE /api/goals."""
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from backend.core.security import create_access_token, hash_password
+from backend.models.library import BookType
+from backend.models.notification import Notification
+from backend.models.reading_goal import ReadingGoal
+from backend.models.tome_sync import ReadingSession
+from backend.models.user import User, UserPermission
+from backend.models.user_book_status import UserBookStatus
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _create_goal(
+    client: TestClient,
+    kind: str,
+    target: int,
+    book_type_id: int | None = None,
+    expected_status: int = 201,
+) -> dict:
+    body: dict = {"kind": kind, "target": target}
+    if book_type_id is not None:
+        body["book_type_id"] = book_type_id
+    resp = client.post("/api/goals", json=body)
+    assert resp.status_code == expected_status, resp.text
+    return resp.json() if resp.status_code == 201 else {}
+
+
+def _list_goals(client: TestClient) -> list[dict]:
+    resp = client.get("/api/goals")
+    assert resp.status_code == 200, resp.text
+    return resp.json()["goals"]
+
+
+def _update_goal(client: TestClient, goal_id: int, target: int, expected_status: int = 200) -> dict:
+    resp = client.put(f"/api/goals/{goal_id}", json={"target": target})
+    assert resp.status_code == expected_status, resp.text
+    return resp.json() if resp.status_code == 200 else {}
+
+
+def _delete_goal(client: TestClient, goal_id: int, expected_status: int = 204) -> None:
+    resp = client.delete(f"/api/goals/{goal_id}")
+    assert resp.status_code == expected_status, resp.text
+
+
+def _make_type(db: Session, slug: str = "test-manga", label: str = "Manga") -> BookType:
+    bt = BookType(slug=slug, label=label)
+    db.add(bt)
+    db.flush()
+    return bt
+
+
+def _finish_book(db: Session, user_id: int, book_id: int, updated_at: datetime | None = None) -> UserBookStatus:
+    ubs = UserBookStatus(
+        user_id=user_id,
+        book_id=book_id,
+        status="read",
+    )
+    db.add(ubs)
+    db.flush()
+    if updated_at is not None:
+        ubs.updated_at = updated_at
+        db.flush()
+    return ubs
+
+
+def _add_session(
+    db: Session,
+    user_id: int,
+    book_id: int,
+    started_at: datetime,
+    duration_seconds: int = 600,
+    pages_turned: int = 0,
+) -> ReadingSession:
+    s = ReadingSession(
+        user_id=user_id,
+        book_id=book_id,
+        started_at=started_at,
+        ended_at=started_at + timedelta(seconds=duration_seconds),
+        duration_seconds=duration_seconds,
+        pages_turned=pages_turned,
+    )
+    db.add(s)
+    db.flush()
+    return s
+
+
+# ── tests — CRUD ──────────────────────────────────────────────────────────────
+
+def test_create_and_list_goal(client: TestClient):
+    """POST creates the goal; GET /goals returns it."""
+    result = _create_goal(client, "books_per_year", 20)
+    assert result["kind"] == "books_per_year"
+    assert result["target"] == 20
+    assert result["book_type_id"] is None
+    assert "id" in result
+    assert "year" in result
+    assert "current" in result
+    assert "pct" in result
+
+    goals = _list_goals(client)
+    assert len(goals) == 1
+    assert goals[0]["kind"] == "books_per_year"
+    assert goals[0]["target"] == 20
+
+
+def test_duplicate_goal_rejected(client: TestClient):
+    """A second goal with the same (kind, book type) is a 409."""
+    _create_goal(client, "books_per_year", 10)
+    _create_goal(client, "books_per_year", 25, expected_status=409)
+
+    goals = _list_goals(client)
+    assert len(goals) == 1
+    assert goals[0]["target"] == 10
+
+
+def test_same_kind_different_type_coexist(client: TestClient, db: Session):
+    """'20 books this year' and '20 manga this year' are separate goals."""
+    manga = _make_type(db)
+    _create_goal(client, "books_per_year", 20)
+    typed = _create_goal(client, "books_per_year", 20, book_type_id=manga.id)
+    assert typed["book_type_id"] == manga.id
+    assert typed["book_type_label"] == "Manga"
+    # but a second manga goal of the same kind is a duplicate
+    _create_goal(client, "books_per_year", 30, book_type_id=manga.id, expected_status=409)
+
+    goals = _list_goals(client)
+    assert len(goals) == 2
+
+
+def test_update_goal_target(client: TestClient):
+    """PUT updates the target."""
+    goal = _create_goal(client, "books_per_year", 10)
+    updated = _update_goal(client, goal["id"], 25)
+    assert updated["target"] == 25
+
+    goals = _list_goals(client)
+    assert len(goals) == 1
+    assert goals[0]["target"] == 25
+
+
+def test_delete_goal(client: TestClient):
+    """DELETE removes the goal; subsequent GET returns empty list."""
+    goal = _create_goal(client, "books_per_year", 12)
+    _delete_goal(client, goal["id"])
+    goals = _list_goals(client)
+    assert goals == []
+
+
+def test_delete_nonexistent_returns_404(client: TestClient):
+    """DELETE on a goal that doesn't exist returns 404."""
+    _delete_goal(client, 9999, expected_status=404)
+
+
+def test_update_nonexistent_returns_404(client: TestClient):
+    _update_goal(client, 9999, 10, expected_status=404)
+
+
+def test_invalid_kind_rejected(client: TestClient):
+    """POST with an unknown kind returns 422."""
+    resp = client.post("/api/goals", json={"kind": "daily_pages", "target": 50})
+    assert resp.status_code == 422
+
+
+def test_unknown_book_type_rejected(client: TestClient):
+    resp = client.post("/api/goals", json={"kind": "books_per_year", "target": 10, "book_type_id": 4242})
+    assert resp.status_code == 422
+
+
+def test_non_positive_target_rejected(client: TestClient):
+    """POST with target <= 0 returns 422."""
+    resp = client.post("/api/goals", json={"kind": "books_per_year", "target": 0})
+    assert resp.status_code == 422
+    resp = client.post("/api/goals", json={"kind": "books_per_year", "target": -5})
+    assert resp.status_code == 422
+
+
+def test_allowed_kinds_all_accepted(client: TestClient):
+    """All 6 allowed kinds are accepted by POST."""
+    allowed = [
+        "books_per_year", "books_per_month",
+        "minutes_per_day", "minutes_per_week",
+        "pages_per_day", "pages_per_week",
+    ]
+    for kind in allowed:
+        result = _create_goal(client, kind, 10)
+        assert result["kind"] == kind
+        assert result["metric"] in ("books", "minutes", "pages")
+        assert result["period"] in ("day", "week", "month", "year")
+    goals = _list_goals(client)
+    assert len(goals) == 6
+
+
+def test_out_of_set_kind_rejected(client: TestClient):
+    """A kind that looks valid but isn't in ALLOWED_KINDS is rejected."""
+    resp = client.post("/api/goals", json={"kind": "books_per_week", "target": 3})
+    assert resp.status_code == 422
+    resp = client.post("/api/goals", json={"kind": "pages_per_year", "target": 1000})
+    assert resp.status_code == 422
+
+
+# ── tests — books_per_year progress ──────────────────────────────────────────
+
+def test_books_per_year_counts_this_year_only(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """books_per_year.current only counts reads updated this calendar year."""
+    user, _ = admin_user
+    book1 = make_book(title="Book A")
+    book2 = make_book(title="Book B")
+    book3 = make_book(title="Book C — Last Year")
+
+    now = datetime.utcnow()
+    year_start = datetime(now.year, 1, 1)
+    last_year = datetime(now.year - 1, 6, 1)
+
+    _finish_book(db, user.id, book1.id, updated_at=now - timedelta(days=10))
+    _finish_book(db, user.id, book2.id, updated_at=year_start + timedelta(days=1))
+    _finish_book(db, user.id, book3.id, updated_at=last_year)
+
+    _create_goal(client, "books_per_year", 20)
+    goals = _list_goals(client)
+    by_year = next(g for g in goals if g["kind"] == "books_per_year")
+
+    # Only book1 and book2 are this-year reads
+    assert by_year["current"] == 2
+    assert by_year["year"] == now.year
+
+
+def test_books_per_year_pct_calculation(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """pct = current / target * 100, rounded to 1 decimal."""
+    user, _ = admin_user
+    now = datetime.utcnow()
+    for i in range(3):
+        book = make_book(title=f"Pct Book {i}")
+        _finish_book(db, user.id, book.id, updated_at=now - timedelta(days=i))
+
+    result = _create_goal(client, "books_per_year", 12)
+    assert result["current"] == 3
+    assert result["pct"] == pytest.approx(25.0, abs=0.1)
+
+
+def test_book_type_filter_counts_only_that_type(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """A manga-scoped goal ignores finished books of other types."""
+    user, _ = admin_user
+    manga = _make_type(db)
+    novel = make_book(title="A Novel")
+    manga_book = make_book(title="A Manga Volume")
+    manga_book.book_type_id = manga.id
+    db.flush()
+
+    now = datetime.utcnow()
+    _finish_book(db, user.id, novel.id, updated_at=now - timedelta(days=1))
+    _finish_book(db, user.id, manga_book.id, updated_at=now - timedelta(days=2))
+
+    all_goal = _create_goal(client, "books_per_year", 20)
+    manga_goal = _create_goal(client, "books_per_year", 20, book_type_id=manga.id)
+
+    assert all_goal["current"] == 2
+    assert manga_goal["current"] == 1
+
+
+def test_book_type_filter_on_session_metrics(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """Typed minutes/pages goals only count sessions on books of that type."""
+    user, _ = admin_user
+    manga = _make_type(db)
+    novel = make_book(title="Session Novel")
+    manga_book = make_book(title="Session Manga")
+    manga_book.book_type_id = manga.id
+    db.flush()
+
+    now = datetime.utcnow()
+    _add_session(db, user.id, novel.id, now - timedelta(minutes=30), duration_seconds=1200, pages_turned=40)
+    _add_session(db, user.id, manga_book.id, now - timedelta(minutes=10), duration_seconds=600, pages_turned=25)
+
+    minutes_goal = _create_goal(client, "minutes_per_day", 60, book_type_id=manga.id)
+    assert minutes_goal["current"] == pytest.approx(10.0, abs=0.5)
+
+    pages_goal = _create_goal(client, "pages_per_day", 100, book_type_id=manga.id)
+    assert pages_goal["current"] == 25
+
+
+# ── tests — books_per_month progress ─────────────────────────────────────────
+
+def test_books_per_month_counts_this_month_only(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """books_per_month.current only counts reads in the current calendar month."""
+    user, _ = admin_user
+    book1 = make_book(title="This Month Book")
+    book2 = make_book(title="Last Month Book")
+
+    now = datetime.utcnow()
+    month_start = datetime(now.year, now.month, 1)
+
+    _finish_book(db, user.id, book1.id, updated_at=month_start + timedelta(days=1))
+    # Put last month's book clearly before this month started
+    last_month = month_start - timedelta(days=5)
+    _finish_book(db, user.id, book2.id, updated_at=last_month)
+
+    result = _create_goal(client, "books_per_month", 4)
+    assert result["kind"] == "books_per_month"
+    assert result["metric"] == "books"
+    assert result["period"] == "month"
+    assert result["current"] == 1
+    assert result["pct"] == pytest.approx(25.0, abs=0.1)
+
+
+def test_books_per_month_response_fields(client: TestClient):
+    """books_per_month response has the generic fields (no year field)."""
+    result = _create_goal(client, "books_per_month", 4)
+    assert "kind" in result
+    assert "metric" in result
+    assert "period" in result
+    assert "current" in result
+    assert "target" in result
+    assert "pct" in result
+    # days_hit_this_week is for daily goals only
+    assert "days_hit_this_week" not in result
+
+
+# ── tests — pace (expected) ───────────────────────────────────────────────────
+
+def test_expected_present_for_calendar_windows(client: TestClient):
+    """expected is the prorated target for month/year, None for day/week."""
+    year_goal = _create_goal(client, "books_per_year", 365)
+    assert year_goal["expected"] is not None
+    # prorated target can never exceed the target itself
+    assert 0 <= year_goal["expected"] <= 365
+
+    day_goal = _create_goal(client, "minutes_per_day", 30)
+    assert day_goal["expected"] is None
+
+    week_goal = _create_goal(client, "pages_per_week", 350)
+    assert week_goal["expected"] is None
+
+
+# ── tests — minutes_per_day progress ─────────────────────────────────────────
+
+def test_minutes_per_day_today_calculation(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """minutes_per_day.current counts only sessions whose local date == today."""
+    user, _ = admin_user
+    book = make_book(title="Timed Book")
+    now = datetime.utcnow()
+
+    # 10 min today
+    _add_session(db, user.id, book.id, now - timedelta(minutes=5), duration_seconds=600)
+    # 5 min yesterday — should NOT count toward today
+    _add_session(db, user.id, book.id, now - timedelta(days=1), duration_seconds=300)
+
+    result = _create_goal(client, "minutes_per_day", 30)
+    assert result["kind"] == "minutes_per_day"
+    # current should be ~10 (from the 600s session today)
+    assert result["current"] == pytest.approx(10.0, abs=0.5)
+    assert "days_hit_this_week" in result
+
+
+def test_minutes_per_day_days_hit_this_week(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """days_hit_this_week counts days in the last 7 where goal was met."""
+    user, _ = admin_user
+    book = make_book(title="Week Book")
+    now = datetime.utcnow()
+    target_minutes = 20
+    target_seconds = target_minutes * 60
+
+    # 3 days ago — hit (1200s = 20min)
+    _add_session(db, user.id, book.id, now - timedelta(days=3), duration_seconds=target_seconds)
+    # 5 days ago — hit
+    _add_session(db, user.id, book.id, now - timedelta(days=5), duration_seconds=target_seconds + 60)
+    # 1 day ago — miss (only 600s = 10min)
+    _add_session(db, user.id, book.id, now - timedelta(days=1), duration_seconds=600)
+
+    result = _create_goal(client, "minutes_per_day", target_minutes)
+    assert result["days_hit_this_week"] == 2
+
+
+# ── tests — minutes_per_week progress ────────────────────────────────────────
+
+def test_minutes_per_week_sums_last_7_days(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """minutes_per_week sums sessions from the last 7 local days."""
+    user, _ = admin_user
+    book = make_book(title="Week Minutes Book")
+    now = datetime.utcnow()
+
+    # 1 day ago: 30 min
+    _add_session(db, user.id, book.id, now - timedelta(days=1), duration_seconds=1800)
+    # 4 days ago: 60 min
+    _add_session(db, user.id, book.id, now - timedelta(days=4), duration_seconds=3600)
+    # 8 days ago: 45 min — outside 7-day window
+    _add_session(db, user.id, book.id, now - timedelta(days=8), duration_seconds=2700)
+
+    result = _create_goal(client, "minutes_per_week", 120)
+    assert result["kind"] == "minutes_per_week"
+    assert result["metric"] == "minutes"
+    assert result["period"] == "week"
+    # Should sum only the in-window sessions: 30 + 60 = 90 min
+    assert result["current"] == pytest.approx(90.0, abs=1.0)
+    # No days_hit_this_week for weekly goals
+    assert "days_hit_this_week" not in result
+
+
+def test_minutes_per_week_pct(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """minutes_per_week pct is computed correctly."""
+    user, _ = admin_user
+    book = make_book(title="Pct Week Book")
+    now = datetime.utcnow()
+
+    # 60 min in window
+    _add_session(db, user.id, book.id, now - timedelta(days=2), duration_seconds=3600)
+
+    result = _create_goal(client, "minutes_per_week", 120)
+    assert result["pct"] == pytest.approx(50.0, abs=1.0)
+
+
+# ── tests — pages_per_day progress ───────────────────────────────────────────
+
+def test_pages_per_day_today_calculation(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """pages_per_day.current sums pages_turned from today's sessions only."""
+    user, _ = admin_user
+    book = make_book(title="Pages Book")
+    now = datetime.utcnow()
+
+    # 50 pages today
+    _add_session(db, user.id, book.id, now - timedelta(minutes=10), duration_seconds=600, pages_turned=50)
+    # 30 pages yesterday — should NOT count
+    _add_session(db, user.id, book.id, now - timedelta(days=1), duration_seconds=600, pages_turned=30)
+
+    result = _create_goal(client, "pages_per_day", 100)
+    assert result["kind"] == "pages_per_day"
+    assert result["metric"] == "pages"
+    assert result["period"] == "day"
+    assert result["current"] == 50
+    assert result["pct"] == pytest.approx(50.0, abs=0.1)
+    assert "days_hit_this_week" in result
+
+
+def test_pages_per_day_days_hit_this_week(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """days_hit_this_week counts days in the last 7 where pages goal was met."""
+    user, _ = admin_user
+    book = make_book(title="Pages Week Book")
+    now = datetime.utcnow()
+    target_pages = 50
+
+    # 2 days ago — hit (60 pages)
+    _add_session(db, user.id, book.id, now - timedelta(days=2), pages_turned=60)
+    # 4 days ago — hit exactly (50 pages)
+    _add_session(db, user.id, book.id, now - timedelta(days=4), pages_turned=target_pages)
+    # 1 day ago — miss (20 pages)
+    _add_session(db, user.id, book.id, now - timedelta(days=1), pages_turned=20)
+
+    result = _create_goal(client, "pages_per_day", target_pages)
+    assert result["days_hit_this_week"] == 2
+
+
+# ── tests — pages_per_week progress ──────────────────────────────────────────
+
+def test_pages_per_week_sums_last_7_days(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """pages_per_week sums pages_turned from the last 7 local days."""
+    user, _ = admin_user
+    book = make_book(title="Pages Per Week Book")
+    now = datetime.utcnow()
+
+    # 80 pages 2 days ago
+    _add_session(db, user.id, book.id, now - timedelta(days=2), pages_turned=80)
+    # 100 pages 5 days ago
+    _add_session(db, user.id, book.id, now - timedelta(days=5), pages_turned=100)
+    # 200 pages 9 days ago — outside window
+    _add_session(db, user.id, book.id, now - timedelta(days=9), pages_turned=200)
+
+    result = _create_goal(client, "pages_per_week", 350)
+    assert result["kind"] == "pages_per_week"
+    assert result["metric"] == "pages"
+    assert result["period"] == "week"
+    # In-window: 80 + 100 = 180
+    assert result["current"] == 180
+    assert "days_hit_this_week" not in result
+
+
+# ── tests — goal_reached notifications ────────────────────────────────────────
+
+def test_year_goal_reached_creates_notification_once(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """Reaching a year goal notifies exactly once per window."""
+    user, _ = admin_user
+    now = datetime.utcnow()
+    for i in range(2):
+        book = make_book(title=f"Reached Book {i}")
+        _finish_book(db, user.id, book.id, updated_at=now - timedelta(days=i + 1))
+
+    goal = _create_goal(client, "books_per_year", 2)
+    assert goal["current"] == 2
+
+    notes = db.query(Notification).filter(Notification.kind == "goal_reached").all()
+    assert len(notes) == 1
+    assert notes[0].user_id == user.id
+    assert "2 books" in (notes[0].body or "")
+    assert notes[0].link == "/stats"
+
+    # Re-reading the list must not create a second notification
+    _list_goals(client)
+    notes = db.query(Notification).filter(Notification.kind == "goal_reached").all()
+    assert len(notes) == 1
+
+
+def test_unreached_goal_does_not_notify(client: TestClient, db: Session):
+    _create_goal(client, "books_per_year", 50)
+    _list_goals(client)
+    notes = db.query(Notification).filter(Notification.kind == "goal_reached").all()
+    assert notes == []
+
+
+def test_daily_goal_does_not_notify(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """Day/week goals never create notifications (rolling windows would flood)."""
+    user, _ = admin_user
+    book = make_book(title="Daily Notify Book")
+    now = datetime.utcnow()
+    _add_session(db, user.id, book.id, now - timedelta(minutes=5), duration_seconds=3600)
+
+    goal = _create_goal(client, "minutes_per_day", 10)
+    assert goal["current"] >= 10
+
+    notes = db.query(Notification).filter(Notification.kind == "goal_reached").all()
+    assert notes == []
+
+
+def test_raised_target_can_renotify(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """Editing the target clears the notified marker; reaching the new target notifies again."""
+    user, _ = admin_user
+    now = datetime.utcnow()
+    books = [make_book(title=f"Renotify Book {i}") for i in range(3)]
+    for i, b in enumerate(books[:2]):
+        _finish_book(db, user.id, b.id, updated_at=now - timedelta(days=i + 1))
+
+    goal = _create_goal(client, "books_per_year", 2)  # reached → notification 1
+    _update_goal(client, goal["id"], 3)  # raised above current → marker cleared
+    _finish_book(db, user.id, books[2].id, updated_at=now)
+    _list_goals(client)  # reached again → notification 2
+
+    notes = db.query(Notification).filter(Notification.kind == "goal_reached").all()
+    assert len(notes) == 2
+
+
+# ── tests — per-user isolation ────────────────────────────────────────────────
+
+def test_goals_are_per_user_isolated(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """One user's goal is invisible to another user."""
+    user, _ = admin_user
+
+    # Create a second user
+    other = User(
+        username="other_user",
+        email="other@example.com",
+        hashed_password=hash_password("pass"),
+        is_active=True,
+        is_admin=False,
+        role="member",
+        must_change_password=False,
+    )
+    db.add(other)
+    db.flush()
+    db.add(UserPermission(user_id=other.id))
+    db.flush()
+    other_token = create_access_token(subject=other.id)
+
+    # Admin sets a goal
+    _create_goal(client, "books_per_year", 15)
+
+    # Other user sees no goals
+    from backend.main import create_app
+    from backend.core.database import get_db
+
+    app = create_app()
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    from starlette.testclient import TestClient as TC
+    with TC(app, raise_server_exceptions=True) as other_client:
+        other_client.headers["Authorization"] = f"Bearer {other_token}"
+        resp = other_client.get("/api/goals")
+        assert resp.status_code == 200
+        assert resp.json()["goals"] == []
+
+    app.dependency_overrides.clear()
+
+
+def test_progress_is_per_user(
+    client: TestClient, make_book, admin_user, db: Session
+):
+    """Books finished by another user don't count toward the current user's goal."""
+    user, _ = admin_user
+    other = User(
+        username="other2",
+        email="other2@example.com",
+        hashed_password=hash_password("pass"),
+        is_active=True,
+        is_admin=False,
+        role="member",
+        must_change_password=False,
+    )
+    db.add(other)
+    db.flush()
+    db.add(UserPermission(user_id=other.id))
+    db.flush()
+
+    book = make_book(title="Shared Book")
+    now = datetime.utcnow()
+    # Other user finished the book — admin user did not
+    _finish_book(db, other.id, book.id, updated_at=now - timedelta(days=1))
+
+    result = _create_goal(client, "books_per_year", 10)
+    assert result["current"] == 0
+
+
+def test_delete_other_users_goal_404(
+    client: TestClient, admin_user, db: Session
+):
+    """Deleting a goal owned by another user is a 404, not a 204."""
+    other = User(
+        username="other3",
+        email="other3@example.com",
+        hashed_password=hash_password("pass"),
+        is_active=True,
+        is_admin=False,
+        role="member",
+        must_change_password=False,
+    )
+    db.add(other)
+    db.flush()
+    goal = ReadingGoal(user_id=other.id, kind="books_per_year", target=5)
+    db.add(goal)
+    db.flush()
+
+    _delete_goal(client, goal.id, expected_status=404)
+    assert db.query(ReadingGoal).filter(ReadingGoal.id == goal.id).first() is not None


### PR DESCRIPTION
## Reading goals

Set a target and watch a ring fill as you read. Goals are computed from data Tome already tracks — KOReader + web-reader sessions and finished books — so there's no new tracking, just a target plus a query.

### What's in it
- **Six curated kinds** — books per year/month, minutes & pages per day/week — each optionally **scoped to a single book type**, so "20 books this year" and "20 manga this year" count separately (no padding the year challenge with one-sitting volumes).
- **One "Reading Goals" tile** on the stats dashboard shows every goal as a card in an even auto-fill grid that adapts from 1 to 6 columns to the tile's width (verified at w3/w6/w12). Add, edit and delete are managed in place on each card; preset chips (the classic 12/24/52-book year challenge) ease you in.
- **Home tab** gets compact read-only rings that mirror the quick-stats strip's visual language.
- **Pace** — month/year goals show whether you're ahead of or behind the prorated target.
- **Notifications** — reaching a month/year goal drops a `goal_reached` notice in the bell (once per window; day/week excluded so rolling windows don't flood it).
- Goals are per-user; nothing is shared.

### Backend
`ReadingGoal` model + `/api/goals` (GET/POST/PUT/DELETE). Progress computed live with tz-aware period windows; lazy `goal_reached` notifications created on read. Startup drops the stale parked-era `reading_goals` table (pre-book_type_id schema) so it recreates cleanly.

### Tests
33 new tests in `tests/test_goals.py` (window boundaries, tz handling, book-type filtering, notification dedup/re-notify, per-user isolation). Full suite: **521 passed**. Frontend `tsc -b` + vite build clean.

### Notes
Branched off `poc/ui-refresh`, rebased onto main after #45 merged — only overlap was the CHANGELOG entry. Built on the new oxblood/Bricolage identity throughout.