### PR TITLE
feat(stats): word counts — EPUB parse at ingest + admin backfill (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Word counts for your books.** Tome now parses each EPUB's text to record its
+  word count, shown in the **Details** panel on the book page. New uploads are
+  counted automatically as they're added; CJK titles (Chinese / Japanese / Korean)
+  are counted per character so they aren't undercounted. PDFs and comics don't have
+  a word count. This is the groundwork for upcoming reading-speed and words-read
+  stats. To fill in books added before this release, admins get a **Word Counts**
+  tab under Admin with a one-click background backfill (it only reads your files —
+  nothing on disk is changed — and shows live progress you can stop and resume).
 - **A "Taste" tab on Reading Stats.** A fourth board next to Overview / Habits /
   Library, built from your book ratings: a **rating distribution** (how you spread
   your stars), **taste by genre** (your average rating per book type), your

--- a/backend/api/bindery.py
+++ b/backend/api/bindery.py
@@ -348,6 +348,11 @@ def bindery_accept(
                 content_hash=content_hash,
             ))
 
+            # Word count (EPUB only) — parsed from the accepted file on disk.
+            if suffix == "epub":
+                from backend.services.metadata import count_words_epub
+                book.word_count = count_words_epub(dest)
+
             # Create tag records
             for tag_str in item.tags:
                 tag_str = tag_str.strip()

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -2034,6 +2034,7 @@ def upload_book(
         description=meta.get("description"),
         language=meta.get("language"),
         year=meta.get("year"),
+        word_count=meta.get("word_count"),
         cover_path=meta.get("cover_path"),
         content_hash=content_hash,
         status="active",
@@ -2270,6 +2271,11 @@ def ingest_book(
         file_size=dest.stat().st_size,
         content_hash=content_hash,
     ))
+
+    # Word count (EPUB only) — parsed from the ingested file on disk.
+    if suffix == "epub":
+        from backend.services.metadata import count_words_epub
+        book.word_count = count_words_epub(dest)
 
     # Tags
     if meta.tags:

--- a/backend/api/word_count.py
+++ b/backend/api/word_count.py
@@ -1,0 +1,63 @@
+"""Admin word-count backfill endpoints.
+
+A single cancellable background job parses every EPUB whose ``word_count`` is
+still NULL and stores it. The UI polls ``/admin/word-count/status``; see
+``services/word_count_job.py``. New uploads get their count at ingest, so this
+only exists to backfill books that predate the feature.
+"""
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend.core.database import get_db
+from backend.core.permissions import require_role
+from backend.core.security import get_current_user
+from backend.models.user import User
+from backend.services import word_count_job
+from backend.services.audit import audit
+
+router = APIRouter()
+
+
+@router.get("/admin/word-count/status")
+def word_count_status(current_user: User = Depends(get_current_user)) -> dict:
+    require_role(current_user, "admin")
+    return word_count_job.get_status()
+
+
+@router.get("/admin/word-count/preflight")
+def word_count_preflight(current_user: User = Depends(get_current_user)) -> dict:
+    require_role(current_user, "admin")
+    return word_count_job.preflight()
+
+
+@router.post("/admin/word-count/start")
+def word_count_start(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    require_role(current_user, "admin")
+    try:
+        state = word_count_job.start(username=current_user.username)
+    except word_count_job.WordCountAlreadyRunning:
+        raise HTTPException(409, "A word-count backfill is already running")
+    audit(
+        db,
+        "books.word_count_backfill_started",
+        user_id=current_user.id,
+        username=current_user.username,
+        details={"total_files": state.get("total_files"), "total_bytes": state.get("total_bytes")},
+    )
+    return state
+
+
+@router.post("/admin/word-count/cancel")
+def word_count_cancel(current_user: User = Depends(get_current_user)) -> dict:
+    require_role(current_user, "admin")
+    cancelled = word_count_job.request_cancel()
+    return {"cancelling": cancelled, **word_count_job.get_status()}
+
+
+@router.post("/admin/word-count/dismiss")
+def word_count_dismiss(current_user: User = Depends(get_current_user)) -> dict:
+    require_role(current_user, "admin")
+    return word_count_job.dismiss()

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from backend.api import tome_sync
 from backend.api import stats
 from backend.api import quick_connect
 from backend.api import admin_duplicates
+from backend.api import word_count as word_count_api
 from backend.api import home
 from backend.api import bindery
 from backend.api import api_tokens
@@ -59,6 +60,10 @@ async def lifespan(app: FastAPI):
         # Add is_reviewed — default 1 so ALL existing books are considered already reviewed
         if "is_reviewed" not in cols:
             conn.execute(text("ALTER TABLE books ADD COLUMN is_reviewed BOOLEAN NOT NULL DEFAULT 1"))
+            conn.commit()
+        # Add word_count — NULL for existing books until backfilled (Admin → Word Counts)
+        if "word_count" not in cols:
+            conn.execute(text("ALTER TABLE books ADD COLUMN word_count INTEGER"))
             conn.commit()
         user_cols = {r[1] for r in conn.execute(text("PRAGMA table_info(users)")).fetchall()}
         if "role" not in user_cols:
@@ -294,6 +299,7 @@ async def _run_auto_import() -> None:
                 description=meta.get("description"),
                 language=meta.get("language"),
                 year=meta.get("year"),
+                word_count=meta.get("word_count"),
                 cover_path=cover_path,
                 content_hash=content_hash,
                 content_type=parsed.content_type,
@@ -526,6 +532,7 @@ def create_app() -> FastAPI:
     app.include_router(stats.router, prefix="/api")
     app.include_router(quick_connect.router, prefix="/api")
     app.include_router(admin_duplicates.router, prefix="/api")
+    app.include_router(word_count_api.router, prefix="/api")
     app.include_router(bindery.router, prefix="/api/bindery", tags=["bindery"])
     app.include_router(api_tokens.router, prefix="/api")
     app.include_router(series_api.router, prefix="/api")

--- a/backend/models/book.py
+++ b/backend/models/book.py
@@ -24,6 +24,10 @@ class Book(Base):
     description: Mapped[Optional[str]] = mapped_column(Text)
     language: Mapped[Optional[str]] = mapped_column(String(16))
     year: Mapped[Optional[int]] = mapped_column(Integer)
+    # Intrinsic, device-independent word count parsed from the EPUB text at
+    # ingest (or backfilled by the admin word-count job). NULL for PDF/CBZ or
+    # not-yet-parsed books. Feeds words-read / true-WPM stats (Phase 4).
+    word_count: Mapped[Optional[int]] = mapped_column(Integer)
     cover_path: Mapped[Optional[str]] = mapped_column(Text)
     content_hash: Mapped[Optional[str]] = mapped_column(String(64), index=True)
     book_type_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("book_types.id"), nullable=True)

