### PR TITLE
chore(release): cut v1.6.0 "Marginalia"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-06-21 — "Marginalia"
+
 ### Added
 - **Filter your library by language.** The dashboard filter bar now has a
   **Language** dropdown alongside Series / Author / Tag / Format. It appears

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tome"
-version = "1.5.1"
+version = "1.6.0"
 description = "Self-hosted ebook library"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Cuts **v1.6.0 — "Marginalia"**, the notes-in-the-margins release. Bumps `pyproject.toml` to 1.6.0 and rolls the `[Unreleased]` changelog into the 1.6.0 section. No code changes.

## Highlights
- **Rate and review books — and whole series.** Per-user 1–5 stars + optional review; stars on cards, sort by *My Rating*, filter the grid, series-level ratings inherited by unrated volumes.
- **Two-way rating sync with KOReader.** Rate on web or device and it flows the other way (web wins on a tie). Requires **TomeSync plugin build 20** / semver 1.5.0.
- **PDF web reader.** pdf.js-based reader with continuous scroll, page tint, fit/zoom, keyboard nav, and progress sync.
- **Filter by language.** New Language filter that folds messy values (`en`/`eng`/`English`) into one entry; saveable as a Shelf.
- **Shelved reading status** + **undo** on status changes.

## Also
- Stats dashboard: auto-fit height for list tiles, non-clipping headline tiles.
- npm dependency bumps (Dependabot/CVE alerts).

## Upgrading
- KOReader plugin: rating sync needs **build 20**. **Graceful** update — older builds keep working and self-update; no manual reinstall.

## After merge
Tag `v1.6.0` on the merge commit to publish `:latest`.