### PR TITLE
chore(release): v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [1.5.1] — 2026-06-16
+
 ### Fixed
 - **Private libraries now actually hide books.** Book visibility is gated solely
   by library membership: a book placed in a private library is hidden from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tome"
-version = "1.5.0"
+version = "1.5.1"
 description = "Self-hosted ebook library"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Patch hotfix. No codename.

**What's inside**
- **#53 — private libraries now actually hide books.** Visibility is gated by library membership across the web UI, OPDS, and the TomeSync series browser (which previously applied no filter at all). Admin uploads no longer override a private library.
- **#55 — custom themes now apply to the stats charts.** Chart accent and card hover-glow derive from the custom palette's primary colour instead of staying coral.

Bumps `pyproject.toml` to 1.5.1 and rolls the changelog. After merge, tagging `v1.5.1` triggers the Docker build and moves `:latest`.