### PR TITLE
feat(books): filter the library by language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Filter your library by language.** The dashboard filter bar now has a
+  **Language** dropdown alongside Series / Author / Tag / Format. It appears
+  whenever your catalogue holds more than one language. Books carry messy
+  language values from their embedded metadata (`en`, `eng`, `en-US`,
+  `English` all mean the same thing) — Tome folds these to a single tidy entry
+  ("English") so the dropdown stays clean. Because a Shelf just saves the active
+  filters, you can save a per-language Shelf (e.g. one Shelf per language) and it
+  populates itself — no manually adding books.
 - **Your book ratings now sync with KOReader (both ways).** KOReader has its own
   native 1–5 star rating and review on the Book status screen — TomeSync now keeps
   it in step with Tome. Rate a book on the web and the next time you open it on the

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -120,6 +120,7 @@ def list_books(
     author: Optional[str] = Query(None, description="Exact author filter"),
     tag: Optional[str] = Query(None, description="Tag name filter"),
     format: Optional[str] = Query(None, description="File format filter (epub, pdf, …)"),
+    language: Optional[str] = Query(None, description="Language filter — canonical code (en, de, …); matches messy stored variants"),
     library_id: Optional[int] = Query(None, description="Filter to books in this library"),
     reading_status: Optional[str] = Query(None, description="Filter by reading status: unread, reading, read"),
     missing: Optional[str] = Query(None, description="Filter books missing a field: cover, description, author, series, any"),
@@ -166,6 +167,18 @@ def list_books(
         query = query.join(Book.tags).filter(BookTag.tag == tag)
     if format:
         query = query.join(Book.files).filter(BookFile.format == format.lower())
+    if language:
+        # The param is a canonical code; stored values are messy. Resolve which
+        # raw variants fold to it and match those (small distinct cardinality).
+        from backend.services.languages import normalize_language
+        target = normalize_language(language)
+        raw_matches = [
+            r[0] for r in db.query(Book.language).filter(
+                Book.language.isnot(None), Book.language != ""
+            ).distinct().all()
+            if normalize_language(r[0]) == target
+        ]
+        query = query.filter(Book.language.in_(raw_matches) if raw_matches else Book.id == -1)
     if library_id:
         query = query.join(Book.libraries).filter(Library.id == library_id)
     if reading_status in ("reading", "read", "shelved"):
@@ -404,7 +417,19 @@ def get_facets(
         Book.status == "active", visibility
     ).distinct().order_by(BookFile.format).all()]
 
-    return {"series": series, "authors": authors, "tags": tags, "formats": formats}
+    # Languages: fold messy stored values (en / eng / en-US / English) to a
+    # canonical code with a human label, deduped, so the dropdown is clean.
+    from backend.services.languages import normalize_language, language_label
+    raw_langs = [r[0] for r in db.query(Book.language).filter(
+        Book.status == "active", Book.language.isnot(None), Book.language != "", visibility
+    ).distinct().all()]
+    lang_codes = {c for c in (normalize_language(l) for l in raw_langs) if c}
+    languages = sorted(
+        ({"code": c, "label": language_label(c)} for c in lang_codes),
+        key=lambda x: x["label"],
+    )
+
+    return {"series": series, "authors": authors, "tags": tags, "formats": formats, "languages": languages}
 
 
 # ── Series list ───────────────────────────────────────────────────────────────

--- a/backend/services/languages.py
+++ b/backend/services/languages.py
@@ -1,0 +1,80 @@
+"""ISO-639 language normalization for the language facet/filter.
+
+Stored ``Book.language`` values are messy — ``en``, ``eng``, ``en-US``,
+``English`` all appear because they come straight from per-file embedded
+metadata. We fold them to a canonical lowercase 2-letter code for filtering and
+show a human label in the UI, so the dropdown has one "English" entry rather
+than four near-duplicates.
+"""
+
+# Canonical 2-letter code -> display name. Scoped to languages plausible in an
+# ebook library; unknown codes fall through and display their raw token.
+_LANG_NAMES = {
+    "en": "English", "de": "German", "fr": "French", "es": "Spanish",
+    "it": "Italian", "pt": "Portuguese", "nl": "Dutch", "sv": "Swedish",
+    "no": "Norwegian", "da": "Danish", "fi": "Finnish", "pl": "Polish",
+    "ru": "Russian", "uk": "Ukrainian", "cs": "Czech", "tr": "Turkish",
+    "ja": "Japanese", "zh": "Chinese", "ko": "Korean", "ar": "Arabic",
+    "he": "Hebrew", "hi": "Hindi", "th": "Thai", "vi": "Vietnamese",
+    "id": "Indonesian", "el": "Greek", "hu": "Hungarian", "ro": "Romanian",
+    "la": "Latin",
+}
+
+# 3-letter (ISO-639-2/B and /T) and English-name aliases -> 2-letter code.
+_ALIASES = {
+    "eng": "en", "english": "en",
+    "ger": "de", "deu": "de", "german": "de",
+    "fre": "fr", "fra": "fr", "french": "fr",
+    "spa": "es", "spanish": "es",
+    "ita": "it", "italian": "it",
+    "por": "pt", "portuguese": "pt",
+    "dut": "nl", "nld": "nl", "dutch": "nl",
+    "swe": "sv", "swedish": "sv",
+    "nor": "no", "norwegian": "no",
+    "dan": "da", "danish": "da",
+    "fin": "fi", "finnish": "fi",
+    "pol": "pl", "polish": "pl",
+    "rus": "ru", "russian": "ru",
+    "ukr": "uk", "ukrainian": "uk",
+    "cze": "cs", "ces": "cs", "czech": "cs",
+    "tur": "tr", "turkish": "tr",
+    "jpn": "ja", "japanese": "ja",
+    "chi": "zh", "zho": "zh", "chinese": "zh",
+    "kor": "ko", "korean": "ko",
+    "ara": "ar", "arabic": "ar",
+    "heb": "he", "hebrew": "he",
+    "hin": "hi", "hindi": "hi",
+    "tha": "th", "thai": "th",
+    "vie": "vi", "vietnamese": "vi",
+    "ind": "id", "indonesian": "id",
+    "gre": "el", "ell": "el", "greek": "el",
+    "hun": "hu", "hungarian": "hu",
+    "rum": "ro", "ron": "ro", "romanian": "ro",
+    "lat": "la", "latin": "la",
+}
+
+
+def normalize_language(raw: str | None) -> str | None:
+    """Fold a raw stored language value to a canonical lowercase code.
+
+    ``en`` / ``eng`` / ``en-US`` / ``English`` all collapse to ``en``. Unknown
+    values return their lowercased base token so they still group consistently.
+    """
+    if not raw:
+        return None
+    s = raw.strip().lower().replace("_", "-")
+    if not s:
+        return None
+    if s in _ALIASES:
+        return _ALIASES[s]
+    base = s.split("-", 1)[0]
+    if base in _LANG_NAMES:
+        return base
+    if base in _ALIASES:
+        return _ALIASES[base]
+    return base
+
+
+def language_label(code: str) -> str:
+    """Human-readable name for a canonical code; falls back to the upper-cased code."""
+    return _LANG_NAMES.get(code, code.upper())

--- a/docs/features.md
+++ b/docs/features.md
@@ -149,9 +149,27 @@ Admins have an additional uploader dropdown filter on the dashboard to view book
 
 ---
 
+## Filtering
+
+The dashboard filter bar narrows the grid by **Series**, **Author**, **Tag**, **Format**, and **Language**, plus reading status, rating, and (for admins) uploader. Filters combine, show as removable chips, and live in the URL — so a filtered view is shareable and can be saved as a Shelf.
+
+### Language
+
+The **Language** dropdown appears whenever your catalogue holds more than one language. There is no language *detection* — Tome never inspects the book's text. It reads the language each file *declares* in its embedded metadata (an EPUB's `<dc:language>`, a CBZ's `LanguageISO`, etc.), captured at scan/upload time. A book whose file declares nothing has no language and simply doesn't appear in the dropdown.
+
+Because that declared value is inconsistent across files — `en`, `eng`, `en-US`, and `English` all mean the same thing — Tome folds it to a single canonical entry before showing it. Matching is a static lookup (`backend/services/languages.py`), tried in order:
+
+1. **Whole-string match** against a table of ISO-639-2 three-letter codes and English names (`eng` / `english` → `en`, `ger` / `deu` / `german` → `de`, …).
+2. **Base token** of a region/script-tagged value against the known two-letter codes (`en-US` → `en`, `zh-Hant` → `zh`).
+3. **Base token** against the alias table, as a fallback (`eng-US` → `en`).
+
+If nothing matches, the lowercased base token is kept as-is, so an unrecognized language still groups consistently — it just shows as an upper-cased code (e.g. `TL`) rather than a friendly name until it's added to the table. Note this is deliberate, not lossy by accident: `pt-BR` and `pt-PT` both collapse to "Portuguese", which is what you want in a filter dropdown.
+
+---
+
 ## Shelves
 
-Shelves (formerly called Saved Filters) let you save any combination of active dashboard filters — search text, book type, library, series, tags, sort order — as a named entry in the sidebar. Click a shelf to instantly restore that view.
+Shelves (formerly called Saved Filters) let you save any combination of active dashboard filters — search text, book type, library, series, author, tags, format, language, sort order — as a named entry in the sidebar. Click a shelf to instantly restore that view. This is also the simplest way to get a "library per language": filter by a language and save it as a Shelf — it self-populates as matching books arrive, with nothing to add by hand.
 
 Shelves are per-user and private. Each shelf can have a custom icon chosen from the icon picker.
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -67,6 +67,7 @@ interface Facets {
   authors: string[]
   tags: string[]
   formats: string[]
+  languages: { code: string; label: string }[]
 }
 
 interface HomeStats {
@@ -454,6 +455,7 @@ export function DashboardPage() {
   const filterAuthor = searchParams.get('author') ?? ''
   const filterTag = searchParams.get('tag') ?? ''
   const filterFormat = searchParams.get('format') ?? ''
+  const filterLanguage = searchParams.get('language') ?? ''
   const filterLibrary = searchParams.get('library_id') ? Number(searchParams.get('library_id')) : null
   const filterReadingStatus = searchParams.get('reading_status') ?? ''
   const filterMinRating = searchParams.get('min_rating') ? Number(searchParams.get('min_rating')) : null
@@ -490,7 +492,7 @@ export function DashboardPage() {
     })
   }
 
-  const hasFilters = !!(search || filterSeries || filterNoSeries || filterAuthor || filterTag || filterFormat || filterReadingStatus || filterMinRating || filterMissing || filterOwnership || filterAddedBy)
+  const hasFilters = !!(search || filterSeries || filterNoSeries || filterAuthor || filterTag || filterFormat || filterLanguage || filterReadingStatus || filterMinRating || filterMissing || filterOwnership || filterAddedBy)
 
   // Grouping is bypassed while drilling into a specific series — the user
   // explicitly asked for that series' volumes, so a single stack is useless.
@@ -683,7 +685,7 @@ export function DashboardPage() {
   }, [gridSize, view, books])
   const [totalCount, setTotalCount] = useState<number | null>(null)
   const [readingStatuses, setReadingStatuses] = useState<Record<number, { status: ReadingStatus; progress_pct: number | null; rating: number | null }>>({})