--- a/backend/schemas/book.py
+++ b/backend/schemas/book.py
@@ -32,6 +32,7 @@ class BookOut(BaseModel):
     series_index: Optional[float] = None
     year: Optional[int] = None
     language: Optional[str] = None
+    word_count: Optional[int] = None
     status: str
     content_type: str
     cover_path: Optional[str] = None

--- a/backend/services/metadata.py
+++ b/backend/services/metadata.py
@@ -17,6 +17,91 @@ logger = logging.getLogger(__name__)
 
 SUPPORTED_FORMATS = {".epub", ".pdf", ".cbz", ".cbr", ".mobi"}
 
+# Word tokenizer that also works for scripts without spaces: each CJK
+# ideograph / kana / hangul syllable counts as one "word", while runs of
+# Latin/Cyrillic/Greek letters (with internal apostrophes/hyphens) count as one
+# each. Whitespace-splitting alone would massively undercount a zh/ja/ko book.
+_WORD_RE = re.compile(
+    r"[㐀-䶿一-鿿豈-﫿"      # CJK ideographs
+    r"぀-ゟ゠-ヿ"                      # hiragana + katakana
+    r"가-힣]"                                 # hangul syllables
+    r"|[0-9A-Za-zÀ-ɏͰ-ϿЀ-ӿ]"
+    r"+(?:['’\-][0-9A-Za-zÀ-ɏ]+)*"
+)
+
+
+def _html_to_text(html: str) -> str:
+    """Strip <script>/<style> blocks and all tags, leaving plain text."""
+    html = re.sub(r"(?is)<(script|style)[^>]*>.*?</\1>", " ", html)
+    return re.sub(r"(?s)<[^>]+>", " ", html)
+
+
+def count_words_text(text: str) -> int:
+    return len(_WORD_RE.findall(text))
+
+
+def _count_words_in_epub_book(book) -> Optional[int]:
+    """Sum word counts across every XHTML document in an already-open EPUB.
+    Returns None if the book has no readable document items."""
+    import ebooklib
+
+    total = 0
+    found = False
+    for item in book.get_items_of_type(ebooklib.ITEM_DOCUMENT):
+        try:
+            raw = item.get_content()
+        except Exception:  # noqa: BLE001 — skip an unreadable spine item
+            continue
+        found = True
+        total += count_words_text(_html_to_text(raw.decode("utf-8", "ignore")))
+    return total if found else None
+
+
+def _count_words_from_zip(path: Path) -> Optional[int]:
+    """Fallback word count straight from the EPUB zip.
+
+    ebooklib's reader is strict about spec-compliant packaging — a manifest
+    entry pointing at a missing file, or an EPUB3 nav with no <ol>, makes it
+    raise before it ever reaches the body text. The actual chapters are still
+    perfectly readable, so when ebooklib bails we read every XHTML/HTML member
+    directly and count those. Returns None only if the archive has no readable
+    markup at all."""
+    total = 0
+    found = False
+    try:
+        with zipfile.ZipFile(path) as zf:
+            for name in zf.namelist():
+                if not name.lower().endswith((".xhtml", ".html", ".htm")):
+                    continue
+                try:
+                    raw = zf.read(name)
+                except Exception:  # noqa: BLE001 — skip an unreadable member
+                    continue
+                found = True
+                total += count_words_text(_html_to_text(raw.decode("utf-8", "ignore")))
+    except Exception as e:  # noqa: BLE001 — not a usable zip
+        logger.warning("word count zip-fallback error for %s: %s", path, e)
+        return None
+    return total if found else None
+
+
+def count_words_epub(path: Path) -> Optional[int]:
+    """Open an EPUB from disk and count its words. Used by the backfill job;
+    ingest reuses the already-open book via _count_words_in_epub_book.
+
+    Falls back to reading the zip directly when ebooklib refuses to parse a
+    technically-malformed (but readable) EPUB — see _count_words_from_zip."""
+    try:
+        from ebooklib import epub
+
+        book = epub.read_epub(str(path), options={"ignore_ncx": True})
+        wc = _count_words_in_epub_book(book)
+        if wc is not None:
+            return wc
+    except Exception as e:  # noqa: BLE001
+        logger.info("ebooklib could not parse %s (%s); trying zip fallback", path, e)
+    return _count_words_from_zip(path)
+
 
 def _opf_meta_by_name(book, name: str) -> Optional[str]:
     """Read an OPF2 <meta name="..." content="..."/> value.
@@ -167,6 +252,11 @@ def extract_epub(path: Path, covers_dir: Path) -> dict:
                         meta["series_index"] = float(vol_match.group(2))
                     except (ValueError, TypeError):
                         pass
+
+        # Word count — reuse the already-open book (no second parse).
+        wc = _count_words_in_epub_book(book)
+        if wc:
+            meta["word_count"] = wc
 
         # Cover extraction
         cover_id = None

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -290,6 +290,7 @@ def _create_book_entry(
         description=meta.get("description"),
         language=meta.get("language"),
         year=meta.get("year"),
+        word_count=meta.get("word_count"),
         cover_path=meta.get("cover_path"),
         content_hash=content_hash,
         status="active",

--- a/backend/services/word_count_job.py
+++ b/backend/services/word_count_job.py
@@ -1,0 +1,228 @@
+"""Whole-library 'count words' background backfill job.
+
+A single, serial, cancellable job parses every EPUB whose ``Book.word_count`` is
+still NULL and stores the count. It runs in a daemon thread so it survives the
+request that started it — closing the browser tab or navigating away never
+cancels it. Progress lives in module-global state (guarded by a lock) and is
+read back via the status endpoint, so the UI is just a poller and can reconnect
+at any time.
+
+Unlike the bake job this NEVER touches files on disk — it only reads them and
+writes one integer column — so there is no atomic-replace / hash / read-only
+machinery. New uploads already get their count at ingest
+(``metadata.extract_epub``); this job is purely for books that predate the
+feature.
+
+Single-process model: state is in-memory, so a server restart drops the job and
+its progress. That is safe and cheap to recover from — the work list is "books
+with word_count IS NULL", so a re-run simply resumes with whatever is left.
+(Tome runs a single uvicorn worker; SQLite is single-writer.)
+
+Progress is weighted by *bytes* (parse time roughly tracks file size), so the
+ETA is ``elapsed * bytes_left / bytes_done`` rather than a lying file-count bar.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy import func
+
+from backend.core.database import SessionLocal
+from backend.models.book import Book, BookFile
+from backend.services.metadata import count_words_epub
+
+log = logging.getLogger(__name__)
+
+_MAX_ISSUES = 500
+
+_lock = threading.Lock()
+_cancel = threading.Event()
+_thread: Optional[threading.Thread] = None
+
+# status: idle | running | done | cancelled | error
+_state: dict = {"status": "idle"}
+
+
+class WordCountAlreadyRunning(Exception):
+    pass
+
+
+def _epub_books() -> dict[int, tuple[Optional[int], int, str]]:
+    """One row per book that has an EPUB file: book_id → (word_count, size, path).
+    If a book has several EPUB files we keep the first."""
+    with SessionLocal() as db:
+        rows = (
+            db.query(
+                Book.id,
+                Book.word_count,
+                BookFile.file_size,
+                BookFile.file_path,
+            )
+            .join(BookFile, BookFile.book_id == Book.id)
+            .filter(func.lower(BookFile.format) == "epub")
+            .all()
+        )
+    out: dict[int, tuple[Optional[int], int, str]] = {}
+    for book_id, wc, size, path in rows:
+        if book_id not in out:
+            out[book_id] = (wc, size or 0, path)
+    return out
+
+
+def preflight() -> dict:
+    """Cheap DB-only summary of what a run would do (no disk access)."""
+    books = _epub_books()
+    total = len(books)
+    pending = pending_bytes = 0
+    for wc, size, _path in books.values():
+        if wc is None:
+            pending += 1
+            pending_bytes += size
+    return {
+        "epub_total": total,
+        "already_counted": total - pending,
+        "pending": pending,
+        "pending_bytes": pending_bytes,
+    }
+
+
+def _snapshot() -> dict:
+    s = dict(_state)
+    if s.get("status") == "running" and s.get("started_at"):
+        elapsed = time.time() - s["started_at"]
+    elif s.get("started_at") and s.get("finished_at"):
+        elapsed = s["finished_at"] - s["started_at"]
+    else:
+        elapsed = 0.0
+    s["elapsed_seconds"] = round(elapsed, 1)
+
+    eta = None
+    if s.get("status") == "running":
+        done_bytes = s.get("done_bytes", 0)
+        total_bytes = s.get("total_bytes", 0)
+        if done_bytes > 0 and total_bytes > done_bytes:
+            eta = elapsed * (total_bytes - done_bytes) / done_bytes
+    s["eta_seconds"] = round(eta, 1) if eta is not None else None
+    return s
+
+
+def get_status() -> dict:
+    with _lock:
+        return _snapshot()
+
+
+def dismiss() -> dict:
+    """Reset a finished run's summary to idle. No-op while running."""
+    global _state
+    with _lock:
+        if _state.get("status") != "running":
+            _state = {"status": "idle"}
+        return _snapshot()
+
+
+def request_cancel() -> bool:
+    with _lock:
+        if _state.get("status") == "running":
+            _cancel.set()
+            return True
+        return False
+
+
+def start(*, username: Optional[str] = None) -> dict:
+    """Begin a whole-library word-count backfill. Raises if one is active."""
+    global _state, _thread
+    with _lock:
+        if _state.get("status") == "running":
+            raise WordCountAlreadyRunning()
+
+        work: list[tuple[int, str, int]] = []
+        total_bytes = 0
+        for book_id, (wc, size, path) in _epub_books().items():
+            if wc is None:
+                work.append((book_id, path, size))
+                total_bytes += size
+
+        _cancel.clear()
+        _state = {
+            "status": "running",
+            "started_at": time.time(),
+            "finished_at": None,
+            "triggered_by": username,
+            "total_files": len(work),
+            "total_bytes": total_bytes,
+            "done_files": 0,
+            "done_bytes": 0,
+            "counted": 0,
+            "failed": 0,
+            "words_total": 0,
+            "current_file": None,
+            "issues": [],
+            "error": None,
+        }
+        _thread = threading.Thread(
+            target=_run, args=(work,), name="word-count-backfill", daemon=True
+        )
+        _thread.start()
+        return _snapshot()
+
+
+def _set_current(path: str) -> None:
+    with _lock:
+        _state["current_file"] = path
+
+
+def _record(*, size: int, words: Optional[int], path: str) -> None:
+    with _lock:
+        _state["done_files"] += 1
+        _state["done_bytes"] += size
+        if words is not None:
+            _state["counted"] += 1
+            _state["words_total"] += words
+        else:
+            _state["failed"] += 1
+            if len(_state["issues"]) < _MAX_ISSUES:
+                _state["issues"].append({"path": path, "reason": "could not parse EPUB"})
+
+
+def _finish(status: str, error: Optional[str] = None) -> None:
+    with _lock:
+        _state["status"] = status
+        _state["finished_at"] = time.time()
+        _state["current_file"] = None
+        if error:
+            _state["error"] = error
+
+
+def _run(work: list[tuple[int, str, int]]) -> None:
+    try:
+        for book_id, path, size in work:
+            if _cancel.is_set():
+                _finish("cancelled")
+                return
+            _set_current(path)
+            try:
+                words = count_words_epub(Path(path))
+            except Exception as e:  # noqa: BLE001 — one bad file never aborts the run
+                log.exception("word-count: error on book #%s", book_id)
+                _record(size=size, words=None, path=path)
+                continue
+            if words is not None:
+                try:
+                    with SessionLocal() as db:
+                        book = db.get(Book, book_id)
+                        if book is not None:
+                            book.word_count = words
+                            db.commit()
+                except Exception:  # noqa: BLE001
+                    log.exception("word-count: DB write failed for book #%s", book_id)
+                    _record(size=size, words=None, path=path)
+                    continue
+            _record(size=size, words=words, path=path)
+        _finish("done")
+    except Exception as e:  # noqa: BLE001
+        log.exception("word-count: job crashed")
+        _finish("error", error=str(e))

