### PR TITLE
feat: Shelved reading status + undo on status changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- **Shelved reading status.** A fourth reading state, set apart from
+  Unread / Reading / Read, for books you've set aside without finishing.
+  Shelving a book pulls it off Continue Reading, Series Progress, and the
+  completion stats, but keeps your exact position (progress + CFI) so you can
+  resume where you left off later — the middle ground between a stalled book
+  cluttering your "reading" list and marking it Unread (which clears progress).
+  A new **Shelved** library filter lists them, and reading the book again on
+  any device moves it back to Reading automatically.
+- **Undo on reading-status changes.** Changing a book's reading status now
+  shows a toast with an **Undo** button (and lingers a little longer than a
+  normal toast). Undo restores the full prior state — status, progress, and
+  reading position — so an accidental tap on **Unread**, which clears your
+  progress, is no longer a one-way trip.
+
 ## [1.5.1] — 2026-06-16
 
 ### Fixed

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -167,7 +167,7 @@ def list_books(
         query = query.join(Book.files).filter(BookFile.format == format.lower())
     if library_id:
         query = query.join(Book.libraries).filter(Library.id == library_id)
-    if reading_status in ("reading", "read"):
+    if reading_status in ("reading", "read", "shelved"):
         query = query.join(
             UserBookStatus,
             (UserBookStatus.book_id == Book.id) & (UserBookStatus.user_id == current_user.id)

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -61,8 +61,8 @@ def set_book_status(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if body.status not in ("unread", "reading", "read"):
-        raise HTTPException(400, "status must be unread, reading, or read")
+    if body.status not in ("unread", "reading", "read", "shelved"):
+        raise HTTPException(400, "status must be unread, reading, read, or shelved")
     from backend.models.book import Book
     book = db.get(Book, book_id)
     if not book:

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -2,17 +2,27 @@ import { createContext, useContext, useState, useCallback, useRef } from 'react'
 import { Check, AlertCircle, Info, X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
+interface ToastAction {
+  label: string
+  onClick: () => void
+}
+
 interface Toast {
   id: number
   type: 'success' | 'error' | 'info'
   message: string
   exiting: boolean
+  action?: ToastAction
+}
+
+interface ToastOptions {
+  action?: ToastAction
 }
 
 interface ToastMethods {
-  success: (message: string) => void
-  error: (message: string) => void
-  info: (message: string) => void
+  success: (message: string, opts?: ToastOptions) => void
+  error: (message: string, opts?: ToastOptions) => void
+  info: (message: string, opts?: ToastOptions) => void
 }
 
 interface ToastContextValue {
@@ -29,6 +39,8 @@ export function useToast() {
 
 const MAX_TOASTS = 5
 const AUTO_DISMISS_MS = 4000
+// Toasts with an action (e.g. Undo) linger a little longer so there's time to act.
+const AUTO_DISMISS_ACTION_MS = 7000
 const EXIT_DURATION_MS = 300
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
@@ -43,22 +55,22 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
     }, EXIT_DURATION_MS)
   }, [])
 
-  const addToast = useCallback((type: Toast['type'], message: string) => {
+  const addToast = useCallback((type: Toast['type'], message: string, action?: ToastAction) => {
     const id = ++idRef.current
     setToasts(prev => {
-      const next = [...prev, { id, type, message, exiting: false }]
+      const next = [...prev, { id, type, message, exiting: false, action }]
       // Cap at MAX_TOASTS — drop oldest
       return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next
     })
-    const timer = setTimeout(() => dismiss(id), AUTO_DISMISS_MS)
+    const timer = setTimeout(() => dismiss(id), action ? AUTO_DISMISS_ACTION_MS : AUTO_DISMISS_MS)
     // Clean up timer if component unmounts (best-effort)
     return () => clearTimeout(timer)
   }, [dismiss])
 
   const toast: ToastMethods = {
-    success: (msg) => addToast('success', msg),
-    error: (msg) => addToast('error', msg),
-    info: (msg) => addToast('info', msg),
+    success: (msg, opts) => addToast('success', msg, opts?.action),
+    error: (msg, opts) => addToast('error', msg, opts?.action),
+    info: (msg, opts) => addToast('info', msg, opts?.action),
   }
 
   return (
@@ -89,6 +101,14 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
               {t.type === 'info' && <Info className="w-4 h-4 text-info" />}
             </span>
             <span className="flex-1 text-foreground leading-snug">{t.message}</span>
+            {t.action && (
+              <button
+                onClick={() => { t.action!.onClick(); dismiss(t.id) }}
+                className="shrink-0 mt-0.5 font-semibold text-primary hover:underline transition-colors"
+              >
+                {t.action.label}
+              </button>
+            )}
             <button
               onClick={() => dismiss(t.id)}
               className="shrink-0 mt-0.5 text-muted-foreground hover:text-foreground transition-colors"

--- a/frontend/src/lib/books.ts
+++ b/frontend/src/lib/books.ts
@@ -106,7 +106,7 @@ export interface SavedFilter {
   sort_order: number
 }
 
-export type ReadingStatus = 'unread' | 'reading' | 'read'
+export type ReadingStatus = 'unread' | 'reading' | 'read' | 'shelved'
 
 export interface Arc {
   id: number
@@ -130,5 +130,6 @@ export interface BookStatus {
   book_id: number
   status: ReadingStatus
   progress_pct: number | null
+  cfi?: string | null
   updated_at: string | null
 }

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -4,7 +4,7 @@ import {
   Camera, Download, Edit2, Save, X,
   Calendar, Globe, Hash, Building2, FileText, Trash2, Loader2,
   Sparkles, Library, Check, BookMarked, ChevronLeft, ChevronRight, Home,
-  Tag as TagIcon, StickyNote, ChevronDown
+  Tag as TagIcon, StickyNote, ChevronDown, Archive
 } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
@@ -105,6 +105,7 @@ export function BookDetailPage() {
   const [localLibIds, setLocalLibIds] = useState<number[]>([])
   const [bookStatus, setBookStatus] = useState<ReadingStatus>('unread')
   const [progressPct, setProgressPct] = useState<number | null>(null)
+  const [cfi, setCfi] = useState<string | null>(null)
   const [progressAnimated, setProgressAnimated] = useState(false)
   const [statusSaving, setStatusSaving] = useState(false)
   const [statusPopKey, setStatusPopKey] = useState(0)
@@ -186,7 +187,7 @@ export function BookDetailPage() {
       .catch(() => setError('Book not found'))
       .finally(() => setLoading(false))
     api.get<LibraryType[]>('/libraries').then(setLibraries).catch(() => toast.error('Failed to load libraries'))
-    api.get<BookStatus>(`/books/${id}/status`).then(s => { setBookStatus(s.status); setProgressPct(s.progress_pct); setProgressAnimated(false) }).catch(() => {})
+    api.get<BookStatus>(`/books/${id}/status`).then(s => { setBookStatus(s.status); setProgressPct(s.progress_pct); setCfi(s.cfi ?? null); setProgressAnimated(false) }).catch(() => {})
     api.get<typeof adjacent>(`/books/${id}/adjacent`).then(setAdjacent).catch(() => {})
     api.get<{ linked: boolean; device?: string }>(`/books/${id}/kosync-progress`)
       .then(r => { if (r.linked && r.device) setKosyncDevice(r.device) })
@@ -223,15 +224,40 @@ export function BookDetailPage() {
     }
   }
 
+  function applyStatus(s: BookStatus) {
+    setBookStatus(s.status)
+    setProgressPct(s.progress_pct)
+    setCfi(s.cfi ?? null)
+    setProgressAnimated(false)
+    setStatusPopKey(k => k + 1)
+  }
+
+  async function restoreStatus(prev: { status: ReadingStatus; progress_pct: number | null; cfi: string | null }) {
+    if (!id) return
+    try {
+      // Send progress + cfi back too, so undoing an "unread" (which clears them) restores your position.
+      const restored = await api.put<BookStatus>(`/books/${id}/status`, prev)
+      applyStatus(restored)
+    } catch {
+      toast.error('Failed to undo')
+    }
+  }
+
+  const STATUS_LABEL: Record<ReadingStatus, string> = {
+    unread: 'Marked unread — reading progress cleared',
+    reading: 'Marked as reading',
+    read: 'Marked as read',
+    shelved: 'Shelved — kept your progress',
+  }
+
   async function handleStatusChange(s: ReadingStatus) {
-    if (!id || statusSaving) return
+    if (!id || statusSaving || s === bookStatus) return
+    const prev = { status: bookStatus, progress_pct: progressPct, cfi }
     setStatusSaving(true)
     try {
       const updated = await api.put<BookStatus>(`/books/${id}/status`, { status: s })
-      setBookStatus(updated.status)
-      setProgressPct(updated.progress_pct)
-      setProgressAnimated(false)
-      setStatusPopKey(k => k + 1)
+      applyStatus(updated)
+      toast.info(STATUS_LABEL[s], { action: { label: 'Undo', onClick: () => restoreStatus(prev) } })
     } catch {
       toast.error('Failed to update reading status')
     } finally {
@@ -516,6 +542,25 @@ export function BookDetailPage() {
           {s}
         </button>
       ))}
+      {/* Shelved — set apart from the linear unread→reading→read progression.
+          Keeps your reading position; just removes the book from Continue
+          Reading, series progress, and stats until you pick it back up. */}
+      <span className="mx-1 h-4 w-px bg-border self-center" aria-hidden />
+      <button
+        key={bookStatus === 'shelved' ? `shelved-${statusPopKey}` : 'shelved'}
+        disabled={statusSaving}
+        onClick={() => handleStatusChange('shelved')}
+        title="Shelved — set aside, keeps your progress"
+        className={cn(
+          'px-2.5 py-1 rounded-md text-xs font-medium border transition-all inline-flex items-center gap-1.5',
+          bookStatus === 'shelved'
+            ? 'bg-muted border-foreground/30 text-foreground animate-[pop_0.2s_ease-out]'
+            : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+        )}
+      >
+        <Archive className="w-3.5 h-3.5" />
+        Shelved
+      </button>
       {statusSaving && <Loader2 className="w-4 h-4 animate-spin text-muted-foreground self-center" />}
       {progressPct != null && progressPct > 0 && bookStatus !== 'unread' && (
         <div className="flex items-center gap-2 w-full mt-1.5">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -49,7 +49,7 @@ interface SeriesDetailBook {
   title: string
   series_index: number | null
   cover_path: string | null
-  reading_status: 'unread' | 'reading' | 'read'
+  reading_status: 'unread' | 'reading' | 'read' | 'shelved'
   progress_pct: number | null
 }
 
@@ -1739,7 +1739,7 @@ export function DashboardPage() {
               </div>
               <div className="flex items-center gap-2 flex-wrap">
                 <span className="text-xs text-muted-foreground font-medium w-14">Status</span>
-                {(['', 'unread', 'reading', 'read'] as const).map(s => (
+                {(['', 'unread', 'reading', 'read', 'shelved'] as const).map(s => (
                   <button
                     key={s}
                     onClick={() => setFilter('reading_status', s)}

--- a/tests/test_shelved_status.py
+++ b/tests/test_shelved_status.py
@@ -1,0 +1,85 @@
+"""Tests for the 'shelved' reading status.
+
+Shelved = a 4th reading state that sets a book aside: it drops off the
+Continue Reading / Series Progress rails and the status-based stats, but
+(unlike 'unread') keeps the reading progress + CFI so you can resume exactly
+where you left off.
+"""
+
+
+def _set_status(client, book_id, status, progress=None, cfi=None):
+    body = {"status": status}
+    if progress is not None:
+        body["progress_pct"] = progress
+    if cfi is not None:
+        body["cfi"] = cfi
+    r = client.put(f"/api/books/{book_id}/status", json=body)
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def test_shelved_is_accepted(client, make_book):
+    book = make_book(title="Shelf Me")
+    out = _set_status(client, book.id, "shelved")
+    assert out["status"] == "shelved"
+
+
+def test_shelved_preserves_progress_and_cfi(client, make_book):
+    book = make_book(title="Keep My Place")
+    _set_status(client, book.id, "reading", progress=0.72, cfi="epubcfi(/6/14!/4/2/2)")
+    out = _set_status(client, book.id, "shelved")
+    # Unlike 'unread', shelving must NOT wipe the position.
+    assert out["status"] == "shelved"
+    assert out["progress_pct"] == 0.72
+    assert out["cfi"] == "epubcfi(/6/14!/4/2/2)"
+
+
+def test_unread_still_clears_progress(client, make_book):
+    """Contrast: 'unread' remains the destructive reset."""
+    book = make_book(title="Reset Me")
+    _set_status(client, book.id, "reading", progress=0.5, cfi="epubcfi(/6/2)")
+    out = _set_status(client, book.id, "unread")
+    assert out["progress_pct"] is None
+    assert out["cfi"] is None
+
+
+def test_shelved_filter_finds_only_shelved(client, make_book):
+    reading = make_book(title="Active Read")
+    shelved = make_book(title="Set Aside")
+    _set_status(client, reading.id, "reading", progress=0.3)
+    _set_status(client, shelved.id, "shelved", progress=0.3)
+
+    def ids(status):
+        r = client.get(f"/api/books?reading_status={status}")
+        assert r.status_code == 200, r.text
+        return {b["id"] for b in r.json()}
+
+    assert shelved.id in ids("shelved")
+    assert reading.id not in ids("shelved")
+    # And a shelved book must not leak into the other status views.
+    assert shelved.id not in ids("reading")
+    assert shelved.id not in ids("read")
+    assert shelved.id not in ids("unread")
+
+
+def test_shelved_excluded_from_continue_reading(client, make_book):
+    book = make_book(title="Was Reading")
+    _set_status(client, book.id, "reading", progress=0.4)
+    _set_status(client, book.id, "shelved")
+    r = client.get("/api/books?reading_status=reading")
+    assert book.id not in {b["id"] for b in r.json()}
+
+
+def test_shelved_excluded_from_completion_stats(client, make_book):
+    finished = make_book(title="Done")
+    shelved = make_book(title="Parked")
+    _set_status(client, finished.id, "read", progress=1.0)
+    _set_status(client, shelved.id, "shelved", progress=0.6)
+
+    r = client.get("/api/stats?range_days=365")
+    assert r.status_code == 200, r.text
+    cr = r.json()["completion_rate"]
+    # 'started' counts only reading/read — the shelved book is not counted as
+    # a started-but-unfinished book dragging the completion rate down.
+    assert cr["started"] == 1
+    assert cr["finished"] == 1

--- a/website/src/pages/docs/stats.astro
+++ b/website/src/pages/docs/stats.astro
@@ -105,6 +105,17 @@ import { withBase } from '../../lib/path'
     else <code>UserBookStatus.progress_pct</code> from the web reader.
   </p>
 
+  <Callout variant="tip" title="Shelving a book you've set aside">
+    Every book has reading-status pills — <strong>Unread / Reading / Read</strong>, plus a fourth
+    set slightly apart: <strong>Shelved</strong>. Shelving a book pulls it off Currently Reading,
+    Series Progress, and the completion stats, but <em>keeps your exact position</em> (progress and
+    CFI), so picking it back up later resumes where you left off. It's the middle ground between
+    leaving a stalled book cluttering your "reading" list and marking it <strong>Unread</strong>
+    — which clears your progress entirely. Find shelved titles again with the <strong>Shelved</strong>
+    filter in the library. Reading the book again on any device automatically moves it back to
+    Reading.
+  </Callout>
+
   <h3>Reading time per day</h3>
   <div class="docs-shot-bare">
     <ThemedShot client:load name="stats-time-per-day" alt="Bar chart: reading time per day" />


### PR DESCRIPTION
Adds a fourth reading state and an undo safety net for status changes.

## Shelved status
A state set apart from Unread / Reading / Read, for books you've set aside without finishing. Shelving a book:
- drops it off **Continue Reading**, **Series Progress**, and the **completion stats** — but keeps its progress + CFI, so resuming picks up exactly where you left off;
- is the middle ground between a stalled book cluttering the "reading" list and **Unread** (which clears progress);
- is findable again via a new **Shelved** library filter;
- flips back to **Reading** automatically when the book is read again on any device (normal sync path, no special-casing).

Because every stats query and homepage rail filters on `reading`/`read`, the new `shelved` value is excluded from them for free; historical reading sessions are left untouched.

## Undo on status changes
Every reading-status change now shows a toast with an **Undo** button (and lingers a bit longer than a normal toast). Undo restores the full prior state — status, progress, and reading position — so an accidental tap on **Unread** (which clears progress) is recoverable.

## UI
Shelved pill in the book-detail status picker (Archive icon, separated by a divider); Shelved option in the library status filter.

## Testing
- `tests/test_shelved_status.py` (6): shelved accepted, preserves progress + CFI, unread still clears, filter isolation, excluded from Continue Reading and completion stats.
- Frontend `npm run build` (tsc + vite) passes.
- Verified live: pill, undo toast + full restore (status/progress/CFI), and the Shelved filter.

Docs: Shelved note in the stats doc + CHANGELOG.