-  const [facets, setFacets] = useState<Facets>({ series: [], authors: [], tags: [], formats: [] })
+  const [facets, setFacets] = useState<Facets>({ series: [], authors: [], tags: [], formats: [], languages: [] })
   const [loading, setLoading] = useState(true)
   const [uploadModalOpen, setUploadModalOpen] = useState(false)
   const [filterOpen, setFilterOpen] = useState(false)
@@ -740,6 +742,7 @@ export function DashboardPage() {
     if (filterAuthor) params.set('author', filterAuthor)
     if (filterTag) params.set('tag', filterTag)
     if (filterFormat) params.set('format', filterFormat)
+    if (filterLanguage) params.set('language', filterLanguage)
     if (filterLibrary) params.set('library_id', String(filterLibrary))
     if (filterReadingStatus) params.set('reading_status', filterReadingStatus)
     if (filterMinRating) params.set('min_rating', String(filterMinRating))
@@ -781,7 +784,7 @@ export function DashboardPage() {
         if (reset) { setLoading(false); setRefreshing(false) }
         else setLoadingMore(false)
       })
-  }, [sort, order, search, filterSeries, filterNoSeries, filterAuthor, filterTag, filterFormat, filterLibrary, filterReadingStatus, filterMinRating, filterMissing, contentType, filterOwnership, filterAddedBy, groupActive])
+  }, [sort, order, search, filterSeries, filterNoSeries, filterAuthor, filterTag, filterFormat, filterLanguage, filterLibrary, filterReadingStatus, filterMinRating, filterMissing, contentType, filterOwnership, filterAddedBy, groupActive])
 
   useEffect(() => { loadBooks() }, [loadBooks])
 
