### PR TITLE
feat(tomesync): queue offline ratings so they sync without reopening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- **Ratings set offline now sync.** A rating or review you set on KOReader while
+  offline (or any time the server can't be reached) is now remembered and pushed
+  to Tome the next time the device is online — on resume, on **Sync now**, or
+  when you next close a book. Previously the rating was only sent when you opened
+  or closed *that* book, so rating a book and never opening it again — the normal
+  case for one you've just finished — could leave the rating stranded on the
+  device. It now rides a small pending queue (like reading sessions do) that
+  survives reboots. Requires TomeSync plugin build 21. (KOReader plugin semver
+  1.5.1.)
+
 ## [1.6.0] — 2026-06-21 — "Marginalia"
 
 ### Added

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -40,8 +40,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 20
-TOMESYNC_PLUGIN_SEMVER = "1.5.0"
+TOMESYNC_PLUGIN_BUILD = 21
+TOMESYNC_PLUGIN_SEMVER = "1.5.1"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1474,6 +1474,12 @@ function TomeSync:init()
     -- Per-book rating sync baseline: book_id (string) -> {{ rating=, review= }} as of
     -- the last reconcile. Lets a diff tell which side (device or Tome) changed.
     self.rating_baseline = G_reader_settings:readSetting("tomesync_rating_baseline") or {{}}
+    -- Ratings set offline (or lost to a server error) that never reached Tome.
+    -- Keyed by book_id (string) so re-rating the same book before a flush keeps
+    -- only the latest value. Flushed on resume / Sync now / close like sessions:
+    -- the per-book open/close push alone misses a book you rate and never reopen
+    -- (e.g. a finished book), so the rating would otherwise sit unsent forever.
+    self.pending_ratings = G_reader_settings:readSetting("tomesync_pending_ratings") or {{}}
     self:onDispatcherRegisterActions()
     self.ui.menu:registerToMainMenu(self)
     logger.info("TomeSync: init complete, menu registered,",
@@ -1600,6 +1606,7 @@ function TomeSync:onPageUpdate(pageno)
         }})
         -- Flush any offline sessions while we know WiFi is up
         self:_flushPendingSessions()
+        self:_flushPendingRatings()
     end
 end
 
@@ -1659,8 +1666,9 @@ function TomeSync:onResume()
     -- Push position on wake — catches up after offline periods
     self:_pushPosition()
 
-    -- Flush any pending sessions from offline periods
+    -- Flush any pending sessions / ratings from offline periods
     self:_flushPendingSessions()
+    self:_flushPendingRatings()
 end
 
 function TomeSync:_flushPendingSessions()
@@ -1881,29 +1889,75 @@ function TomeSync:_pullRatingAtOpen()
         base.rating, base.review = remote_rating, remote_review
         self.rating_baseline[key] = base
         G_reader_settings:saveSetting("tomesync_rating_baseline", self.rating_baseline)
+        -- Tome's value supersedes any device rating still queued for this book.
+        if self.pending_ratings[key] ~= nil then
+            self.pending_ratings[key] = nil
+            G_reader_settings:saveSetting("tomesync_pending_ratings", self.pending_ratings)
+        end
         logger.info("TomeSync: applied Tome rating to device for book", self.book_id)
     elseif local_changed then
         self:_pushRating(loc.rating, loc.review)
     end
 end
 