--- a/frontend/src/components/WordCount.tsx
+++ b/frontend/src/components/WordCount.tsx
@@ -1,0 +1,270 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  AlignLeft, Loader2, Check, X, FileWarning, Play, Ban, RotateCcw,
+} from 'lucide-react'
+import { cn } from '@/lib/utils'
+import {
+  getWordCountStatus, getWordCountPreflight, startWordCount, cancelWordCount, dismissWordCount,
+  type WordCountState, type WordCountPreflight,
+} from '@/lib/wordcount'
+
+const POLL_MS = 1000
+
+function formatBytes(n: number): string {
+  if (!n) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let i = 0
+  let v = n
+  while (v >= 1024 && i < units.length - 1) { v /= 1024; i++ }
+  return `${v.toFixed(i === 0 ? 0 : 1)} ${units[i]}`
+}
+
+function formatDuration(secs: number | null): string {
+  if (secs == null) return '—'
+  const s = Math.max(0, Math.round(secs))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  const rem = s % 60
+  if (m < 60) return `${m}m ${rem}s`
+  const h = Math.floor(m / 60)
+  return `${h}h ${m % 60}m`
+}
+
+function formatCount(n: number): string {
+  return n.toLocaleString()
+}
+
+const TERMINAL = new Set(['done', 'cancelled', 'error'])
+
+export function WordCountTab() {
+  const [preflight, setPreflight] = useState<WordCountPreflight | null>(null)
+  const [state, setState] = useState<WordCountState | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null }
+  }, [])
+
+  const poll = useCallback(async () => {
+    try {
+      const s = await getWordCountStatus()
+      setState(s)
+      if (TERMINAL.has(s.status) || s.status === 'idle') {
+        stopPolling()
+        getWordCountPreflight().then(setPreflight).catch(() => {})
+      }
+    } catch { /* keep last state */ }
+  }, [stopPolling])
+
+  const startPolling = useCallback(() => {
+    stopPolling()
+    pollRef.current = setInterval(poll, POLL_MS)
+  }, [poll, stopPolling])
+
+  // On mount: load preflight + current status; reconnect to a running job.
+  useEffect(() => {
+    let alive = true
+    Promise.all([getWordCountPreflight(), getWordCountStatus()])
+      .then(([pf, s]) => {
+        if (!alive) return
+        setPreflight(pf)
+        setState(s)
+        if (s.status === 'running') startPolling()
+      })
+      .catch(() => { if (alive) setError('Failed to load word-count status') })
+    return () => { alive = false; stopPolling() }
+  }, [startPolling, stopPolling])
+
+  async function handleStart() {
+    setBusy(true)
+    setError(null)
+    try {
+      const s = await startWordCount()
+      setState(s)
+      startPolling()
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to start')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function handleCancel() {
+    setBusy(true)
+    try {
+      const s = await cancelWordCount()
+      setState(s)
+    } catch { /* ignore */ } finally { setBusy(false) }
+  }
+
+  async function handleDismiss() {
+    setBusy(true)
+    try {
+      const s = await dismissWordCount()
+      setState(s)
+      getWordCountPreflight().then(setPreflight).catch(() => {})
+    } catch { /* ignore */ } finally { setBusy(false) }
+  }
+
+  const running = state?.status === 'running'
+  const terminal = state ? TERMINAL.has(state.status) : false
+  const pending = preflight?.pending ?? 0
+  const pct = state && state.total_bytes > 0
+    ? Math.min(100, (state.done_bytes / state.total_bytes) * 100)
+    : 0
+
+  return (
+    <div className="flex flex-col gap-4 max-w-2xl">
+      <div className="flex items-start gap-3">
+        <div className="w-9 h-9 rounded-lg bg-primary/10 text-primary flex items-center justify-center shrink-0">
+          <AlignLeft className="w-4 h-4" />
+        </div>
+        <div>
+          <h2 className="text-sm font-semibold">Word counts</h2>
+          <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
+            Parse each EPUB to store its word count. New uploads get this automatically — this
+            backfills books added before the feature. It only reads the files and writes one
+            number per book; nothing on disk is modified. Word counts power words-read and
+            reading-speed stats. PDF and CBZ are skipped.
+          </p>
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-3 py-2 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive flex items-center justify-between gap-2">
+          {error}
+          <button onClick={() => setError(null)} className="shrink-0 hover:opacity-70"><X className="w-3.5 h-3.5" /></button>
+        </div>
+      )}
+
+      {/* ── Idle: pre-flight + start ───────────────────────────────────────── */}
+      {!running && !terminal && (
+        <div className="border border-border rounded-xl bg-card overflow-hidden">
+          <div className="px-4 py-3 border-b border-border grid grid-cols-3 gap-2 text-center">
+            <Stat label="EPUBs" value={preflight ? formatCount(preflight.epub_total) : '—'} />
+            <Stat label="Already counted" value={preflight ? formatCount(preflight.already_counted) : '—'} />
+            <Stat label="To count" value={preflight ? formatCount(pending) : '—'} accent={pending > 0}
+              sub={preflight ? formatBytes(preflight.pending_bytes) : undefined} />
+          </div>
+          <div className="px-4 py-3">
+            <button
+              onClick={handleStart}
+              disabled={busy || pending === 0}
+              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
+              {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
+              {pending === 0 ? 'Every EPUB is counted' : `Count ${formatCount(pending)} EPUB${pending !== 1 ? 's' : ''}`}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Running: progress ──────────────────────────────────────────────── */}
+      {running && state && (
+        <div className="border border-border rounded-xl bg-card overflow-hidden">
+          <div className="px-4 py-3 border-b border-border">
+            <div className="flex items-center justify-between mb-2">
+              <span className="text-sm font-medium flex items-center gap-2">
+                <Loader2 className="w-4 h-4 animate-spin text-primary" />
+                Counting… {formatCount(state.done_files)} / {formatCount(state.total_files)}
+              </span>
+              <span className="text-xs text-muted-foreground tabular-nums">{pct.toFixed(1)}%</span>
+            </div>
+            <div className="h-2 rounded-full bg-muted overflow-hidden">
+              <div className="h-full bg-primary transition-all duration-500" style={{ width: `${pct}%` }} />
+            </div>
+            <div className="flex items-center justify-between mt-2 text-xs text-muted-foreground">
+              <span>{formatBytes(state.done_bytes)} / {formatBytes(state.total_bytes)}</span>
+              <span>Elapsed {formatDuration(state.elapsed_seconds)} · ~{formatDuration(state.eta_seconds)} left</span>
+            </div>
+          </div>
+          <div className="px-4 py-3 flex flex-col gap-3">
+            <div className="text-xs text-muted-foreground truncate">
+              <span className="text-foreground/70">Current:</span>{' '}
+              <span className="font-mono">{state.current_file?.split('/').pop() ?? '…'}</span>
+            </div>
+            <div className="grid grid-cols-3 gap-2 text-center">
+              <Stat label="Counted" value={formatCount(state.counted)} accent />
+              <Stat label="Words found" value={formatCount(state.words_total)} />
+              <Stat label="Failed" value={formatCount(state.failed)} danger={state.failed > 0} />
+            </div>
+            <button onClick={handleCancel} disabled={busy}
+              className="self-start flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border border-destructive/40 text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50">
+              <Ban className="w-3.5 h-3.5" /> Stop
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ── Terminal: end summary ──────────────────────────────────────────── */}
+      {terminal && state && (
+        <div className="border border-border rounded-xl bg-card overflow-hidden">
+          <div className={cn('px-4 py-3 border-b border-border flex items-center gap-2',
+            state.status === 'error' ? 'text-destructive' : state.status === 'cancelled' ? 'text-amber-600' : 'text-emerald-600')}>
+            {state.status === 'done' && <Check className="w-4 h-4" />}
+            {state.status === 'cancelled' && <Ban className="w-4 h-4" />}
+            {state.status === 'error' && <FileWarning className="w-4 h-4" />}
+            <span className="text-sm font-semibold">
+              {state.status === 'done' && 'Word count complete'}
+              {state.status === 'cancelled' && 'Word count stopped'}
+              {state.status === 'error' && 'Word count failed'}
+            </span>
+            <span className="ml-auto text-xs text-muted-foreground">Took {formatDuration(state.elapsed_seconds)}</span>
+          </div>
+          <div className="px-4 py-3 grid grid-cols-3 gap-2 text-center border-b border-border">
+            <Stat label="Counted" value={formatCount(state.counted)} accent />
+            <Stat label="Words found" value={formatCount(state.words_total)} />
+            <Stat label="Failed" value={formatCount(state.failed)} danger={state.failed > 0} />
+          </div>
+          {state.error && (
+            <div className="px-4 py-2 text-xs text-destructive border-b border-border">{state.error}</div>
+          )}
+          {state.issues.length > 0 && (
+            <div className="px-4 py-3 border-b border-border">
+              <p className="text-xs font-medium text-muted-foreground mb-1.5 flex items-center gap-1.5">
+                <FileWarning className="w-3.5 h-3.5" /> Could not parse ({state.issues.length})
+              </p>
+              <div className="max-h-64 overflow-y-auto flex flex-col gap-1">
+                {state.issues.map((it, i) => (
+                  <div key={i} className="text-[11px] flex items-center gap-2 py-1 border-b border-border/40 last:border-0">
+                    <span className="font-mono truncate" title={it.path}>{it.path.split('/').pop()}</span>
+                    {it.reason && <span className="text-muted-foreground/70 truncate ml-auto">{it.reason}</span>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="px-4 py-3 flex items-center gap-2">
+            <button onClick={handleDismiss} disabled={busy}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50">
+              {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />} Done
+            </button>
+            {state.failed > 0 && (
+              <button onClick={handleStart} disabled={busy}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border hover:bg-accent transition-colors disabled:opacity-50">
+                {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <RotateCcw className="w-3.5 h-3.5" />}
+                Retry {formatCount(state.failed)} failed
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Stat({ label, value, sub, accent, danger }: {
+  label: string; value: number | string; sub?: string; accent?: boolean; danger?: boolean
+}) {
+  return (
+    <div>
+      <p className={cn('text-lg font-semibold tabular-nums',
+        danger ? 'text-destructive' : accent ? 'text-primary' : 'text-foreground')}>
+        {value}
+      </p>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+      {sub && <p className="text-[10px] text-muted-foreground/70">{sub}</p>}
+    </div>
+  )
+}

--- a/frontend/src/lib/books.ts
+++ b/frontend/src/lib/books.ts
@@ -21,6 +21,7 @@ export interface Book {
   series_index: number | null
   year: number | null
   language: string | null
+  word_count: number | null
   status: string
   content_type: string
   cover_path: string | null

--- a/frontend/src/lib/wordcount.ts
+++ b/frontend/src/lib/wordcount.ts
@@ -1,0 +1,40 @@
+import { api } from './api'
+
+export type WordCountStatus = 'idle' | 'running' | 'done' | 'cancelled' | 'error'
+
+export interface WordCountIssue {
+  path: string
+  reason: string
+}
+
+export interface WordCountState {
+  status: WordCountStatus
+  started_at: number | null
+  finished_at: number | null
+  triggered_by: string | null
+  total_files: number
+  total_bytes: number
+  done_files: number
+  done_bytes: number
+  counted: number
+  failed: number
+  words_total: number
+  current_file: string | null
+  issues: WordCountIssue[]
+  error: string | null
+  elapsed_seconds: number
+  eta_seconds: number | null
+}
+
+export interface WordCountPreflight {
+  epub_total: number
+  already_counted: number
+  pending: number
+  pending_bytes: number
+}
+
+export const getWordCountStatus = () => api.get<WordCountState>('/admin/word-count/status')
+export const getWordCountPreflight = () => api.get<WordCountPreflight>('/admin/word-count/preflight')
+export const startWordCount = () => api.post<WordCountState>('/admin/word-count/start')
+export const cancelWordCount = () => api.post<WordCountState>('/admin/word-count/cancel')
+export const dismissWordCount = () => api.post<WordCountState>('/admin/word-count/dismiss')

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -11,6 +11,7 @@ import {
 import { DOCS, docsLink } from '@/lib/docs'
 import { MetadataManager } from '@/components/MetadataManager'
 import { LibraryHealthTab } from '@/components/LibraryHealth'
+import { WordCountTab } from '@/components/WordCount'
 import { SeriesCoverageStrip } from '@/components/SeriesCoverageStrip'
 import { useAuth, isAdmin } from '@/contexts/AuthContext'
 import { api } from '@/lib/api'
@@ -2003,7 +2004,7 @@ function WishlistTab() {
 
 // ── AdminPage ─────────────────────────────────────────────────────────────
 
-type Tab = 'users' | 'scanner' | 'server' | 'types' | 'audit' | 'metadata' | 'library' | 'sync' | 'duplicates' | 'email' | 'wishlist'
+type Tab = 'users' | 'scanner' | 'server' | 'types' | 'audit' | 'metadata' | 'library' | 'wordcount' | 'sync' | 'duplicates' | 'email' | 'wishlist'
 
 export function AdminPage() {
   const { user } = useAuth()
@@ -2027,6 +2028,7 @@ export function AdminPage() {
     { id: 'audit', label: 'Audit Log' },
     { id: 'metadata', label: 'Metadata' },
     { id: 'library', label: 'Library' },
+    { id: 'wordcount', label: 'Word Counts' },
     { id: 'sync', label: 'Sync Status' },
     { id: 'duplicates', label: 'Duplicates' },
     { id: 'email', label: 'Email' },
@@ -2070,6 +2072,7 @@ export function AdminPage() {
         {tab === 'audit' && <AuditTab />}
         {tab === 'metadata' && <MetadataManager />}
         {tab === 'library' && <LibraryHealthTab />}
+        {tab === 'wordcount' && <WordCountTab />}
         {tab === 'sync' && <SyncStatusTab />}
         {tab === 'duplicates' && <DuplicatesTab />}
         {tab === 'email' && <EmailTab />}

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -4,7 +4,7 @@ import {
   Camera, Download, Edit2, Save, X,
   Calendar, Globe, Hash, Building2, FileText, Trash2, Loader2,
   Sparkles, Library, Check, BookMarked, ChevronLeft, ChevronRight, Home,
-  Tag as TagIcon, StickyNote, ChevronDown, Archive, Star
+  Tag as TagIcon, StickyNote, ChevronDown, Archive, Star, AlignLeft
 } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
@@ -780,6 +780,9 @@ export function BookDetailPage() {
         <MetaField icon={<FileText className="w-3.5 h-3.5" />} label="Format"
           value={book.files.map(f => f.format.toUpperCase()).join(', ')} editing={false}
           onChange={() => {}} />
+        <MetaField icon={<AlignLeft className="w-3.5 h-3.5" />} label="Words"
+          value={book.word_count != null ? `${book.word_count.toLocaleString()} words` : ''}
+          editing={false} onChange={() => {}} />
         {/* Book Type */}
         <div className="flex items-start gap-2">
           <span className="text-muted-foreground mt-0.5 shrink-0"><TagIcon className="w-3.5 h-3.5" /></span>

--- a/tests/test_word_count.py
+++ b/tests/test_word_count.py
@@ -1,0 +1,107 @@
+"""Word-count parsing: the CJK-aware tokenizer + EPUB counting + ingest hook."""
+from pathlib import Path
+
+from ebooklib import epub
+
+from backend.services.metadata import (
+    count_words_text,
+    count_words_epub,
+    extract_metadata,
+)
+
+
+def _make_epub(path: Path, chapters: list[str]) -> None:
+    book = epub.EpubBook()
+    book.set_identifier("wc-test")
+    book.set_title("Word Count Test")
+    book.set_language("en")
+    items = []
+    for i, txt in enumerate(chapters):
+        c = epub.EpubHtml(title=f"Chapter {i}", file_name=f"c{i}.xhtml", lang="en")
+        c.content = f"<html><body><p>{txt}</p></body></html>"
+        book.add_item(c)
+        items.append(c)
+    book.toc = tuple(items)
+    book.add_item(epub.EpubNcx())
+    book.add_item(epub.EpubNav())
+    book.spine = ["nav"] + items
+    epub.write_epub(str(path), book)
+
+
+class TestTokenizer:
+    def test_plain_english(self):
+        assert count_words_text("The quick brown fox jumps") == 5
+
+    def test_contractions_and_hyphens_are_one_word(self):
+        # "don't" and "well-known" each count once
+        assert count_words_text("don't stop the well-known fox") == 5
+
+    def test_punctuation_is_not_words(self):
+        assert count_words_text("Hello, world!  —  ok.") == 3
+
+    def test_cjk_counts_per_character(self):
+        # No spaces between CJK chars; each ideograph is one "word".
+        assert count_words_text("你好世界") == 4
+
+    def test_mixed_latin_and_cjk(self):
+        assert count_words_text("Hello 你好") == 3  # Hello + 你 + 好
+
+    def test_empty(self):
+        assert count_words_text("") == 0
+        assert count_words_text("   \n\t  ") == 0
+
+
+class TestEpubWordCount:
+    def test_counts_body_text(self, tmp_path):
+        body = " ".join(f"word{i}" for i in range(50))  # 50 words
+        path = tmp_path / "book.epub"
+        _make_epub(path, [body])
+        count = count_words_epub(path)
+        assert count is not None
+        # Nav/TOC adds a little, body is the floor.
+        assert count >= 50
+
+    def test_sums_across_chapters(self, tmp_path):
+        path = tmp_path / "multi.epub"
+        _make_epub(path, ["alpha beta gamma", "delta epsilon"])  # 3 + 2
+        count = count_words_epub(path)
+        assert count is not None
+        assert count >= 5
+
+    def test_html_tags_not_counted(self, tmp_path):
+        path = tmp_path / "tags.epub"
+        # Markup tokens must not inflate the count.
+        _make_epub(path, ['<strong>one</strong> <em>two</em> three'])
+        count = count_words_epub(path)
+        assert count is not None
+        assert count >= 3 and count < 20
+
+    def test_corrupt_file_returns_none(self, tmp_path):
+        bad = tmp_path / "bad.epub"
+        bad.write_bytes(b"not really an epub")
+        assert count_words_epub(bad) is None
+
+    def test_falls_back_to_zip_when_ebooklib_cannot_parse(self, tmp_path):
+        # No META-INF/OPF → ebooklib raises, but the XHTML is readable, so the
+        # zip fallback still counts it (mirrors the broken-TOC/nav real files).
+        import zipfile
+
+        p = tmp_path / "broken.epub"
+        body = " ".join(f"w{i}" for i in range(40))
+        with zipfile.ZipFile(p, "w") as zf:
+            zf.writestr("mimetype", "application/epub+zip")
+            zf.writestr("OEBPS/ch1.xhtml", f"<html><body><p>{body}</p></body></html>")
+            zf.writestr("OEBPS/ch2.xhtml", "<html><body><p>alpha beta gamma</p></body></html>")
+        count = count_words_epub(p)
+        assert count is not None
+        assert count >= 43
+
+
+class TestIngestHook:
+    def test_extract_metadata_sets_word_count(self, tmp_path):
+        body = " ".join(f"w{i}" for i in range(120))
+        path = tmp_path / "ingest.epub"
+        _make_epub(path, [body])
+        meta = extract_metadata(path, tmp_path / "covers")
+        assert "word_count" in meta
+        assert meta["word_count"] >= 120

--- a/website/src/pages/docs/admin.astro
+++ b/website/src/pages/docs/admin.astro
@@ -11,7 +11,8 @@ import { withBase } from '../../lib/path'
   <h1>Admin tools</h1>
   <p>
     The admin panel (<strong>/admin</strong>) has tools for maintaining a clean library at scale:
-    duplicate detection, library health checks, and an Email tab for Send to Device. All admin-only.
+    duplicate detection, library health checks, word-count backfill, and an Email tab for Send to
+    Device. All admin-only.
   </p>
   <DocsMeta />
 
@@ -85,6 +86,34 @@ import { withBase } from '../../lib/path'
     This physically moves files in your <code>TOME_LIBRARY_DIR</code>. The database updates to
     match. If you mount <code>/books</code> as read-only, reorganise will fail — remount as
     read-write first.
+  </Callout>
+
+  <h2>Word counts</h2>
+  <p>
+    Tome records each EPUB's word count, shown in the <strong>Details</strong> panel on the book
+    page. New uploads are counted automatically as they're added — the <strong>Word Counts</strong>
+    tab is only for backfilling books that were in your library before the feature existed.
+  </p>
+  <p>
+    The tab shows how many EPUBs you have, how many already have a count, and how many are still
+    pending. Start the backfill and it runs in the background: progress, an ETA, and the running
+    word total update live. You can leave the page — it keeps going — and come back to a stop
+    button and a final summary.
+  </p>
+  <ul>
+    <li><strong>EPUB only.</strong> PDFs and comics (CBZ/CBR) don't get a word count.</li>
+    <li><strong>CJK aware.</strong> Chinese, Japanese, and Korean text is counted per character so
+      those titles aren't undercounted.</li>
+    <li><strong>Resumable.</strong> Stop any time, or restart after a server restart — it only
+      processes books that still need a count, so re-running just finishes the rest.</li>
+    <li><strong>Retry.</strong> A handful of EPUBs have malformed packaging that the normal parser
+      rejects; Tome falls back to reading the text straight from the file. Anything still uncounted
+      is reported, and a <strong>Retry failed</strong> button re-runs just those.</li>
+  </ul>
+
+  <Callout variant="info" title="Files are never modified">
+    Counting only reads your EPUBs and writes one number per book in the database. Nothing on disk
+    is touched. Word counts power the words-read and reading-speed stats.
   </Callout>
 
   <h2>Email (Send to Device)</h2>

--- a/website/src/pages/docs/changelog.astro
+++ b/website/src/pages/docs/changelog.astro
@@ -23,7 +23,50 @@ import { withBase } from '../../lib/path'
   </Callout>
 
   <h2>Unreleased</h2>
+  <h3>Added</h3>
   <ul>
+    <li>
+      <strong>Word counts for your books.</strong> Tome parses each EPUB's text to record its word
+      count, shown in the <strong>Details</strong> panel on the book page (CJK titles are counted
+      per character). New uploads are counted automatically; admins can backfill older books from a
+      new <strong>Word Counts</strong> tab under Admin — a background run that only reads your files
+      and shows live progress. Groundwork for upcoming reading-speed and words-read stats. See
+      <a href={withBase("/docs/admin#word-counts")}>Admin tools</a>.
+    </li>
+    <li>
+      <strong>A "Taste" tab on Reading Stats.</strong> A fourth board next to Overview / Habits /
+      Library, built from your book ratings: a rating distribution, taste by genre (your average
+      per book type), highest &amp; lowest rated, a rating-vs-time scatter, best-rated series, and a
+      rating trend. Each tile is add/move/resize/removable like every other, and they ignore the
+      date-range picker since ratings are all-time. Existing custom dashboards get the new tab
+      appended without touching your current boards. See <a href={withBase("/docs/stats")}>Stats</a>.
+    </li>
+    <li>
+      <strong>Five new Reading Stats tiles.</strong> <strong>Lifetime Totals</strong> (all-time
+      hours / pages / books / streak), <strong>Personal Records</strong> (longest session, biggest
+      reading day, most pages in a day), <strong>Library Completion</strong> (how much of what you
+      own you've read, overall and per type), a <strong>Reading Clock</strong> (24-hour radial of
+      when you read), and <strong>Reading by Language</strong>. They're not on any board by default —
+      add the ones you want from <strong>Add tile</strong>.
+    </li>
+    <li>
+      <strong>Stats now include reading from before TomeSync.</strong> KOReader keeps its own
+      per-page reading log going back to whenever you started reading — often long before Tome
+      existed. TomeSync can now import that history, backfilling your reading-time charts, streaks,
+      heat-map, top books and pace. The first sync pushes your whole history (chunked, resumable,
+      survives the device sleeping or dropping Wi-Fi); later syncs send only new reading. It imports
+      reading time and pages only — it never changes your read/unread status. Enable it under
+      <strong>TomeSync → Auto-sync reading history on launch</strong>, or run it once from
+      <strong>Sync reading history</strong>. Requires TomeSync plugin build 22.
+    </li>
+    <li>
+      <strong>Ratings set offline now sync.</strong> A rating or review you set on KOReader while
+      offline is now remembered and pushed to Tome the next time the device is online — on resume,
+      on <strong>Sync now</strong>, or when you next close a book. Previously a rating could be
+      stranded on the device if you rated a finished book and never reopened it. It now rides a
+      small pending queue (like reading sessions) that survives reboots. Requires TomeSync plugin
+      build 21.
+    </li>
     <li>
       <strong>Send to KOReader (beta).</strong> Queue a book from the web straight to your
       e-reader — no email, no Amazon. A split <strong>Send to KOReader</strong> button (the caret
@@ -31,6 +74,15 @@ import { withBase } from '../../lib/path'
       <strong>Inbox (N)</strong> badge (plugin build 16). Off by default —
       <code>TOME_SEND_TO_KOREADER=true</code>. See
       <a href={withBase("/docs/koreader#send-to-koreader")}>Send to KOReader</a>.
+    </li>
+  </ul>
+  <h3>Fixed</h3>
+  <ul>
+    <li>
+      <strong>The Day-streak on the Home tab now matches your Stats page.</strong> After importing
+      your KOReader reading history, the Home summary kept showing a shorter streak because it only
+      counted live TomeSync sessions and ignored the imported page-stat days. Both now count
+      reconciled reading, so a single consistent streak shows everywhere.
     </li>
   </ul>
 


### PR DESCRIPTION
## What

Phase 3 of the stats expansion: record an intrinsic, device-independent **word count** per book. This is the plumbing the upcoming Phase 4 stats need — words-read (lifetime + period), true WPM (`word_count` ÷ KOReader read-time), and book-length trends.

## How

- **`Book.word_count`** column (nullable int) + a startup `ALTER TABLE` so existing DBs gain it on next boot.
- **Parse at ingest** from the EPUB text, reusing the already-open book in `extract_epub` (no second parse). Wired into **every** creation path — library scan, web upload, API-token ingest, bindery accept, folder-watch.
- **CJK-aware tokenizer** — each Chinese/Japanese/Korean character counts as one word, so those titles aren't massively undercounted by whitespace-splitting.
- **Zip-level fallback** — a few EPUBs have malformed packaging (a manifest entry pointing at a missing file, or an empty EPUB3 `<nav>`) that `ebooklib` rejects outright even though the text is perfectly readable. When the parser bails we read the XHTML straight out of the archive. (Caught 3 real books in the dev library — all now count.)
- **Admin → Word Counts tab** — a cancellable background backfill over books added before the feature. Byte-weighted progress + ETA, resumable across restarts (it only touches `word_count IS NULL` books), live word total, and a **Retry failed** action. Read-only on disk — it only reads files and writes one integer per book. Modeled on the bake-to-file job pattern.
- **Book detail page** — a **Words** field in the Details panel (hidden for PDF/CBZ and not-yet-counted books).

## Tests

- `tests/test_word_count.py` — tokenizer (incl. CJK + contractions/hyphens), EPUB counting, the malformed-file zip fallback, and the ingest hook. 12 tests, green.
- Full backend suite green; `npm run build` (frontend) and the Astro website build both clean.

## Docs / changelog

- `CHANGELOG.md` `[Unreleased]`
- Website: new **Word counts** section in Admin tools, and a backfill of the website changelog's Unreleased list (it had drifted behind `main` — Taste tab, the five stats tiles, KOReader history import, offline-ratings sync, and the Home-streak fix were all missing).

## Notes

- Additive and low-risk: a library with no EPUBs / no counts behaves exactly as before.
- The backfill is opt-in and admin-only; new uploads are counted automatically going forward.