@@ -915,6 +918,7 @@ export function DashboardPage() {
     ...(filterAuthor ? [{ label: `Author: ${filterAuthor}`, key: 'author' }] : []),
     ...(filterTag ? [{ label: `Tag: ${filterTag}`, key: 'tag' }] : []),
     ...(filterFormat ? [{ label: `Format: ${filterFormat.toUpperCase()}`, key: 'format' }] : []),
+    ...(filterLanguage ? [{ label: `Language: ${facets.languages.find(l => l.code === filterLanguage)?.label ?? filterLanguage}`, key: 'language' }] : []),
     ...(filterReadingStatus ? [{ label: `Status: ${filterReadingStatus.charAt(0).toUpperCase() + filterReadingStatus.slice(1)}`, key: 'reading_status' }] : []),
     ...(filterMinRating ? [{ label: filterMinRating === 5 ? 'Rated: 5 stars' : `Rated: ${filterMinRating}+ stars`, key: 'min_rating' }] : []),
     ...(filterMissing ? [{ label: `Missing: ${filterMissing.charAt(0).toUpperCase() + filterMissing.slice(1)}`, key: 'missing' }] : []),
@@ -929,6 +933,7 @@ export function DashboardPage() {
   if (filterAuthor) saveableParams.author = filterAuthor
   if (filterTag) saveableParams.tag = filterTag
   if (filterFormat) saveableParams.format = filterFormat
+  if (filterLanguage) saveableParams.language = filterLanguage
 
   // Grid columns flow from the spring-smoothed cover size; card typography
   // follows the slider value. view-fade covers the grid/list switch.
@@ -1755,6 +1760,9 @@ export function DashboardPage() {
                 <FilterSelect label="Author" value={filterAuthor} options={facets.authors} onChange={v => setFilter('author', v)} />
                 <FilterSelect label="Tag" value={filterTag} options={facets.tags} onChange={v => setFilter('tag', v)} />
                 <FilterSelect label="Format" value={filterFormat} options={facets.formats.map(f => f.toUpperCase())} onChange={v => setFilter('format', v.toLowerCase())} />
+                {facets.languages.length > 1 && (
+                  <FilterSelect label="Language" value={filterLanguage} options={facets.languages.map(l => ({ value: l.code, label: l.label }))} onChange={v => setFilter('language', v)} />
+                )}
               </div>
               <div className="flex items-center gap-2 flex-wrap">
                 <span className="text-xs text-muted-foreground font-medium w-14">Status</span>
@@ -2180,15 +2188,16 @@ export function DashboardPage() {
 }
 
 function FilterSelect({ label, value, options, onChange }: {
-  label: string; value: string; options: string[]; onChange: (v: string) => void
+  label: string; value: string; options: (string | { value: string; label: string })[]; onChange: (v: string) => void
 }) {
+  const opts = options.map(o => typeof o === 'string' ? { value: o, label: o } : o)
   return (
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-muted-foreground">{label}</label>
       <select value={value} onChange={e => onChange(e.target.value)}
         className="h-8 rounded-md border border-border bg-background px-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-foreground">
         <option value="">All</option>
-        {options.map(o => <option key={o} value={o}>{o}</option>)}
+        {opts.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
       </select>
     </div>
   )

--- a/tests/test_language_filter.py
+++ b/tests/test_language_filter.py
@@ -1,0 +1,71 @@
+"""Regression tests for the language facet + filter (dashboard "Language" dropdown).
+
+`Book.language` is populated straight from per-file embedded metadata, so the
+stored values are messy: en / eng / en-US / English all mean English. The facet
+folds them to one canonical code with a human label, and the list filter matches
+all raw variants that fold to the requested code.
+"""
+from backend.services.languages import normalize_language, language_label
+
+
+def _hdr(token: str) -> dict[str, str]:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_normalize_folds_variants():
+    for raw in ("en", "eng", "en-US", "English", "EN", "en_GB"):
+        assert normalize_language(raw) == "en"
+    assert normalize_language("de_DE") == "de"
+    assert normalize_language("German") == "de"
+    assert normalize_language("zh-Hant") == "zh"
+    assert normalize_language("") is None
+    assert normalize_language("   ") is None
+    assert normalize_language(None) is None
+    # Unknown codes pass through as their lowercased base token, still grouped.
+    assert normalize_language("xx") == "xx"
+
+
+def test_label_falls_back_to_upper_code():
+    assert language_label("en") == "English"
+    assert language_label("xx") == "XX"
+
+
+def test_facet_dedupes_messy_values(client, admin_user, make_book):
+    _, token = admin_user
+    make_book(title="A", language="en")
+    make_book(title="B", language="eng")
+    make_book(title="C", language="English")
+    make_book(title="D", language="de")
+    make_book(title="E", language=None)
+
+    r = client.get("/api/books/facets", headers=_hdr(token))
+    assert r.status_code == 200
+    langs = r.json()["languages"]
+    # en collapses three variants into one; de is its own; None is excluded.
+    assert {l["code"] for l in langs} == {"en", "de"}
+    by_code = {l["code"]: l["label"] for l in langs}
+    assert by_code["en"] == "English"
+    assert by_code["de"] == "German"
+
+
+def test_filter_matches_all_raw_variants(client, admin_user, make_book):
+    _, token = admin_user
+    make_book(title="A", language="en")
+    make_book(title="B", language="eng")
+    make_book(title="C", language="English")
+    make_book(title="D", language="de")
+
+    r = client.get("/api/books?language=en", headers=_hdr(token))
+    assert r.status_code == 200
+    assert {b["title"] for b in r.json()} == {"A", "B", "C"}
+
+    r = client.get("/api/books?language=de", headers=_hdr(token))
+    assert {b["title"] for b in r.json()} == {"D"}
+
+
+def test_filter_unknown_language_returns_empty(client, admin_user, make_book):
+    _, token = admin_user
+    make_book(title="A", language="en")
+    r = client.get("/api/books?language=ja", headers=_hdr(token))
+    assert r.status_code == 200
+    assert r.json() == []

--- a/website/src/pages/docs/books.astro
+++ b/website/src/pages/docs/books.astro
@@ -99,6 +99,24 @@ import { withBase } from '../../lib/path'
     <a href={withBase("/docs/scribe")}>Scribe</a> which handles thousands.
   </Callout>
 
+  <h2>Filtering</h2>
+  <p>
+    The dashboard filter bar narrows the grid by <strong>series</strong>, <strong>author</strong>,
+    <strong>tag</strong>, <strong>format</strong>, and <strong>language</strong>, plus reading status
+    and rating. Filters combine, show as removable chips, and live in the URL, so any filtered view
+    can be saved as a <a href={withBase("/docs/libraries")}>Shelf</a> that re-populates itself.
+  </p>
+  <p>
+    The <strong>Language</strong> dropdown appears once your catalogue holds more than one language.
+    Tome doesn't detect language from a book's text — it reads the language each file <em>declares</em>
+    in its embedded metadata (an EPUB's <code>&lt;dc:language&gt;</code>, a CBZ's <code>LanguageISO</code>)
+    when it's scanned or uploaded. Those declared values are inconsistent across files, so
+    <code>en</code>, <code>eng</code>, <code>en-US</code>, and <code>English</code> are all folded to a
+    single "English" entry. Matching is a fixed lookup of ISO-639 codes and English names; an
+    unrecognized language still groups correctly but shows as a short code until it's added to the
+    table.
+  </p>
+
   <h2>Reading status</h2>
   <p>
     Every book has a per-user reading status: <strong>unread</strong>, <strong>reading</strong>, or


### PR DESCRIPTION
## What

Adds a **Language** filter to the dashboard, the most-requested half of [a Reddit ask](https://www.reddit.com/r/selfhosted/) for "a library per language without adding books by hand". The other half (filter-based collections) already exists as **Shelves** — this change makes language a filterable dimension so a per-language Shelf is one save away.

## How it works

- **No language detection.** Tome reads the language each file *declares* in its embedded metadata (EPUB `<dc:language>`, CBZ `LanguageISO`), captured at scan/upload. A book that declares nothing has no language and isn't in the dropdown.
- **Normalization.** Declared values are inconsistent (`en` / `eng` / `en-US` / `English`), so a new `backend/services/languages.py` folds them to a canonical code + human label via a static ISO-639 lookup (three match strategies: whole-string alias → base-token known-code → base-token alias; unknown values pass through as an upper-cased code). `pt-BR` and `pt-PT` both collapse to "Portuguese" — deliberate for a filter dropdown.
- **Facet** dedupes to one entry per language; the **list filter** resolves which raw stored variants fold to the requested code and matches those with `IN`.

## UI

- `Language` dropdown in the filter bar, shown only when >1 language is present (single-language libraries don't get a dead control).
- Wired through the full filter plumbing: URL param, active-filter chip, and `saveableParams` — so a **per-language Shelf** works and self-populates.
- `FilterSelect` generalized to accept `{value, label}` options.

## Tests

`tests/test_language_filter.py` — normalization folding, label fallback, facet dedupe, filter matching all raw variants, unknown-language empty result. Frontend `npm run build` clean; full backend suite green.

## Docs

Documented the matching behaviour in both `docs/features.md` and the website (`website/src/pages/docs/books.astro`), including the explicit "this reads declared metadata, not detected language" caveat.