### PR TITLE
fix(stats): reconcile the Home-tab streak with the stats page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ All notable changes to Tome are documented here. Format loosely follows
   survives reboots. Requires TomeSync plugin build 21. (KOReader plugin semver
   1.5.1.)
 
+### Fixed
+- **The Day-streak on the Home tab now matches your stats page.** After importing
+  your KOReader reading history, the Home summary kept showing a shorter streak
+  than the Stats page because it only counted live TomeSync sessions and ignored
+  the imported page-stat days. Both now count reconciled reading, so a single,
+  consistent streak shows everywhere.
+
 ## [1.6.0] — 2026-06-21 — "Marginalia"
 
 ### Added

--- a/backend/api/home.py
+++ b/backend/api/home.py
@@ -11,7 +11,7 @@ from backend.models.user import User
 from backend.models.tome_sync import ReadingSession
 from backend.models.book import Book
 from backend.models.user_book_status import UserBookStatus
-from backend.services.streaks import compute_user_streaks
+from backend.services.streaks import reconciled_user_streaks
 
 router = APIRouter(prefix="/home", tags=["home"])
 
@@ -51,7 +51,9 @@ def get_home_stats(
         .count()
     )
 
-    current_streak_days, _ = compute_user_streaks(db, current_user.id, tz_offset)
+    # Reconciled so the home streak matches the stats page: imported KOReader
+    # page-stat days count alongside live sessions (no-op without imported stats).
+    current_streak_days, _ = reconciled_user_streaks(db, current_user.id, tz_offset)
 
     return {
         "current_streak_days": current_streak_days,

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -18,9 +18,7 @@ from backend.models.tome_sync import ReadingSession, TomeSyncPosition
 from backend.models.book import Book, BookFile
 from backend.models.user_book_status import UserBookStatus
 from backend.models.library import BookType
-from backend.services.streaks import (
-    compute_user_streaks, streaks_from_dates, effective_today, date_modifier,
-)
+from backend.services.streaks import reconciled_user_streaks
 from backend.services import reconciled_reading as rr
 
 router = APIRouter(tags=["stats"])
@@ -137,12 +135,9 @@ def get_stats(
     books_finished_count = finished_query.count()
 
     # Streaks (all time, local-day with 4h rollover). Reconciled: page-stat days count too.
-    # Streaks use the rollover modifier, distinct from the plain tz_modifier above.
-    if covered:
-        streak_days = rr.active_days(db, current_user.id, date_modifier(tz_offset), covered)
-        current_streak, longest_streak = streaks_from_dates(streak_days, effective_today(tz_offset))
-    else:
-        current_streak, longest_streak = compute_user_streaks(db, current_user.id, tz_offset)
+    current_streak, longest_streak = reconciled_user_streaks(
+        db, current_user.id, tz_offset, covered
+    )
 
     # Daily aggregation (for selected range) — reconciled (page-stats win per book).
     daily = _fill_daily_map(

--- a/backend/services/streaks.py
+++ b/backend/services/streaks.py
@@ -69,3 +69,28 @@ def compute_user_streaks(
     )
     day_set = {date.fromisoformat(r.d) for r in rows if r.d}
     return streaks_from_dates(day_set, effective_today(tz_offset_minutes))
+
+
+def reconciled_user_streaks(
+    db: Session,
+    user_id: int,
+    tz_offset_minutes: int,
+    covered: list[int] | None = None,
+) -> tuple[int, int]:
+    """Return (current, longest) streaks counting reconciled reading.
+
+    When the user has imported KOReader page-stats, those days count toward the
+    streak alongside live reading sessions; otherwise this is identical to
+    ``compute_user_streaks``. This is the single source of truth so the home and
+    stats endpoints can't drift apart. Pass ``covered`` to reuse an already-fetched
+    covered-book-id list.
+    """
+    # Imported lazily to avoid a circular import (reconciled_reading pulls in models).
+    from backend.services import reconciled_reading as rr
+
+    if covered is None:
+        covered = rr.covered_book_ids(db, user_id)
+    if not covered:
+        return compute_user_streaks(db, user_id, tz_offset_minutes)
+    day_set = rr.active_days(db, user_id, date_modifier(tz_offset_minutes), covered)
+    return streaks_from_dates(day_set, effective_today(tz_offset_minutes))

--- a/tests/test_home_streak_reconciliation.py
+++ b/tests/test_home_streak_reconciliation.py
@@ -1,0 +1,36 @@
+"""Home tab streak must reconcile imported KOReader page-stats, same as the stats page.
+
+Regression for the home/stats streak drift: the home summary used a session-only
+streak (e.g. 85) while the stats page counted page-stat days too (e.g. 166). Both
+endpoints now route through ``reconciled_user_streaks``.
+"""
+from datetime import datetime, timedelta, timezone
+
+from backend.models.ko_stats import PageStat
+from backend.services.streaks import effective_today
+
+
+def _add_pagestat_day(db, user, book, eff_day):
+    """One page-stat at 12:00 UTC on eff_day → maps to that effective reading day."""
+    start = int(datetime(eff_day.year, eff_day.month, eff_day.day, 12, tzinfo=timezone.utc).timestamp())
+    db.add(PageStat(user_id=user.id, book_id=book.id, page=1, total_pages=100,
+                    start_time=start, duration_seconds=300, device="Kindle"))
+
+
+def test_home_streak_counts_pagestat_days_and_matches_stats(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Kindle History")
+
+    # Three consecutive effective reading days ending today — page-stats only, no sessions.
+    today = effective_today(0)
+    for offset in range(3):
+        _add_pagestat_day(db, user, book, today - timedelta(days=offset))
+    db.flush()
+
+    home = client.get("/api/home/stats?tz_offset=0").json()
+    stats = client.get("/api/stats?days=0&tz_offset=0").json()["headline"]
+
+    # Page-stat days feed the home streak (session-only would be 0 here)...
+    assert home["current_streak_days"] == 3
+    # ...and the two endpoints never disagree.
+    assert home["current_streak_days"] == stats["current_streak_days"]


### PR DESCRIPTION
## Problem

The Home tab and Stats page showed **different Day-streaks** for the same user (observed on prod: Home **85** vs Stats **166**).

Root cause: after the KOReader reading-history import (PR #69) landed on main, `stats.py` was rewired to count **reconciled** reading — imported `statistics.sqlite3` page-stat days **+** live TomeSync sessions — but `home.py` was left counting **sessions only**. The two diverged whenever a user imported KOReader history.

Verified against prod:
| Endpoint | Streak |
|---|---|
| `GET /api/home/stats` | 85 |
| `GET /api/stats` (`headline`) | 166 |

Same user, same `tz_offset` — purely a data-source mismatch, not a timezone/rollover bug.

## Fix

Extract the reconciled-aware streak into a single shared helper, `reconciled_user_streaks()`, and route **both** endpoints through it so they can't drift again:

- `backend/services/streaks.py` — new `reconciled_user_streaks(db, user_id, tz_offset, covered=None)`. Counts page-stat days when present, falls back to `compute_user_streaks` otherwise. Optional `covered` lets stats reuse its already-fetched list (no extra query).
- `backend/api/home.py` — now uses the helper → Home matches Stats.
- `backend/api/stats.py` — inline `if covered: … else: …` block replaced by the helper (behaviour identical, deduplicated).

No-op for users without imported page-stats.

## Tests

- New `tests/test_home_streak_reconciliation.py`: asserts page-stat days feed the Home streak **and** Home == Stats.
- Full backend suite: **606 passed**.