### PR TITLE
feat(stats): "Taste" tab — ratings tiles on Reading Stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ All notable changes to Tome are documented here. Format loosely follows
   time. Like every other tile, each is add/move/resize/removable, and these ignore
   the date-range picker since ratings are all-time. Existing customised dashboards
   get the new tab appended without touching your current boards.
+- **More Reading Stats tiles.** Five new tiles across the existing boards:
+  **Lifetime Totals** (all-time hours / pages / books / streak), **Personal
+  Records** (longest session, biggest reading day, most pages in a day),
+  **Library Completion** (how much of what you own you've read, overall and per
+  type), a **Reading Clock** (a 24-hour radial of when you read), and **Reading by
+  Language**. Add any of them from the tile gallery; new boards include them by
+  default.
 - **Your stats now include reading from before TomeSync.** KOReader keeps its own
   per-page reading log (`statistics.sqlite3`) going back to whenever you started
   reading — often long before Tome existed. TomeSync can now import that history,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **A "Taste" tab on Reading Stats.** A fourth board next to Overview / Habits /
+  Library, built from your book ratings: a **rating distribution** (how you spread
+  your stars), **taste by genre** (your average rating per book type), your
+  **highest & lowest rated** books, a **rating-vs-time** scatter (do you linger on
+  the ones you rate higher?), **best-rated series**, and a **rating trend** over
+  time. Like every other tile, each is add/move/resize/removable, and these ignore
+  the date-range picker since ratings are all-time. Existing customised dashboards
+  get the new tab appended without touching your current boards.
 - **Your stats now include reading from before TomeSync.** KOReader keeps its own
   per-page reading log (`statistics.sqlite3`) going back to whenever you started
   reading — often long before Tome existed. TomeSync can now import that history,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,13 @@ All notable changes to Tome are documented here. Format loosely follows
   time. Like every other tile, each is add/move/resize/removable, and these ignore
   the date-range picker since ratings are all-time. Existing customised dashboards
   get the new tab appended without touching your current boards.
-- **More Reading Stats tiles.** Five new tiles across the existing boards:
+- **Five new Reading Stats tiles, available from the tile gallery.**
   **Lifetime Totals** (all-time hours / pages / books / streak), **Personal
   Records** (longest session, biggest reading day, most pages in a day),
   **Library Completion** (how much of what you own you've read, overall and per
   type), a **Reading Clock** (a 24-hour radial of when you read), and **Reading by
-  Language**. Add any of them from the tile gallery; new boards include them by
-  default.
+  Language**. They're not on any board by default — add the ones you want to any
+  tab from **Add tile**.
 - **Your stats now include reading from before TomeSync.** KOReader keeps its own
   per-page reading log (`statistics.sqlite3`) going back to whenever you started
   reading — often long before Tome existed. TomeSync can now import that history,

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -719,6 +719,97 @@ def get_stats(
         "trend": rating_trend,
     }
 
