### PR TITLE
fix: apply custom themes to stats charts (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+- **Custom themes now apply to the stats charts.** The reading-stats widgets
+  (activity heatmaps, progress rings, bars) and the card hover-glow read
+  dedicated `--chart-accent` / `--accent-soft` CSS variables that a custom
+  theme never set, so they kept rendering in the built-in coral accent no
+  matter which palette you picked. Custom themes now derive both from the
+  palette's primary colour, like the built-in themes do. (#55)
+
 ## [1.5.0] — 2026-06-13 — "Rubric"
 
 ### Added

--- a/frontend/src/lib/theme.ts
+++ b/frontend/src/lib/theme.ts
@@ -55,6 +55,12 @@ function getDerivedVars(values: string[]): Record<string, string> {
     '--input':                  values[8],  // = --border
     '--ring':                   values[6],  // = --muted-foreground
     '--destructive-foreground': values[4],  // = --primary-foreground
+    // Brand-derived vars built-in themes set but the palette doesn't expose.
+    // Charts read --chart-accent via getComputedStyle (raw value), so it must
+    // be a concrete colour, not var(--primary) — mirror the built-in themes
+    // where --chart-accent tracks the primary brand colour. (#55)
+    '--chart-accent':           values[3],  // = --primary
+    '--accent-soft':            `color-mix(in oklab, ${values[3]} 14%, transparent)`,
   }
 }
 
@@ -69,6 +75,8 @@ const CUSTOM_THEME_INLINE_VARS: string[] = [
   '--input',
   '--ring',
   '--destructive-foreground',
+  '--chart-accent',
+  '--accent-soft',
 ]
 
 const BUILT_IN_THEME_CLASSES = THEMES.map(t => `theme-${t.id}`)


### PR DESCRIPTION
Fixes #55: custom themes didn't apply to the Stats charts — every widget stayed coral regardless of the chosen palette.

## Cause
Stats widgets read their colour from `--chart-accent` (and card hover-glows from `--accent-soft`). Built-in themes define both, but the custom-theme path in `theme.ts` only set the 10 palette slots plus a few derived neutrals — never those two — so they inherited `:root`'s coral.

## Change
- Derive `--chart-accent` and `--accent-soft` from the palette's primary colour. `--chart-accent` is set to the concrete primary hex (the hook reads it via `getComputedStyle`, which returns the raw string, so `var(--primary)` wouldn't resolve); `--accent-soft` uses a `color-mix` on it.
- Added both to the inline-var clear list, so switching back to a built-in theme drops them.

## Testing
- Frontend `npm run build` (tsc + vite) passes.
- Verified live in a headless browser with the issue's exact palette: `--chart-accent` now resolves to the palette primary (`#3B82F6`), not coral.