### PR TITLE
feat(tomesync): bidirectional book-rating sync with KOReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Your book ratings now sync with KOReader (both ways).** KOReader has its own
+  native 1–5 star rating and review on the Book status screen — TomeSync now keeps
+  it in step with Tome. Rate a book on the web and the next time you open it on the
+  device (if it came over via TomeSync) the stars and review are written into the
+  book, and rate it on KOReader and it flows back up to Tome when you close or
+  suspend. A saved per-book baseline means only the side that actually changed is
+  pushed; if both changed since the last sync, the web rating wins (Tome stays the
+  single source of truth). Reading status (reading / finished) is untouched — that
+  already syncs separately. Requires TomeSync plugin build 20. (KOReader plugin
+  semver 1.5.0.)
 - **Rate and review your books — and whole series.** Each book's detail page now
   has a 1–5 star rating and an optional review (auto-saved; collapses to a tidy
   quote with an edit affordance rather than an always-open box). Ratings are

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -40,8 +40,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 19
-TOMESYNC_PLUGIN_SEMVER = "1.4.0"
+TOMESYNC_PLUGIN_BUILD = 20
+TOMESYNC_PLUGIN_SEMVER = "1.5.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -247,6 +247,72 @@ def put_position(
 
     db.commit()
     return {"ok": True, "timestamp": datetime.utcnow().isoformat() + "Z"}
+
+
+# ── Rating endpoints ──────────────────────────────────────────────────────────
+# The per-user star rating + review live on UserBookStatus, same as the web
+# `/books/{id}/rating` and `/status` endpoints — but those authenticate via
+# get_current_user (JWT / tome_ tokens) which does not accept the plugin's tk_
+# API key. These mirror them under the api-key auth the plugin already uses for
+# position/session, so KOReader's native rating can sync both ways.
+
+
+@router.get("/tome-sync/rating/{book_id}")
+def get_rating(
+    book_id: int,
+    db: Session = Depends(get_db),
+    user: User = Depends(_get_api_key_user),
+):
+    book = db.get(Book, book_id)
+    if not book or book.status != "active":
+        raise HTTPException(status_code=404, detail="Book not found")
+
+    row = (
+        db.query(UserBookStatus)
+        .filter(UserBookStatus.user_id == user.id, UserBookStatus.book_id == book_id)
+        .first()
+    )
+    return {
+        "book_id": book_id,
+        "rating": row.rating if row else None,
+        "review": row.review if row else None,
+    }
+
+
+class PutRatingRequest(PydanticBaseModel):
+    rating: Optional[int] = None  # 1–5, or null to clear
+    review: Optional[str] = None  # free-text, or null to clear
+
+
+@router.put("/tome-sync/rating/{book_id}")
+def put_rating(
+    book_id: int,
+    body: PutRatingRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(_get_api_key_user),
+):
+    book = db.get(Book, book_id)
+    if not book or book.status != "active":
+        raise HTTPException(status_code=404, detail="Book not found")
+    if body.rating is not None and not (1 <= body.rating <= 5):
+        raise HTTPException(status_code=400, detail="rating must be 1-5, or null to clear")
+
+    row = (
+        db.query(UserBookStatus)
+        .filter(UserBookStatus.user_id == user.id, UserBookStatus.book_id == book_id)
+        .first()
+    )
+    if not row:
+        row = UserBookStatus(user_id=user.id, book_id=book_id, status="unread")
+        db.add(row)
+
+    # The plugin always sends both fields (nil → JSON null), so set both. A null
+    # clears, matching the web endpoint's semantics.
+    row.rating = body.rating
+    row.rated_at = datetime.utcnow() if body.rating is not None else None
+    row.review = body.review or None
+    db.commit()
+    return {"ok": True, "rating": row.rating, "review": row.review}
 
 
 # ── Session endpoint ──────────────────────────────────────────────────────────
@@ -1113,6 +1179,13 @@ local function urlEncode(s)
     end)
 end
 
+-- rapidjson decodes JSON null to a sentinel (rapidjson.null), not Lua nil.
+-- Normalize it so "no rating" compares equal to an absent baseline value.
+local function jval(v)
+    if v == nil or v == rapidjson.null then return nil end
+    return v
+end
+
 local function deviceName()
     local ok, name = pcall(function() return Device:getFriendlyDeviceName() end)
     return (ok and name) or "KOReader"
