### PR TITLE
fix: gate book visibility by library membership (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+- **Private libraries now actually hide books.** Book visibility is gated solely
+  by library membership: a book placed in a private library is hidden from
+  everyone except the library's owner, its assigned users, and admins —
+  regardless of who uploaded it. Previously every book uploaded by an admin was
+  shown to all members and guests no matter which library it was in, so an admin
+  who filed books into a private library still leaked their contents. Books that
+  aren't in any library remain visible to everyone (a member's own unfiled
+  uploads stay private to them); to restrict a book, place it in a private
+  library. The rule is now applied consistently everywhere books surface — the
+  library grid, the series and filter (facet) lists, single-book and series
+  pages, OPDS, and the TomeSync (KOReader) series browser, which previously
+  applied no visibility filter at all and exposed the entire catalogue. (#53)
+
 ## [1.5.0] — 2026-06-13 — "Rubric"
 
 ### Added

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -130,48 +130,16 @@ def list_books(
     current_user: User = Depends(get_current_user),
 ):
     from backend.core.permissions import is_admin as _is_admin
-    from sqlalchemy import or_
 
     query = db.query(Book).filter(Book.status == "active")
 
     # ── Role-based visibility ────────────────────────────────────────────────
+    # Single source of truth lives in backend.core.permissions; see there for
+    # the full rule (library membership gates everything; unfiled admin/legacy
+    # books stay shared; admins see all).
     if not _is_admin(current_user):
-        from backend.models.library import library_users_table
-        # Collect admin user IDs (NULL added_by also treated as admin-uploaded)
-        admin_ids = [
-            u.id for u in db.query(User).filter(
-                (User.is_admin == True) | (User.role == "admin")
-            ).all()
-        ]
-        if current_user.role == "member":
-            # Member sees: admin-uploaded books + own uploads + books in assigned libraries
-            assigned_lib_ids = [
-                row[1] for row in db.execute(
-                    library_users_table.select().where(
-                        library_users_table.c.user_id == current_user.id
-                    )
-                ).fetchall()
-            ]
-            visibility_conditions = [
-                Book.added_by.in_(admin_ids),
-                Book.added_by.is_(None),        # legacy books without uploader = shared
-                Book.added_by == current_user.id,
-                Book.libraries.any(Library.is_public == True),  # public = shared with all
-            ]
-            if assigned_lib_ids:
-                visibility_conditions.append(
-                    Book.libraries.any(Library.id.in_(assigned_lib_ids))
-                )
-            query = query.filter(or_(*visibility_conditions))
-        else:
-            # Guest sees: admin-uploaded books + books in public libraries
-            query = query.filter(
-                or_(
-                    Book.added_by.in_(admin_ids),
-                    Book.added_by.is_(None),    # legacy books without uploader = shared
-                    Book.libraries.any(Library.is_public == True),
-                )
-            )
+        from backend.core.permissions import book_visibility_filter
+        query = query.filter(book_visibility_filter(db, current_user))
 
     if q:
         from sqlalchemy import text as sa_text
@@ -379,25 +347,27 @@ def list_books(
 @router.get("/facets", response_model=dict)
 def get_facets(
     db: Session = Depends(get_db),
-    _: User = Depends(get_current_user),
+    current_user: User = Depends(get_current_user),
 ):
     """Return distinct values for filter dropdowns: series, authors, tags, formats."""
     from sqlalchemy import func
+    from backend.core.permissions import book_visibility_filter
+    visibility = book_visibility_filter(db, current_user)
 
     series = [r[0] for r in db.query(Book.series).filter(
-        Book.status == "active", Book.series.isnot(None)
+        Book.status == "active", Book.series.isnot(None), visibility
     ).distinct().order_by(Book.series).all()]
 
     authors = [r[0] for r in db.query(Book.author).filter(
-        Book.status == "active", Book.author.isnot(None)
+        Book.status == "active", Book.author.isnot(None), visibility
     ).distinct().order_by(Book.author).all()]
 
     tags = [r[0] for r in db.query(BookTag.tag).join(Book).filter(
-        Book.status == "active"
+        Book.status == "active", visibility
     ).distinct().order_by(BookTag.tag).all()]
 
     formats = [r[0] for r in db.query(BookFile.format).join(Book).filter(
-        Book.status == "active"
+        Book.status == "active", visibility
     ).distinct().order_by(BookFile.format).all()]
 
     return {"series": series, "authors": authors, "tags": tags, "formats": formats}
@@ -412,10 +382,12 @@ def get_series(
 ):
     """Return all series with book count, cover book id, description snippet, and reading status counts."""
     from sqlalchemy import func
+    from backend.core.permissions import book_visibility_filter
+    visibility = book_visibility_filter(db, current_user)
 
     series_rows = (
         db.query(Book.series, func.count(Book.id).label("book_count"))
-        .filter(Book.status == "active", Book.series.isnot(None))
+        .filter(Book.status == "active", Book.series.isnot(None), visibility)
         .group_by(Book.series)
         .order_by(Book.series)
         .all()
@@ -436,7 +408,7 @@ def get_series(
         # Pick the book with the lowest series_index as the cover; fall back to lowest id if all null
         series_books = (
             db.query(Book)
-            .filter(Book.status == "active", Book.series == series_name)
+            .filter(Book.status == "active", Book.series == series_name, visibility)
             .order_by(
                 Book.series_index.is_(None),  # nulls last
                 Book.series_index,
@@ -462,13 +434,13 @@ def get_series(
     # Append unserialized bucket if any books have no series
     unserialized_count = (
         db.query(func.count(Book.id))
-        .filter(Book.status == "active", Book.series.is_(None))
+        .filter(Book.status == "active", Book.series.is_(None), visibility)
         .scalar()
     )
     if unserialized_count:
         first_unserialized = (
             db.query(Book)
-            .filter(Book.status == "active", Book.series.is_(None))
+            .filter(Book.status == "active", Book.series.is_(None), visibility)
             .order_by(Book.id)
             .first()
         )
@@ -494,9 +466,10 @@ def get_series_detail(
     current_user: User = Depends(get_current_user),
 ):
     """Return all books in a series with per-user reading status, ordered by series_index."""
+    from backend.core.permissions import book_visibility_filter
     books = (
         db.query(Book)
-        .filter(Book.status == "active", Book.series == name)
+        .filter(Book.status == "active", Book.series == name, book_visibility_filter(db, current_user))
         .order_by(Book.series_index.asc().nullslast(), Book.title.asc())
         .all()
     )
@@ -934,9 +907,14 @@ def get_adjacent_books(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
+    from backend.core.permissions import book_visibility_filter
     book = db.get(Book, book_id)
-    if not book:
+    if not book or not user_can_see_book(db, current_user, book):
         raise HTTPException(status_code=404, detail="Book not found")
+
+    # Peers must respect the same visibility rules — don't leak titles/covers of
+    # sibling books the user can't otherwise see (e.g. private-library volumes).
+    visibility = book_visibility_filter(db, current_user)
 
     def to_stub(b: Book | None) -> dict | None:
         if b is None:
@@ -946,7 +924,7 @@ def get_adjacent_books(
     if book.series:
         peers = (
             db.query(Book)
-            .filter(Book.series == book.series, Book.status == "active")
+            .filter(Book.series == book.series, Book.status == "active", visibility)
             .order_by(Book.series_index.asc().nullslast(), Book.title.asc())
             .all()
         )
@@ -954,7 +932,7 @@ def get_adjacent_books(
     elif book.author:
         peers = (
             db.query(Book)
-            .filter(Book.author == book.author, Book.status == "active")
+            .filter(Book.author == book.author, Book.status == "active", visibility)
             .order_by(Book.title.asc())
             .all()
         )
@@ -1057,39 +1035,13 @@ def get_book(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    from backend.core.permissions import is_admin as _is_admin
-    from sqlalchemy import or_
+    from backend.core.permissions import is_admin as _is_admin, user_can_see_book
     book = db.query(Book).filter(Book.id == book_id).first()
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
-    # Visibility check for non-admins
-    if not _is_admin(current_user):
-        from backend.models.library import library_users_table
-        admin_ids = {
-            u.id for u in db.query(User).filter(
-                (User.is_admin == True) | (User.role == "admin")
-            ).all()
-        }
-        is_admin_book = book.added_by is None or book.added_by in admin_ids
-        is_own_book = book.added_by == current_user.id
-        if current_user.role == "member":
-            assigned_lib_ids = {
-                row[1] for row in db.execute(
-                    library_users_table.select().where(
-                        library_users_table.c.user_id == current_user.id
-                    )
-                ).fetchall()
-            }
-            book_lib_ids = {lib.id for lib in book.libraries}
-            in_assigned_library = bool(assigned_lib_ids & book_lib_ids)
-            in_public_library = any(lib.is_public for lib in book.libraries)
-            if not (is_admin_book or is_own_book or in_assigned_library or in_public_library):
-                raise HTTPException(status_code=404, detail="Book not found")
-        else:
-            # Guest
-            in_public_library = any(lib.is_public for lib in book.libraries)
-            if not (is_admin_book or in_public_library):
-                raise HTTPException(status_code=404, detail="Book not found")
+    # Visibility check for non-admins (shared rule, see permissions.py)
+    if not _is_admin(current_user) and not user_can_see_book(db, current_user, book):
+        raise HTTPException(status_code=404, detail="Book not found")
     return book
 
 

--- a/backend/api/opds.py
+++ b/backend/api/opds.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session, joinedload
 from backend.core.database import get_db
 from backend.core.security import get_current_user_basic
 from backend.core.config import settings
-from backend.core.permissions import is_admin as _is_admin
+from backend.core.permissions import book_visibility_filter, is_admin as _is_admin
 from backend.models.book import Book, BookFile
 from backend.models.library import Library
 from backend.models.user import User
@@ -32,20 +32,21 @@ def _base_url(request: Request) -> str:
     return str(request.base_url).rstrip("/")
 
 
-def _apply_visibility(query, user: User):
-    """Replicate the same visibility rules as the main books API."""
+def _apply_visibility(query, db: Session, user: User):
+    """Restrict to books the user can see, using the shared visibility rule
+    (backend.core.permissions.book_visibility_filter) so OPDS stays in lockstep
+    with the web/TomeSync surfaces. Uses EXISTS subqueries, so it doesn't
+    duplicate rows under aggregate/group_by queries."""
     if _is_admin(user):
         return query
-    return query.join(Book.libraries).filter(
-        (Library.is_public == True) |  # noqa: E712
-        Library.assigned_users.any(User.id == user.id)
-    )
+    return query.filter(book_visibility_filter(db, user))
 
 
 def _book_query(db: Session, user: User):
     return (
         _apply_visibility(
             db.query(Book).options(joinedload(Book.files), joinedload(Book.tags)),
+            db,
             user,
         )
         .filter(Book.status == "active")
@@ -153,7 +154,7 @@ def opds_series(
 ):
     base = _base_url(request)
     rows = (
-        _apply_visibility(db.query(Book.series, func.count(Book.id.distinct())), user)
+        _apply_visibility(db.query(Book.series, func.count(Book.id.distinct())), db, user)
         .filter(Book.series.isnot(None), Book.status == "active")
         .group_by(Book.series)
         .order_by(Book.series.asc())
@@ -208,7 +209,7 @@ def opds_authors(
 ):
     base = _base_url(request)
     rows = (
-        _apply_visibility(db.query(Book.author, func.count(Book.id.distinct())), user)
+        _apply_visibility(db.query(Book.author, func.count(Book.id.distinct())), db, user)
         .filter(Book.author.isnot(None), Book.status == "active")
         .group_by(Book.author)
         .order_by(Book.author.asc())
@@ -264,6 +265,7 @@ def opds_libraries(
             db.query(Library)
             .filter(
                 (Library.is_public == True) |  # noqa: E712
+                (Library.owner_id == user.id) |
                 Library.assigned_users.any(User.id == user.id)
             )
             .order_by(Library.sort_order.asc(), Library.name.asc())
@@ -293,7 +295,7 @@ def opds_library_books(
     lib = db.get(Library, library_id)
     if not lib:
         raise HTTPException(status_code=404, detail="Library not found")
-    if not _is_admin(user) and not lib.is_public:
+    if not _is_admin(user) and not lib.is_public and lib.owner_id != user.id:
         if not any(u.id == user.id for u in lib.assigned_users):
             raise HTTPException(status_code=403)
 

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import Session, joinedload
 from backend.core.config import settings
 from backend.core.database import get_db
 from backend.core.urls import public_base_url
-from backend.core.permissions import user_can_see_book
+from backend.core.permissions import book_visibility_filter, user_can_see_book
 from backend.core.security import get_current_user
 from backend.models.user import User
 from backend.models.book import Book, BookFile
@@ -526,9 +526,13 @@ def list_series(
     user: User = Depends(_get_api_key_user),
 ):
     """List all series for the series browser menu."""
+    # Only count/expose books this user is allowed to see. book_visibility_filter
+    # uses correlated EXISTS subqueries (no joins), so it doesn't duplicate rows
+    # under the group_by, and returns True (no-op) for admins.
+    visibility = book_visibility_filter(db, user)
     rows = (
         db.query(Book.series, func.count(Book.id).label("book_count"))
-        .filter(Book.status == "active", Book.series.isnot(None))
+        .filter(Book.status == "active", Book.series.isnot(None), visibility)
         .group_by(Book.series)
         .order_by(Book.series)
         .all()
@@ -538,7 +542,7 @@ def list_series(
     for series_name, book_count in rows:
         first_book = (
             db.query(Book)
-            .filter(Book.status == "active", Book.series == series_name)
+            .filter(Book.status == "active", Book.series == series_name, visibility)
             .order_by(Book.series_index.asc().nullslast(), Book.title.asc())
             .first()
         )
@@ -559,13 +563,13 @@ def list_series(
     # standalone books can be browsed and downloaded.
     unserialized_count = (
         db.query(func.count(Book.id))
-        .filter(Book.status == "active", Book.series.is_(None))
+        .filter(Book.status == "active", Book.series.is_(None), visibility)
         .scalar()
     )
     if unserialized_count:
         first_unserialized = (
             db.query(Book)
-            .filter(Book.status == "active", Book.series.is_(None))
+            .filter(Book.status == "active", Book.series.is_(None), visibility)
             .order_by(Book.id)
             .first()
         )
@@ -586,7 +590,7 @@ def get_series_books(
 ):
     """Given a book_id, return all books in the same series with file info."""
     book = db.get(Book, book_id)
-    if not book or book.status != "active":
+    if not book or book.status != "active" or not user_can_see_book(db, user, book):
         raise HTTPException(status_code=404, detail="Book not found")
 
     if book.series:
@@ -601,7 +605,7 @@ def get_series_books(
     books = (
         db.query(Book)
         .options(joinedload(Book.files), joinedload(Book.book_type))
-        .filter(Book.status == "active", series_filter)
+        .filter(Book.status == "active", series_filter, book_visibility_filter(db, user))
         .order_by(Book.series_index.asc().nullslast(), Book.title.asc())
         .all()
     )

--- a/backend/core/permissions.py
+++ b/backend/core/permissions.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fastapi import HTTPException
-from sqlalchemy import or_
+from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 from backend.models.user import User
 
@@ -34,11 +34,19 @@ def is_member_or_above(user: User) -> bool:
 
 def book_visibility_filter(db: Session, user: User):
     """Return a SQLAlchemy filter expression restricting Book rows to those
-    the user is allowed to see. Kept in sync with the visibility logic in
-    GET /api/books. If you change one, change the other.
+    the user is allowed to see. This is the single source of truth for book
+    visibility — the books, downloads, stats, OPDS and TomeSync surfaces all
+    route through it (directly or via :func:`user_can_see_book`).
+
+    Library membership is the gate: a book placed in a private library is
+    visible only to the library owner, its assigned users, and admins. A book
+    that is in *no* library at all falls back to the legacy "shared
+    collection" rule — admin-uploaded (or uploader-less, legacy) unfiled books
+    stay visible to everyone, while a member's own unfiled upload stays private
+    to just them. Admins always see everything.
     """
     from backend.models.book import Book
-    from backend.models.library import Library, library_users_table
+    from backend.models.library import Library
     from backend.models.user import User as _User
 
     if is_admin(user):
@@ -50,28 +58,21 @@ def book_visibility_filter(db: Session, user: User):
         ).all()
     ]
 
-    if user.role == "member":
-        assigned_lib_ids = [
-            row[1] for row in db.execute(
-                library_users_table.select().where(
-                    library_users_table.c.user_id == user.id
-                )
-            ).fetchall()
-        ]
-        conditions = [
-            Book.added_by.in_(admin_ids),
-            Book.added_by.is_(None),
-            Book.added_by == user.id,
-            Book.libraries.any(Library.is_public == True),  # noqa: E712
-        ]
-        if assigned_lib_ids:
-            conditions.append(Book.libraries.any(Library.id.in_(assigned_lib_ids)))
-        return or_(*conditions)
-
+    no_library = ~Book.libraries.any()
     return or_(
-        Book.added_by.in_(admin_ids),
-        Book.added_by.is_(None),
+        # Own uploads are always visible to their uploader.
+        Book.added_by == user.id,
+        # Unfiled books fall back to the shared-collection rule: admin-uploaded
+        # or legacy (no uploader) books stay public; a member's own unfiled
+        # upload is already covered by the clause above and stays private.
+        and_(
+            no_library,
+            or_(Book.added_by.is_(None), Book.added_by.in_(admin_ids)),
+        ),
+        # Library membership gates everything else.
         Book.libraries.any(Library.is_public == True),  # noqa: E712
+        Book.libraries.any(Library.owner_id == user.id),
+        Book.libraries.any(Library.assigned_users.any(_User.id == user.id)),
     )
 
 

--- a/tests/test_book_visibility.py
+++ b/tests/test_book_visibility.py
@@ -1,0 +1,260 @@
+"""Regression tests for book visibility (issue #53).
+
+Before the fix, every admin-uploaded book was visible to all members/guests
+regardless of library membership (`Book.added_by.in_(admin_ids)`), so placing
+an admin's book in a *private* library did not hide it. TomeSync's series
+browser applied no visibility filter at all, leaking the whole catalogue.
+
+The rule now: library membership is the gate. A book in a private library is
+visible only to the owner, its assigned users, and admins. A book in *no*
+library falls back to the legacy shared-collection rule — admin/legacy unfiled
+books stay public; a member's own unfiled upload stays private to them.
+"""
+from sqlalchemy.orm import Session
+
+from backend.core.security import hash_password, create_access_token
+from backend.models.book import Book, BookFile
+from backend.models.library import Library
+from backend.models.tome_sync import ApiKey
+from backend.models.user import User
+
+
+def _make_user(db: Session, username: str, role: str, is_admin: bool = False) -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password=hash_password("password123"),
+        is_active=True,
+        is_admin=is_admin,
+        role=role,
+        must_change_password=False,
+    )
+    db.add(user)
+    db.flush()
+    return user, create_access_token(subject=user.id)
+
+
+def _make_book(db: Session, title: str, added_by: int | None,
+               series: str | None = None, series_index: float | None = None) -> Book:
+    book = Book(
+        title=title,
+        author="Some Author",
+        series=series,
+        series_index=series_index,
+        status="active",
+        added_by=added_by,
+    )
+    db.add(book)
+    db.flush()
+    db.add(BookFile(book_id=book.id, file_path=f"/library/{book.id}/{title}.epub",
+                    format="epub", file_size=1024))
+    db.flush()
+    return book
+
+
+def _make_lib(db: Session, name: str, is_public: bool, owner_id: int | None = None) -> Library:
+    lib = Library(name=name, is_public=is_public, owner_id=owner_id)
+    db.add(lib)
+    db.flush()
+    return lib
+
+
+def _file_in(db: Session, book: Book, lib: Library) -> None:
+    book.libraries.append(lib)
+    db.flush()
+
+
+def _hdr(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _book_ids(client, token: str) -> set[int]:
+    r = client.get("/api/books", headers=_hdr(token))
+    assert r.status_code == 200, r.text
+    return {b["id"] for b in r.json()}
+
+
+def _series_names(client, token: str) -> set[str]:
+    r = client.get("/api/books/series", headers=_hdr(token))
+    assert r.status_code == 200, r.text
+    return {s["name"] for s in r.json()}
+
+
+def _api_key_hdr(db: Session, user_id: int) -> dict:
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(user_id=user_id, key_hash=ApiKey.hash_key(plaintext), label="test"))
+    db.flush()
+    return {"Authorization": f"Bearer {plaintext}"}
+
+
+# ── The core bug: admin book in a private library ───────────────────────────────
+
+def test_admin_book_in_private_library_hidden_from_member(client, db, admin_user):
+    """Issue #53: an admin-uploaded book in a private-only library must NOT be
+    visible to a member who isn't assigned to that library."""
+    admin, admin_token = admin_user
+    _member, m_token = _make_user(db, "mem53", "member")
+
+    priv = _make_lib(db, "Admin Private", is_public=False, owner_id=admin.id)
+    book = _make_book(db, "Hidden Admin Book", added_by=admin.id)
+    _file_in(db, book, priv)
+
+    assert book.id not in _book_ids(client, m_token)
+    assert client.get(f"/api/books/{book.id}", headers=_hdr(m_token)).status_code == 404
+    # Admin still sees it
+    assert book.id in _book_ids(client, admin_token)
+
+
+def test_admin_book_in_private_library_hidden_from_guest(client, db, admin_user):
+    admin, _ = admin_user
+    _guest, g_token = _make_user(db, "gst53", "guest")
+    priv = _make_lib(db, "Admin Private G", is_public=False, owner_id=admin.id)
+    book = _make_book(db, "Hidden From Guest", added_by=admin.id)
+    _file_in(db, book, priv)
+    assert book.id not in _book_ids(client, g_token)
+    assert client.get(f"/api/books/{book.id}", headers=_hdr(g_token)).status_code == 404
+
+
+def test_public_library_book_visible_to_everyone(client, db, admin_user):
+    admin, _ = admin_user
+    _member, m_token = _make_user(db, "mem_pub", "member")
+    _guest, g_token = _make_user(db, "gst_pub", "guest")
+    pub = _make_lib(db, "Public", is_public=True, owner_id=admin.id)
+    book = _make_book(db, "Public Book", added_by=admin.id)
+    _file_in(db, book, pub)
+    assert book.id in _book_ids(client, m_token)
+    assert book.id in _book_ids(client, g_token)
+
+
+def test_book_in_both_public_and_private_is_visible(client, db, admin_user):
+    """Public membership wins even when the book is also in a private library."""
+    admin, _ = admin_user
+    _member, m_token = _make_user(db, "mem_both", "member")
+    pub = _make_lib(db, "Public Both", is_public=True, owner_id=admin.id)
+    priv = _make_lib(db, "Private Both", is_public=False, owner_id=admin.id)
+    book = _make_book(db, "Dual Book", added_by=admin.id)
+    _file_in(db, book, pub)
+    _file_in(db, book, priv)
+    assert book.id in _book_ids(client, m_token)
+
+
+# ── No-library fallback (scoped option A) ───────────────────────────────────────
+
+def test_admin_unfiled_book_visible_to_all(client, db, admin_user):
+    admin, _ = admin_user
+    _member, m_token = _make_user(db, "mem_unf", "member")
+    _guest, g_token = _make_user(db, "gst_unf", "guest")
+    book = _make_book(db, "Admin Unfiled", added_by=admin.id)  # no library
+    assert book.id in _book_ids(client, m_token)
+    assert book.id in _book_ids(client, g_token)
+
+
+def test_legacy_unfiled_book_visible_to_all(client, db, admin_user):
+    _member, m_token = _make_user(db, "mem_leg", "member")
+    book = _make_book(db, "Legacy Book", added_by=None)  # no uploader, no library
+    assert book.id in _book_ids(client, m_token)
+
+
+def test_member_unfiled_upload_private_to_uploader(client, db, admin_user):
+    """A member's own unfiled upload stays visible to them but not other members."""
+    member_a, a_token = _make_user(db, "memA53", "member")
+    _member_b, b_token = _make_user(db, "memB53", "member")
+    book = _make_book(db, "A's Draft", added_by=member_a.id)  # no library
+    assert book.id in _book_ids(client, a_token)        # uploader sees own
+    assert book.id not in _book_ids(client, b_token)    # other member does not
+
+
+# ── Owner / assigned access to private libraries ────────────────────────────────
+
+def test_member_sees_books_in_library_they_own(client, db, admin_user):
+    member, m_token = _make_user(db, "owner53", "member")
+    priv = _make_lib(db, "My Private", is_public=False, owner_id=member.id)
+    # Book uploaded by admin but filed into the member's own private library
+    admin, _ = admin_user
+    book = _make_book(db, "In My Library", added_by=admin.id)
+    _file_in(db, book, priv)
+    assert book.id in _book_ids(client, m_token)
+
+
+def test_member_sees_books_in_assigned_library(client, db, admin_user):
+    admin, _ = admin_user
+    member, m_token = _make_user(db, "assigned53", "member")
+    priv = _make_lib(db, "Shared Private", is_public=False, owner_id=admin.id)
+    priv.assigned_users.append(member)
+    db.flush()
+    book = _make_book(db, "Assigned Book", added_by=admin.id)
+    _file_in(db, book, priv)
+    assert book.id in _book_ids(client, m_token)
+
+
+# ── Aggregation surfaces (series / facets) ──────────────────────────────────────
+
+def test_series_listing_excludes_private(client, db, admin_user):
+    admin, _ = admin_user
+    _member, m_token = _make_user(db, "mem_series", "member")
+    pub = _make_lib(db, "Pub S", is_public=True, owner_id=admin.id)
+    priv = _make_lib(db, "Priv S", is_public=False, owner_id=admin.id)
+    pub_book = _make_book(db, "Pub V1", added_by=admin.id, series="Visible Series", series_index=1)
+    priv_book = _make_book(db, "Priv V1", added_by=admin.id, series="Secret Series", series_index=1)
+    _file_in(db, pub_book, pub)
+    _file_in(db, priv_book, priv)
+
+    names = _series_names(client, m_token)
+    assert "Visible Series" in names
+    assert "Secret Series" not in names
+
+
+def test_facets_exclude_private_series_and_authors(client, db, admin_user):
+    admin, _ = admin_user
+    _member, m_token = _make_user(db, "mem_facet", "member")
+    priv = _make_lib(db, "Priv F", is_public=False, owner_id=admin.id)
+    book = _make_book(db, "Secret Facet", added_by=admin.id, series="Secret Facet Series")
+    _file_in(db, book, priv)
+
+    r = client.get("/api/books/facets", headers=_hdr(m_token))
+    assert r.status_code == 200, r.text
+    assert "Secret Facet Series" not in r.json()["series"]
+
+
+# ── TomeSync series browser (was completely unfiltered) ─────────────────────────
+
+def test_tomesync_series_browser_excludes_private(client, db, admin_user):
+    admin, _ = admin_user
+    member, _ = _make_user(db, "mem_ts", "member")
+    pub = _make_lib(db, "Pub TS", is_public=True, owner_id=admin.id)
+    priv = _make_lib(db, "Priv TS", is_public=False, owner_id=admin.id)
+    pub_book = _make_book(db, "TS Pub", added_by=admin.id, series="TS Visible", series_index=1)
+    priv_book = _make_book(db, "TS Priv", added_by=admin.id, series="TS Secret", series_index=1)
+    _file_in(db, pub_book, pub)
+    _file_in(db, priv_book, priv)
+
+    hdr = _api_key_hdr(db, member.id)
+    r = client.get("/api/tome-sync/series", headers=hdr)
+    assert r.status_code == 200, r.text
+    names = {s["name"] for s in r.json()}
+    assert "TS Visible" in names
+    assert "TS Secret" not in names
+
+    # Direct series fetch on the private book's id must 404
+    r2 = client.get(f"/api/tome-sync/series/{priv_book.id}", headers=hdr)
+    assert r2.status_code == 404
+
+
+def test_tomesync_series_books_filtered(client, db, admin_user):
+    """Within a visible series, volumes that live only in a private library are
+    excluded from the per-series book list."""
+    admin, _ = admin_user
+    member, _ = _make_user(db, "mem_ts2", "member")
+    pub = _make_lib(db, "Pub TS2", is_public=True, owner_id=admin.id)
+    priv = _make_lib(db, "Priv TS2", is_public=False, owner_id=admin.id)
+    v1 = _make_book(db, "Mixed V1", added_by=admin.id, series="Mixed Series", series_index=1)
+    v2 = _make_book(db, "Mixed V2", added_by=admin.id, series="Mixed Series", series_index=2)
+    _file_in(db, v1, pub)
+    _file_in(db, v2, priv)
+
+    hdr = _api_key_hdr(db, member.id)
+    r = client.get(f"/api/tome-sync/series/{v1.id}", headers=hdr)
+    assert r.status_code == 200, r.text
+    ids = {b["id"] for b in r.json()["books"]}
+    assert v1.id in ids
+    assert v2.id not in ids

--- a/tests/test_opds_visibility.py
+++ b/tests/test_opds_visibility.py
@@ -1,0 +1,151 @@
+"""Visibility regression tests for the OPDS feed (issue #53).
+
+OPDS previously used its own visibility copy (an inner join on libraries) and
+had no coverage. It now routes through the shared
+``backend.core.permissions.book_visibility_filter`` like every other surface,
+so private-library books are hidden, unfiled admin books stay visible, and a
+member's own unfiled upload stays private.
+"""
+from sqlalchemy.orm import Session
+
+from backend.core.security import hash_password, create_access_token, get_current_user_basic
+from backend.models.book import Book, BookFile
+from backend.models.library import Library
+from backend.models.user import User
+
+
+def _make_user(db: Session, username: str, role: str, is_admin: bool = False) -> User:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password=hash_password("password123"),
+        is_active=True,
+        is_admin=is_admin,
+        role=role,
+        must_change_password=False,
+    )
+    db.add(user)
+    db.flush()
+    return user
+
+
+def _make_book(db: Session, title: str, added_by: int | None,
+               series: str | None = None) -> Book:
+    book = Book(title=title, author="Auth", series=series, status="active", added_by=added_by)
+    db.add(book)
+    db.flush()
+    db.add(BookFile(book_id=book.id, file_path=f"/library/{book.id}/{title}.epub",
+                    format="epub", file_size=1024))
+    db.flush()
+    return book
+
+
+def _make_lib(db: Session, name: str, is_public: bool, owner_id: int | None = None) -> Library:
+    lib = Library(name=name, is_public=is_public, owner_id=owner_id)
+    db.add(lib)
+    db.flush()
+    return lib
+
+
+def _as(client, user: User):
+    client.app.dependency_overrides[get_current_user_basic] = lambda: user
+
+
+def _clear(client):
+    client.app.dependency_overrides.pop(get_current_user_basic, None)
+
+
+def _all_books_text(client, user: User) -> str:
+    _as(client, user)
+    try:
+        r = client.get("/opds/all")
+        assert r.status_code == 200, r.text
+        return r.text
+    finally:
+        _clear(client)
+
+
+def test_opds_hides_private_admin_book_from_member(client, db, admin_user):
+    admin, _ = admin_user
+    member = _make_user(db, "opds_mem", "member")
+    priv = _make_lib(db, "OPDS Priv", is_public=False, owner_id=admin.id)
+    pub = _make_lib(db, "OPDS Pub", is_public=True, owner_id=admin.id)
+    private_book = _make_book(db, "ZZ Private Title", added_by=admin.id)
+    public_book = _make_book(db, "ZZ Public Title", added_by=admin.id)
+    private_book.libraries.append(priv)
+    public_book.libraries.append(pub)
+    db.flush()
+
+    body = _all_books_text(client, member)
+    assert "ZZ Public Title" in body
+    assert "ZZ Private Title" not in body
+
+
+def test_opds_hides_private_admin_book_from_guest(client, db, admin_user):
+    admin, _ = admin_user
+    guest = _make_user(db, "opds_gst", "guest")
+    priv = _make_lib(db, "OPDS Priv G", is_public=False, owner_id=admin.id)
+    private_book = _make_book(db, "ZZ Guest Hidden", added_by=admin.id)
+    private_book.libraries.append(priv)
+    db.flush()
+    body = _all_books_text(client, guest)
+    assert "ZZ Guest Hidden" not in body
+
+
+def test_opds_shows_unfiled_admin_book(client, db, admin_user):
+    admin, _ = admin_user
+    member = _make_user(db, "opds_mem2", "member")
+    book = _make_book(db, "ZZ Unfiled Admin", added_by=admin.id)  # no library
+    db.flush()
+    assert "ZZ Unfiled Admin" in _all_books_text(client, member)
+
+
+def test_opds_hides_member_unfiled_upload_from_others(client, db, admin_user):
+    member_a = _make_user(db, "opds_a", "member")
+    member_b = _make_user(db, "opds_b", "member")
+    book = _make_book(db, "ZZ A Draft", added_by=member_a.id)  # no library
+    db.flush()
+    assert "ZZ A Draft" in _all_books_text(client, member_a)       # owner sees own
+    assert "ZZ A Draft" not in _all_books_text(client, member_b)   # other member does not
+
+
+def test_opds_member_sees_owned_private_library(client, db, admin_user):
+    member = _make_user(db, "opds_owner", "member")
+    priv = _make_lib(db, "Owned Priv", is_public=False, owner_id=member.id)
+    book = _make_book(db, "ZZ In Owned Lib", added_by=member.id)
+    book.libraries.append(priv)
+    db.flush()
+    assert "ZZ In Owned Lib" in _all_books_text(client, member)
+
+
+def test_opds_series_feed_excludes_private(client, db, admin_user):
+    admin, _ = admin_user
+    member = _make_user(db, "opds_series", "member")
+    priv = _make_lib(db, "OPDS Priv S", is_public=False, owner_id=admin.id)
+    book = _make_book(db, "ZZ Secret Vol", added_by=admin.id, series="ZZ Secret OPDS Series")
+    book.libraries.append(priv)
+    db.flush()
+    _as(client, member)
+    try:
+        r = client.get("/opds/series")
+        assert r.status_code == 200, r.text
+        assert "ZZ Secret OPDS Series" not in r.text
+    finally:
+        _clear(client)
+
+
+def test_opds_libraries_nav_hides_others_private(client, db, admin_user):
+    admin, _ = admin_user
+    member = _make_user(db, "opds_libnav", "member")
+    other = _make_user(db, "opds_other", "member")
+    others_priv = _make_lib(db, "Someone Elses Private", is_public=False, owner_id=other.id)
+    owned = _make_lib(db, "My Own Private", is_public=False, owner_id=member.id)
+    db.flush()
+    _as(client, member)
+    try:
+        r = client.get("/opds/libraries")
+        assert r.status_code == 200, r.text
+        assert "My Own Private" in r.text
+        assert "Someone Elses Private" not in r.text
+    finally:
+        _clear(client)

--- a/website/src/components/mockups/RolesVisibilityDemo.tsx
+++ b/website/src/components/mockups/RolesVisibilityDemo.tsx
@@ -3,21 +3,31 @@ import { useState } from 'react'
 
 type Role = 'admin' | 'member' | 'guest'
 
-interface Book { title: string; ownedBy: 'admin' | 'member' | 'public'; library: string }
+interface Book {
+  title: string
+  uploader: 'admin' | 'me' | 'other'
+  library: string | null   // null = not in any library
+  libraryPublic: boolean
+  myLibraryAccess: boolean  // the member owns or is assigned to this library
+}
 
+// "member" perspective is "me". Library membership is the gate: a private
+// library hides its books from everyone except the owner/assigned/admins,
+// regardless of uploader. Unfiled admin books fall back to being public.
 const BOOKS: Book[] = [
-  { title: 'Berserk, Vol. 1',         ownedBy: 'admin',  library: 'Manga' },
-  { title: 'Frankenstein',            ownedBy: 'admin',  library: 'Classics' },
-  { title: 'Project Hail Mary',       ownedBy: 'member', library: 'My sci-fi' },
-  { title: "Stefan's secret diary",   ownedBy: 'member', library: 'Private' },
-  { title: 'The Three-Body Problem',  ownedBy: 'admin',  library: 'Sci-Fi' },
-  { title: "Family album '24",        ownedBy: 'admin',  library: 'Public — Kids' },
+  { title: 'Berserk, Vol. 1',        uploader: 'admin', library: 'Manga',      libraryPublic: true,  myLibraryAccess: false },
+  { title: 'Frankenstein',           uploader: 'admin', library: 'Classics',   libraryPublic: true,  myLibraryAccess: false },
+  { title: 'Project Hail Mary',      uploader: 'me',    library: 'My sci-fi',  libraryPublic: false, myLibraryAccess: true },
+  { title: "Stefan's secret diary",  uploader: 'other', library: 'Private',    libraryPublic: false, myLibraryAccess: false },
+  { title: 'The Three-Body Problem', uploader: 'admin', library: 'Restricted', libraryPublic: false, myLibraryAccess: false },
+  { title: "Family album '24",       uploader: 'admin', library: null,         libraryPublic: false, myLibraryAccess: false },
 ]
 
-function canSee(role: Role, book: Book): boolean {
+function canSee(role: Role, b: Book): boolean {
   if (role === 'admin') return true
-  if (role === 'member') return book.ownedBy === 'admin' || book.library === 'My sci-fi'
-  return book.ownedBy === 'admin' && book.library !== 'Private' && book.library !== 'Sci-Fi'
+  const unfiledShared = b.library === null && b.uploader === 'admin'
+  if (role === 'member') return b.uploader === 'me' || b.libraryPublic || b.myLibraryAccess || unfiledShared
+  return b.libraryPublic || unfiledShared
 }
 
 export function RolesVisibilityDemo() {
@@ -55,7 +65,9 @@ export function RolesVisibilityDemo() {
             >
               <div>
                 <div className="text-sm font-medium">{b.title}</div>
-                <div className="text-[11px] text-[var(--muted)]">{b.library} · uploaded by {b.ownedBy}</div>
+                <div className="text-[11px] text-[var(--muted)]">
+                  {b.library === null ? 'no library' : `${b.library} (${b.libraryPublic ? 'public' : 'private'})`} · uploaded by {b.uploader}
+                </div>
               </div>
               <div className="text-[11px]" style={{ color: visible ? 'var(--accent)' : 'var(--muted)' }}>
                 {visible ? '✓ visible' : '— hidden'}

--- a/website/src/pages/docs/libraries.astro
+++ b/website/src/pages/docs/libraries.astro
@@ -80,7 +80,14 @@ import { withBase } from '../../lib/path'
   </p>
   <ul>
     <li><strong>Admins</strong> see all books in all libraries</li>
-    <li><strong>Members</strong> see admin-uploaded books + their own uploads + books in assigned libraries</li>
-    <li><strong>Guests</strong> see admin-uploaded books + books in public libraries</li>
+    <li><strong>Members</strong> see books in public libraries, in libraries they own, and in
+      libraries shared with them — plus their own uploads</li>
+    <li><strong>Guests</strong> see books in public libraries</li>
   </ul>
+  <p>
+    Library membership is the gate: place a book in a private library and it's hidden from
+    everyone except the owner, assigned users, and admins — <em>regardless of who uploaded it</em>.
+    A book that isn't in any library at all remains visible to everyone (a member's own unfiled
+    uploads stay private to them); to restrict a book, put it in a private library.
+  </p>
 </DocsLayout>

--- a/website/src/pages/docs/users-and-roles.astro
+++ b/website/src/pages/docs/users-and-roles.astro
@@ -74,8 +74,12 @@ const visibilitySvg = fs.readFileSync(path.resolve(process.cwd(), 'public/diagra
   <h3>The rules in words</h3>
   <ul>
     <li><strong>Admins see everything.</strong> No filtering.</li>
-    <li><strong>Members</strong> see: books uploaded by any admin, books they uploaded themselves, and books in libraries they're explicitly assigned to.</li>
-    <li><strong>Guests</strong> see: books uploaded by any admin, and books in libraries marked <code>is_public = true</code>.</li>
+    <li><strong>Members</strong> see: books in public libraries, books in libraries they own or are
+      explicitly assigned to, and books they uploaded themselves.</li>
+    <li><strong>Guests</strong> see: books in libraries marked <code>is_public = true</code>.</li>
+    <li><strong>Books in no library at all</strong> stay visible to everyone (a member's own
+      unfiled uploads remain private to them). To restrict a book, put it in a private library —
+      library membership is the gate, regardless of who uploaded the book.</li>
   </ul>
   <p>
     The dashboard has a "My books / Shared library" toggle for members so they can flip between


### PR DESCRIPTION
Fixes the bug in #53: books in a private library were still visible to all members and guests, because any admin-uploaded book was treated as globally shared regardless of library. The TomeSync series endpoints applied no visibility filter at all, exposing the whole catalogue (series browse + per-series download) to any API-key user.

## Change
- Library membership is now the gate, with a single source of truth in `permissions.book_visibility_filter`. A book in a private library is visible only to the owner, assigned users, and admins — regardless of who uploaded it. A book in no library stays visible to everyone, **except** a member's own unfiled upload, which stays private to them.
- Routed every surface through it (or `user_can_see_book`): books list/detail/adjacent/series/facets, downloads, stats, OPDS, and the two TomeSync series endpoints. Added owner access to OPDS library nav for consistency.

## Docs
- Corrected the contradictory visibility docs (`libraries.astro`, `users-and-roles.astro`) and the interactive `RolesVisibilityDemo`.

## Testing
- 544 backend tests pass, incl. new `tests/test_book_visibility.py` (13) and `tests/test_opds_visibility.py` (7); no regression on existing privacy tests.
- Verified live on a seeded instance: web API, rendered UI (private library absent from sidebar/grid/series), OPDS, and the KOReader emulator series browser all hide the private book/series; admin still sees everything.