+    # ── Lifetime / records / TBR / language (all-time, ignore the date range) ──
+    lt_secs, lt_sessions, lt_pages = rr.totals(db, current_user.id, tz_modifier, covered, None, None)
+    all_daily = rr.daily_map(db, current_user.id, tz_modifier, covered, None, None)
+    lifetime = {
+        "seconds": lt_secs,
+        "sessions": lt_sessions,
+        "pages": lt_pages,
+        "books_finished": db.query(UserBookStatus).filter(
+            UserBookStatus.user_id == current_user.id, UserBookStatus.status == "read").count(),
+        "active_days": sum(1 for v in all_daily.values() if v[0] > 0),
+        "longest_streak_days": longest_streak,
+    }
+
+    # Personal records
+    longest_sess = (
+        db.query(ReadingSession.duration_seconds, Book.title)
+        .join(Book, Book.id == ReadingSession.book_id)
+        .filter(ReadingSession.user_id == current_user.id, ReadingSession.duration_seconds.isnot(None))
+        .order_by(ReadingSession.duration_seconds.desc())
+        .first()
+    )
+    biggest_day = max(all_daily.items(), key=lambda kv: kv[1][0], default=None)   # by reading time
+    pages_day = max(all_daily.items(), key=lambda kv: kv[1][2], default=None)      # by pages turned
+    records = {
+        "longest_session_seconds": int(longest_sess[0]) if longest_sess else 0,
+        "longest_session_title": longest_sess[1] if longest_sess else None,
+        "biggest_day_seconds": biggest_day[1][0] if biggest_day else 0,
+        "biggest_day_date": biggest_day[0] if biggest_day else None,
+        "most_pages_day": pages_day[1][2] if pages_day else 0,
+        "most_pages_date": pages_day[0] if pages_day else None,
+    }
+
+    # TBR / library completion
+    owned = db.query(Book).filter(
+        Book.status == "active", book_visibility_filter(db, current_user)).count()
+    status_counts = dict(
+        db.query(UserBookStatus.status, func.count(UserBookStatus.id))
+        .filter(UserBookStatus.user_id == current_user.id).group_by(UserBookStatus.status).all()
+    )
+    tbr_read = status_counts.get("read", 0)
+    tbr_reading = status_counts.get("reading", 0)
+    tbr_shelved = status_counts.get("shelved", 0)
+    type_rows = (
+        db.query(
+            func.coalesce(BookType.label, "Uncategorized"),
+            func.count(func.distinct(Book.id)),
+            func.sum(case((UserBookStatus.status == "read", 1), else_=0)),
+        )
+        .select_from(Book)
+        .outerjoin(BookType, BookType.id == Book.book_type_id)
+        .outerjoin(UserBookStatus, (UserBookStatus.book_id == Book.id) & (UserBookStatus.user_id == current_user.id))
+        .filter(Book.status == "active", book_visibility_filter(db, current_user))
+        .group_by(func.coalesce(BookType.label, "Uncategorized"))
+        .all()
+    )
+    tbr = {
+        "owned": owned,
+        "read": tbr_read,
+        "reading": tbr_reading,
+        "shelved": tbr_shelved,
+        # books with no status row are implicitly unread
+        "unread": max(owned - tbr_read - tbr_reading - tbr_shelved, 0),
+        "pct": round(tbr_read / owned * 100, 1) if owned else 0,
+        "by_type": sorted(
+            [
+                {"type": label, "owned": int(o), "read": int(rd or 0),
+                 "pct": round(int(rd or 0) / int(o) * 100, 1) if o else 0}
+                for label, o, rd in type_rows if o
+            ],
+            key=lambda x: x["owned"], reverse=True,
+        ),
+    }
+
+    # Reading time by language (normalized: en/eng/English -> one entry)
+    from backend.services.languages import normalize_language, language_label
+    lang_acc: dict[str, list] = {}
+    if book_seconds_all:
+        for bid, lang in db.query(Book.id, Book.language).filter(Book.id.in_(list(book_seconds_all.keys()))):
+            code = normalize_language(lang) or ""
+            e = lang_acc.setdefault(code, [0, 0])
+            e[0] += int(book_seconds_all.get(bid, (0, 0, 0))[0])
+            e[1] += 1
+    language = sorted(
+        [
+            {"language": language_label(c) if c else "Unknown", "code": c or "unknown",
+             "seconds": v[0], "books": v[1]}
+            for c, v in lang_acc.items()
+        ],
+        key=lambda x: x["seconds"], reverse=True,
+    )
+
     return {
         "range_days": effective_days,
         "headline": {
@@ -751,6 +842,10 @@ def get_stats(
         "pace_by_format": pace_by_format,
         "library_growth": library_growth,
         "ratings": ratings,
+        "lifetime": lifetime,
+        "records": records,
+        "tbr": tbr,
+        "language": language,
     }
 
 

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -17,6 +17,7 @@ from backend.models.user_dashboard import UserDashboard
 from backend.models.tome_sync import ReadingSession, TomeSyncPosition
 from backend.models.book import Book, BookFile
 from backend.models.user_book_status import UserBookStatus
+from backend.models.user_series_rating import UserSeriesRating
 from backend.models.library import BookType
 from backend.services.streaks import reconciled_user_streaks
 from backend.services import reconciled_reading as rr
@@ -636,6 +637,88 @@ def get_stats(
             entry[cat] = running_total[cat]
         library_growth.append(entry)
 
+    # ── Ratings / taste (all-time, independent of the date window) ─────────────
+    # Your taste isn't a 30-day thing, so these ignore cutoff/range entirely.
+    book_seconds_all = rr.book_seconds(db, current_user.id, tz_modifier, covered, None, None)
+    rated_rows = (
+        db.query(
+            Book.id, Book.title, Book.author, Book.cover_path,
+            func.coalesce(BookType.label, "Uncategorized").label("category"),
+            UserBookStatus.rating, UserBookStatus.rated_at, UserBookStatus.updated_at,
+        )
+        .select_from(UserBookStatus)
+        .join(Book, Book.id == UserBookStatus.book_id)
+        .outerjoin(BookType, BookType.id == Book.book_type_id)
+        .filter(
+            UserBookStatus.user_id == current_user.id,
+            UserBookStatus.rating.isnot(None),
+            Book.status == "active",
+            book_visibility_filter(db, current_user),
+        )
+        .all()
+    )
+    rated_books = sorted(
+        [
+            {
+                "book_id": r.id, "title": r.title, "author": r.author,
+                "has_cover": bool(r.cover_path), "category": r.category,
+                "rating": int(r.rating),
+                "seconds": int(book_seconds_all.get(r.id, (0, 0, 0))[0]),
+                "rated_at": (r.rated_at or r.updated_at).isoformat() if (r.rated_at or r.updated_at) else None,
+            }
+            for r in rated_rows
+        ],
+        key=lambda b: b["rating"], reverse=True,
+    )
+
+    dist_counts = {i: 0 for i in range(1, 6)}
+    cat_acc: dict[str, list[int]] = {}
+    for b in rated_books:
+        if 1 <= b["rating"] <= 5:
+            dist_counts[b["rating"]] += 1
+        cat_acc.setdefault(b["category"], []).append(b["rating"])
+    rating_distribution = [{"rating": i, "count": dist_counts[i]} for i in range(1, 6)]
+    rating_by_category = [
+        {"category": c, "avg": round(sum(v) / len(v), 2), "count": len(v)}
+        for c, v in sorted(cat_acc.items(), key=lambda kv: sum(kv[1]) / len(kv[1]), reverse=True)
+    ]
+
+    series_rating_rows = (
+        db.query(UserSeriesRating.series_name, UserSeriesRating.rating)
+        .filter(UserSeriesRating.user_id == current_user.id, UserSeriesRating.rating.isnot(None))
+        .order_by(UserSeriesRating.rating.desc())
+        .all()
+    )
+    series_sample: dict[str, int] = {}
+    if series_rating_rows:
+        names = [s.series_name for s in series_rating_rows]
+        for sname, bid in (
+            db.query(Book.series, func.min(Book.id))
+            .filter(Book.series.in_(names), Book.status == "active")
+            .group_by(Book.series)
+        ):
+            series_sample[sname] = bid
+    series_ratings = [
+        {"series": s.series_name, "rating": int(s.rating),
+         "sample_book_id": series_sample.get(s.series_name)}
+        for s in series_rating_rows
+    ]
+
+    rating_trend = sorted(
+        [{"date": b["rated_at"][:10], "rating": b["rating"]} for b in rated_books if b["rated_at"]],
+        key=lambda x: x["date"],
+    )
+
+    ratings = {
+        "count": len(rated_books),
+        "avg": round(sum(b["rating"] for b in rated_books) / len(rated_books), 2) if rated_books else 0,
+        "distribution": rating_distribution,
+        "by_category": rating_by_category,
+        "books": rated_books,          # sorted rating desc; powers top/lowest + scatter
+        "series": series_ratings,
+        "trend": rating_trend,
+    }
+
     return {
         "range_days": effective_days,
         "headline": {
@@ -667,6 +750,7 @@ def get_stats(
         "completion_by_type": completion_by_type,
         "pace_by_format": pace_by_format,
         "library_growth": library_growth,
+        "ratings": ratings,
     }
 
 

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -44,6 +44,15 @@ export interface StatsResponse {
   completion_by_type: { category: string; started: number; finished: number; pct: number }[]
   pace_by_format: { format: string; pages_per_min: number; sessions: number; pages: number; seconds: number }[]
   library_growth: { month: string; total: number; [category: string]: number | string }[]
+  ratings: {
+    count: number
+    avg: number
+    distribution: { rating: number; count: number }[]
+    by_category: { category: string; avg: number; count: number }[]
+    books: { book_id: number; title: string; author: string | null; has_cover: boolean; category: string; rating: number; seconds: number; rated_at: string | null }[]
+    series: { series: string; rating: number; sample_book_id: number | null }[]
+    trend: { date: string; rating: number }[]
+  }
 }
 
 export interface CompletionEstimate {

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -53,6 +53,10 @@ export interface StatsResponse {
     series: { series: string; rating: number; sample_book_id: number | null }[]
     trend: { date: string; rating: number }[]
   }
+  lifetime: { seconds: number; sessions: number; pages: number; books_finished: number; active_days: number; longest_streak_days: number }
+  records: { longest_session_seconds: number; longest_session_title: string | null; biggest_day_seconds: number; biggest_day_date: string | null; most_pages_day: number; most_pages_date: string | null }
+  tbr: { owned: number; read: number; reading: number; shelved: number; unread: number; pct: number; by_type: { type: string; owned: number; read: number; pct: number }[] }
+  language: { language: string; code: string; seconds: number; books: number }[]
 }
 
 export interface CompletionEstimate {

--- a/frontend/src/components/stats/widgets/insights.tsx
+++ b/frontend/src/components/stats/widgets/insights.tsx
@@ -1,0 +1,159 @@
+// Batch-2 "insights" stats widgets — lifetime, records, TBR, reading clock, language.
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { Clock, FileText, BookCheck, Activity, Calendar, Flame, Timer, Sun, type LucideIcon } from 'lucide-react'
+import { formatDuration } from '@/lib/utils'
+import { useChartColors } from '@/lib/useChartAccent'
+import { useChartPalette } from '@/lib/useChartPalette'
+import { ChartTooltip, type StatsResponse } from '@/components/stats/shared'
+
+const fmtDay = (d: string | null) =>
+  d ? new Date(d + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) : '--'
+
+const Empty = () => <p className="py-10 text-center text-sm text-muted-foreground">No data yet.</p>
+
+// ── Lifetime totals (all-time, range-independent) ───────────────────────────────
+export function LifetimeTotals({ data }: { data: StatsResponse['lifetime'] }) {
+  if (!data) return <Empty />
+  const items: { icon: LucideIcon; label: string; value: string }[] = [
+    { icon: Clock, label: 'Total Time', value: formatDuration(data.seconds) },
+    { icon: FileText, label: 'Pages', value: data.pages.toLocaleString() },
+    { icon: BookCheck, label: 'Books Finished', value: String(data.books_finished) },
+    { icon: Activity, label: 'Sessions', value: String(data.sessions) },
+    { icon: Calendar, label: 'Active Days', value: String(data.active_days) },
+    { icon: Flame, label: 'Longest Streak', value: `${data.longest_streak_days}d` },
+  ]
+  return (
+    <div className="grid h-full grid-cols-2 gap-2 sm:grid-cols-3">
+      {items.map((it) => (
+        <div key={it.label} className="flex flex-col justify-center rounded-lg border border-border bg-muted/20 px-3 py-1.5">
+          <div className="flex items-center gap-1 text-muted-foreground">
+            <it.icon className="h-3 w-3 shrink-0" />
+            <span className="truncate text-[10px]">{it.label}</span>
+          </div>
+          <p className="truncate text-base font-bold leading-tight text-foreground sm:text-lg">{it.value}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Personal records ────────────────────────────────────────────────────────────
+export function PersonalRecords({ data }: { data: StatsResponse['records'] }) {
+  if (!data) return <Empty />
+  const rows: { icon: LucideIcon; label: string; value: string; sub: string | null }[] = [
+    { icon: Timer, label: 'Longest session', value: formatDuration(data.longest_session_seconds), sub: data.longest_session_title },
+    { icon: Sun, label: 'Biggest reading day', value: formatDuration(data.biggest_day_seconds), sub: fmtDay(data.biggest_day_date) },
+    { icon: FileText, label: 'Most pages in a day', value: data.most_pages_day.toLocaleString(), sub: fmtDay(data.most_pages_date) },
+  ]
+  return (
+    <div className="flex flex-col gap-2.5">
+      {rows.map((r) => (
+        <div key={r.label} className="flex items-center gap-3 rounded-lg border border-border bg-muted/20 px-3 py-2">
+          <r.icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <div className="min-w-0 flex-1">
+            <p className="text-xs text-muted-foreground">{r.label}</p>
+            {r.sub && <p className="truncate text-[11px] text-muted-foreground/70">{r.sub}</p>}
+          </div>
+          <p className="shrink-0 text-base font-bold tabular-nums text-foreground">{r.value}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Library completion / TBR ────────────────────────────────────────────────────
+export function LibraryCompletion({ data }: { data: StatsResponse['tbr'] }) {
+  const { accent } = useChartColors()
+  if (!data) return <Empty />
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-2">
+        <span className="text-2xl font-bold text-foreground">{data.pct}%</span>
+        <span className="text-xs text-muted-foreground">{data.read} of {data.owned} owned read{data.reading ? ` · ${data.reading} reading` : ''}</span>
+      </div>
+      <div className="flex flex-col gap-2">
+        {data.by_type.map((t) => (
+          <div key={t.type}>
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="truncate font-medium text-foreground">{t.type}</span>
+              <span className="shrink-0 tabular-nums text-muted-foreground">{t.read}/{t.owned} · {t.pct}%</span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+              <div className="h-full rounded-full" style={{ width: `${Math.min(t.pct, 100)}%`, backgroundColor: accent }} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── Reading clock — 24h radial of when you read ─────────────────────────────────
+export function ReadingClock({ data }: { data: StatsResponse['hour_dow_heatmap'] }) {
+  const { accent, tick } = useChartColors()
+  if (!data) return <Empty />
+  const byHour = Array(24).fill(0) as number[]
+  for (const c of data) byHour[c.hour] += c.seconds
+  const max = Math.max(...byHour, 1)
+  if (max <= 1) return <p className="py-10 text-center text-sm text-muted-foreground">No session-time data yet.</p>
+
+  const SIZE = 200, cx = SIZE / 2, cy = SIZE / 2, r0 = 24, rmax = 74
+  const total = byHour.reduce((s, v) => s + v, 0)
+  const peak = byHour.indexOf(Math.max(...byHour))
+  const ang = (h: number) => (h / 24) * 2 * Math.PI - Math.PI / 2 // 0h at top, clockwise
+  return (
+    <div className="flex h-full flex-col items-center justify-center">
+      <svg viewBox={`0 0 ${SIZE} ${SIZE}`} className="h-full max-h-[220px] w-auto">
+        <circle cx={cx} cy={cy} r={rmax} fill="none" stroke={tick} strokeOpacity={0.15} />
+        {byHour.map((v, h) => {
+          const len = r0 + (v / max) * (rmax - r0)
+          const a = ang(h)
+          return (
+            <line key={h}
+              x1={cx + r0 * Math.cos(a)} y1={cy + r0 * Math.sin(a)}
+              x2={cx + len * Math.cos(a)} y2={cy + len * Math.sin(a)}
+              stroke={accent} strokeOpacity={v === 0 ? 0.12 : 0.85} strokeWidth={4} strokeLinecap="round" />
+          )
+        })}
+        {[0, 6, 12, 18].map((h) => {
+          const a = ang(h), lr = rmax + 10
+          return <text key={h} x={cx + lr * Math.cos(a)} y={cy + lr * Math.sin(a) + 3} fontSize={9} fill={tick} textAnchor="middle">{h}h</text>
+        })}
+      </svg>
+      <p className="text-[11px] text-muted-foreground">Peak hour: <span className="font-medium text-foreground">{peak}:00–{(peak + 1) % 24}:00</span> · {formatDuration(total)} total</p>
+    </div>
+  )
+}
+
+// ── Reading time by language ────────────────────────────────────────────────────
+export function ReadingByLanguage({ data }: { data: StatsResponse['language'] }) {
+  const palette = useChartPalette()
+  const pts = (data ?? []).filter((l) => l.seconds > 0)
+  if (pts.length === 0) return <p className="py-12 text-center text-sm text-muted-foreground">No reading-time data yet.</p>
+  if (pts.length === 1) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-1">
+        <p className="text-xl font-bold text-foreground">{pts[0].language}</p>
+        <p className="text-xs text-muted-foreground">{formatDuration(pts[0].seconds)} · {pts[0].books} books — your only language</p>
+      </div>
+    )
+  }
+  const total = pts.reduce((s, l) => s + l.seconds, 0)
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <PieChart>
+        <Pie data={pts} dataKey="seconds" nameKey="language" cx="50%" cy="50%" innerRadius="45%" outerRadius="85%" label={false} stroke="none" isAnimationActive={false}>
+          {pts.map((_, i) => <Cell key={i} fill={palette[i % palette.length]} />)}
+        </Pie>
+        <Tooltip
+          wrapperStyle={{ outline: 'none' }} isAnimationActive={false}
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null
+            const d = payload[0].payload
+            return <ChartTooltip><div className="font-medium">{d.language}</div><div>{formatDuration(d.seconds)} ({Math.round((d.seconds / total) * 100)}%)</div><div className="text-muted-foreground">{d.books} book{d.books !== 1 ? 's' : ''}</div></ChartTooltip>
+          }}
+        />
+      </PieChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/src/components/stats/widgets/taste.tsx
+++ b/frontend/src/components/stats/widgets/taste.tsx
@@ -1,0 +1,220 @@
+// Taste-tab stats widgets (ratings) — chart/content-only, shared by StatsPage and the Lab.
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  ScatterChart,
+  Scatter,
+  RadarChart,
+  Radar,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from 'recharts'
+import { Star, FileText } from 'lucide-react'
+import { cn, formatDuration } from '@/lib/utils'
+import { useChartColors } from '@/lib/useChartAccent'
+import { ChartTooltip, type StatsResponse } from '@/components/stats/shared'
+
+type Ratings = StatsResponse['ratings']
+
+function Empty({ text = 'No ratings yet.' }: { text?: string }) {
+  return <p className="text-sm text-muted-foreground text-center py-10">{text}</p>
+}
+
+function Stars({ value }: { value: number }) {
+  return (
+    <span className="inline-flex shrink-0">
+      {[1, 2, 3, 4, 5].map((i) => (
+        <Star key={i} className={cn('h-3 w-3', i <= value ? 'fill-amber-400 text-amber-400' : 'text-muted-foreground/30')} />
+      ))}
+    </span>
+  )
+}
+
+function Cover({ id, has, alt }: { id: number | null; has: boolean; alt: string }) {
+  return (
+    <div className="h-12 w-8 shrink-0 overflow-hidden rounded bg-muted flex items-center justify-center">
+      {id && has ? (
+        <img src={`/api/books/${id}/cover`} alt={alt} className="h-full w-full object-cover" loading="lazy"
+          onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }} />
+      ) : (
+        <FileText className="h-3.5 w-3.5 text-muted-foreground" />
+      )}
+    </div>
+  )
+}
+
+// 1 ── How you rate: 1–5★ histogram ─────────────────────────────────────────────
+export function RatingDistribution({ data }: { data: Ratings['distribution'] }) {
+  const { accent, tick, cursor } = useChartColors()
+  const total = data.reduce((s, d) => s + d.count, 0)
+  if (total === 0) return <Empty />
+  const chartData = data.map((d) => ({ label: `${d.rating}★`, count: d.count, rating: d.rating }))
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <BarChart data={chartData} margin={{ top: 6, right: 4, bottom: 0, left: 0 }}>
+        <XAxis dataKey="label" tick={{ fontSize: 12, fill: tick }} axisLine={false} tickLine={false} />
+        <YAxis allowDecimals={false} tick={{ fontSize: 10, fill: tick }} width={26} axisLine={false} tickLine={false} />
+        <Tooltip
+          cursor={cursor} wrapperStyle={{ outline: 'none' }} isAnimationActive={false}
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null
+            const d = payload[0].payload
+            return <ChartTooltip><div className="font-medium">{d.rating}★</div><div className="text-muted-foreground">{d.count} book{d.count !== 1 ? 's' : ''} ({Math.round((d.count / total) * 100)}%)</div></ChartTooltip>
+          }}
+        />
+        <Bar dataKey="count" fill={accent} radius={[4, 4, 0, 0]} isAnimationActive={false} />
+      </BarChart>
+    </ResponsiveContainer>
+  )
+}
+
+// 2 ── Taste by genre: avg rating per book-type (radar, bars fallback) ──────────
+export function TasteByGenre({ data }: { data: Ratings['by_category'] }) {
+  const { accent, tick } = useChartColors()
+  if (data.length === 0) return <Empty text="No rated books yet." />
+  if (data.length < 3) {
+    return (
+      <div className="flex h-full flex-col justify-center gap-3">
+        {data.map((d) => (
+          <div key={d.category}>
+            <div className="mb-1 flex items-center justify-between text-xs">
+              <span className="truncate font-medium text-foreground">{d.category}</span>
+              <span className="tabular-nums text-muted-foreground">{d.avg.toFixed(1)} · {d.count}</span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+              <div className="h-full rounded-full" style={{ width: `${(d.avg / 5) * 100}%`, backgroundColor: accent }} />
+            </div>
+          </div>
+        ))}
+      </div>
+    )
+  }
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <RadarChart data={data} margin={{ top: 8, right: 28, bottom: 8, left: 28 }}>
+        <PolarGrid stroke={tick} strokeOpacity={0.2} />
+        <PolarAngleAxis dataKey="category" tick={{ fontSize: 10, fill: tick }} />
+        <PolarRadiusAxis domain={[0, 5]} tickCount={6} tick={{ fontSize: 9, fill: tick }} angle={90} axisLine={false} />
+        <Radar dataKey="avg" stroke={accent} fill={accent} fillOpacity={0.35} isAnimationActive={false} />
+        <Tooltip
+          wrapperStyle={{ outline: 'none' }} isAnimationActive={false}
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null
+            const d = payload[0].payload
+            return <ChartTooltip><div className="font-medium">{d.category}</div><div className="text-muted-foreground">avg {d.avg.toFixed(1)}★ · {d.count} book{d.count !== 1 ? 's' : ''}</div></ChartTooltip>
+          }}
+        />
+      </RadarChart>
+    </ResponsiveContainer>
+  )
+}
+
+function RatedRow({ b }: { b: Ratings['books'][number] }) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <Cover id={b.book_id} has={b.has_cover} alt="" />
+      <div className="min-w-0 flex-1">
+        <a href={`/books/${b.book_id}`} className="line-clamp-1 text-sm font-medium text-foreground hover:text-primary transition-colors">{b.title}</a>
+        {b.author && <p className="truncate text-xs text-muted-foreground">{b.author}</p>}
+      </div>
+      <Stars value={b.rating} />
+    </div>
+  )
+}
+
+// 3 ── Highest & lowest rated books ──────────────────────────────────────────────
+export function TopRatedBooks({ books }: { books: Ratings['books'] }) {
+  if (books.length === 0) return <Empty />
+  const top = books.slice(0, 5)
+  const low = books.length > 8 ? books.slice(-4).reverse() : []
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2.5">
+        {low.length > 0 && <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Highest</p>}
+        {top.map((b) => <RatedRow key={b.book_id} b={b} />)}
+      </div>
+      {low.length > 0 && (
+        <div className="flex flex-col gap-2.5">
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Lowest</p>
+          {low.map((b) => <RatedRow key={b.book_id} b={b} />)}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// 4 ── Rating vs time spent (scatter) ────────────────────────────────────────────
+export function RatingVsTime({ books }: { books: Ratings['books'] }) {
+  const { accent, tick, cursor } = useChartColors()
+  const pts = books.filter((b) => b.seconds > 0).map((b) => ({ hours: +(b.seconds / 3600).toFixed(1), rating: b.rating, title: b.title }))
+  if (pts.length === 0) return <Empty text="No rated books with reading time yet." />
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <ScatterChart margin={{ top: 8, right: 12, bottom: 4, left: 0 }}>
+        <CartesianGrid stroke={tick} strokeOpacity={0.15} />
+        <XAxis type="number" dataKey="hours" name="Hours" tick={{ fontSize: 10, fill: tick }} axisLine={false} tickLine={false} tickFormatter={(v: number) => `${v}h`} />
+        <YAxis type="number" dataKey="rating" domain={[0, 5.5]} ticks={[1, 2, 3, 4, 5]} tick={{ fontSize: 10, fill: tick }} width={24} axisLine={false} tickLine={false} />
+        <Tooltip
+          cursor={cursor} wrapperStyle={{ outline: 'none' }} isAnimationActive={false}
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null
+            const d = payload[0].payload
+            return <ChartTooltip><div className="line-clamp-1 max-w-[180px] font-medium">{d.title}</div><div className="text-muted-foreground">{d.rating}★ · {formatDuration(d.hours * 3600)}</div></ChartTooltip>
+          }}
+        />
+        <Scatter data={pts} fill={accent} fillOpacity={0.75} isAnimationActive={false} />
+      </ScatterChart>
+    </ResponsiveContainer>
+  )
+}
+
+// 5 ── Best-rated series ─────────────────────────────────────────────────────────
+export function BestRatedSeries({ series }: { series: Ratings['series'] }) {
+  if (series.length === 0) return <Empty text="No rated series yet." />
+  return (
+    <div className="flex flex-col gap-2.5">
+      {series.slice(0, 12).map((s) => (
+        <div key={s.series} className="flex items-center gap-2.5">
+          <Cover id={s.sample_book_id} has={!!s.sample_book_id} alt="" />
+          <p className="min-w-0 flex-1 line-clamp-1 text-sm font-medium text-foreground">{s.series}</p>
+          <Stars value={s.rating} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// 6 ── Rating trend over time ────────────────────────────────────────────────────
+export function RatingTrend({ trend }: { trend: Ratings['trend'] }) {
+  const { accent, tick, cursor } = useChartColors()
+  if (trend.length < 2) return <Empty text="Rate a few books to see a trend." />
+  const fmt = (d: string) => {
+    try { return new Date(d + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', year: '2-digit' }) } catch { return d }
+  }
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={trend} margin={{ top: 8, right: 12, bottom: 0, left: 0 }}>
+        <CartesianGrid stroke={tick} strokeOpacity={0.15} vertical={false} />
+        <XAxis dataKey="date" tickFormatter={fmt} tick={{ fontSize: 10, fill: tick }} axisLine={false} tickLine={false} minTickGap={28} />
+        <YAxis domain={[0, 5.5]} ticks={[1, 2, 3, 4, 5]} tick={{ fontSize: 10, fill: tick }} width={24} axisLine={false} tickLine={false} />
+        <Tooltip
+          cursor={cursor} wrapperStyle={{ outline: 'none' }} isAnimationActive={false}
+          content={({ active, payload }) => {
+            if (!active || !payload?.length) return null
+            const d = payload[0].payload
+            return <ChartTooltip><div className="font-medium">{d.rating}★</div><div className="text-muted-foreground">{fmt(d.date)}</div></ChartTooltip>
+          }}
+        />
+        <Line type="monotone" dataKey="rating" stroke={accent} strokeWidth={2} dot={{ r: 2.5, fill: accent }} isAnimationActive={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  )
+}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -661,9 +661,9 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
 type TabState = { id: string; label: string; tiles: Tile[]; layout: Layout }
 
 const TAB_DEFS: { id: string; label: string; ids: string[] }[] = [
-  { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'lifetime-totals', 'session-log', 'goal'] },
-  { id: 'habits', label: 'Habits', ids: ['hour-dow', 'reading-clock', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
-  { id: 'library', label: 'Library', ids: ['year-in-review', 'library-completion', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'per-book-table'] },
+  { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log', 'goal'] },
+  { id: 'habits', label: 'Habits', ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
+  { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
   { id: 'taste', label: 'Taste', ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'] },
 ]
 

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -8,7 +8,7 @@ import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import { Link } from 'react-router-dom'
 import { toPng } from 'html-to-image'
-import { ArrowLeft, Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, type LucideIcon } from 'lucide-react'
+import { ArrowLeft, Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, Trophy, Globe, Library as LibraryIcon, Clock3, Infinity as InfinityIcon, type LucideIcon } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { api } from '@/lib/api'
 import { SyncStatusBadge } from '@/components/SyncStatusBadge'
@@ -61,6 +61,13 @@ import {
   BestRatedSeries,
   RatingTrend,
 } from '@/components/stats/widgets/taste'
+import {
+  LifetimeTotals,
+  PersonalRecords,
+  LibraryCompletion,
+  ReadingClock,
+  ReadingByLanguage,
+} from '@/components/stats/widgets/insights'
 
 /**
  * Reading Stats — a fully customisable dashboard. Every chart is a tile on a
@@ -473,6 +480,48 @@ const WIDGETS: WidgetDef[] = [
     fixedWindow: 'all',
     render: ({ stats }) => <RatingTrend trend={stats.ratings.trend} />,
   },
+  // Batch-2 insights
+  {
+    id: 'lifetime-totals',
+    title: 'Lifetime Totals',
+    icon: InfinityIcon,
+    size: { w: 6, h: 2, minW: 4, minH: 1 },
+    fixedWindow: 'all',
+    render: ({ stats }) => <LifetimeTotals data={stats.lifetime} />,
+  },
+  {
+    id: 'personal-records',
+    title: 'Personal Records',
+    icon: Trophy,
+    size: { w: 4, h: 3, minW: 3, minH: 2 },
+    autoH: true,
+    fixedWindow: 'all',
+    render: ({ stats }) => <PersonalRecords data={stats.records} />,
+  },
+  {
+    id: 'library-completion',
+    title: 'Library Completion',
+    icon: LibraryIcon,
+    size: { w: 4, h: 3, minW: 3, minH: 2 },
+    autoH: true,
+    fixedWindow: 'all',
+    render: ({ stats }) => <LibraryCompletion data={stats.tbr} />,
+  },
+  {
+    id: 'reading-clock',
+    title: 'Reading Clock',
+    icon: Clock3,
+    size: { w: 4, h: 3, minW: 3, minH: 2 },
+    render: ({ stats }) => <ReadingClock data={stats.hour_dow_heatmap} />,
+  },
+  {
+    id: 'reading-by-language',
+    title: 'Reading by Language',
+    icon: Globe,
+    size: { w: 4, h: 2, minW: 3, minH: 2 },
+    fixedWindow: 'all',
+    render: ({ stats }) => <ReadingByLanguage data={stats.language} />,
+  },
 ]
 
 const defById = (id: string) => WIDGETS.find((w) => w.id === id.replace(/--[a-z0-9]+$/, ''))!
@@ -514,6 +563,17 @@ const WIDGET_DESC: Record<string, string> = {
   'genre-over-time': 'Category mix over the year',
   'library-growth': 'Library size over time',
   'per-book-table': 'Sortable table of every book',
+  'rating-distribution': 'How you spread your 1–5 stars',
+  'taste-by-genre': 'Average rating per book type',
+  'rating-vs-time': 'Do you rate books you spend longer on higher?',
+  'rating-trend': 'Your ratings over time',
+  'top-rated': 'Your highest & lowest rated books',
+  'best-rated-series': 'Series ranked by your rating',
+  'lifetime-totals': 'All-time hours, pages, books, streak',
+  'personal-records': 'Longest session, biggest day, most pages',
+  'library-completion': 'How much of what you own you’ve read',
+  'reading-clock': 'A 24-hour radial of when you read',
+  'reading-by-language': 'Reading time split by language',
 }
 
 // Widgets that are a number/short text — render their preview at natural size (no scale).
@@ -530,15 +590,15 @@ const SCROLL_IDS = new Set([
 const GALLERY_GROUPS: { label: string; ids: string[] }[] = [
   {
     label: 'Overview',
-    ids: ['stat-time', 'stat-sessions', 'stat-finished', 'stat-streak', 'stat-pages', 'stat-completion', 'stat-metric', 'goal', 'currently-reading', 'recently-finished', 'streak-calendar', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log'],
+    ids: ['stat-time', 'stat-sessions', 'stat-finished', 'stat-streak', 'stat-pages', 'stat-completion', 'stat-metric', 'goal', 'currently-reading', 'recently-finished', 'streak-calendar', 'daily', 'top-books', 'books-finished', 'activity-365', 'lifetime-totals', 'session-log'],
   },
   {
     label: 'Habits',
-    ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'dow-bar', 'time-of-day', 'time-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'],
+    ids: ['hour-dow', 'reading-clock', 'session-timeline', 'reading-pace', 'pace-by-format', 'dow-bar', 'time-of-day', 'time-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'],
   },
   {
     label: 'Library',
-    ids: ['year-in-review', 'series-completion', 'series-spotlight', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'],
+    ids: ['year-in-review', 'library-completion', 'series-completion', 'series-spotlight', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'per-book-table'],
   },
   {
     label: 'Taste',
@@ -589,15 +649,21 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
   'rating-trend': { x: 6, y: 2, w: 6, h: 2 },
   'top-rated': { x: 0, y: 4, w: 6, h: 3 },
   'best-rated-series': { x: 6, y: 4, w: 6, h: 3 },
+  // Batch-2 insights — placed at the bottom of their home tabs
+  'lifetime-totals': { x: 0, y: 23, w: 12, h: 2 },     // Overview
+  'reading-clock': { x: 0, y: 17, w: 4, h: 3 },        // Habits
+  'library-completion': { x: 0, y: 25, w: 4, h: 3 },   // Library
+  'personal-records': { x: 4, y: 25, w: 4, h: 3 },     // Library
+  'reading-by-language': { x: 8, y: 25, w: 4, h: 2 },  // Library
 }
 
 // Each tab is its own board (own tiles + layout), independently customizable.
 type TabState = { id: string; label: string; tiles: Tile[]; layout: Layout }
 
 const TAB_DEFS: { id: string; label: string; ids: string[] }[] = [
-  { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log', 'goal'] },
-  { id: 'habits', label: 'Habits', ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
-  { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
+  { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'lifetime-totals', 'session-log', 'goal'] },
+  { id: 'habits', label: 'Habits', ids: ['hour-dow', 'reading-clock', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
+  { id: 'library', label: 'Library', ids: ['year-in-review', 'library-completion', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'per-book-table'] },
   { id: 'taste', label: 'Taste', ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'] },
 ]
 
@@ -624,9 +690,17 @@ const buildTabs = (): TabState[] => TAB_DEFS.map(buildTab)
 // touched. User-created tabs use `newId('tab')` (= `tab--...`), so they can never collide
 // with a default id like 'taste'; the worst case is a harmless duplicate *label*.
 const withMissingDefaultTabs = (tabs: TabState[]): TabState[] => {
-  const have = new Set(tabs.map((t) => t.id))
+  const byId = new Map(TAB_DEFS.map((d) => [d.id, d]))
+  // Repair a default tab that somehow got persisted empty (a transient build bug
+  // saved an empty board) by rebuilding it from its def; user-customised non-empty
+  // tabs are left untouched.
+  const repaired = tabs.map((t) => {
+    const def = byId.get(t.id)
+    return def && def.ids.length > 0 && (!t.tiles || t.tiles.length === 0) ? buildTab(def) : t
+  })
+  const have = new Set(repaired.map((t) => t.id))
   const missing = TAB_DEFS.filter((d) => !have.has(d.id)).map(buildTab)
-  return missing.length ? [...tabs, ...missing] : tabs
+  return missing.length ? [...repaired, ...missing] : repaired
 }
 
 const RANGES = [

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -8,7 +8,7 @@ import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import { Link } from 'react-router-dom'
 import { toPng } from 'html-to-image'
-import { ArrowLeft, Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, type LucideIcon } from 'lucide-react'
+import { ArrowLeft, Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, type LucideIcon } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { api } from '@/lib/api'
 import { SyncStatusBadge } from '@/components/SyncStatusBadge'
@@ -53,6 +53,14 @@ import { SeriesCompletionGrid } from '@/components/stats/SeriesCompletionGrid'
 import { AuthorAffinity } from '@/components/stats/AuthorAffinity'
 import { CompletionByType } from '@/components/stats/CompletionByType'
 import { LibraryGrowthChart } from '@/components/stats/LibraryGrowthChart'
+import {
+  RatingDistribution,
+  TasteByGenre,
+  TopRatedBooks,
+  RatingVsTime,
+  BestRatedSeries,
+  RatingTrend,
+} from '@/components/stats/widgets/taste'
 
 /**
  * Reading Stats — a fully customisable dashboard. Every chart is a tile on a
@@ -414,6 +422,57 @@ const WIDGETS: WidgetDef[] = [
     titleFor: (cfg) => cfg.series ?? 'Series Spotlight',
     render: ({ stats }, cfg) => <SeriesSpotlight data={stats.series_completion} series={cfg.series} />,
   },
+  // Taste tab — ratings (all-time, ignore the date range)
+  {
+    id: 'rating-distribution',
+    title: 'Rating Distribution',
+    icon: Star,
+    size: { w: 4, h: 2, minW: 3, minH: 2 },
+    fixedWindow: 'all',
+    render: ({ stats }) => <RatingDistribution data={stats.ratings.distribution} />,
+  },
+  {
+    id: 'taste-by-genre',
+    title: 'Taste by Genre',
+    icon: Sparkles,
+    size: { w: 4, h: 2, minW: 3, minH: 2 },
+    fixedWindow: 'all',
+    render: ({ stats }) => <TasteByGenre data={stats.ratings.by_category} />,
+  },
+  {
+    id: 'top-rated',
+    title: 'Highest & Lowest Rated',
+    icon: Star,
+    size: { w: 4, h: 3, minW: 3, minH: 2 },
+    autoH: true,
+    fixedWindow: 'all',
+    render: ({ stats }) => <TopRatedBooks books={stats.ratings.books} />,
+  },
+  {
+    id: 'rating-vs-time',
+    title: 'Rating vs Time Spent',
+    icon: ScatterIcon,
+    size: { w: 6, h: 2, minW: 3, minH: 2 },
+    fixedWindow: 'all',
+    render: ({ stats }) => <RatingVsTime books={stats.ratings.books} />,
+  },
+  {
+    id: 'best-rated-series',
+    title: 'Best-Rated Series',
+    icon: Star,
+    size: { w: 4, h: 3, minW: 3, minH: 2 },
+    autoH: true,
+    fixedWindow: 'all',
+    render: ({ stats }) => <BestRatedSeries series={stats.ratings.series} />,
+  },
+  {
+    id: 'rating-trend',
+    title: 'Rating Trend',
+    icon: TrendingUp,
+    size: { w: 6, h: 2, minW: 3, minH: 2 },
+    fixedWindow: 'all',
+    render: ({ stats }) => <RatingTrend trend={stats.ratings.trend} />,
+  },
 ]
 
 const defById = (id: string) => WIDGETS.find((w) => w.id === id.replace(/--[a-z0-9]+$/, ''))!
@@ -481,6 +540,10 @@ const GALLERY_GROUPS: { label: string; ids: string[] }[] = [
     label: 'Library',
     ids: ['year-in-review', 'series-completion', 'series-spotlight', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'],
   },
+  {
+    label: 'Taste',
+    ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'],
+  },
 ]
 
 type Tile = { id: string; defId: string; config: TileConfig }
@@ -519,6 +582,13 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
   'genre-over-time': { x: 0, y: 13, w: 12, h: 3 },
   'library-growth': { x: 0, y: 16, w: 12, h: 3 },
   'per-book-table': { x: 0, y: 19, w: 12, h: 6 },
+  // Taste — three rows of two
+  'rating-distribution': { x: 0, y: 0, w: 6, h: 2 },
+  'taste-by-genre': { x: 6, y: 0, w: 6, h: 2 },
+  'rating-vs-time': { x: 0, y: 2, w: 6, h: 2 },
+  'rating-trend': { x: 6, y: 2, w: 6, h: 2 },
+  'top-rated': { x: 0, y: 4, w: 6, h: 3 },
+  'best-rated-series': { x: 6, y: 4, w: 6, h: 3 },
 }
 
 // Each tab is its own board (own tiles + layout), independently customizable.
@@ -528,6 +598,7 @@ const TAB_DEFS: { id: string; label: string; ids: string[] }[] = [
   { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log', 'goal'] },
   { id: 'habits', label: 'Habits', ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
   { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
+  { id: 'taste', label: 'Taste', ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'] },
 ]
 
 function buildTab(def: { id: string; label: string; ids: string[] }): TabState {
@@ -547,6 +618,16 @@ function buildTab(def: { id: string; label: string; ids: string[] }): TabState {
 }
 
 const buildTabs = (): TabState[] => TAB_DEFS.map(buildTab)
+
+// Additive migration: append any default tab (e.g. a newly-shipped "Taste" tab) that a
+// saved dashboard predates — keyed by id, so an existing board's tiles/layout are never
+// touched. User-created tabs use `newId('tab')` (= `tab--...`), so they can never collide
+// with a default id like 'taste'; the worst case is a harmless duplicate *label*.
+const withMissingDefaultTabs = (tabs: TabState[]): TabState[] => {
+  const have = new Set(tabs.map((t) => t.id))
+  const missing = TAB_DEFS.filter((d) => !have.has(d.id)).map(buildTab)
+  return missing.length ? [...tabs, ...missing] : tabs
+}
 
 const RANGES = [
   { days: 7, label: '7d' },
@@ -1442,7 +1523,10 @@ export function StatsPage() {
   const [estimates, setEstimates] = useState<CompletionEstimate[] | null>(null)
   const [goals, setGoals] = useState<Goal[] | null>(null)
   const [loading, setLoading] = useState(true)
-  const [tabs, setTabs] = useState<TabState[]>(() => loadPersisted()?.tabs ?? buildTabs())
+  const [tabs, setTabs] = useState<TabState[]>(() => {
+    const p = loadPersisted()?.tabs
+    return p ? withMissingDefaultTabs(p) : buildTabs()
+  })
   const [activeTabId, setActiveTabId] = useState(() => loadPersisted()?.activeTabId ?? 'overview')
   const [renamingId, setRenamingId] = useState<string | null>(null)
   const [tabMenuOpen, setTabMenuOpen] = useState(false)
@@ -1518,7 +1602,7 @@ export function StatsPage() {
       .then((res) => {
         const p = res.data ? sanitizePersisted(res.data) : null
         if (p && (p.savedAt ?? 0) >= localSavedAt) {
-          setTabs(p.tabs)
+          setTabs(withMissingDefaultTabs(p.tabs))
           setActiveTabId(p.activeTabId)
           if (p.pad) setPad(p.pad)
           if (p.days != null) setDays(p.days)

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -664,7 +664,7 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
 type TabState = { id: string; label: string; tiles: Tile[]; layout: Layout }
 
 const TAB_DEFS: { id: string; label: string; ids: string[] }[] = [
-  { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log', 'goal'] },
+  { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log'] },
   { id: 'habits', label: 'Habits', ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
   { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
   { id: 'taste', label: 'Taste', ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'] },

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -240,6 +240,7 @@ const WIDGETS: WidgetDef[] = [
     title: 'Currently Reading',
     size: { w: 6, h: 2, minW: 3, minH: 1 },
     autoH: true,
+    defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
     render: ({ stats }) => <CurrentlyReading books={stats.books_in_progress} />,
   },
   {
@@ -346,6 +347,7 @@ const WIDGETS: WidgetDef[] = [
     title: 'Completion Estimates',
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     autoH: true,
+    defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
     render: ({ estimates }) => <CompletionEstimatesList estimates={estimates} />,
   },
   {
@@ -376,6 +378,7 @@ const WIDGETS: WidgetDef[] = [
     title: 'Series Completion',
     size: { w: 6, h: 3, minW: 3, minH: 2 },
     autoH: true,
+    defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
     render: ({ stats }) => <SeriesCompletionGrid data={stats.series_completion} />,
   },
   {

--- a/tests/test_stats_insights.py
+++ b/tests/test_stats_insights.py
@@ -1,0 +1,46 @@
+"""Batch 2 — insights blocks on /api/stats: lifetime, records, tbr, language."""
+from datetime import datetime
+
+from backend.models.user_book_status import UserBookStatus
+from backend.models.tome_sync import ReadingSession
+
+
+def _sess(db, user, book, secs, when, pages):
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when, ended_at=when,
+                          duration_seconds=secs, pages_turned=pages))
+
+
+def test_insights_blocks(client, db, admin_user, make_book):
+    user, _ = admin_user
+    a = make_book(title="A", language="en")
+    b = make_book(title="B", language="eng")   # folds to English too
+    make_book(title="C", language="de")        # owned, unread, no reading time
+    db.add(UserBookStatus(user_id=user.id, book_id=a.id, status="read"))
+    db.add(UserBookStatus(user_id=user.id, book_id=b.id, status="reading"))
+    _sess(db, user, a, 600, datetime(2026, 1, 1, 10), 20)
+    _sess(db, user, b, 300, datetime(2026, 1, 2, 10), 10)
+    db.flush()
+
+    s = client.get("/api/stats?days=0").json()
+
+    # lifetime (all-time)
+    assert s["lifetime"]["seconds"] == 900
+    assert s["lifetime"]["books_finished"] == 1
+    assert s["lifetime"]["active_days"] == 2
+
+    # records
+    assert s["records"]["longest_session_seconds"] == 600
+    assert s["records"]["longest_session_title"] == "A"
+    assert s["records"]["biggest_day_seconds"] == 600
+
+    # tbr: 3 owned, 1 read, 1 reading, 1 implicitly unread
+    assert s["tbr"]["owned"] == 3
+    assert s["tbr"]["read"] == 1 and s["tbr"]["reading"] == 1
+    assert s["tbr"]["unread"] == 1
+    assert s["tbr"]["pct"] == 33.3
+
+    # language: en + eng fold into one "English" entry (900s, 2 books); 'C' has no time
+    langs = {l["language"]: l for l in s["language"]}
+    assert "English" in langs
+    assert langs["English"]["seconds"] == 900 and langs["English"]["books"] == 2
+    assert "German" not in langs  # C was never read, so no reading time

--- a/tests/test_stats_ratings.py
+++ b/tests/test_stats_ratings.py
@@ -1,0 +1,51 @@
+"""Batch 1 — the Taste tab: ratings aggregations in /api/stats."""
+from datetime import datetime
+
+from backend.models.user_book_status import UserBookStatus
+from backend.models.user_series_rating import UserSeriesRating
+
+
+def _rate(db, user, book, rating, rated_at):
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="read",
+                          rating=rating, rated_at=rated_at))
+
+
+def test_ratings_block(client, db, admin_user, make_book):
+    user, _ = admin_user
+    great = make_book(title="Great", series="S1", series_index=1.0)
+    ok = make_book(title="Ok")
+    bad = make_book(title="Bad")
+    _rate(db, user, great, 5, datetime(2026, 1, 1))
+    _rate(db, user, ok, 3, datetime(2026, 2, 1))
+    _rate(db, user, bad, 1, datetime(2026, 3, 1))
+    db.add(UserSeriesRating(user_id=user.id, series_name="S1", rating=4))
+    db.flush()
+
+    r = client.get("/api/stats?days=0").json()["ratings"]
+    assert r["count"] == 3
+    assert r["avg"] == 3.0
+
+    dist = {d["rating"]: d["count"] for d in r["distribution"]}
+    assert dist == {1: 1, 2: 0, 3: 1, 4: 0, 5: 1}
+
+    # books sorted by rating desc; powers top + lowest tiles
+    assert [b["title"] for b in r["books"]] == ["Great", "Ok", "Bad"]
+    assert r["books"][0]["rating"] == 5 and r["books"][-1]["rating"] == 1
+
+    # by-category avg (all Uncategorized here)
+    assert r["by_category"][0]["category"] == "Uncategorized"
+    assert r["by_category"][0]["avg"] == 3.0 and r["by_category"][0]["count"] == 3
+
+    # series rating, with a sample book for the cover
+    assert r["series"] == [{"series": "S1", "rating": 4, "sample_book_id": great.id}]
+
+    # trend ordered by rated_at
+    assert [t["rating"] for t in r["trend"]] == [5, 3, 1]
+
+
+def test_ratings_empty_user(client, db, admin_user, make_book):
+    make_book(title="Unrated")
+    r = client.get("/api/stats?days=0").json()["ratings"]
+    assert r["count"] == 0 and r["avg"] == 0
+    assert r["books"] == [] and r["series"] == [] and r["trend"] == []
+    assert sum(d["count"] for d in r["distribution"]) == 0


### PR DESCRIPTION
Adds a fourth **Taste** board to Reading Stats, built from your existing book and
series ratings (independent of the KOReader import — it just visualizes ratings you
already have).

## Tiles (6)
- **Rating Distribution** — how you spread 1–5★
- **Taste by Genre** — average rating per book *type* (radar at 3+ types, bars below)
- **Highest & Lowest Rated** — your best + worst with covers
- **Rating vs Time Spent** — scatter; do you linger on books you rate higher?
- **Best-Rated Series** — your series ratings
- **Rating Trend** — ratings over time

## How
- Backend: an all-time `ratings` block on `GET /api/stats` (ignores the date range,
  since ratings aren't a 7d/30d thing). Reuses `reconciled_reading.book_seconds` for
  per-book time.
- Frontend: 6 `WidgetDef` tiles + a new **Taste** tab. Each is add/move/resize/remove
  like every other tile; they carry an "all" badge.
- **Additive tab migration:** existing customised dashboards get the new tab *appended*
  (keyed by tab id) — existing boards/tiles/layout are never touched.

## Tests
- `tests/test_stats_ratings.py` (block shape + empty-user). Full suite green.

Follow-up commits (more tiles — language / device / TBR / records, etc.) can land on
this same PR.