@@ -1398,6 +1471,9 @@ function TomeSync:init()
     -- Per-book annotation sync baseline: book_id -> {{ anchor -> mtime }} as of last
     -- sync. Lets a diff tell "I deleted this" from "this is new from another device".
     self.annot_baseline = G_reader_settings:readSetting("tomesync_annot_baseline") or {{}}
+    -- Per-book rating sync baseline: book_id (string) -> {{ rating=, review= }} as of
+    -- the last reconcile. Lets a diff tell which side (device or Tome) changed.
+    self.rating_baseline = G_reader_settings:readSetting("tomesync_rating_baseline") or {{}}
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
     logger.info("TomeSync: init complete, menu registered,",
@@ -1495,6 +1571,9 @@ function TomeSync:onReaderReady()
     -- moment a device picks up annotations made elsewhere. Deferred a tick so the
     -- annotation module is fully settled before we merge into it.
     UIManager:scheduleIn(1, function() pcall(function() self:_syncAnnotations() end) end)
+    -- Reconcile the book's rating with Tome (pull web rating onto the device, or
+    -- push a device rating that never reached the server). Deferred likewise.
+    UIManager:scheduleIn(1, function() pcall(function() self:_pullRatingAtOpen() end) end)
 end
 
 function TomeSync:onPageUpdate(pageno)
@@ -1539,6 +1618,8 @@ function TomeSync:onSuspend()
 
     -- Sync highlights/notes alongside position (bidirectional merge with the server).
     pcall(function() self:_syncAnnotations() end)
