### PR TITLE
feat(stats): import KOReader reading history (statistics.sqlite3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ docs/transfer.md
 docs/plans/
 scripts/tome_transfer.py
 graphify-out/
+
+# Local-only personal data: copied KOReader stats + prod DB for stats-expansion work (never commit)
+.statsdb/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Your stats now include reading from before TomeSync.** KOReader keeps its own
+  per-page reading log (`statistics.sqlite3`) going back to whenever you started
+  reading — often long before Tome existed. TomeSync can now import that history,
+  backfilling your reading-time charts, streaks, heat-map, top books and pace with
+  everything you read on the device. The first sync pushes your whole history
+  (chunked and resumable, so it survives the device sleeping or dropping Wi-Fi);
+  later syncs send only new reading. Turn it on in **TomeSync → Auto-sync reading
+  history on launch**, or run it once from **TomeSync → Sync reading history**
+  (also assignable to a gesture). It imports **reading time and pages only** — it
+  never changes your read/unread status; that stays yours to set. Books are matched
+  to your library automatically; anything it can't confidently match is left out
+  rather than guessed. Requires TomeSync plugin build 22. (KOReader plugin semver
+  1.6.0.)
 - **Ratings set offline now sync.** A rating or review you set on KOReader while
   offline (or any time the server can't be reached) is now remembered and pushed
   to Tome the next time the device is online — on resume, on **Sync now**, or

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, HTTPException
-from sqlalchemy import func, Integer, case
+from sqlalchemy import func, case
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -18,7 +18,10 @@ from backend.models.tome_sync import ReadingSession, TomeSyncPosition
 from backend.models.book import Book, BookFile
 from backend.models.user_book_status import UserBookStatus
 from backend.models.library import BookType
-from backend.services.streaks import compute_user_streaks
+from backend.services.streaks import (
+    compute_user_streaks, streaks_from_dates, effective_today, date_modifier,
+)
+from backend.services import reconciled_reading as rr
 
 router = APIRouter(tags=["stats"])
 
@@ -32,11 +35,22 @@ def _date_range(days: int) -> Optional[datetime]:
 def _fill_daily(rows: list, start_date, end_date) -> list[dict]:
     """Fill gaps so every day in [start_date, end_date] has an entry."""
     row_map: dict[str, dict] = {r.date: {"seconds": r.seconds or 0, "sessions": r.sessions or 0, "pages": r.pages or 0} for r in rows}
+    return _fill_daily_map(row_map, start_date, end_date)
+
+
+def _fill_daily_map(day_map: dict, start_date, end_date) -> list[dict]:
+    """Fill gaps from a {day_str: dict_or_(secs,sessions,pages)} map."""
     result = []
     d = start_date
     while d <= end_date:
         key = d.isoformat()
-        entry = row_map.get(key, {"seconds": 0, "sessions": 0, "pages": 0})
+        v = day_map.get(key)
+        if v is None:
+            entry = {"seconds": 0, "sessions": 0, "pages": 0}
+        elif isinstance(v, dict):
+            entry = {"seconds": v.get("seconds", 0), "sessions": v.get("sessions", 0), "pages": v.get("pages", 0)}
+        else:  # tuple (seconds, sessions, pages)
+            entry = {"seconds": v[0], "sessions": v[1], "pages": v[2]}
         result.append({"date": key, **entry})
         d += timedelta(days=1)
     return result
@@ -93,22 +107,21 @@ def get_stats(
     offset_hours = -(tz_offset // 60)
     tz_modifier = f"{offset_hours:+d} hours"
 
-    # Base query filtered to this user
+    # Base query filtered to this user (still used by session-level tiles: pace, timeline,
+    # pace-by-format — page-stats have no natural "sessions" so those stay session-sourced).
     base = db.query(ReadingSession).filter(ReadingSession.user_id == current_user.id)
     if cutoff:
         base = base.filter(ReadingSession.started_at >= cutoff)
     if range_end:
         base = base.filter(ReadingSession.started_at < range_end)
 
-    total_seconds = base.with_entities(
-        func.coalesce(func.sum(ReadingSession.duration_seconds), 0)
-    ).scalar() or 0
+    # Books whose time comes from imported KOReader page-stats (those win; their live
+    # sessions are excluded to avoid double-counting). Empty -> identical to session-only.
+    covered = rr.covered_book_ids(db, current_user.id)
 
-    total_sessions = base.count()
-
-    pages_turned = base.with_entities(
-        func.coalesce(func.sum(ReadingSession.pages_turned), 0)
-    ).scalar() or 0
+    total_seconds, total_sessions, pages_turned = rr.totals(
+        db, current_user.id, tz_modifier, covered, cutoff, range_end
+    )
 
     avg_session = int(total_seconds / total_sessions) if total_sessions > 0 else 0
 
@@ -123,42 +136,26 @@ def get_stats(
         finished_query = finished_query.filter(UserBookStatus.updated_at < range_end)
     books_finished_count = finished_query.count()
 
-    # Streaks (all time, local-day with 4h rollover so late-night reading still counts)
-    current_streak, longest_streak = compute_user_streaks(db, current_user.id, tz_offset)
+    # Streaks (all time, local-day with 4h rollover). Reconciled: page-stat days count too.
+    # Streaks use the rollover modifier, distinct from the plain tz_modifier above.
+    if covered:
+        streak_days = rr.active_days(db, current_user.id, date_modifier(tz_offset), covered)
+        current_streak, longest_streak = streaks_from_dates(streak_days, effective_today(tz_offset))
+    else:
+        current_streak, longest_streak = compute_user_streaks(db, current_user.id, tz_offset)
 
-    # Daily aggregation (for selected range)
-    daily_rows = (
-        base.with_entities(
-            func.date(ReadingSession.started_at, tz_modifier).label("date"),
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
-            func.count(ReadingSession.id).label("sessions"),
-            func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages"),
-        )
-        .group_by(func.date(ReadingSession.started_at, tz_modifier))
-        .order_by(func.date(ReadingSession.started_at, tz_modifier))
-        .all()
+    # Daily aggregation (for selected range) — reconciled (page-stats win per book).
+    daily = _fill_daily_map(
+        rr.daily_map(db, current_user.id, tz_modifier, covered, cutoff, range_end),
+        fill_start, fill_end,
     )
-    daily = _fill_daily(daily_rows, fill_start, fill_end)
 
-    # Heatmap daily — always last 365 days
+    # Heatmap daily — always last 365 days — reconciled.
     heatmap_cutoff = now - timedelta(days=365)
-    heatmap_rows = (
-        db.query(ReadingSession)
-        .filter(
-            ReadingSession.user_id == current_user.id,
-            ReadingSession.started_at >= heatmap_cutoff,
-        )
-        .with_entities(
-            func.date(ReadingSession.started_at, tz_modifier).label("date"),
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
-            func.count(ReadingSession.id).label("sessions"),
-            func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages"),
-        )
-        .group_by(func.date(ReadingSession.started_at, tz_modifier))
-        .order_by(func.date(ReadingSession.started_at, tz_modifier))
-        .all()
+    heatmap_daily = _fill_daily_map(
+        rr.daily_map(db, current_user.id, tz_modifier, covered, heatmap_cutoff, None),
+        heatmap_cutoff.date(), now.date(),
     )
-    heatmap_daily = _fill_daily(heatmap_rows, heatmap_cutoff.date(), now.date())
 
     # Books finished list (for chart)
     finished_books = (
@@ -177,47 +174,38 @@ def get_stats(
         for row in finished_books
     ]
 
+    # Reconciled per-book reading time for the window (page-stats win per book), reused by
+    # top-books, category, per-book table, and author-affinity below.
+    win_book = rr.book_seconds(db, current_user.id, tz_modifier, covered, cutoff, range_end)
+    book_meta: dict[int, tuple] = {}
+    if win_book:
+        for bid, title, author, cover, label in (
+            db.query(Book.id, Book.title, Book.author, Book.cover_path,
+                     func.coalesce(BookType.label, "Uncategorized"))
+            .outerjoin(BookType, BookType.id == Book.book_type_id)
+            .filter(Book.id.in_(list(win_book.keys())))
+        ):
+            book_meta[bid] = (title, author, cover, label)
+
+    def _bsorted():
+        return sorted(win_book.items(), key=lambda kv: kv[1][0], reverse=True)
+
     # Top books by reading time
-    top_books_rows = (
-        base.filter(ReadingSession.book_id.isnot(None))
-        .join(Book, Book.id == ReadingSession.book_id)
-        .with_entities(
-            ReadingSession.book_id,
-            Book.title,
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
-            func.count(ReadingSession.id).label("sessions"),
-        )
-        .group_by(ReadingSession.book_id, Book.title)
-        .order_by(func.sum(ReadingSession.duration_seconds).desc())
-        .limit(10)
-        .all()
-    )
     top_books = [
-        {"book_id": r.book_id, "title": r.title, "seconds": r.seconds, "sessions": r.sessions}
-        for r in top_books_rows
+        {"book_id": bid, "title": book_meta.get(bid, (None,))[0], "seconds": v[0], "sessions": v[1]}
+        for bid, v in _bsorted()[:10]
     ]
 
-    # By category
-    category_rows = (
-        base.filter(ReadingSession.book_id.isnot(None))
-        .join(Book, Book.id == ReadingSession.book_id)
-        .outerjoin(BookType, BookType.id == Book.book_type_id)
-        .with_entities(
-            func.coalesce(BookType.label, "Uncategorized").label("category"),
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
-            func.count(ReadingSession.id).label("sessions"),
-            func.count(func.distinct(ReadingSession.book_id)).label("book_count"),
-        )
-        .group_by(func.coalesce(BookType.label, "Uncategorized"))
-        .order_by(func.sum(ReadingSession.duration_seconds).desc())
-        .all()
-    )
+    # By category — roll the reconciled per-book time up to book-type.
+    _cat: dict[str, list[int]] = {}
+    for bid, v in win_book.items():
+        label = book_meta.get(bid, (None, None, None, "Uncategorized"))[3] or "Uncategorized"
+        e = _cat.setdefault(label, [0, 0, 0])
+        e[0] += v[0]; e[1] += v[1]; e[2] += 1
     by_category = [
-        {"category": r.category, "seconds": r.seconds, "sessions": r.sessions, "book_count": r.book_count}
-        for r in category_rows
+        {"category": c, "seconds": e[0], "sessions": e[1], "book_count": e[2]}
+        for c, e in sorted(_cat.items(), key=lambda kv: kv[1][0], reverse=True)
     ]
-
-    local_time_expr = func.datetime(ReadingSession.started_at, tz_modifier)
 
     # Reading pace — per session, pages/minute
     pace_rows = (
@@ -318,13 +306,9 @@ def get_stats(
         start_date = cutoff
         duration = (range_end or now) - cutoff
         prev_start = start_date - duration
-        prev_seconds = db.query(
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0)
-        ).filter(
-            ReadingSession.user_id == current_user.id,
-            ReadingSession.started_at >= prev_start,
-            ReadingSession.started_at < start_date,
-        ).scalar() or 0
+        prev_seconds = rr.totals(
+            db, current_user.id, tz_modifier, covered, prev_start, start_date
+        )[0]
         pct_change: Optional[float] = 0.0
         if prev_seconds > 0:
             pct_change = round(((total_seconds - prev_seconds) / prev_seconds) * 100, 1)
@@ -384,57 +368,25 @@ def get_stats(
             "most_active_month": most_active_month,
         }
 
-    # ── Per-book time breakdown (full list, no limit) ────────────────────────
-    per_book_rows = (
-        base.filter(ReadingSession.book_id.isnot(None))
-        .join(Book, Book.id == ReadingSession.book_id)
-        .with_entities(
-            ReadingSession.book_id,
-            Book.title,
-            Book.author,
-            Book.cover_path,
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
-            func.count(ReadingSession.id).label("sessions"),
-            func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages_turned"),
-        )
-        .group_by(ReadingSession.book_id, Book.title, Book.author, Book.cover_path)
-        .order_by(func.sum(ReadingSession.duration_seconds).desc())
-        .all()
-    )
+    # ── Per-book time breakdown (full list, no limit) — reconciled ───────────
     per_book_time = [
         {
-            "book_id": r.book_id,
-            "title": r.title,
-            "author": r.author,
-            "has_cover": bool(r.cover_path),
-            "seconds": r.seconds,
-            "sessions": r.sessions,
-            "pages_turned": r.pages_turned,
+            "book_id": bid,
+            "title": book_meta.get(bid, (None, None, None, None))[0],
+            "author": book_meta.get(bid, (None, None, None, None))[1],
+            "has_cover": bool(book_meta.get(bid, (None, None, None, None))[2]),
+            "seconds": v[0],
+            "sessions": v[1],
+            "pages_turned": v[2],
         }
-        for r in per_book_rows
+        for bid, v in _bsorted()
     ]
 
-    # ── Monthly comparison (last 12 months) ───────────────────────────────
+    # ── Monthly comparison (last 12 months) ── reconciled ──────────────────
     month_cutoff = now - timedelta(days=365)
-    month_expr = func.strftime('%Y-%m', func.datetime(ReadingSession.started_at, tz_modifier))
-
-    monthly_session_rows = (
-        db.query(ReadingSession)
-        .filter(
-            ReadingSession.user_id == current_user.id,
-            ReadingSession.started_at >= month_cutoff,
-        )
-        .with_entities(
-            month_expr.label("month"),
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
-            func.count(ReadingSession.id).label("sessions"),
-        )
-        .group_by(month_expr)
-        .all()
-    )
+    _mm = rr.monthly_map(db, current_user.id, tz_modifier, covered, month_cutoff)
     month_session_map: dict[str, dict] = {
-        r.month: {"seconds": int(r.seconds), "sessions": int(r.sessions)}
-        for r in monthly_session_rows
+        m: {"seconds": v[0], "sessions": v[1]} for m, v in _mm.items()
     }
 
     # Books finished per month
@@ -469,34 +421,25 @@ def get_stats(
             "reading_seconds": sdata["seconds"],
         })
 
-    # ── Genre over time (last 12 months, stacked) ─────────────────────────
-    genre_month_expr = func.strftime('%Y-%m', func.datetime(ReadingSession.started_at, tz_modifier))
-    genre_time_rows = (
-        db.query(ReadingSession)
-        .filter(
-            ReadingSession.user_id == current_user.id,
-            ReadingSession.started_at >= month_cutoff,
-            ReadingSession.book_id.isnot(None),
-        )
-        .join(Book, Book.id == ReadingSession.book_id)
-        .outerjoin(BookType, BookType.id == Book.book_type_id)
-        .with_entities(
-            genre_month_expr.label("month"),
-            func.coalesce(BookType.label, "Uncategorized").label("category"),
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
-        )
-        .group_by(genre_month_expr, func.coalesce(BookType.label, "Uncategorized"))
-        .all()
-    )
-
-    # Pivot: each row = { month, Cat1: secs, Cat2: secs, ... }
+    # ── Genre over time (last 12 months, stacked) ── reconciled ───────────
+    # Reconciled per-(book, month) seconds, rolled up to book-type per month.
+    _bm = rr.book_month_seconds(db, current_user.id, tz_modifier, covered, month_cutoff)
+    _genre_ids = {bid for (bid, _m) in _bm.keys()}
+    _genre_cat: dict[int, str] = {}
+    if _genre_ids:
+        for bid, label in (
+            db.query(Book.id, func.coalesce(BookType.label, "Uncategorized"))
+            .outerjoin(BookType, BookType.id == Book.book_type_id)
+            .filter(Book.id.in_(list(_genre_ids)))
+        ):
+            _genre_cat[bid] = label or "Uncategorized"
     genre_month_map: dict[str, dict[str, int]] = {}
     all_categories: set[str] = set()
-    for r in genre_time_rows:
-        if r.month not in genre_month_map:
-            genre_month_map[r.month] = {}
-        genre_month_map[r.month][r.category] = int(r.seconds)
-        all_categories.add(r.category)
+    for (bid, m), secs in _bm.items():
+        cat = _genre_cat.get(bid, "Uncategorized")
+        genre_month_map.setdefault(m, {})
+        genre_month_map[m][cat] = genre_month_map[m].get(cat, 0) + secs
+        all_categories.add(cat)
 
     genre_over_time = []
     for i in range(11, -1, -1):
@@ -508,18 +451,8 @@ def get_stats(
             entry[cat] = cat_data.get(cat, 0)
         genre_over_time.append(entry)
 
-    # ── Hour × day-of-week heatmap (168 cells) ───────────────────────────────
-    hour_dow_rows = (
-        base.with_entities(
-            func.cast(func.strftime('%w', local_time_expr), Integer).label("dow"),
-            func.cast(func.strftime('%H', local_time_expr), Integer).label("hour"),
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
-            func.count(ReadingSession.id).label("sessions"),
-        )
-        .group_by("dow", "hour")
-        .all()
-    )
-    hour_dow_map = {(r.dow, r.hour): (r.seconds, r.sessions) for r in hour_dow_rows}
+    # ── Hour × day-of-week heatmap (168 cells) ── reconciled ─────────────────
+    hour_dow_map = rr.hour_dow(db, current_user.id, tz_modifier, covered, cutoff, range_end)
     hour_dow_heatmap = [
         {
             "dow": d,
@@ -573,22 +506,7 @@ def get_stats(
         for r in series_rows
     ]
 
-    # ── Author affinity ───────────────────────────────────────────────────────
-    author_rows = (
-        base.filter(ReadingSession.book_id.isnot(None))
-        .join(Book, Book.id == ReadingSession.book_id)
-        .filter(Book.author.isnot(None), Book.author != "")
-        .with_entities(
-            Book.author.label("author"),
-            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
-            func.count(func.distinct(ReadingSession.book_id)).label("book_count"),
-            func.count(ReadingSession.id).label("sessions"),
-        )
-        .group_by(Book.author)
-        .order_by(func.sum(ReadingSession.duration_seconds).desc())
-        .limit(10)
-        .all()
-    )
+    # ── Author affinity ── reconciled: roll per-book time up to author ──────────
     finished_by_author = dict(
         db.query(Book.author, func.count(Book.id))
         .join(UserBookStatus, UserBookStatus.book_id == Book.id)
@@ -599,15 +517,22 @@ def get_stats(
         .group_by(Book.author)
         .all()
     )
+    _auth: dict[str, list[int]] = {}
+    for bid, v in win_book.items():
+        author = (book_meta.get(bid, (None, None))[1] or "").strip()
+        if not author:
+            continue
+        e = _auth.setdefault(author, [0, 0, 0])
+        e[0] += v[0]; e[1] += v[1]; e[2] += 1
     author_affinity = [
         {
-            "author": r.author,
-            "seconds": int(r.seconds),
-            "sessions": int(r.sessions),
-            "book_count": int(r.book_count),
-            "books_finished": int(finished_by_author.get(r.author, 0)),
+            "author": a,
+            "seconds": e[0],
+            "sessions": e[1],
+            "book_count": e[2],
+            "books_finished": int(finished_by_author.get(a, 0)),
         }
-        for r in author_rows
+        for a, e in sorted(_auth.items(), key=lambda kv: kv[1][0], reverse=True)[:10]
     ]
 
     # ── Completion rate ───────────────────────────────────────────────────────

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -26,6 +26,7 @@ from backend.models.user import User
 from backend.models.book import Book, BookFile
 from backend.models.user_book_status import UserBookStatus
 from backend.models.tome_sync import Annotation, AnnotationTombstone, ApiKey, ReadingSession, TomeSyncPosition
+from backend.models.ko_stats import StatsImport
 from backend.models.send_queue import SendQueueItem
 
 router = APIRouter(tags=["tome-sync"])
@@ -404,6 +405,67 @@ def post_session(
     db.commit()
     db.refresh(session)
     return {"session_id": session.id}
+
+
+# ── KOReader statistics.sqlite3 import ────────────────────────────────────────
+# Backfills the user's full KOReader reading history (page-level dwell data) into
+# Tome. Books are matched to Tome books by filename (exact) or fuzzy title+series+
+# volume. Idempotent: re-uploading the same rows is a no-op. See
+# backend/services/ko_stats_import.py and docs/plans/stats-expansion-plan.md.
+
+class KoStatBookItem(PydanticBaseModel):
+    ko_id: int                       # KOReader's local book.id (joins page_stats below)
+    md5: str = ""                    # KOReader partial md5 (stable per-device identity)
+    title: str = ""
+    authors: Optional[str] = None
+    series: Optional[str] = None
+    filename: Optional[str] = None   # device file path, when the book is still present
+    pages: Optional[int] = None              # KOReader book.pages (total)
+    total_read_pages: Optional[int] = None   # KOReader book.total_read_pages (distinct read)
+
+
+class KoStatPageItem(PydanticBaseModel):
+    ko_id: int
+    page: int
+    start_time: int                  # epoch seconds
+    duration: int = 0
+    total_pages: int = 0
+
+
+class StatsImportRequest(PydanticBaseModel):
+    device: str = ""
+    books: list[KoStatBookItem]
+    page_stats: list[KoStatPageItem]
+
+
+@router.get("/tome-sync/stats/watermark")
+def ko_stats_watermark(
+    device: str = "",
+    db: Session = Depends(get_db),
+    user: User = Depends(_get_api_key_user),
+):
+    """Last synced page_stat start_time for this device, so the plugin uploads only newer rows."""
+    wm = (
+        db.query(StatsImport)
+        .filter(StatsImport.user_id == user.id, StatsImport.device == device)
+        .first()
+    )
+    return {"device": device, "last_start_time_synced": wm.last_start_time_synced if wm else 0}
+
+
+@router.post("/tome-sync/stats/import", status_code=201)
+def import_ko_stats(
+    body: StatsImportRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(_get_api_key_user),
+):
+    from backend.services.ko_stats_import import import_batch
+    return import_batch(
+        db, user,
+        device=body.device,
+        books=[b.model_dump() for b in body.books],
+        page_stats=[p.model_dump() for p in body.page_stats],
+    )
 
 
 # ── Annotation endpoints ──────────────────────────────────────────────────────

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 21
-TOMESYNC_PLUGIN_SEMVER = "1.5.1"
+TOMESYNC_PLUGIN_BUILD = 22
+TOMESYNC_PLUGIN_SEMVER = "1.6.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1570,6 +1570,12 @@ function TomeSync:init()
     -- an "Inbox (N)" badge. Guarded (offline = no-op; 404 = feature off → no
     -- badge), so it is safe to run on every launch regardless of server support.
     UIManager:scheduleIn(8, function() pcall(function() self:_refreshInbox() end) end)
+
+    -- Reading-history backfill: opt-in, deferred, non-blocking. First run pushes
+    -- the entire KOReader history (chunked + resumable); later runs only new rows.
+    if G_reader_settings:isTrue("tomesync_auto_sync_stats") then
+        UIManager:scheduleIn(12, function() pcall(function() self:_syncReadingStats(false) end) end)
+    end
 end
 
 function TomeSync:onDispatcherRegisterActions()
@@ -1590,6 +1596,12 @@ function TomeSync:onDispatcherRegisterActions()
         event    = "TomeSyncAnnotations",
         title    = "TomeSync: Sync highlights",
         reader   = true,
+    }})
+    Dispatcher:registerAction("tome_sync_stats", {{
+        category = "none",
+        event    = "TomeSyncStats",
+        title    = "TomeSync: Sync reading history",
+        general  = true,
     }})
 end
 
@@ -1617,6 +1629,11 @@ function TomeSync:onTomeSyncAnnotations()
             UIManager:show(InfoMessage:new{{ text = "Highlights synced (" .. n .. " on this book).", timeout = 3 }})
         end
     end)
+    return true
+end
+
+function TomeSync:onTomeSyncStats()
+    whenConnected(function() self:_syncReadingStats(true) end)
     return true
 end
 
@@ -1731,6 +1748,97 @@ function TomeSync:onResume()
     -- Flush any pending sessions / ratings from offline periods
     self:_flushPendingSessions()
     self:_flushPendingRatings()
+end
+
+-- ── KOReader statistics.sqlite3 import (reading-history backfill) ────────────
+-- Pushes KOReader's own per-page reading log to Tome (time & pages ONLY — never
+-- read-status). Chunked + resumable: the server keeps a per-device watermark, so
+-- an interrupted run resumes next launch and never re-sends (idempotent server
+-- side). First run backfills the whole history; later runs send only new rows.
+function TomeSync:_statsDbPath()
+    return require("datastorage"):getSettingsDir() .. "/statistics.sqlite3"
+end
+
+function TomeSync:_syncReadingStats(manual)
+    local function tell(msg)
+        if manual then UIManager:show(InfoMessage:new{{ text = msg, timeout = 3 }}) end
+    end
+    if self._stats_syncing then tell("Reading-history sync already running."); return end
+    if not NetworkMgr:isConnected() then tell("Offline - reading history will sync later."); return end
+    local path = self:_statsDbPath()
+    if lfs.attributes(path, "mode") ~= "file" then tell("No KOReader statistics database found."); return end
+
+    -- Server is the source of truth for "how far did we get".
+    local wm = apiRequest("GET", "/tome-sync/stats/watermark?device=" .. urlEncode(deviceName()))
+    local since = 0
+    if type(wm) == "table" and tonumber(wm.last_start_time_synced) then
+        since = tonumber(wm.last_start_time_synced)
+    end
+
+    local SQ3 = require("lua-ljsqlite3/init")
+    local opened, conn = pcall(SQ3.open, path, "ro")
+    if not opened or not conn then tell("Could not open statistics database."); return end
+
+    local books, rows = {{}}, {{}}
+    local read_ok = pcall(function()
+        -- ljsqlite3 returns INTEGER columns as int64 cdata, which rapidjson can't
+        -- encode — tonumber() every numeric field. (TEXT comes back as Lua strings.)
+        local bstmt = conn:prepare("SELECT id, md5, title, authors, pages, total_read_pages FROM book")
+        for r in bstmt:rows() do
+            books[#books + 1] = {{ ko_id = tonumber(r[1]), md5 = r[2] or "", title = r[3] or "",
+                                   authors = r[4], pages = tonumber(r[5]), total_read_pages = tonumber(r[6]) }}
+        end
+        bstmt:close()
+        local pstmt = conn:prepare(
+            "SELECT id_book, page, start_time, duration, total_pages FROM page_stat_data "
+            .. "WHERE start_time >= " .. since .. " ORDER BY start_time")
+        for r in pstmt:rows() do
+            rows[#rows + 1] = {{ ko_id = tonumber(r[1]), page = tonumber(r[2]), start_time = tonumber(r[3]),
+                                duration = tonumber(r[4]), total_pages = tonumber(r[5]) }}
+        end
+        pstmt:close()
+    end)
+    pcall(function() conn:close() end)
+    if not read_ok then tell("Could not read statistics database."); return end
+    if #rows == 0 then tell("Reading history already up to date."); return end
+
+    self._stats_syncing = true
+    local dev   = deviceName()
+    local CHUNK = 2000
+    local total = #rows
+    local sent  = 0
+    local function finish(msg, force)
+        self._stats_syncing = false
+        if manual or force then UIManager:show(InfoMessage:new{{ text = msg, timeout = 3 }}) end
+    end
+    local sendNext
+    sendNext = function()
+        if sent >= total then
+            finish(string.format("Reading history synced (%d records).", total))
+            return
+        end
+        if not NetworkMgr:isConnected() then
+            finish("Reading-history sync paused (offline). Resumes later.")
+            return
+        end
+        local chunk = {{}}
+        local stop = math.min(sent + CHUNK, total)
+        for i = sent + 1, stop do chunk[#chunk + 1] = rows[i] end
+        local resp = apiRequest("POST", "/tome-sync/stats/import",
+            {{ device = dev, books = books, page_stats = chunk }})
+        if type(resp) ~= "table" then
+            finish("Reading-history sync interrupted. Resumes next launch.")
+            return
+        end
+        sent = stop
+        -- Yield to the UI between chunks (the device stays responsive).
+        UIManager:scheduleIn(0.05, sendNext)
+    end
+    if manual then
+        UIManager:show(InfoMessage:new{{
+            text = string.format("Syncing reading history (%d records)...", total), timeout = 2 }})
+    end
+    sendNext()
 end
 
 function TomeSync:_flushPendingSessions()
@@ -2810,6 +2918,12 @@ function TomeSync:_menuItems()
         text     = "Browse series",
         callback = function() self:_browseSeriesMenu() end,
     }})
+    table.insert(sub_items, {{
+        text     = "Sync reading history",
+        callback = function()
+            whenConnected(function() self:_syncReadingStats(true) end)
+        end,
+    }})
     -- Inbox: only shown when the server has Send-to-KOReader enabled (set by the
     -- launch poll). Badge shows the pending count.
     if self.inbox_enabled then
@@ -2881,6 +2995,19 @@ function TomeSync:_menuItems()
         callback     = function()
             G_reader_settings:saveSetting("tomesync_auto_check",
                 not G_reader_settings:isTrue("tomesync_auto_check"))
+        end,
+    }})
+    table.insert(settings_items, {{
+        text         = "Auto-sync reading history on launch",
+        help_text    = "Pushes KOReader's own page-level reading history to Tome so "
+                       .. "your stats include reading from before TomeSync. The first "
+                       .. "sync backfills everything (chunked and resumable); later "
+                       .. "syncs send only new reading. Reading time and pages only - "
+                       .. "never your read/unread status.",
+        checked_func = function() return G_reader_settings:isTrue("tomesync_auto_sync_stats") end,
+        callback     = function()
+            G_reader_settings:saveSetting("tomesync_auto_sync_stats",
+                not G_reader_settings:isTrue("tomesync_auto_sync_stats"))
         end,
     }})
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -11,3 +11,4 @@ from backend.models.wish import Wish  # noqa: F401
 from backend.models.notification import Notification  # noqa: F401
 from backend.models.send_queue import SendQueueItem  # noqa: F401
 from backend.models.user_dashboard import UserDashboard  # noqa: F401
+from backend.models.ko_stats import PageStat, StatsImport, KoStatsBookMatch  # noqa: F401

--- a/backend/models/ko_stats.py
+++ b/backend/models/ko_stats.py
@@ -1,0 +1,128 @@
+"""Models for importing KOReader's `statistics.sqlite3` into Tome.
+
+Phase 2.1 of the stats-expansion plan. KOReader records every page's dwell time in
+its own SQLite DB, going back to whenever the user started reading — well before Tome
+existed. Importing it backfills the entire reading history and gives ground-truth,
+idle-capped read time. See docs/plans/stats-expansion-plan.md.
+
+Three tables:
+- ``PageStat``         — the imported per-page dwell rows (mirror of KOReader ``page_stat_data``).
+- ``StatsImport``      — per-device watermark so the plugin can sync incrementally.
+- ``KoStatsBookMatch`` — cached KOReader-book → Tome-book resolution (the md5 join is dead
+                         for plugin users; matching is by filename/fuzzy, so we cache it).
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from backend.core.database import Base
+
+
+class PageStat(Base):
+    """One page-dwell record imported from KOReader ``page_stat_data``.
+
+    Stored raw (we keep ``total_pages`` per row, as KOReader does, so a later
+    pagination change can still be rescaled). Idempotent on
+    (user, book, page, start_time, device) — re-importing the same rows is a no-op,
+    and the same page read on two devices in the same second stays two events.
+    """
+    __tablename__ = "ko_page_stats"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "book_id", "page", "start_time", "device",
+            name="uq_ko_page_stat_identity",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    book_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    page: Mapped[int] = mapped_column(Integer, nullable=False)
+    # KOReader's page count *at the time the row was written* — needed to rescale to
+    # the book's current pagination (KOReader's page_stat view does the same).
+    total_pages: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # KOReader wall-clock, epoch seconds (page_stat_data.start_time).
+    start_time: Mapped[int] = mapped_column(Integer, nullable=False, index=True)
+    duration_seconds: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Source device (whole statistics.sqlite3 is per-device, so this is per-import).
+    device: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+
+    user: Mapped["User"] = relationship("User")  # type: ignore[name-defined]
+    book: Mapped["Book"] = relationship("Book")  # type: ignore[name-defined]
+
+
+class StatsImport(Base):
+    """Per-user, per-device import watermark for incremental sync.
+
+    The plugin asks "what's my last synced start_time for this device?" and only
+    uploads newer page_stat rows. Server-side reconstruction is therefore cheap and
+    resumable.
+    """
+    __tablename__ = "ko_stats_imports"
+    __table_args__ = (
+        UniqueConstraint("user_id", "device", name="uq_ko_stats_import_user_device"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    device: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+    last_start_time_synced: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_run_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+    rows_imported: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+
+
+class KoStatsBookMatch(Base):
+    """Cached resolution of a KOReader book (identified by its partial md5) to a Tome book.
+
+    The md5 join against ``kosync_document_map`` is dead for plugin users (those tables
+    are empty), so matching is by filename (exact, for books still on the device) or
+    fuzzy title+series+volume (the historical tail). We cache the result so we match
+    once, reuse it, and so manual confirmations stick. ``book_id`` null = parked
+    (unmatched / awaiting review), re-matched when the library grows.
+    """
+    __tablename__ = "ko_stats_book_matches"
+    __table_args__ = (
+        UniqueConstraint("user_id", "ko_md5", name="uq_ko_stats_match_user_md5"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    ko_md5: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    ko_title: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    ko_authors: Mapped[Optional[str]] = mapped_column(String(1024), nullable=True)
+    book_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("books.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    confidence: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    # 'filename' (exact), 'fuzzy', 'manual', or 'none'
+    method: Mapped[str] = mapped_column(String(16), nullable=False, default="none")
+    # 'matched' | 'review' | 'unmatched' — drives the manual-review UI.
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="unmatched")
+    confirmed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    book: Mapped[Optional["Book"]] = relationship("Book")  # type: ignore[name-defined]

--- a/backend/services/ko_stats_import.py
+++ b/backend/services/ko_stats_import.py
@@ -1,0 +1,310 @@
+"""Import KOReader `statistics.sqlite3` data into Tome (stats-expansion Phase 2.1).
+
+Matching is layered (see docs/plans/stats-expansion-plan.md):
+  1. Exact by filename — for books still on the device (esp. TomeSync downloads, which
+     save with Tome's own filenames → exact `BookFile.file_path` hit).
+  2. Fuzzy title + series + volume — the historical tail (deleted / sideloaded books,
+     and the manual-upload path where no device file list exists).
+
+The fuzzy rules were validated against a real Kindle DB (84 strong / 5 review / 7 none of
+96, zero high-confidence wrong matches). The crux is *volume-aware* matching: extract the
+volume and match on fuzzy series name + EXACT index, or whole multi-volume series collapse
+onto one book.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from difflib import SequenceMatcher
+from typing import Iterable, Optional
+
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.orm import Session
+
+from backend.core.permissions import book_visibility_filter
+from backend.models.book import Book, BookFile
+from backend.models.ko_stats import KoStatsBookMatch, PageStat, StatsImport
+
+# NOTE: the import deliberately does NOT write Tome read-status (read/reading/finished).
+# Status is user-curation, not telemetry — a fuzzy match plus possibly-incomplete history
+# must not flip a hard, library-wide flag. KOReader data feeds *time & pages* only; status
+# stays owned by the user and the live position sync.
+
+# ── Title parsing / normalization ─────────────────────────────────────────────
+
+_VOL_RE = re.compile(r"\b(?:vol(?:ume)?\.?|book|tome|part)\s*0*(\d+)\b", re.I)
+_MID_RE = re.compile(r"(.*?)\s+0*(\d{1,3})\s*[-–]\s+\S")   # "Series 01 - Subtitle"
+_TRAIL_RE = re.compile(r"(.*?)[\s,:–-]+0*(\d{1,3})\s*$")    # "Series 05" / "Series - 02"
+
+
+def _strip_paren(s: str) -> str:
+    return re.sub(r"\([^)]*\)\s*$", "", s or "").strip()
+
+
+def _desub(s: str) -> str:
+    """Drop a real ': ' subtitle but keep title-internal colons like 'Re:ZERO'."""
+    return re.split(r":\s+", _strip_paren(s))[0]
+
+
+def _norm(s: str) -> str:
+    s = (s or "").lower()
+    s = re.sub(r"[^a-z0-9 ]", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _author_key(a: str) -> str:
+    a = (a or "").lower().split("\n")[0]
+    if "," in a:                       # "Ugland, Eric" -> "eric ugland"
+        last, first = a.split(",", 1)
+        a = f"{first.strip()} {last.strip()}"
+    return re.sub(r"[^a-z ]", " ", a).strip()
+
+
+def parse_ko_title(title: str) -> tuple[str, Optional[int]]:
+    """-> (normalized base, volume:int|None)."""
+    t = _strip_paren(title or "")
+    vol: Optional[int] = None
+    m = _VOL_RE.search(t)
+    if m:
+        vol = int(m.group(1))
+        base = _VOL_RE.sub(" ", t)
+    elif _MID_RE.match(t):
+        m3 = _MID_RE.match(t); base, vol = m3.group(1), int(m3.group(2))
+    elif _TRAIL_RE.match(t):
+        m2 = _TRAIL_RE.match(t); base, vol = m2.group(1), int(m2.group(2))
+    else:
+        base = t
+    return _norm(_desub(base)), vol
+
+
+# ── Pure matcher ──────────────────────────────────────────────────────────────
+
+@dataclass
+class BookCandidate:
+    id: int
+    title: str
+    author: Optional[str]
+    series: Optional[str]
+    series_index: Optional[float]
+
+
+@dataclass
+class MatchResult:
+    book_id: Optional[int]
+    confidence: float
+    method: str   # 'filename' | 'fuzzy' | 'none'
+    status: str   # 'matched' | 'review' | 'unmatched'
+
+
+STRONG = 0.9
+STRONG_WITH_AUTHOR = 0.8
+REVIEW = 0.6
+
+
+def _basename(p: str) -> str:
+    return os.path.basename((p or "").replace("\\", "/")).strip().lower()
+
+
+def match_book(
+    candidates: list[BookCandidate],
+    ko_title: str,
+    ko_authors: Optional[str],
+    *,
+    filename: Optional[str] = None,
+    path_index: Optional[dict[str, int]] = None,
+) -> MatchResult:
+    """Resolve a KOReader book to a Tome book id. Pure — no DB access."""
+    # Layer 1: exact filename (basename of a known BookFile path).
+    if filename and path_index:
+        bid = path_index.get(_basename(filename))
+        if bid is not None:
+            return MatchResult(bid, 1.0, "filename", "matched")
+
+    kbase, kvol = parse_ko_title(ko_title)
+    kauth = _author_key(ko_authors or "")
+    knt = _norm(_desub(ko_title or ""))
+
+    # Pre-index candidates by (norm series, int index) and norm title.
+    series_vol: dict[tuple[str, int], list[BookCandidate]] = {}
+    series_names: set[str] = set()
+    for c in candidates:
+        if c.series and c.series_index is not None and float(c.series_index).is_integer():
+            key = (_norm(c.series), int(c.series_index))
+            series_vol.setdefault(key, []).append(c)
+            series_names.add(_norm(c.series))
+
+    best = 0.0
+    best_c: Optional[BookCandidate] = None
+    best_auth = False
+
+    # Layer 2: volume-aware — fuzzy series name + EXACT index.
+    parsed_vol_candidate = False
+    if kvol is not None and series_names:
+        bs_name, bs_ratio = None, 0.0
+        for ns in series_names:
+            r = SequenceMatcher(None, kbase, ns).ratio()
+            if r > bs_ratio:
+                bs_ratio, bs_name = r, ns
+        if bs_name and (bs_name, kvol) in series_vol:
+            cands = series_vol[(bs_name, kvol)]
+            c = max(
+                cands,
+                key=lambda x: SequenceMatcher(None, kauth, _author_key(x.author or "")).ratio()
+                if kauth else 0.0,
+            )
+            best, best_c = bs_ratio, c
+            best_auth = bool(kauth and SequenceMatcher(None, kauth, _author_key(c.author or "")).ratio() > 0.8)
+            parsed_vol_candidate = True
+
+    # Layer 3: plain title fuzzy (distinct-title volumes like "Dungeon Mauling").
+    for c in candidates:
+        r = SequenceMatcher(None, knt, _norm(_desub(c.title or ""))).ratio()
+        if r > best:
+            best, best_c = r, c
+            best_auth = bool(kauth and SequenceMatcher(None, kauth, _author_key(c.author or "")).ratio() > 0.8)
+
+    if best_c is None:
+        return MatchResult(None, 0.0, "none", "unmatched")
+
+    if best >= STRONG or (best >= STRONG_WITH_AUTHOR and best_auth):
+        status = "matched"
+    elif best >= REVIEW or parsed_vol_candidate:
+        # A confidently-parsed volume with an exact (series,index) hit is never silently
+        # dropped — surface it for review even on a weak series-name score.
+        status = "review"
+    else:
+        return MatchResult(None, best, "none", "unmatched")
+    return MatchResult(best_c.id, round(best, 4), "fuzzy", status)
+
+
+# ── DB orchestration ──────────────────────────────────────────────────────────
+
+def _load_candidates(db: Session, user) -> tuple[list[BookCandidate], dict[str, int]]:
+    """Visible active books + a basename→book_id index for exact filename matching."""
+    rows = (
+        db.query(Book.id, Book.title, Book.author, Book.series, Book.series_index)
+        .filter(Book.status == "active", book_visibility_filter(db, user))
+        .all()
+    )
+    candidates = [BookCandidate(*r) for r in rows]
+    ids = [c.id for c in candidates]
+    path_index: dict[str, int] = {}
+    if ids:
+        for bid, path in db.query(BookFile.book_id, BookFile.file_path).filter(BookFile.book_id.in_(ids)):
+            base = _basename(path)
+            if base:
+                path_index.setdefault(base, bid)
+    return candidates, path_index
+
+
+def import_batch(
+    db: Session,
+    user,
+    *,
+    device: str,
+    books: list[dict],
+    page_stats: list[dict],
+) -> dict:
+    """Match a batch of KOReader books and ingest their per-page dwell rows idempotently.
+
+    `books`: dicts with ko_id, md5, title, authors, (optional) series, filename, pages,
+             total_read_pages.
+    `page_stats`: dicts with ko_id, page, start_time, duration, total_pages.
+
+    Status is NOT written — read/reading/finished stays user-curated. Only *confident*
+    (matched) books contribute data; the review tail and unmatched books are parked, so
+    nothing uncertain reaches the dashboard.
+    """
+    candidates, path_index = _load_candidates(db, user)
+
+    ko_to_book: dict[int, Optional[int]] = {}
+    counts = {"matched": 0, "review": 0, "unmatched": 0}
+
+    for b in books:
+        ko_id = b["ko_id"]
+        md5 = b.get("md5") or ""
+        existing = (
+            db.query(KoStatsBookMatch)
+            .filter(KoStatsBookMatch.user_id == user.id, KoStatsBookMatch.ko_md5 == md5)
+            .first()
+        )
+        if existing and existing.confirmed:
+            ko_to_book[ko_id] = existing.book_id
+            counts["matched" if existing.book_id else "unmatched"] += 1
+            continue
+
+        res = match_book(
+            candidates, b.get("title") or "", b.get("authors"),
+            filename=b.get("filename"), path_index=path_index,
+        )
+        # Only confident matches contribute time data; review/unmatched are parked.
+        ko_to_book[ko_id] = res.book_id if res.status == "matched" else None
+        counts[res.status] += 1
+
+        if existing:
+            existing.book_id = res.book_id
+            existing.confidence = res.confidence
+            existing.method = res.method
+            existing.status = res.status
+            existing.ko_title = b.get("title")
+            existing.ko_authors = b.get("authors")
+        else:
+            db.add(KoStatsBookMatch(
+                user_id=user.id, ko_md5=md5,
+                ko_title=b.get("title"), ko_authors=b.get("authors"),
+                book_id=res.book_id, confidence=res.confidence,
+                method=res.method, status=res.status,
+            ))
+
+    # Idempotent page-stat ingest: INSERT OR IGNORE on the identity unique constraint.
+    rows = []
+    max_start = 0
+    for ps in page_stats:
+        bid = ko_to_book.get(ps["ko_id"])
+        if bid is None:
+            continue
+        st = int(ps["start_time"])
+        max_start = max(max_start, st)
+        rows.append({
+            "user_id": user.id, "book_id": bid,
+            "page": int(ps["page"]), "total_pages": int(ps.get("total_pages") or 0),
+            "start_time": st, "duration_seconds": int(ps.get("duration") or 0),
+            "device": device or "",
+        })
+
+    imported = 0
+    if rows:
+        for chunk in (rows[i:i + 500] for i in range(0, len(rows), 500)):
+            stmt = sqlite_insert(PageStat).values(chunk).on_conflict_do_nothing(
+                index_elements=["user_id", "book_id", "page", "start_time", "device"]
+            )
+            imported += db.execute(stmt).rowcount or 0
+
+    # Per-device watermark.
+    wm = (
+        db.query(StatsImport)
+        .filter(StatsImport.user_id == user.id, StatsImport.device == (device or ""))
+        .first()
+    )
+    if wm:
+        wm.last_start_time_synced = max(wm.last_start_time_synced, max_start)
+        wm.rows_imported += imported
+        wm.last_run_at = datetime.utcnow()
+    else:
+        db.add(StatsImport(
+            user_id=user.id, device=device or "",
+            last_start_time_synced=max_start, rows_imported=imported,
+        ))
+
+    db.commit()
+    return {
+        "books": len(books),
+        "matched": counts["matched"],
+        "review": counts["review"],
+        "unmatched": counts["unmatched"],
+        "page_rows_imported": imported,
+        "page_rows_skipped": len(rows) - imported,
+        "watermark": max_start,
+    }

--- a/backend/services/ko_stats_import.py
+++ b/backend/services/ko_stats_import.py
@@ -221,18 +221,31 @@ def import_batch(
 
     ko_to_book: dict[int, Optional[int]] = {}
     counts = {"matched": 0, "review": 0, "unmatched": 0}
+    # Per-batch md5 cache. KOReader re-downloads create multiple `book` rows sharing
+    # one partial md5; the server session is autoflush=False, so a query won't see a
+    # pending add — without this we'd INSERT two rows for the same (user, md5) and the
+    # UNIQUE constraint would blow up the whole batch. Maps md5 -> resolved book_id.
+    seen_md5: dict[str, Optional[int]] = {}
 
     for b in books:
         ko_id = b["ko_id"]
         md5 = b.get("md5") or ""
+
+        if md5 and md5 in seen_md5:
+            ko_to_book[ko_id] = seen_md5[md5]   # same file already handled this batch
+            continue
+
         existing = (
             db.query(KoStatsBookMatch)
             .filter(KoStatsBookMatch.user_id == user.id, KoStatsBookMatch.ko_md5 == md5)
             .first()
-        )
+        ) if md5 else None
+
         if existing and existing.confirmed:
             ko_to_book[ko_id] = existing.book_id
             counts["matched" if existing.book_id else "unmatched"] += 1
+            if md5:
+                seen_md5[md5] = existing.book_id
             continue
 
         res = match_book(
@@ -240,23 +253,27 @@ def import_batch(
             filename=b.get("filename"), path_index=path_index,
         )
         # Only confident matches contribute time data; review/unmatched are parked.
-        ko_to_book[ko_id] = res.book_id if res.status == "matched" else None
+        resolved = res.book_id if res.status == "matched" else None
+        ko_to_book[ko_id] = resolved
         counts[res.status] += 1
 
-        if existing:
-            existing.book_id = res.book_id
-            existing.confidence = res.confidence
-            existing.method = res.method
-            existing.status = res.status
-            existing.ko_title = b.get("title")
-            existing.ko_authors = b.get("authors")
-        else:
-            db.add(KoStatsBookMatch(
-                user_id=user.id, ko_md5=md5,
-                ko_title=b.get("title"), ko_authors=b.get("authors"),
-                book_id=res.book_id, confidence=res.confidence,
-                method=res.method, status=res.status,
-            ))
+        # An empty md5 can't key the cache table; map the book but don't persist a row.
+        if md5:
+            if existing:
+                existing.book_id = res.book_id
+                existing.confidence = res.confidence
+                existing.method = res.method
+                existing.status = res.status
+                existing.ko_title = b.get("title")
+                existing.ko_authors = b.get("authors")
+            else:
+                db.add(KoStatsBookMatch(
+                    user_id=user.id, ko_md5=md5,
+                    ko_title=b.get("title"), ko_authors=b.get("authors"),
+                    book_id=res.book_id, confidence=res.confidence,
+                    method=res.method, status=res.status,
+                ))
+            seen_md5[md5] = resolved
 
     # Idempotent page-stat ingest: INSERT OR IGNORE on the identity unique constraint.
     rows = []

--- a/backend/services/reconciled_reading.py
+++ b/backend/services/reconciled_reading.py
@@ -1,0 +1,265 @@
+"""Query-time reconciliation of imported KOReader page-stats with live reading sessions.
+
+Both sources can describe the *same* Kindle reading (the plugin POSTs live sessions AND
+KOReader's statistics.sqlite3 records every page), so naively summing them double-counts.
+
+Rule (book-level): if a book has ANY imported `ko_page_stats`, those are authoritative for
+its reading time (idle-capped, full history) and its live `reading_sessions` are ignored;
+books with no page-stats fall back to sessions (web reader, or never read on KOReader).
+
+Invariant: when a user has no page-stats at all, `covered_book_ids` is empty and every
+helper returns exactly what the session-only query would — so existing stats behaviour is
+unchanged (and the existing test suite stays valid).
+
+Each helper returns plain Python structures keyed the way `stats.py` needs, merging:
+  - page-stat aggregates (for covered books), and
+  - session aggregates for books NOT covered.
+Sessions count from page-stats is approximated as one "session" per (book, local-day).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import Integer, func
+from sqlalchemy.orm import Session
+
+from backend.models.ko_stats import PageStat
+from backend.models.tome_sync import ReadingSession
+
+
+def _epoch(dt: Optional[datetime]) -> Optional[int]:
+    return int(dt.replace(tzinfo=timezone.utc).timestamp()) if dt else None
+
+
+def covered_book_ids(db: Session, user_id: int) -> list[int]:
+    """Book ids that have imported page-stats (page-stats win for these books)."""
+    return [r[0] for r in db.query(PageStat.book_id).filter(PageStat.user_id == user_id).distinct()]
+
+
+def _ps_filtered(db: Session, user_id: int, cutoff: Optional[datetime], range_end: Optional[datetime]):
+    q = db.query(PageStat).filter(PageStat.user_id == user_id)
+    ce, ee = _epoch(cutoff), _epoch(range_end)
+    if ce is not None:
+        q = q.filter(PageStat.start_time >= ce)
+    if ee is not None:
+        q = q.filter(PageStat.start_time < ee)
+    return q
+
+
+def _rs_filtered(db: Session, user_id: int, covered: list[int],
+                 cutoff: Optional[datetime], range_end: Optional[datetime]):
+    q = db.query(ReadingSession).filter(ReadingSession.user_id == user_id)
+    if covered:
+        q = q.filter(ReadingSession.book_id.notin_(covered))
+    if cutoff is not None:
+        q = q.filter(ReadingSession.started_at >= cutoff)
+    if range_end is not None:
+        q = q.filter(ReadingSession.started_at < range_end)
+    return q
+
+
+def _ps_day(tzm: str):
+    return func.date(PageStat.start_time, "unixepoch", tzm)
+
+
+def _ps_local(tzm: str):
+    return func.datetime(PageStat.start_time, "unixepoch", tzm)
+
+
+# ── Totals ────────────────────────────────────────────────────────────────────
+
+def totals(db, user_id, tzm, covered, cutoff, range_end) -> tuple[int, int, int]:
+    """(seconds, sessions, pages) reconciled over the window."""
+    rs = _rs_filtered(db, user_id, covered, cutoff, range_end).with_entities(
+        func.coalesce(func.sum(ReadingSession.duration_seconds), 0),
+        func.count(ReadingSession.id),
+        func.coalesce(func.sum(ReadingSession.pages_turned), 0),
+    ).one()
+    secs, sessions, pages = int(rs[0] or 0), int(rs[1] or 0), int(rs[2] or 0)
+    if covered:
+        # page-stat day-groups: one "session" per (book, local-day)
+        day_groups = (
+            _ps_filtered(db, user_id, cutoff, range_end)
+            .with_entities(
+                PageStat.book_id, _ps_day(tzm).label("day"),
+                func.sum(PageStat.duration_seconds).label("secs"),
+                func.count(PageStat.id).label("pages"),
+            )
+            .group_by(PageStat.book_id, "day")
+            .all()
+        )
+        secs += sum(int(g.secs or 0) for g in day_groups)
+        pages += sum(int(g.pages or 0) for g in day_groups)
+        sessions += len(day_groups)
+    return secs, sessions, pages
+
+
+# ── Daily (per local-day) ───────────────────────────────────────────────────────
+
+def daily_map(db, user_id, tzm, covered, start_dt, end_dt) -> dict[str, tuple[int, int, int]]:
+    """day_str -> (seconds, sessions, pages). Caller fills the gaps."""
+    rows = (
+        _rs_filtered(db, user_id, covered, start_dt, end_dt)
+        .with_entities(
+            func.date(ReadingSession.started_at, tzm).label("day"),
+            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("secs"),
+            func.count(ReadingSession.id).label("sessions"),
+            func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages"),
+        )
+        .group_by("day").all()
+    )
+    out: dict[str, list[int]] = {r.day: [int(r.secs or 0), int(r.sessions or 0), int(r.pages or 0)] for r in rows}
+    if covered:
+        # aggregate page-stats per (book, day) first, then roll up to day so "sessions"
+        # = distinct books read that day.
+        day_groups = (
+            _ps_filtered(db, user_id, start_dt, end_dt)
+            .with_entities(
+                PageStat.book_id, _ps_day(tzm).label("day"),
+                func.sum(PageStat.duration_seconds).label("secs"),
+                func.count(PageStat.id).label("pages"),
+            )
+            .group_by(PageStat.book_id, "day").all()
+        )
+        for g in day_groups:
+            e = out.setdefault(g.day, [0, 0, 0])
+            e[0] += int(g.secs or 0); e[1] += 1; e[2] += int(g.pages or 0)
+    return {d: (v[0], v[1], v[2]) for d, v in out.items()}
+
+
+# ── Per-book ────────────────────────────────────────────────────────────────────
+
+def book_seconds(db, user_id, tzm, covered, cutoff, range_end) -> dict[int, tuple[int, int, int]]:
+    """book_id -> (seconds, sessions, pages) reconciled over the window."""
+    rows = (
+        _rs_filtered(db, user_id, covered, cutoff, range_end)
+        .filter(ReadingSession.book_id.isnot(None))
+        .with_entities(
+            ReadingSession.book_id,
+            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("secs"),
+            func.count(ReadingSession.id).label("sessions"),
+            func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages"),
+        )
+        .group_by(ReadingSession.book_id).all()
+    )
+    out: dict[int, list[int]] = {r.book_id: [int(r.secs or 0), int(r.sessions or 0), int(r.pages or 0)] for r in rows}
+    if covered:
+        rows2 = (
+            _ps_filtered(db, user_id, cutoff, range_end)
+            .with_entities(
+                PageStat.book_id,
+                func.sum(PageStat.duration_seconds).label("secs"),
+                func.count(func.distinct(_ps_day(tzm))).label("sessions"),
+                func.count(PageStat.id).label("pages"),
+            )
+            .group_by(PageStat.book_id).all()
+        )
+        for r in rows2:
+            e = out.setdefault(r.book_id, [0, 0, 0])
+            e[0] += int(r.secs or 0); e[1] += int(r.sessions or 0); e[2] += int(r.pages or 0)
+    return {b: (v[0], v[1], v[2]) for b, v in out.items()}
+
+
+def book_month_seconds(db, user_id, tzm, covered, start_dt) -> dict[tuple[int, str], int]:
+    """(book_id, 'YYYY-MM') -> seconds. For the genre-over-time stack."""
+    rs_month = func.strftime("%Y-%m", func.datetime(ReadingSession.started_at, tzm))
+    rows = (
+        _rs_filtered(db, user_id, covered, start_dt, None)
+        .filter(ReadingSession.book_id.isnot(None))
+        .with_entities(ReadingSession.book_id, rs_month.label("m"),
+                       func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("secs"))
+        .group_by(ReadingSession.book_id, "m").all()
+    )
+    out: dict[tuple[int, str], int] = {(r.book_id, r.m): int(r.secs or 0) for r in rows}
+    if covered:
+        ps_month = func.strftime("%Y-%m", _ps_local(tzm))
+        rows2 = (
+            _ps_filtered(db, user_id, start_dt, None)
+            .with_entities(PageStat.book_id, ps_month.label("m"),
+                           func.coalesce(func.sum(PageStat.duration_seconds), 0).label("secs"))
+            .group_by(PageStat.book_id, "m").all()
+        )
+        for r in rows2:
+            out[(r.book_id, r.m)] = out.get((r.book_id, r.m), 0) + int(r.secs or 0)
+    return out
+
+
+# ── Hour × day-of-week ──────────────────────────────────────────────────────────
+
+def hour_dow(db, user_id, tzm, covered, cutoff, range_end) -> dict[tuple[int, int], tuple[int, int]]:
+    """(dow, hour) -> (seconds, sessions)."""
+    rs_local = func.datetime(ReadingSession.started_at, tzm)
+    rows = (
+        _rs_filtered(db, user_id, covered, cutoff, range_end)
+        .with_entities(
+            func.cast(func.strftime("%w", rs_local), Integer).label("dow"),
+            func.cast(func.strftime("%H", rs_local), Integer).label("hour"),
+            func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("secs"),
+            func.count(ReadingSession.id).label("sessions"),
+        )
+        .group_by("dow", "hour").all()
+    )
+    out: dict[tuple[int, int], list[int]] = {(r.dow, r.hour): [int(r.secs or 0), int(r.sessions or 0)] for r in rows}
+    if covered:
+        rows2 = (
+            _ps_filtered(db, user_id, cutoff, range_end)
+            .with_entities(
+                func.cast(func.strftime("%w", _ps_local(tzm)), Integer).label("dow"),
+                func.cast(func.strftime("%H", _ps_local(tzm)), Integer).label("hour"),
+                func.coalesce(func.sum(PageStat.duration_seconds), 0).label("secs"),
+                func.count(func.distinct(PageStat.book_id)).label("sessions"),
+            )
+            .group_by("dow", "hour").all()
+        )
+        for r in rows2:
+            e = out.setdefault((r.dow, r.hour), [0, 0])
+            e[0] += int(r.secs or 0); e[1] += int(r.sessions or 0)
+    return {k: (v[0], v[1]) for k, v in out.items()}
+
+
+# ── Monthly (per 'YYYY-MM') ─────────────────────────────────────────────────────
+
+def monthly_map(db, user_id, tzm, covered, start_dt) -> dict[str, tuple[int, int]]:
+    """'YYYY-MM' -> (seconds, sessions)."""
+    rs_month = func.strftime("%Y-%m", func.datetime(ReadingSession.started_at, tzm))
+    rows = (
+        _rs_filtered(db, user_id, covered, start_dt, None)
+        .with_entities(rs_month.label("m"),
+                       func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("secs"),
+                       func.count(ReadingSession.id).label("sessions"))
+        .group_by("m").all()
+    )
+    out: dict[str, list[int]] = {r.m: [int(r.secs or 0), int(r.sessions or 0)] for r in rows}
+    if covered:
+        day_groups = (
+            _ps_filtered(db, user_id, start_dt, None)
+            .with_entities(PageStat.book_id, _ps_day(tzm).label("day"),
+                           func.sum(PageStat.duration_seconds).label("secs"))
+            .group_by(PageStat.book_id, "day").all()
+        )
+        for g in day_groups:
+            m = g.day[:7]
+            e = out.setdefault(m, [0, 0])
+            e[0] += int(g.secs or 0); e[1] += 1
+    return {m: (v[0], v[1]) for m, v in out.items()}
+
+
+# ── Reconciled active-day set (for streaks) ─────────────────────────────────────
+
+def active_days(db, user_id, tzm, covered) -> set:
+    from datetime import date as _date
+    rs_days = {
+        r[0] for r in
+        _rs_filtered(db, user_id, covered, None, None)
+        .with_entities(func.date(ReadingSession.started_at, tzm)).distinct().all()
+        if r[0]
+    }
+    if covered:
+        rs_days |= {
+            r[0] for r in
+            _ps_filtered(db, user_id, None, None)
+            .with_entities(_ps_day(tzm)).distinct().all()
+            if r[0]
+        }
+    return {_date.fromisoformat(d) for d in rs_days}

--- a/docs/features.md
+++ b/docs/features.md
@@ -177,7 +177,7 @@ Shelves are per-user and private. Each shelf can have a custom icon chosen from 
 
 ## Reading Stats
 
-The Stats page has three tabs, all powered by KOReader session data via TomeSync.
+The Stats page has three tabs, all powered by KOReader session data via TomeSync. The time-based charts can also be **backfilled from KOReader's own per-page reading history** (from before TomeSync) by enabling reading-history import in the plugin — see the [KOReader plugin](koreader-plugin.md#reading-history-import) docs. The backfill adds reading time and pages only; it never changes your read/unread status.
 
 ### Overview
 

--- a/docs/koreader-plugin.md
+++ b/docs/koreader-plugin.md
@@ -22,6 +22,7 @@ The plugin is pre-configured with your server URL and API key. No manual configu
 
 - **Reading sync** -- position, progress, and reading sessions sync between KOReader and Tome's web reader
 - **Rating sync** -- KOReader's native star rating and review sync both ways with Tome
+- **Reading-history import** -- backfill Tome's Stats with KOReader's own per-page reading history from before TomeSync (reading time and pages only -- never your read/unread status)
 - **Series browser** -- browse your library's series and download entire series to your device in one tap
 - **Offline-safe** -- everything works seamlessly when your server is unreachable; sessions queue and flush later
 - **Context-aware menu** -- different options when a book is open vs. from the home screen
@@ -71,6 +72,24 @@ Every time you close the lid or close a book, the plugin records a session with:
 Sessions shorter than 10 seconds are filtered out. Each session has a unique ID to prevent duplicates.
 
 These sessions power the **Stats** page in Tome, showing reading time, streaks, and charts.
+
+### Reading-History Import
+
+KOReader keeps its own per-page reading log in `statistics.sqlite3` — often going back
+years, long before you installed TomeSync. The plugin can import that log into Tome so
+your **Stats** page reflects reading from before TomeSync existed.
+
+- Enable **TomeSync > Auto-sync reading history on launch**, or run it once from
+  **TomeSync > Sync reading history** (also assignable to a gesture).
+- The first sync pushes your **entire** history; it is **chunked and resumable** — the
+  server tracks a per-device watermark and ignores duplicates, so it survives the device
+  sleeping or Wi-Fi dropping mid-sync. Later syncs send only new reading.
+- It imports **reading time and pages only** — it never changes your read/unread status.
+  That stays yours to set (only the live progress sync above moves status).
+- Books are matched to your library by title/series/volume; anything the matcher can't
+  place confidently is left out rather than guessed at, so nothing wrong appears in your
+  stats. Multiple devices each sync their own history without double-counting the same
+  reading.
 
 ### Reading Status
 
@@ -207,6 +226,7 @@ The plugin menu is context-aware. It self-registers in the **wrench menu** (afte
 | Option | Description |
 |---|---|
 | **Browse series** | Opens the series browser. Lists all series with book count and author. Tap to download. |
+| **Sync reading history** | Imports KOReader's per-page reading log into Tome's Stats (time and pages only). First run backfills everything; chunked and resumable. See [Reading-History Import](#reading-history-import). |
 | **Settings** | Submenu with persistent options and diagnostics (see below). |
 | **About** | Version info (semver + build). |
 
@@ -230,16 +250,18 @@ The plugin menu is context-aware. It self-registers in the **wrench menu** (afte
 | **Re-resolve all books** | Wipes the local filename-to-book-ID cache. Use if a book matched incorrectly. |
 | **Check for updates** | Fetches the latest plugin build from your server and installs it if newer (then prompts to restart). |
 | **Auto-check for updates on launch** | Opt-in toggle. When on, TomeSync checks for updates shortly after startup and prompts only when one is available. |
+| **Auto-sync reading history on launch** | Opt-in toggle, off by default. When on, TomeSync pushes new KOReader reading history to Tome shortly after startup (the first run backfills your whole history; chunked and resumable). Reading time and pages only — never your read/unread status. See [Reading-History Import](#reading-history-import). |
 
 ### Gestures
 
-TomeSync registers two bindable gesture actions (KOReader **Settings → Taps and gestures → Gesture manager**, listed under *General* — available in both the reader and the file manager):
+TomeSync registers bindable gesture actions (KOReader **Settings → Taps and gestures → Gesture manager**, listed under *General* — available in both the reader and the file manager):
 
 | Action | Does |
 |---|---|
 | **TomeSync: Open menu** | Pops the full context-aware TomeSync menu as a standalone popup. |
 | **TomeSync: Browse series** | Jumps straight to the series browser/downloader. |
 | **TomeSync: Sync highlights** | Pushes the current book's highlights and notes to Tome immediately. |
+| **TomeSync: Sync reading history** | Imports KOReader's per-page reading history into Tome's Stats (time and pages only). |
 
 ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,7 @@ def _init_test_db():
     import backend.models.wish  # noqa: F401
     import backend.models.notification  # noqa: F401
     import backend.models.send_queue  # noqa: F401
+    import backend.models.ko_stats  # noqa: F401
 
     Base.metadata.create_all(bind=test_engine)
 

--- a/tests/test_ko_stats_import.py
+++ b/tests/test_ko_stats_import.py
@@ -1,0 +1,142 @@
+"""Tests for the KOReader statistics.sqlite3 importer (stats-expansion Phase 2.1).
+
+Covers the validated matcher rules (volume-aware, filename-exact, colon-in-title) and
+the idempotent page-stat ingest. Synthetic data — no dependency on local personal DBs.
+"""
+from backend.services.ko_stats_import import (
+    BookCandidate,
+    match_book,
+    parse_ko_title,
+    import_batch,
+)
+from backend.models.ko_stats import PageStat, KoStatsBookMatch, StatsImport
+
+
+# ── Title parsing ─────────────────────────────────────────────────────────────
+
+def test_parse_volume_forms():
+    assert parse_ko_title("Black Summoner: Volume 5") == ("black summoner", 5)
+    assert parse_ko_title("That Time I Got Reincarnated as a Slime, Vol. 14")[1] == 14
+    assert parse_ko_title("The Beginning After the End: Book 1: Early Years")[1] == 1
+    assert parse_ko_title("Die Legende vom Tränenvogel 02 - Der träumende Krieger")[1] == 2
+    # No volume -> None
+    assert parse_ko_title("Dungeon Mauling")[1] is None
+
+
+def test_colon_in_title_not_truncated():
+    # 'Re:ZERO' must keep both words (no space after colon) — not collapse to 'Re'.
+    base, _ = parse_ko_title("Re:ZERO -Starting Life in Another World- Vol. 28")
+    assert base.startswith("re zero")
+
+
+# ── Matcher ───────────────────────────────────────────────────────────────────
+
+def _summoner(n: int) -> BookCandidate:
+    return BookCandidate(id=100 + n, title="Black Summoner", author="Doufu Mayoi",
+                         series="Black Summoner", series_index=float(n))
+
+
+def test_volume_aware_does_not_collapse_series():
+    cands = [_summoner(n) for n in range(1, 16)]
+    # Each KOReader volume must map to its OWN book, not all to v1.
+    r5 = match_book(cands, "Black Summoner: Volume 5", "Doufu Mayoi")
+    r12 = match_book(cands, "Black Summoner: Volume 12", "Doufu Mayoi")
+    assert r5.book_id == 105 and r5.status == "matched"
+    assert r12.book_id == 112 and r12.status == "matched"
+    assert r5.book_id != r12.book_id
+
+
+def test_distinct_title_volume_matches_by_title():
+    cands = [
+        BookCandidate(1, "Dungeon Mauling", "Eric Ugland", "The Good Guys", 3.0),
+        BookCandidate(2, "Heir Today, Pawn Tomorrow", "Eric Ugland", "The Good Guys", 2.0),
+    ]
+    r = match_book(cands, "Dungeon Mauling", "Eric Ugland")
+    assert r.book_id == 1 and r.status == "matched"
+
+
+def test_filename_exact_wins():
+    cands = [BookCandidate(1, "Whatever", None, None, None)]
+    idx = {"the_good_guys_-_vol._3.epub": 42}
+    r = match_book(cands, "unrelated title", None,
+                   filename="/mnt/us/books/The_Good_Guys_-_Vol._3.epub", path_index=idx)
+    assert r.book_id == 42 and r.method == "filename" and r.confidence == 1.0
+
+
+def test_junk_is_unmatched():
+    cands = [BookCandidate(1, "Black Summoner", "x", "Black Summoner", 1.0)]
+    r = match_book(cands, "T6otB1gNHQ9I9yFg089KuOD4wpJ0PMRkTC3mlT4nMV8", None)
+    assert r.status == "unmatched" and r.book_id is None
+
+
+def test_parsed_volume_weak_series_goes_to_review_not_dropped():
+    # Volume parsed + exact (series,index) candidate exists, but series name barely matches
+    # -> review, never silently unmatched.
+    cands = [BookCandidate(1, "Re:ZERO", "Tappei", "Re:ZERO", 28.0)]
+    r = match_book(cands, "Re:ZERO -Starting Life in Another World- Vol. 28", "Tappei")
+    assert r.book_id == 1 and r.status in ("matched", "review")
+
+
+# ── Import orchestration ──────────────────────────────────────────────────────
+
+def test_import_idempotent_and_backfills(db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Black Summoner", author="Doufu Mayoi",
+                     series="Black Summoner", series_index=1.0)
+    payload = dict(
+        device="Kindle",
+        books=[{"ko_id": 7, "md5": "abc123", "title": "Black Summoner: Volume 1",
+                "authors": "Doufu Mayoi"}],
+        page_stats=[
+            {"ko_id": 7, "page": 10, "start_time": 1700000000, "duration": 30, "total_pages": 200},
+            {"ko_id": 7, "page": 11, "start_time": 1700000050, "duration": 45, "total_pages": 200},
+        ],
+    )
+    r1 = import_batch(db, user, **payload)
+    assert r1["matched"] == 1
+    assert r1["page_rows_imported"] == 2
+    assert db.query(PageStat).filter(PageStat.user_id == user.id).count() == 2
+
+    # Re-running the exact same batch imports nothing new (idempotent).
+    r2 = import_batch(db, user, **payload)
+    assert r2["page_rows_imported"] == 0
+    assert r2["page_rows_skipped"] == 2
+    assert db.query(PageStat).filter(PageStat.user_id == user.id).count() == 2
+
+    # Match cached + watermark advanced.
+    m = db.query(KoStatsBookMatch).filter(KoStatsBookMatch.ko_md5 == "abc123").one()
+    assert m.book_id == book.id and m.status == "matched"
+    wm = db.query(StatsImport).filter(StatsImport.device == "Kindle").one()
+    assert wm.last_start_time_synced == 1700000050
+
+
+def test_import_never_writes_read_status(db, admin_user, make_book):
+    """Status is user-curation: the import must never create/flip read/reading status,
+    even for a book KOReader shows fully read."""
+    from backend.models.user_book_status import UserBookStatus
+    user, _ = admin_user
+    book = make_book(title="Black Summoner", author="Doufu Mayoi",
+                     series="Black Summoner", series_index=1.0)
+    import_batch(
+        db, user, device="Kindle",
+        books=[{"ko_id": 1, "md5": "a", "title": "Black Summoner: Volume 1",
+                "authors": "Doufu Mayoi", "pages": 200, "total_read_pages": 200}],
+        page_stats=[{"ko_id": 1, "page": 199, "start_time": 1700000000, "duration": 30, "total_pages": 200}],
+    )
+    # Page data imported, but no status row was created.
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=book.id).count() == 1
+    assert db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).first() is None
+
+
+def test_unmatched_book_parks_its_pages(db, admin_user, make_book):
+    user, _ = admin_user
+    make_book(title="Some Other Book", author="Nobody")
+    r = import_batch(
+        db, user, device="Kindle",
+        books=[{"ko_id": 1, "md5": "zzz", "title": "Totally Unowned Title XYZ", "authors": "Ghost"}],
+        page_stats=[{"ko_id": 1, "page": 1, "start_time": 1700000000, "duration": 10, "total_pages": 100}],
+    )
+    assert r["unmatched"] == 1
+    assert r["page_rows_imported"] == 0          # parked, not attributed to a wrong book
+    m = db.query(KoStatsBookMatch).filter(KoStatsBookMatch.ko_md5 == "zzz").one()
+    assert m.book_id is None and m.status == "unmatched"

--- a/tests/test_ko_stats_import.py
+++ b/tests/test_ko_stats_import.py
@@ -128,6 +128,31 @@ def test_import_never_writes_read_status(db, admin_user, make_book):
     assert db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).first() is None
 
 
+def test_duplicate_md5_in_batch_no_crash(db, admin_user, make_book):
+    """KOReader re-downloads create multiple book rows sharing one md5. With the
+    server's autoflush=False session this must not violate UNIQUE(user, md5)."""
+    user, _ = admin_user
+    book = make_book(title="Black Summoner", author="x", series="Black Summoner", series_index=1.0)
+    db.autoflush = False  # mirror backend SessionLocal (the POC masked this with autoflush=True)
+    try:
+        res = import_batch(
+            db, user, device="Kindle",
+            books=[
+                {"ko_id": 1, "md5": "samehash", "title": "Black Summoner: Volume 1", "authors": "x"},
+                {"ko_id": 2, "md5": "samehash", "title": "Black Summoner: Volume 1", "authors": "x"},
+            ],
+            page_stats=[
+                {"ko_id": 1, "page": 1, "start_time": 1700000000, "duration": 10, "total_pages": 100},
+                {"ko_id": 2, "page": 2, "start_time": 1700000100, "duration": 10, "total_pages": 100},
+            ],
+        )
+    finally:
+        db.autoflush = True
+    assert db.query(KoStatsBookMatch).filter_by(user_id=user.id, ko_md5="samehash").count() == 1
+    assert res["page_rows_imported"] == 2
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=book.id).count() == 2
+
+
 def test_unmatched_book_parks_its_pages(db, admin_user, make_book):
     user, _ = admin_user
     make_book(title="Some Other Book", author="Nobody")

--- a/tests/test_stats_reconciliation.py
+++ b/tests/test_stats_reconciliation.py
@@ -1,0 +1,74 @@
+"""2.4 — stats endpoint reconciles imported KOReader page-stats with live sessions.
+
+Book-level rule: a book with any page-stats uses page-stats (page-stats win, its live
+sessions are ignored to avoid double-counting); books with no page-stats fall back to
+sessions. When no page-stats exist, behaviour is identical to before (covered elsewhere).
+"""
+from datetime import datetime, timezone
+
+from backend.models.tome_sync import ReadingSession
+from backend.models.ko_stats import PageStat
+
+
+def _epoch(y, mo, d, h=12):
+    return int(datetime(y, mo, d, h, tzinfo=timezone.utc).timestamp())
+
+
+def _add_session(db, user, book, secs, when, pages=5):
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when,
+                          ended_at=when, duration_seconds=secs, pages_turned=pages))
+
+
+def _add_pagestats(db, user, book, rows, day=(2026, 1, 10), device="Kindle"):
+    base = _epoch(*day)
+    for i, secs in enumerate(rows):
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=i + 1, total_pages=100,
+                        start_time=base + i * 60, duration_seconds=secs, device=device))
+
+
+def test_no_double_count_for_covered_book(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Both Sources")
+    _add_session(db, user, book, 100, datetime(2026, 1, 10, 12, tzinfo=timezone.utc).replace(tzinfo=None))
+    _add_pagestats(db, user, book, [120, 80])   # 200s of page-stats for the same book
+    db.flush()
+    h = client.get("/api/stats?days=0").json()["headline"]
+    # page-stats win; the 100s session is NOT added on top.
+    assert h["total_reading_seconds"] == 200
+    assert h["pages_turned"] == 2                # 2 page-stat rows
+
+
+def test_web_only_book_falls_back_to_sessions(client, db, admin_user, make_book):
+    user, _ = admin_user
+    covered = make_book(title="Kindle Book")
+    webonly = make_book(title="Web Book")
+    _add_pagestats(db, user, covered, [200])
+    _add_session(db, user, webonly, 50, datetime(2026, 1, 11, 9), pages=7)
+    db.flush()
+    stats = client.get("/api/stats?days=0").json()
+    h = stats["headline"]
+    assert h["total_reading_seconds"] == 250        # 200 page-stats + 50 session
+    titles = {b["title"]: b["seconds"] for b in stats["top_books"]}
+    assert titles.get("Kindle Book") == 200 and titles.get("Web Book") == 50
+
+
+def test_pagestat_only_history_appears(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Old History")
+    # reading recorded only in page-stats, months before any session existed
+    _add_pagestats(db, user, book, [300, 300], day=(2025, 10, 20))
+    db.flush()
+    stats = client.get("/api/stats?days=0").json()
+    assert stats["headline"]["total_reading_seconds"] == 600
+    assert any(d["date"] == "2025-10-20" and d["seconds"] == 600 for d in stats["heatmap_daily"])
+
+
+def test_top_books_reconciled_ordering(client, db, admin_user, make_book):
+    user, _ = admin_user
+    big = make_book(title="Big")
+    small = make_book(title="Small")
+    _add_pagestats(db, user, big, [500, 500])      # 1000s
+    _add_pagestats(db, user, small, [100], day=(2026, 1, 12))
+    db.flush()
+    top = client.get("/api/stats?days=0").json()["top_books"]
+    assert [b["title"] for b in top[:2]] == ["Big", "Small"]

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -148,5 +148,7 @@ def test_build_bumped_for_rebake():
     # star rating + review <-> Tome) on top of 19's download path templates.
     # 1.5.1 / build 21 queues ratings set offline so a finished book you never
     # reopen still syncs its rating (the per-book open/close push alone missed it).
-    assert TOMESYNC_PLUGIN_BUILD >= 21
-    assert TOMESYNC_PLUGIN_SEMVER == "1.5.1"
+    # 1.6.0 / build 22 imports KOReader's statistics.sqlite3 (per-page reading
+    # history) so stats backfill reading from before TomeSync (time & pages only).
+    assert TOMESYNC_PLUGIN_BUILD >= 22
+    assert TOMESYNC_PLUGIN_SEMVER == "1.6.0"


### PR DESCRIPTION
Backfills Tome's reading stats with KOReader's own per-page reading history
(`statistics.sqlite3`) — often going back years, long before TomeSync existed.
**Reading time and pages only — never read/unread status** (that stays user-curated).

## What's in it
- **Backend ingest** (`fc38217`): `PageStat` / `StatsImport` / `KoStatsBookMatch` models
  (auto-create on startup, no migration); `POST /api/tome-sync/stats/import` +
  watermark (idempotent batch upsert); matcher (filename-exact → volume-aware fuzzy,
  ~84% on real data; **confident-only** — uncertain matches are parked, not guessed).
- **Reconciled stats endpoint** (`fc38217`, `backend/services/reconciled_reading.py`):
  book-level prefer/fallback so the same Kindle reading in both page-stats and live
  sessions isn't double-counted. Wired into ~12 time tiles; session-level tiles
  unchanged. **No-page-stats users get byte-identical behaviour.**
- **Plugin auto-sync, build 22 / semver 1.6.0** (`5e0e45b`): reads `statistics.sqlite3`,
  chunked + resumable via the server watermark, backgrounded. Menu **Sync reading
  history** + **Auto-sync on launch** toggle + gesture.
- **Docs** (`e422f6c`): plugin + features docs. Changelog updated.

## Testing
- 11 importer + 4 reconciliation tests; full suite green (604).
- **Emulator round-trip with a real Kindle `statistics.sqlite3`**: 34,553 rows /
  269 h imported, idempotent on re-run. Two bugs the POC's `autoflush=True` session
  masked, caught here + fixed: ljsqlite3 int64 cdata encode, and dup-md5 insert under
  the server's `autoflush=False`.

## Deploy / enable
1. Merge + deploy (tables auto-create; no migration, no env var).
2. Update the KOReader plugin to build 22 (Check for updates).
3. Enable **TomeSync → Auto-sync reading history on launch** — first sync backfills,
   then trickles.

Optional follow-up (deferred, not needed for the core use case): a match-review /
onboarding UI for the fuzzy tail.