### PR TITLE
Stats tiles: tidy headline figures + opt-in auto-fit height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **"Auto-fit height" toggle for list tiles on the Reading Stats dashboard.** Tiles
+  like *Currently Reading* and *Reading Goals* can now size themselves to their
+  content instead of a fixed height. Open a tile's config (gear icon in edit mode)
+  and tick **Auto-fit height**: the tile then grows and shrinks to fit exactly how
+  many items it holds — no half-empty box when you have one book in progress, and
+  no need to resize by hand when you have a dozen. It's off by default, so existing
+  tiles keep their manual size (and scroll); when on, the height handle is hidden
+  (only width stays adjustable) and the tile carries a small "Auto" tag in edit
+  mode, where it also previews its fitted height as you arrange the board. The book
+  rows in *Currently Reading* are more compact, and the tile now shows a
+  "No books in progress" placeholder instead of rendering blank when empty.
 - **PDF books are now readable in the web reader.** Opening a PDF previously
   landed on "No readable file found" — the book detail page offered a **Read**
   button, but the reader only knew how to render EPUB and comics. PDFs now open
@@ -30,6 +41,15 @@ All notable changes to Tome are documented here. Format loosely follows
   normal toast). Undo restores the full prior state — status, progress, and
   reading position — so an accidental tap on **Unread**, which clears your
   progress, is no longer a one-way trip.
+
+### Fixed
+- **Stats headline tiles no longer clip their numbers.** The small metric tiles
+  on the Reading Stats dashboard (Reading Time, Sessions, Streak, …) now keep
+  their value on a single line and on a shared baseline, so a long figure like a
+  multi-hundred-hour reading time no longer wraps and gets cut off at the top,
+  and the smaller "Longest: …" / "x of y started" captions no longer clip at the
+  bottom. The "Completion Rate" and "Books Finished" tile titles were shortened
+  to "Completion" and "Finished" so their headers fit without truncating.
 
 ## [1.5.1] — 2026-06-16
 

--- a/frontend/src/components/stats/widgets/overview.tsx
+++ b/frontend/src/components/stats/widgets/overview.tsx
@@ -12,7 +12,7 @@ import {
   YAxis,
   Tooltip,
 } from 'recharts'
-import { FileText, Trash2, Loader2, ChevronDown } from 'lucide-react'
+import { FileText, Trash2, Loader2, ChevronDown, BookOpen } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { api } from '@/lib/api'
 import { useChartColors } from '@/lib/useChartAccent'