+    -- Push a rating set this session (lid close ends the session like a book close).
+    pcall(function() self:_pushRatingOnLeave() end)
 
     if duration > 10 then
         local session = {{
@@ -1617,6 +1698,8 @@ function TomeSync:onCloseDocument()
 
     -- Flush + merge highlights/notes before the book closes.
     pcall(function() self:_syncAnnotations() end)
+    -- Push a rating the reader set this session up to Tome before we drop book_id.
+    pcall(function() self:_pushRatingOnLeave() end)
 
     if duration > 10 then
         local uuid = string.format("%d-%d-%s", self.book_id, self.session_start or 0, dev)
@@ -1744,6 +1827,95 @@ function TomeSync:_pushPosition()
     pcall(apiRequest, "PUT", "/tome-sync/position/" .. self.book_id, {{
         progress = self:_getCurrentProgress(), percentage = pct, device = deviceName(),
     }})
+end
+
+-- ── Rating sync (bidirectional, per open book) ───────────────────────────────
+-- KOReader's native Book status screen stores a 1–5 star rating + a free-text
+-- review in the per-book sidecar under `summary` (`rating` / `note`). Tome holds
+-- the same per-user rating/review on UserBookStatus. We mirror both directions
+-- using a saved baseline to tell which side changed since the last reconcile:
+--   only device changed  -> push device → Tome
+--   only Tome changed     -> write Tome → device sidecar
+--   both changed (tie)    -> Tome wins (single source of truth)
+-- `summary.status` (reading/complete/abandoned) is left untouched — reading
+-- status already syncs via TomeSyncPosition.
+
+-- Read the live sidecar summary's rating/review for the open book.
+function TomeSync:_localRating()
+    local ds = self.ui and self.ui.doc_settings
+    if not ds then return nil end
+    local summary = ds:readSetting("summary") or {{}}
+    return {{ rating = summary.rating, review = summary.note }}, summary
+end
+
+-- Reconcile on open: pull Tome's rating into the device sidecar, or push a
+-- device rating that hasn't reached Tome yet (e.g. set last session, offline).
+function TomeSync:_pullRatingAtOpen()
+    if not self.enabled or not self.book_id then return end
+    local loc = self:_localRating()
+    if not loc then return end
+
+    local ok, status, code = pcall(apiRequest, "GET", "/tome-sync/rating/" .. self.book_id)
+    if not ok or not status or code ~= 200 then return end
+    local remote_rating = jval(status.rating)
+    local remote_review = jval(status.review)
+
+    local key  = tostring(self.book_id)
+    local base = self.rating_baseline[key] or {{}}
+    local local_changed  = (loc.rating ~= base.rating) or (loc.review ~= base.review)
+    local remote_changed = (remote_rating ~= base.rating) or (remote_review ~= base.review)
+
+    if remote_changed then
+        -- Tome changed (and, on a both-changed tie, Tome wins): write the sidecar.
+        local _, summary = self:_localRating()
+        summary.rating   = remote_rating
+        summary.note     = remote_review
+        summary.modified = os.date("%Y-%m-%d")
+        self.ui.doc_settings:saveSetting("summary", summary)
+        if type(remote_rating) == "number" then
+            pcall(function()
+                require("ui/widget/booklist")
+                    .setBookInfoCacheProperty(self.ui.document.file, "rating", remote_rating)
+            end)
+        end
+        base.rating, base.review = remote_rating, remote_review
+        self.rating_baseline[key] = base
+        G_reader_settings:saveSetting("tomesync_rating_baseline", self.rating_baseline)
+        logger.info("TomeSync: applied Tome rating to device for book", self.book_id)
+    elseif local_changed then
+        self:_pushRating(loc.rating, loc.review)
+    end
+end
+
+-- PUT the device rating/review up to Tome and advance the baseline on success.
+-- nil must go on the wire as JSON null (an absent Lua key would be dropped from
+-- the body, leaving Tome's old value in place instead of clearing it). rating is
+-- always nil or 1–5, never 0, so `or` is safe.
+function TomeSync:_pushRating(rating, review)
+    if not self.book_id then return end
+    local sok, resp, code = pcall(apiRequest, "PUT",
+        "/tome-sync/rating/" .. self.book_id,
+        {{ rating = rating or rapidjson.null, review = review or rapidjson.null }})
+    if sok and resp and type(code) == "number" and code < 300 then
+        local key = tostring(self.book_id)
+        local base = self.rating_baseline[key] or {{}}
+        base.rating, base.review = rating, review
+        self.rating_baseline[key] = base
+        G_reader_settings:saveSetting("tomesync_rating_baseline", self.rating_baseline)
+        logger.info("TomeSync: pushed device rating to Tome for book", self.book_id)
+    end
+end
+
+-- Reconcile on close/suspend: if the device rating changed during the session,
+-- push it up. Tome-wins at open already settled any conflict, so a divergence
+-- here is a fresh on-device edit and is safe to send.
+function TomeSync:_pushRatingOnLeave()
+    if not self.enabled or not self.book_id then return end
+    local loc = self:_localRating()
+    if not loc then return end
+    local base = self.rating_baseline[tostring(self.book_id)] or {{}}
+    if loc.rating == base.rating and loc.review == base.review then return end
+    self:_pushRating(loc.rating, loc.review)
 end
 
 -- ── Annotation sync (bidirectional: KOReader <-> Tome <-> KOReader) ──────────

--- a/docs/features.md
+++ b/docs/features.md
@@ -87,6 +87,18 @@ The sidebar shows all series in your library. Click a series to open an inline d
 
 ---
 
+## Ratings & Reviews
+
+Rate the books you read on a 1–5 star scale, with an optional written review. Ratings are **per-user and private to you** — everyone keeps their own.
+
+- **Per book** — the book detail page has a star rating and a review field. Both auto-save; the review collapses to a tidy quote (with an edit affordance) once written, rather than sitting as an always-open box.
+- **On book cards** — your stars show across the library grid. You can **sort by "My Rating"** and **filter** the grid to `Rated`, `3+`, `4+`, or `5` stars.
+- **Per series** — rate a whole series from its page. A series rating is **inherited** by every volume you haven't rated individually (your own volume rating always wins). A series' shown rating is your explicit rating if you set one, otherwise the average of your volume ratings — surfaced on series cards too. (The "No Series" group can't be rated.)
+
+Stars use a theme-aware "rating gold" that fits each theme's palette. Ratings also sync both ways with KOReader's native Book status screen — see the [KOReader plugin](koreader-plugin.md) docs.
+
+---
+
 ## Bulk Operations
 
 Multi-select books on the dashboard to:

--- a/docs/koreader-plugin.md
+++ b/docs/koreader-plugin.md
@@ -21,6 +21,7 @@ The plugin is pre-configured with your server URL and API key. No manual configu
 ## Features
 
 - **Reading sync** -- position, progress, and reading sessions sync between KOReader and Tome's web reader
+- **Rating sync** -- KOReader's native star rating and review sync both ways with Tome
 - **Series browser** -- browse your library's series and download entire series to your device in one tap
 - **Offline-safe** -- everything works seamlessly when your server is unreachable; sessions queue and flush later
 - **Context-aware menu** -- different options when a book is open vs. from the home screen
@@ -46,11 +47,11 @@ If no match is found, the plugin silently skips sync for that book.
 
 | Event | What happens |
 |---|---|
-| **Open a book** | Pulls latest position from server. If the server is ahead, jumps to that position. |
+| **Open a book** | Pulls latest position from server. If the server is ahead, jumps to that position. Also reconciles the book's rating with Tome. |
 | **Every 50 page turns** | Pushes current position to server (heartbeat). |
-| **Close the lid (suspend)** | Pushes position and records a reading session. |
+| **Close the lid (suspend)** | Pushes position, records a reading session, and pushes a rating you set this session. |
 | **Open the lid (resume)** | Starts a new session, pushes position, and flushes any pending offline sessions. |
-| **Close a book** | Pushes final position and records a reading session. |
+| **Close a book** | Pushes final position, records a reading session, and pushes a rating you set this session. |
 | **"Sync now" in menu** | Manual push of current position and flushes pending offline sessions. |
 
 ### Web Reader → KOReader Sync
@@ -260,6 +261,28 @@ Device→device sync needs both devices to have the **Tome-served copy** of the 
 
 Rendering highlights *inside the web reader* is a separate, later step — for now
 the web side shows them as a list on the detail page.
+
+---
+
+## Ratings & reviews sync
+
+KOReader has its own **Book status** screen with a 1–5 star rating and a review
+(long-press a book → *Book status*, or the end-of-book screen). The plugin keeps
+that in step with the rating and review on Tome's book detail page, **both ways**:
+
+- Rate a book **on the web** and the next time you open it in KOReader (for a book
+  that came from Tome), the stars and review are written into the book.
+- Rate a book **in KOReader** and it flows up to Tome when you close or suspend.
+
+Ratings are **per user** and private to you. Reading status (reading / finished)
+is left untouched — that already syncs separately via reading progress.
+
+**How conflicts resolve.** The plugin remembers the last value it synced for each
+book, so normally only the side that actually changed is sent. If a book's rating
+changed on **both** the web and the device since the last sync, **Tome wins** — it
+is the single source of truth. As with highlights, this needs the **Tome-served
+copy** of the book so the plugin can match it to the right library entry; a
+sideloaded different copy won't sync its rating.
 
 ---
 

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -144,7 +144,7 @@ def test_zip_download_bakes_https_with_forwarded_proto(app_client):
 def test_build_bumped_for_rebake():
     # Must exceed every build already live (v1.2.0 shipped 10; main reached 12),
     # so all existing installs re-download and re-bake the corrected URL.
-    # 1.4.0 / build 19 adds the download location & naming templates (presets
-    # + custom token template) on top of 18's auto-connect and Settings menu.
-    assert TOMESYNC_PLUGIN_BUILD >= 19
-    assert TOMESYNC_PLUGIN_SEMVER == "1.4.0"
+    # 1.5.0 / build 20 adds bidirectional book-rating sync (KOReader's native
+    # star rating + review <-> Tome) on top of 19's download path templates.
+    assert TOMESYNC_PLUGIN_BUILD >= 20
+    assert TOMESYNC_PLUGIN_SEMVER == "1.5.0"

--- a/tests/test_tomesync_rating_endpoints.py
+++ b/tests/test_tomesync_rating_endpoints.py
@@ -1,0 +1,90 @@
+"""Tests for the TomeSync rating endpoints (`/tome-sync/rating/{id}`).
+
+The KOReader plugin syncs its native star rating + review through these. They
+mirror the web `/books/{id}/rating` + `/status` endpoints but authenticate via
+the plugin's tk_ API key (`_get_api_key_user`) — the web ones use
+get_current_user, which rejects that key (401). Both write the same
+UserBookStatus row, so a rating set on either side is the same per-user value.
+"""
+from backend.models.tome_sync import ApiKey
+
+
+def _api_key_for(db, user_id: int) -> str:
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(user_id=user_id, key_hash=ApiKey.hash_key(plaintext),
+                  key_prefix=plaintext[:11], label="test"))
+    db.flush()
+    return plaintext
+
+
+def test_put_then_get_roundtrips(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book()
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+
+    r = client.put(f"/api/tome-sync/rating/{book.id}", headers=hdr,
+                   json={"rating": 4, "review": "solid"})
+    assert r.status_code == 200, r.text
+
+    g = client.get(f"/api/tome-sync/rating/{book.id}", headers=hdr).json()
+    assert g["rating"] == 4
+    assert g["review"] == "solid"
+
+
+def test_no_row_returns_nulls(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book()
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    g = client.get(f"/api/tome-sync/rating/{book.id}", headers=hdr).json()
+    assert g == {"book_id": book.id, "rating": None, "review": None}
+
+
+def test_null_clears_rating_and_review(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book()
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    client.put(f"/api/tome-sync/rating/{book.id}", headers=hdr,
+               json={"rating": 5, "review": "great"})
+    # Explicit nulls clear both (the plugin always sends both fields).
+    r = client.put(f"/api/tome-sync/rating/{book.id}", headers=hdr,
+                   json={"rating": None, "review": None})
+    assert r.status_code == 200
+    g = client.get(f"/api/tome-sync/rating/{book.id}", headers=hdr).json()
+    assert g["rating"] is None and g["review"] is None
+
+
+def test_out_of_range_rating_rejected(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book()
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    r = client.put(f"/api/tome-sync/rating/{book.id}", headers=hdr,
+                   json={"rating": 6})
+    assert r.status_code == 400
+
+
+def test_shares_row_with_web_status(client, db, admin_user, make_book):
+    # A rating set via the plugin endpoint is visible on the web status endpoint
+    # (same UserBookStatus row), and reading status is left untouched.
+    user, _ = admin_user
+    book = make_book()
+    keyhdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    from backend.core.security import create_access_token
+    jwthdr = {"Authorization": f"Bearer {create_access_token(subject=user.id)}"}
+
+    client.put(f"/api/tome-sync/rating/{book.id}", headers=keyhdr,
+               json={"rating": 3, "review": "ok"})
+    s = client.get(f"/api/books/{book.id}/status", headers=jwthdr).json()
+    assert s["rating"] == 3
+    assert s["review"] == "ok"
+    assert s["status"] == "unread"  # rating never touches reading status
+
+
+def test_web_key_rejected_by_get_current_user(client, db, admin_user, make_book):
+    # Guards the reason these endpoints exist: the plugin's tk_ key does NOT
+    # authenticate against the web rating endpoint.
+    user, _ = admin_user
+    book = make_book()
+    key = _api_key_for(db, user.id)
+    r = client.get(f"/api/books/{book.id}/status",
+                   headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 401

--- a/tests/test_tomesync_rating_sync.py
+++ b/tests/test_tomesync_rating_sync.py
@@ -1,0 +1,116 @@
+"""Tripwires for the plugin's bidirectional book-rating sync.
+
+KOReader stores a native 1–5 star rating + free-text review in each book's
+sidecar (`summary.rating` / `summary.note`). Tome holds the same per-user
+rating/review on UserBookStatus. The plugin reconciles them, using a saved
+baseline to tell which side changed since the last sync:
+
+    only device changed  -> push device → Tome
+    only Tome changed     -> write Tome → device sidecar
+    both changed (tie)    -> Tome wins (single source of truth)
+
+These can't execute KOReader; they pin the load-bearing properties on the
+generated Lua so a refactor can't silently revert them.
+"""
+import re
+import shutil
+import subprocess
+import tempfile
+
+from backend.api.tome_sync import _main_impl_lua
+
+
+def _impl() -> str:
+    return _main_impl_lua("http://localhost:8080", "tk_test", "tester")
+
+
+def _body(lua: str, fn: str) -> str:
+    match = re.search(r"function TomeSync:" + re.escape(fn) + r"\(.*?\).*?\nend\n", lua, re.S)
+    assert match, f"{fn} not found in generated impl"
+    return match.group(0)
+
+
+def test_rating_functions_exist():
+    lua = _impl()
+    assert "function TomeSync:_pullRatingAtOpen" in lua
+    assert "function TomeSync:_pushRating" in lua
+    assert "function TomeSync:_pushRatingOnLeave" in lua
+
+
+def test_uses_correct_endpoints():
+    lua = _impl()
+    # Must use the tome-sync rating endpoints (api-key auth the plugin's baked
+    # tk_ key satisfies), NOT the web /books/{id}/rating + /status ones, which
+    # authenticate via get_current_user and reject the tk_ key (401).
+    assert '"GET", "/tome-sync/rating/" .. self.book_id' in lua
+    assert '"PUT",\n        "/tome-sync/rating/" .. self.book_id' in lua
+    assert "/status" not in lua.split("function TomeSync:_pullRatingAtOpen")[1].split("\nend\n")[0]
+
+
+def test_reconcile_is_tome_wins_on_conflict():
+    # remote_changed is checked first, so a both-changed tie writes Tome onto the
+    # device (Tome wins). Device-only changes fall through to the push branch.
+    body = _body(_impl(), "_pullRatingAtOpen")
+    remote_branch = body.find("if remote_changed then")
+    local_branch = body.find("elseif local_changed then")
+    assert remote_branch != -1 and local_branch != -1
+    assert remote_branch < local_branch, "remote (Tome-wins) branch must come first"
+
+
+def test_maps_koreader_note_to_tome_review():
+    # KOReader's review text lives in summary.note; Tome calls it review.
+    lua = _impl()
+    assert "review = summary.note" in lua
+    assert "summary.note     = remote_review" in lua
+
+
+def test_status_field_is_left_untouched():
+    # Reading status (reading/complete/abandoned) already syncs via position;
+    # the rating path must never write summary.status.
+    body = _body(_impl(), "_pullRatingAtOpen")
+    assert "summary.status" not in body
+
+
+def test_nil_rating_clears_on_the_wire():
+    # An absent Lua key is dropped from the JSON body, which would leave Tome's
+    # old value in place. nil must be sent as rapidjson.null so clears propagate.
+    body = _body(_impl(), "_pushRating")
+    assert "rating = rating or rapidjson.null" in body
+    assert "review = review or rapidjson.null" in body
+
+
+def test_json_null_is_normalized_to_nil_on_read():
+    # rapidjson decodes JSON null to a sentinel, not nil; without normalizing it,
+    # "no rating" would never compare equal to an absent baseline value.
+    lua = _impl()
+    assert "local remote_rating = jval(status.rating)" in lua
+    assert "local remote_review = jval(status.review)" in lua
+
+
+def test_baseline_is_persisted():
+    lua = _impl()
+    assert 'G_reader_settings:readSetting("tomesync_rating_baseline")' in lua
+    assert 'G_reader_settings:saveSetting("tomesync_rating_baseline"' in lua
+
+
+def test_open_and_leave_hooks_are_wired():
+    lua = _impl()
+    assert "self:_pullRatingAtOpen()" in _body(lua, "onReaderReady")
+    assert "self:_pushRatingOnLeave()" in _body(lua, "onCloseDocument")
+    assert "self:_pushRatingOnLeave()" in _body(lua, "onSuspend")
+
+
+def test_impl_compiles_under_luajit():
+    # KOReader runs LuaJIT (5.1). Compile the rendered impl if a checker is on
+    # PATH; skip cleanly in CI environments without one.
+    checker = shutil.which("luajit") or shutil.which("luac5.1")
+    if not checker:
+        import pytest
+
+        pytest.skip("no LuaJIT/luac5.1 available to syntax-check")
+    with tempfile.NamedTemporaryFile("w", suffix=".lua", delete=False) as f:
+        f.write(_impl())
+        path = f.name
+    args = [checker, "-bl", path, "/dev/null"] if "luajit" in checker else [checker, "-p", path]
+    proc = subprocess.run(args, capture_output=True, text=True)
+    assert proc.returncode == 0, proc.stderr

--- a/website/src/pages/docs/books.astro
+++ b/website/src/pages/docs/books.astro
@@ -106,4 +106,19 @@ import { withBase } from '../../lib/path'
     them. If you're using <a href={withBase("/docs/koreader")}>TomeSync</a>, status updates
     automatically based on your reading sessions.
   </p>
+
+  <h2>Ratings &amp; reviews</h2>
+  <p>
+    Rate books on a 1–5 star scale with an optional written review. Ratings are
+    <strong>per user and private to you</strong> — everyone keeps their own.
+  </p>
+  <ul>
+    <li><strong>Per book</strong> — the detail page has a star rating and a review field; both auto-save, and the review collapses to a tidy quote (with an edit affordance) once written.</li>
+    <li><strong>On book cards</strong> — your stars show across the grid. You can <strong>sort by "My Rating"</strong> and filter the grid to <strong>Rated</strong>, <strong>3+</strong>, <strong>4+</strong>, or <strong>5</strong> stars.</li>
+    <li><strong>Per series</strong> — rate a whole series from its page. A series rating is inherited by every volume you haven't rated individually (your own volume rating always wins); a series' shown rating is your explicit rating if set, otherwise the average of your volume ratings. The "No Series" group can't be rated.</li>
+  </ul>
+  <p>
+    Ratings also sync both ways with KOReader's native Book status screen — see the
+    <a href={withBase("/docs/koreader")}>KOReader plugin</a> docs.
+  </p>
 </DocsLayout>

--- a/website/src/pages/docs/koreader.astro
+++ b/website/src/pages/docs/koreader.astro
@@ -79,6 +79,18 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
     </figcaption>
   </figure>
 
+  <h3>Ratings &amp; reviews sync</h3>
+  <p>
+    KOReader has a native <strong>Book status</strong> screen with a 1–5 star rating and a
+    review. The plugin keeps it in step with the rating and review on Tome's book detail page,
+    <strong>both ways</strong>: rate a book on the web and it appears in KOReader the next time
+    you open it (for a book that came from Tome); rate it in KOReader and it flows up to Tome when
+    you close or suspend. Ratings are per user and private to you, and your reading status
+    (reading / finished) is left untouched — that syncs separately. The plugin tracks the last
+    value it synced, so normally only the side that changed is sent; if a rating changed on both
+    the web and the device since the last sync, <strong>Tome wins</strong>.
+  </p>
+
   <h3>Offline-first</h3>
   <p>
     When your server is unreachable, sync silently skips with zero delay — no freezing, no error
@@ -152,11 +164,11 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
   <h3>When it syncs</h3>
   <p>TomeSync hooks into KOReader's lifecycle events:</p>
   <ul>
-    <li><strong>Open a book</strong> — pulls the latest position from the server. If the server is ahead, jumps there.</li>
+    <li><strong>Open a book</strong> — pulls the latest position from the server. If the server is ahead, jumps there. Also reconciles the book's rating.</li>
     <li><strong>Every 50 page turns</strong> — heartbeat push of current position.</li>
-    <li><strong>Close the lid (suspend)</strong> — pushes position and highlights, and records a reading session.</li>
+    <li><strong>Close the lid (suspend)</strong> — pushes position, highlights, and a rating set this session, and records a reading session.</li>
     <li><strong>Open the lid (resume)</strong> — starts a new session, pushes position, flushes any queued offline sessions.</li>
-    <li><strong>Close a book</strong> — pushes final position and highlights, and records a session.</li>
+    <li><strong>Close a book</strong> — pushes final position, highlights, and a rating set this session, and records a session.</li>
   </ul>
   <p>Sessions shorter than 10 seconds are filtered out.</p>
 


### PR DESCRIPTION
Syncs KOReader's native star rating + review with Tome's per-user book ratings, both ways. Builds on the web ratings feature (#64).

## What it does
- **Tome → device:** rate a book on the web → it's written into KOReader's native Book status sidecar (`summary.rating`/`note`) the next time you open it (for a book that came from Tome).
- **device → Tome:** rate a book in KOReader → it flows up to Tome on close/suspend.
- Ratings stay **per-user and private**; reading status (reading/finished) is left to the existing position sync.

## How
- New api-key endpoints `GET`/`PUT /tome-sync/rating/{book_id}`, authenticated via the plugin's `tk_` key. The web `/books/{id}/rating` + `/status` use `get_current_user`, which rejects the `tk_` key — so the plugin couldn't use them (a 401 the emulator round-trip caught). Both paths write the same `UserBookStatus` row.
- Plugin keeps a saved per-book baseline, so normally only the side that changed is sent. On a both-changed tie, **Tome wins** (single source of truth). `nil` ratings go on the wire as JSON `null` so clears propagate.
- Plugin **build 20 / semver 1.5.0** (ships via the existing self-update path).

## Testing
- Full suite green (584 passed).
- New: rating-endpoint behaviour + auth guard, Lua tripwires, LuaJIT compile check.
- **Emulator round-trip verified both directions** against a live server through the real plugin handlers (`onReaderReady` pull, `onCloseDocument` push).

## Docs
- KOReader plugin docs (repo + website): new "Ratings & reviews sync" section.
- Documented the underlying web ratings feature (per-book + per-series), which had shipped undocumented.