--- PUT the device rating/review up to Tome and advance the baseline on success.
+-- PUT a rating/review for an arbitrary book up to Tome and advance its baseline
+-- on success. Returns true on success, false otherwise (offline / server error).
 -- nil must go on the wire as JSON null (an absent Lua key would be dropped from
 -- the body, leaving Tome's old value in place instead of clearing it). rating is
 -- always nil or 1–5, never 0, so `or` is safe.
+function TomeSync:_putRating(book_id, rating, review)
+    local sok, resp, code = pcall(apiRequest, "PUT",
+        "/tome-sync/rating/" .. book_id,
+        {{ rating = rating or rapidjson.null, review = review or rapidjson.null }})
+    if not (sok and resp and type(code) == "number" and code < 300) then
+        return false
+    end
+    local key = tostring(book_id)
+    local base = self.rating_baseline[key] or {{}}
+    base.rating, base.review = rating, review
+    self.rating_baseline[key] = base
+    G_reader_settings:saveSetting("tomesync_rating_baseline", self.rating_baseline)
+    return true
+end
+
+-- Push the open book's rating up to Tome. On failure, persist it to the pending
+-- queue so a later flush retries it even if this book is never reopened (the
+-- close-time trigger only ever fires for the book you're currently in).
 function TomeSync:_pushRating(rating, review)
     if not self.book_id then return end
-    local sok, resp, code = pcall(apiRequest, "PUT",
-        "/tome-sync/rating/" .. self.book_id,
-        {{ rating = rating or rapidjson.null, review = review or rapidjson.null }})
-    if sok and resp and type(code) == "number" and code < 300 then
-        local key = tostring(self.book_id)
-        local base = self.rating_baseline[key] or {{}}
-        base.rating, base.review = rating, review
-        self.rating_baseline[key] = base
-        G_reader_settings:saveSetting("tomesync_rating_baseline", self.rating_baseline)
+    local key = tostring(self.book_id)
+    if self:_putRating(self.book_id, rating, review) then
+        if self.pending_ratings[key] ~= nil then
+            self.pending_ratings[key] = nil
+            G_reader_settings:saveSetting("tomesync_pending_ratings", self.pending_ratings)
+        end
         logger.info("TomeSync: pushed device rating to Tome for book", self.book_id)
+    else
+        self.pending_ratings[key] = {{ rating = rating, review = review }}
+        G_reader_settings:saveSetting("tomesync_pending_ratings", self.pending_ratings)
+        logger.info("TomeSync: rating queued for retry for book", self.book_id)
     end
+end
+
+-- Flush ratings that failed to send earlier (set offline, or while the server
+-- was unreachable). Mirrors _flushPendingSessions; survives reboots via
+-- G_reader_settings. A blind last-write-wins push, same as the close-time path.
+function TomeSync:_flushPendingRatings()
+    if not next(self.pending_ratings) then return end
+    if not NetworkMgr:isConnected() then return end
+
+    local remaining = {{}}
+    local flushed = false
+    for key, entry in pairs(self.pending_ratings) do
+        if self:_putRating(key, entry.rating, entry.review) then
+            flushed = true
+        else
+            remaining[key] = entry
+        end
+    end
+    self.pending_ratings = remaining
+    G_reader_settings:saveSetting("tomesync_pending_ratings", remaining)
+    if flushed then logger.info("TomeSync: pending ratings flushed") end
 end
 
 -- Reconcile on close/suspend: if the device rating changed during the session,
@@ -2785,8 +2839,10 @@ function TomeSync:_menuItems()
                     if self.book_id then
                         self:_pushPosition()
                         self:_syncAnnotations()
+                        self:_pushRatingOnLeave()
                     end
                     self:_flushPendingSessions()
+                    self:_flushPendingRatings()
                     local pending = #self.pending_sessions
                     local msg
                     if self.book_id then

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -144,7 +144,9 @@ def test_zip_download_bakes_https_with_forwarded_proto(app_client):
 def test_build_bumped_for_rebake():
     # Must exceed every build already live (v1.2.0 shipped 10; main reached 12),
     # so all existing installs re-download and re-bake the corrected URL.
-    # 1.5.0 / build 20 adds bidirectional book-rating sync (KOReader's native
+    # 1.5.0 / build 20 added bidirectional book-rating sync (KOReader's native
     # star rating + review <-> Tome) on top of 19's download path templates.
-    assert TOMESYNC_PLUGIN_BUILD >= 20
-    assert TOMESYNC_PLUGIN_SEMVER == "1.5.0"
+    # 1.5.1 / build 21 queues ratings set offline so a finished book you never
+    # reopen still syncs its rating (the per-book open/close push alone missed it).
+    assert TOMESYNC_PLUGIN_BUILD >= 21
+    assert TOMESYNC_PLUGIN_SEMVER == "1.5.1"

--- a/tests/test_tomesync_rating_sync.py
+++ b/tests/test_tomesync_rating_sync.py
@@ -43,7 +43,7 @@ def test_uses_correct_endpoints():
     # tk_ key satisfies), NOT the web /books/{id}/rating + /status ones, which
     # authenticate via get_current_user and reject the tk_ key (401).
     assert '"GET", "/tome-sync/rating/" .. self.book_id' in lua
-    assert '"PUT",\n        "/tome-sync/rating/" .. self.book_id' in lua
+    assert '"PUT",\n        "/tome-sync/rating/" .. book_id' in lua
     assert "/status" not in lua.split("function TomeSync:_pullRatingAtOpen")[1].split("\nend\n")[0]
 
 
@@ -74,9 +74,24 @@ def test_status_field_is_left_untouched():
 def test_nil_rating_clears_on_the_wire():
     # An absent Lua key is dropped from the JSON body, which would leave Tome's
     # old value in place. nil must be sent as rapidjson.null so clears propagate.
-    body = _body(_impl(), "_pushRating")
+    # The wire-level PUT lives in the shared _putRating helper.
+    body = _body(_impl(), "_putRating")
     assert "rating = rating or rapidjson.null" in body
     assert "review = review or rapidjson.null" in body
+
+
+def test_failed_rating_push_is_queued_and_flushed():
+    # A rating set offline (or while the server is down) must be persisted, not
+    # lost — the per-book close trigger never fires again for a book you rate and
+    # never reopen (e.g. a finished book). It rides a pending queue, like sessions.
+    lua = _impl()
+    assert 'G_reader_settings:readSetting("tomesync_pending_ratings")' in lua
+    # On a failed push, _pushRating stows the value for retry.
+    push = _body(lua, "_pushRating")
+    assert "self.pending_ratings[key] = { rating = rating, review = review }" in push
+    # A dedicated flush exists and is wired into the offline-recovery triggers.
+    assert "function TomeSync:_flushPendingRatings" in lua
+    assert "self:_flushPendingRatings()" in _body(lua, "onResume")
 
 
 def test_json_null_is_normalized_to_nil_on_read():


### PR DESCRIPTION
## Problem
A device rating was only pushed to Tome on **open / close of that specific book**. So rating a book and never opening it again — the normal case for one you've just **finished** — stranded the rating if the close-time push didn't land (offline, or server unreachable). The per-book trigger never fires again for a book you've moved on from, and `Sync now` didn't touch ratings.

## Fix
A persistent pending-rating queue, mirroring how reading sessions already work:

- `_pushRating` enqueues to `tomesync_pending_ratings` (in `G_reader_settings`, survives reboots) on failure, and clears the entry on success.
- New `_flushPendingRatings()` retries queued ratings for **any** book — not just the one currently open — wired into the same offline-recovery triggers as sessions: **onResume**, **Sync now**, and the close/position-push path.
- PUT logic extracted into a shared `_putRating(book_id, …)` helper so an arbitrary book's rating can be pushed.
- Open-time "Tome wins" reconcile drops a now-superseded queued entry.

Plugin **build 20 → 21**, semver **1.5.0 → 1.5.1**.

## Verification
- Full backend suite: **590 passing**. New tripwire pins the queue behaviour; existing rating-sync assertions repointed to the refactored `_putRating`/`_pushRating` shape (intent unchanged). LuaJIT compiles the rendered plugin clean.
- **Emulator round-trip** (build 21 baked from a live server, real KOReader LuaJIT runtime):
  - failed push (404) → enqueued to the durable queue with rating + review intact;
  - flushing a queued rating **for a book that was not the open document** → reached Tome (verified in the DB);
  - successful entry cleared, still-failing entry retained for retry.

## Upgrading
KOReader plugin: graceful self-update to **build 21**. Older builds keep working; they pick up the queue on next update.