@@ -24,35 +24,51 @@ export type ChartKind = 'bar' | 'line' | 'area'
 // Bare headline-stat body (value + sub) for use as a standalone dashboard tile —
 // the tile itself provides the card frame + the label (in its header).
 export function HeadlineStatBody({ value, sub }: { value: string; sub?: string }) {
+  // Uniform value size + an always-present sub line keep the figure on the same
+  // baseline across every headline tile (mixed sizes / optional subs misalign a
+  // row). truncate over wrap so a long value (e.g. "568h 28m") never spills onto
+  // a second line and clips inside the fixed-height tile.
   return (
     <div className="flex h-full flex-col justify-center">
-      <p className="text-xl font-bold leading-none text-foreground tabular-nums sm:text-2xl">{value}</p>
-      {sub && <p className="mt-1.5 text-xs text-muted-foreground">{sub}</p>}
+      <p className="truncate text-xl font-bold leading-none text-foreground tabular-nums">{value}</p>
+      <p className="mt-1 truncate text-[11px] leading-tight text-muted-foreground">{sub ?? ' '}</p>
     </div>
   )
 }
 
 export function CurrentlyReading({ books }: { books: StatsResponse['books_in_progress'] }) {
   const { accent } = useChartColors()
+  if (books.length === 0) {
+    return (
+      <div className="flex h-full min-h-[3.5rem] flex-col items-center justify-center gap-1 py-3 text-center">
+        <BookOpen className="h-5 w-5 text-muted-foreground/40" />
+        <p className="text-sm text-muted-foreground">No books in progress</p>
+        <p className="text-xs text-muted-foreground/60">Start reading one and it'll show up here</p>
+      </div>
+    )
+  }
+  // Compact rows (~40px each): a single book then fits one grid row, so the
+  // autoH tile snugs down to it instead of rounding up to a half-empty 2-row
+  // box — and still grows by a row for every extra ~2 books (2-up on sm+).
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+    <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
       {books.map((b) => (
-        <a key={b.book_id} href={`/books/${b.book_id}`} className="group flex items-center gap-3 hover:bg-accent/30 rounded-lg p-2 transition-colors">
-          <div className="w-8 h-11 rounded bg-muted flex items-center justify-center shrink-0 overflow-hidden">
+        <a key={b.book_id} href={`/books/${b.book_id}`} className="group flex items-center gap-2.5 rounded-lg px-2 py-0.5 transition-colors hover:bg-accent/30">
+          <div className="h-9 w-6 shrink-0 overflow-hidden rounded bg-muted flex items-center justify-center">
             {b.has_cover ? (
-              <img src={`/api/books/${b.book_id}/cover`} alt="" className="w-full h-full object-cover" />
+              <img src={`/api/books/${b.book_id}/cover`} alt="" className="h-full w-full object-cover" />
             ) : (
-              <FileText className="w-4 h-4 text-muted-foreground" />
+              <FileText className="h-3.5 w-3.5 text-muted-foreground" />
             )}
           </div>
-          <div className="flex-1 min-w-0">
-            <div className="text-sm font-medium text-foreground truncate group-hover:text-primary transition-colors">{b.title}</div>
-            {b.author && <div className="text-xs text-muted-foreground truncate">{b.author}</div>}
-            <div className="mt-1.5 flex items-center gap-2">
-              <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-sm font-medium text-foreground transition-colors group-hover:text-primary">{b.title}</div>
+            <div className="mt-0.5 flex items-center gap-2">
+              {b.author && <span className="max-w-[45%] shrink-0 truncate text-xs text-muted-foreground">{b.author}</span>}
+              <div className="h-1 flex-1 overflow-hidden rounded-full bg-muted">
                 <div className="h-full rounded-full transition-all" style={{ width: `${Math.min(b.progress, 100)}%`, backgroundColor: accent }} />
               </div>
-              <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">{b.progress}%</span>
+              <span className="shrink-0 text-[10px] text-muted-foreground tabular-nums">{b.progress}%</span>
             </div>
           </div>
         </a>

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type ReactNode, type MouseEve
 import ReactGridLayout, {
   useContainerWidth,
   type Layout,
+  type ResizeHandleAxis,
 } from 'react-grid-layout'
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
@@ -63,7 +64,7 @@ import { LibraryGrowthChart } from '@/components/stats/LibraryGrowthChart'
 // metric. days = 0 follows the page range; days = N shows the last N days of the
 // fetched window (sliced client-side, no extra fetches) — so two copies of one
 // widget can show different timeframes.
-type TileConfig = { chartType: ChartKind; days: number; metric?: string; series?: string }
+type TileConfig = { chartType: ChartKind; days: number; metric?: string; series?: string; autoFit?: boolean }
 
 // ── Widget catalog (renders shared Stats components from live data) ─────────────
 
@@ -172,7 +173,7 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'stat-finished',
-    title: 'Books Finished',
+    title: 'Finished',
     icon: BookCheck,
     size: STAT_SIZE,
     render: ({ stats }) => <HeadlineStatBody value={String(stats.headline.books_finished)} />,
@@ -193,7 +194,7 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'stat-completion',
-    title: 'Completion Rate',
+    title: 'Completion',
     icon: Target,
     size: STAT_SIZE,
     render: ({ stats }) => <HeadlineStatBody value={`${stats.completion_rate.pct}%`} sub={`${stats.completion_rate.finished} of ${stats.completion_rate.started} started`} />,
@@ -577,12 +578,28 @@ function ConfigPopover({
   onChange: (partial: Partial<TileConfig>) => void
   onClose: () => void
 }) {
+  // Close on outside click / Escape via a document listener rather than a fixed
+  // overlay: the tile's RGL transform traps `position: fixed` inside the tile, so
+  // an overlay can't cover the rest of the page. The opening click is stopped at
+  // the trigger button, so it never reaches this listener and self-closes.
+  const popRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    const onDown = (e: PointerEvent) => {
+      if (popRef.current && !popRef.current.contains(e.target as Node)) onClose()
+    }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('pointerdown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('pointerdown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [onClose])
   return (
-    <>
-      <div className="fixed inset-0 z-40" onPointerDown={onClose} />
-      <div
-        className="no-drag absolute right-2 top-9 z-50 w-48 rounded-lg border border-border bg-card p-3 text-xs shadow-xl"
-        onPointerDown={(e) => e.stopPropagation()}
+    <div
+      ref={popRef}
+      className="no-drag absolute right-2 top-9 z-50 w-48 rounded-lg border border-border bg-card p-3 text-xs shadow-xl"
+      onPointerDown={(e) => e.stopPropagation()}
       >
         {def.seriesPicker && (
           <>
@@ -661,8 +678,35 @@ function ConfigPopover({
             <p className="mt-2 text-[10px] leading-snug text-muted-foreground/70">Range follows the page's range picker; days show the newest slice of it.</p>
           </>
         )}
-      </div>
-    </>
+        {def.autoH && (
+          <div className={cn((def.chartTypes || def.metrics || def.seriesPicker) && 'mt-3 border-t border-border pt-3')}>
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-medium text-muted-foreground">Auto-fit height</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={!!config.autoFit}
+                aria-label="Auto-fit height"
+                onClick={() => onChange({ autoFit: !config.autoFit })}
+                className={cn(
+                  'relative h-4 w-7 shrink-0 rounded-full transition-colors',
+                  config.autoFit ? 'bg-primary' : 'bg-muted',
+                )}
+              >
+                <span
+                  className={cn(
+                    'absolute left-0.5 top-0.5 h-3 w-3 rounded-full bg-white shadow-sm transition-transform',
+                    config.autoFit && 'translate-x-3',
+                  )}
+                />
+              </button>
+            </div>
+            <p className="mt-1 text-[10px] leading-snug text-muted-foreground/70">
+              Shrink/grow this tile to fit its content. Off: set the height yourself (content scrolls).
+            </p>
+          </div>
+        )}
+    </div>
   )
 }
 
@@ -835,10 +879,15 @@ function TileShell({
       : 0
     const chrome = tiltRef.current.offsetHeight - box.offsetHeight
     const desired = chrome + Math.max(extent, box.scrollHeight > box.clientHeight ? box.scrollHeight : 0)
-    // grid: rowHeight 104 + margin 16 => h rows span 120h - 16 px
-    onMeasure(Math.max(1, Math.ceil((desired + 16) / 120)))
+    // grid: a tile of height h spans (rowHeight 104)*h + (margin 16)*(h-1) px, i.e.
+    // 120h - 16. Report a *fractional* h so the tile lands exactly on the content
+    // height instead of rounding up to a whole row (which leaves a dead half-row,
+    // e.g. a 12-book list). +2px guards against clipping when we round down, and
+    // the 0.01-row (~1.2px) quantum keeps sub-pixel measurement noise from churning
+    // re-renders. RGL's calcGridItemWHPx rounds the resulting px, so this is exact.
+    onMeasure(Math.max(1, Math.round(((desired + 2 + 16) / 120) * 100) / 100))
   })
-  const configurable = !!def.chartTypes || !!def.metrics || !!def.seriesPicker
+  const configurable = !!def.chartTypes || !!def.metrics || !!def.seriesPicker || !!def.autoH
   const tiltOn = editMode && !dragging && !cfgOpen
 
   function onMove(e: MouseEvent<HTMLDivElement>) {
@@ -896,6 +945,11 @@ function TileShell({
         {def.fixedWindow && (
           <span title="This tile uses a fixed window and ignores the range picker" className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
             {def.fixedWindow}
+          </span>
+        )}
+        {editMode && def.autoH && config.autoFit && (
+          <span title="Height auto-fits the content — only width is resizable" className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
+            Auto
           </span>
         )}
         {editMode && (
@@ -985,23 +1039,39 @@ function FreeGrid({
   const badgeRef = useRef<HTMLDivElement>(null)
   const seriesOptions = ctx.stats.series_completion.map((x) => x.series)
 
-  // autoH: list-like tiles report the rows their content needs; in view mode the
-  // tile shrinks to that (never below minH, never above the saved size) and RGL's
-  // vertical compaction pulls the rest of the board up. Edit mode shows the saved
-  // template untouched, and only edit-mode layouts are ever persisted — so this
-  // stays a render-time fit, reactive to whatever the data does next.
+  // Auto-fit (opt-in per tile, via the "Auto-fit height" toggle): a list-like tile
+  // (def.autoH) whose config.autoFit is on reports the rows its content needs, and
+  // in view mode the tile fits that exactly — growing past the saved height as well
+  // as shrinking below it (never below minH) — while RGL's vertical compaction
+  // reflows the board around it. The measured height is box-independent (constant
+  // chrome + intrinsic content extent), so growth can't feed back and oscillate.
+  // Tiles with auto-fit off keep their saved height and resize by hand (content
+  // scrolls). The fit applies in edit mode too (WYSIWYG — what you arrange is what
+  // you get), but its transient fractional height is never persisted: onLayoutChange
+  // restores each auto-fit tile's saved integer height before saving.
+  const autoFitIds = useMemo(
+    () => new Set(tiles.filter((t) => defById(t.defId).autoH && t.config.autoFit).map((t) => t.id)),
+    [tiles],
+  )
   const [autoRows, setAutoRows] = useState<Record<string, number>>({})
   const reportRows = useCallback((id: string, rows: number) => {
     setAutoRows((prev) => (prev[id] === rows ? prev : { ...prev, [id]: rows }))
   }, [])
   const displayLayout = useMemo(() => {
-    if (editMode) return layout
     return layout.map((it) => {
+      const auto = autoFitIds.has(it.i)
+      // Auto-fit tiles drop the height resize handles — height is content-driven,
+      // so a height handle would only fight the auto-size. They keep the width
+      // ('e') handle; non-auto tiles get `undefined` (the grid's full handle set).
+      // Always set it explicitly so a stale value baked into a saved layout — from
+      // a tile that used to be auto-fit — is cleared rather than inherited.
+      const base: Layout[number] = { ...it, resizeHandles: auto ? (['e'] as ResizeHandleAxis[]) : undefined }
+      if (!auto) return base
       const rows = autoRows[it.i]
-      if (!rows || rows >= it.h) return it
-      return { ...it, h: Math.max(rows, it.minH ?? 1) }
+      if (!rows) return base
+      return { ...base, h: Math.max(rows, it.minH ?? 1) }
     })
-  }, [layout, autoRows, editMode])
+  }, [layout, autoRows, autoFitIds])
 
   // RGL doesn't scroll the window when a drag/resize gesture reaches the viewport
   // edge, which makes a bottom-of-page tile impossible to grow — the pointer just
@@ -1112,15 +1182,30 @@ function FreeGrid({
           gridConfig={{ cols: 12, rowHeight: 104, margin: [16, 16], containerPadding: [0, 0] }}
           dragConfig={{ enabled: editMode, handle: '.tile-drag-handle', cancel: '.no-drag' }}
           resizeConfig={{ enabled: editMode, handles: ['se', 'e', 's'] }}
-          // view mode renders the auto-fitted layout — persisting that would bake
-          // a transient content size into the saved board, so edit-mode only
-          onLayoutChange={(l: Layout) => { if (editMode) onLayoutChange(l) }}
+          // Only persist in edit mode. Strip `resizeHandles` (a render-time value
+          // derived from the auto-fit toggle — persisting it would freeze a tile's
+          // handles), and never bake an auto-fit tile's transient fitted height into
+          // the board — restore its saved integer height (width/position still save).
+          onLayoutChange={(l: Layout) => {
+            if (!editMode) return
+            onLayoutChange(
+              l.map((it) => {
+                const next = { ...it }
+                delete next.resizeHandles
+                if (autoFitIds.has(it.i)) {
+                  const saved = layout.find((s) => s.i === it.i)
+                  if (saved) next.h = saved.h
+                }
+                return next
+              }),
+            )
+          }}
         >
           {tiles.map((t) => {
             const def = defById(t.defId)
             return (
               <div key={t.id}>
-                <TileShell def={def} config={t.config} editMode={editMode} seriesOptions={seriesOptions} onRemove={() => onRemove(t.id)} onDuplicate={() => onDuplicate(t.id)} onConfigChange={(p) => onConfigChange(t.id, p)} onMeasure={def.autoH ? (rows: number) => reportRows(t.id, rows) : undefined}>
+                <TileShell def={def} config={t.config} editMode={editMode} seriesOptions={seriesOptions} onRemove={() => onRemove(t.id)} onDuplicate={() => onDuplicate(t.id)} onConfigChange={(p) => onConfigChange(t.id, p)} onMeasure={def.autoH && t.config.autoFit ? (rows: number) => reportRows(t.id, rows) : undefined}>
                   {def.render(ctx, t.config)}
                 </TileShell>
               </div>


### PR DESCRIPTION
Polish pass on the Reading Stats dashboard tiles.

## Headline metric tiles
- Values stay on a single line at a uniform size on a shared baseline — a long figure (e.g. a multi-hundred-hour reading time) no longer wraps and clips at the top, and the `Longest: …` / `x of y started` captions no longer clip at the bottom.
- Shortened `Completion Rate` → **Completion** and `Books Finished` → **Finished** so the 2-column tile headers fit without ellipsis.

## Currently Reading
- Compact rows (smaller cover, author + progress + % folded onto one line) so the tile tracks its content tightly.
- Empty-state placeholder ("No books in progress") instead of a blank box.

## Auto-fit height (opt-in)
A per-tile **Auto-fit height** toggle in the tile config (Currently Reading, Reading Goals):
- The tile grows **and** shrinks to fit its content using a fractional grid-row height — exact fit, no rounded-up dead row. Applies in edit mode too (WYSIWYG).
- When on: only the width handle is offered (height is content-driven), the header carries a small **Auto** badge, and the transient fitted height is never persisted (`resizeHandles` no longer leak into the saved layout either).
- Off by default — existing tiles keep their manual size and scroll.

## Config popover
- Closes on outside click + **Escape** via a document listener. The previous fixed-overlay approach failed because the grid item's `transform` traps `position: fixed` inside the tile, so clicks outside the tile never dismissed it.

## Testing
- `tsc -b` and `npm run build` green.
- Verified manually against a dev instance seeded with realistic reading stats (one in-progress book → snug single row; twelve → grows to fit; toggle on/off; outside-click/Esc close).