### PR TITLE
feat(stats): word-count tiles — Words Read, Reading Speed, Book Length (Phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ All notable changes to Tome are documented here. Format loosely follows
   stats. To fill in books added before this release, admins get a **Word Counts**
   tab under Admin with a one-click background backfill (it only reads your files —
   nothing on disk is changed — and shows live progress you can stop and resume).
+- **Three reading-speed & length tiles on Reading Stats.** Now that Tome counts
+  the words in your books, three new tiles turn that into insight: **Words Read**
+  (your lifetime word count, broken out by year once you've finished books across
+  more than one), **Reading Speed** (your true words-per-minute — words divided by
+  the time KOReader actually recorded — with your fastest and slowest books, side
+  by side on a wide tile), and **Book Length** (how long the books you finish tend
+  to be, as a distribution with your average, median and longest). They're not on
+  any board by default — add the ones you want from **Add tile** under Overview /
+  Habits / Library.
 - **A "Taste" tab on Reading Stats.** A fourth board next to Overview / Habits /
   Library, built from your book ratings: a **rating distribution** (how you spread
   your stars), **taste by genre** (your average rating per book type), your

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -810,6 +810,96 @@ def get_stats(
         key=lambda x: x["seconds"], reverse=True,
     )
 
+    # ── Word-count powered insights (Phase 4, all-time) ────────────────────────
+    # Words read (lifetime + by finish-year), true WPM (words ÷ reconciled
+    # read-time), and book-length distribution/trend. All derive from one pass
+    # over the user's finished ("read") books that have a parsed word_count.
+    import statistics as _statistics
+
+    read_word_rows = (
+        db.query(
+            Book.id, Book.title, Book.author, Book.cover_path, Book.word_count,
+            UserBookStatus.updated_at,
+        )
+        .select_from(UserBookStatus)
+        .join(Book, Book.id == UserBookStatus.book_id)
+        .filter(
+            UserBookStatus.user_id == current_user.id,
+            UserBookStatus.status == "read",
+            Book.status == "active",
+            Book.word_count.isnot(None),
+            book_visibility_filter(db, current_user),
+        )
+        .all()
+    )
+
+    WPM_MIN_SECONDS = 300  # below ~5 min of read-time a pace number is just noise
+
+    total_words = 0
+    words_by_year: dict[int, int] = {}
+    length_books: list[dict] = []
+    wpm_books: list[dict] = []
+    for r in read_word_rows:
+        wc = int(r.word_count)
+        total_words += wc
+        finished = r.updated_at
+        if finished:
+            words_by_year[finished.year] = words_by_year.get(finished.year, 0) + wc
+        length_books.append({
+            "book_id": r.id, "title": r.title, "has_cover": bool(r.cover_path),
+            "words": wc,
+            "finished": finished.date().isoformat() if finished else None,
+        })
+        secs = int(book_seconds_all.get(r.id, (0, 0, 0))[0])
+        if secs >= WPM_MIN_SECONDS:
+            wpm_books.append({
+                "book_id": r.id, "title": r.title, "author": r.author,
+                "has_cover": bool(r.cover_path),
+                "words": wc, "seconds": secs,
+                "wpm": round(wc * 60 / secs, 1),
+            })
+
+    words = {
+        "total_words": total_words,
+        "books_counted": len(length_books),
+        "by_year": [{"year": y, "words": w} for y, w in sorted(words_by_year.items())],
+    }
+
+    wpm_secs = sum(b["seconds"] for b in wpm_books)
+    wpm_words = sum(b["words"] for b in wpm_books)
+    wpm = {
+        "overall": round(wpm_words * 60 / wpm_secs, 1) if wpm_secs else 0,
+        "books_counted": len(wpm_books),
+        "books": sorted(wpm_books, key=lambda b: b["wpm"], reverse=True),
+    }
+
+    length_vals = [b["words"] for b in length_books]
+    _bucket_defs = [
+        (0, 50_000, "<50k"), (50_000, 100_000, "50–100k"),
+        (100_000, 150_000, "100–150k"), (150_000, 250_000, "150–250k"),
+        (250_000, None, "250k+"),
+    ]
+    length_buckets = [
+        {"label": lbl, "count": sum(1 for v in length_vals if v >= lo and (hi is None or v < hi))}
+        for lo, hi, lbl in _bucket_defs
+    ]
+    _len_year: dict[int, list[int]] = {}
+    for b in length_books:
+        if b["finished"]:
+            _len_year.setdefault(int(b["finished"][:4]), []).append(b["words"])
+    book_lengths = {
+        "count": len(length_vals),
+        "avg_words": int(_statistics.mean(length_vals)) if length_vals else 0,
+        "median_words": int(_statistics.median(length_vals)) if length_vals else 0,
+        "longest": max(length_books, key=lambda b: b["words"]) if length_books else None,
+        "buckets": length_buckets,
+        "by_year": [
+            {"year": y, "avg_words": int(_statistics.mean(v)), "count": len(v)}
+            for y, v in sorted(_len_year.items())
+        ],
+        "books": length_books,
+    }
+
     return {
         "range_days": effective_days,
         "headline": {
@@ -846,6 +936,9 @@ def get_stats(
         "records": records,
         "tbr": tbr,
         "language": language,
+        "words": words,
+        "wpm": wpm,
+        "book_lengths": book_lengths,
     }
 
 

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -57,6 +57,25 @@ export interface StatsResponse {
   records: { longest_session_seconds: number; longest_session_title: string | null; biggest_day_seconds: number; biggest_day_date: string | null; most_pages_day: number; most_pages_date: string | null }
   tbr: { owned: number; read: number; reading: number; shelved: number; unread: number; pct: number; by_type: { type: string; owned: number; read: number; pct: number }[] }
   language: { language: string; code: string; seconds: number; books: number }[]
+  words: {
+    total_words: number
+    books_counted: number
+    by_year: { year: number; words: number }[]
+  }
+  wpm: {
+    overall: number
+    books_counted: number
+    books: { book_id: number; title: string; author: string | null; has_cover: boolean; words: number; seconds: number; wpm: number }[]
+  }
+  book_lengths: {
+    count: number
+    avg_words: number
+    median_words: number
+    longest: { book_id: number; title: string; has_cover: boolean; words: number; finished: string | null } | null
+    buckets: { label: string; count: number }[]
+    by_year: { year: number; avg_words: number; count: number }[]
+    books: { book_id: number; title: string; has_cover: boolean; words: number; finished: string | null }[]
+  }
 }
 
 export interface CompletionEstimate {

--- a/frontend/src/components/stats/widgets/wordstats.tsx
+++ b/frontend/src/components/stats/widgets/wordstats.tsx
@@ -1,0 +1,139 @@
+// Phase 4 word-count stats widgets — words read, true WPM, book length.
+// All all-time (range-independent), powered by Book.word_count + reconciled read-time.
+import {
+  ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip,
+} from 'recharts'
+import { FileText } from 'lucide-react'
+import { useChartColors } from '@/lib/useChartAccent'
+import { ChartTooltip, type StatsResponse } from '@/components/stats/shared'
+
+function Empty({ text = 'No word counts yet.' }: { text?: string }) {
+  return <p className="py-10 text-center text-sm text-muted-foreground">{text}</p>
+}
+
+// Compact number: 1_240_000 -> "1.2M", 84_300 -> "84k", 932 -> "932".
+function compact(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n >= 10_000_000 ? 0 : 1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n >= 10_000 ? 0 : 1)}k`
+  return String(n)
+}
+
+function Cover({ id, has, alt }: { id: number | null; has: boolean; alt: string }) {
+  return (
+    <div className="flex h-12 w-8 shrink-0 items-center justify-center overflow-hidden rounded bg-muted">
+      {id && has ? (
+        <img src={`/api/books/${id}/cover`} alt={alt} className="h-full w-full object-cover" loading="lazy"
+          onError={(e) => { (e.target as HTMLImageElement).style.display = 'none' }} />
+      ) : (
+        <FileText className="h-3.5 w-3.5 text-muted-foreground" />
+      )}
+    </div>
+  )
+}
+
+// 1 ── Words Read: lifetime total + per-year bars (auto-fit, no fill-the-box chart)
+export function WordsRead({ data }: { data: StatsResponse['words'] }) {
+  const { accent } = useChartColors()
+  if (!data || data.books_counted === 0) return <Empty />
+  const years = data.by_year
+  const maxYear = Math.max(...years.map((y) => y.words), 1)
+  const avgPerBook = Math.round(data.total_words / data.books_counted)
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-2">
+        <span className="text-3xl font-bold leading-none text-foreground">{compact(data.total_words)}</span>
+        <span className="text-xs text-muted-foreground">words read · {data.books_counted} book{data.books_counted !== 1 ? 's' : ''}</span>
+      </div>
+      {years.length >= 2 && (
+        <div className="flex flex-col gap-1.5">
+          {years.map((y) => (
+            <div key={y.year}>
+              <div className="mb-0.5 flex items-center justify-between text-xs">
+                <span className="font-medium text-foreground">{y.year}</span>
+                <span className="tabular-nums text-muted-foreground">{compact(y.words)}</span>
+              </div>
+              <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+                <div className="h-full rounded-full" style={{ width: `${(y.words / maxYear) * 100}%`, backgroundColor: accent }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      <p className="text-xs text-muted-foreground">avg <span className="font-medium text-foreground">{compact(avgPerBook)}</span> words per book</p>
+    </div>
+  )
+}
+
+function WpmRow({ b }: { b: StatsResponse['wpm']['books'][number] }) {
+  return (
+    <div className="flex items-center gap-2.5">
+      <Cover id={b.book_id} has={b.has_cover} alt="" />
+      <div className="min-w-0 flex-1">
+        <a href={`/books/${b.book_id}`} className="line-clamp-1 text-sm font-medium text-foreground transition-colors hover:text-primary">{b.title}</a>
+        {b.author && <p className="truncate text-xs text-muted-foreground">{b.author}</p>}
+      </div>
+      <span className="shrink-0 text-sm font-bold tabular-nums text-foreground">{b.wpm.toLocaleString()}<span className="ml-0.5 text-[10px] font-normal text-muted-foreground">wpm</span></span>
+    </div>
+  )
+}
+
+// 2 ── True WPM: words ÷ reconciled read-time, overall + fastest/slowest ─────────
+// The fastest/slowest lists go side-by-side once the tile is wide enough
+// (container query, not viewport) — so a wide tile fills with two columns
+// instead of one tall list with dead space on the right.
+export function TrueWpm({ data }: { data: StatsResponse['wpm'] }) {
+  if (!data || data.books_counted === 0) return <Empty text="No timed reading with word counts yet." />
+  const fast = data.books.slice(0, 3)
+  const slow = data.books.length > 6 ? data.books.slice(-3).reverse() : []
+  return (
+    <div className="@container flex flex-col gap-3">
+      <div className="flex items-baseline gap-2">
+        <span className="text-3xl font-bold leading-none text-foreground">{data.overall.toLocaleString()}</span>
+        <span className="text-xs text-muted-foreground">words/min · across {data.books_counted} book{data.books_counted !== 1 ? 's' : ''}</span>
+      </div>
+      <div className="grid grid-cols-1 gap-x-8 gap-y-2.5 @md:grid-cols-2">
+        <div className="flex flex-col gap-2.5">
+          {fast.length > 0 && slow.length > 0 && <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Fastest</p>}
+          {fast.map((b) => <WpmRow key={b.book_id} b={b} />)}
+        </div>
+        {slow.length > 0 && (
+          <div className="flex flex-col gap-2.5">
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Slowest</p>
+            {slow.map((b) => <WpmRow key={b.book_id} b={b} />)}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// 3 ── Book Length: word-count distribution of finished books + avg/median ───────
+export function BookLength({ data }: { data: StatsResponse['book_lengths'] }) {
+  const { accent, tick, cursor } = useChartColors()
+  if (!data || data.count === 0) return <Empty />
+  return (
+    <div className="flex h-full flex-col gap-2">
+      <div className="min-h-0 flex-1">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data.buckets} margin={{ top: 8, right: 4, bottom: 0, left: 0 }}>
+            <XAxis dataKey="label" tick={{ fontSize: 10, fill: tick }} axisLine={false} tickLine={false} />
+            <YAxis allowDecimals={false} tick={{ fontSize: 9, fill: tick }} width={26} axisLine={false} tickLine={false} />
+            <Tooltip
+              cursor={cursor} wrapperStyle={{ outline: 'none' }} isAnimationActive={false}
+              content={({ active, payload }) => {
+                if (!active || !payload?.length) return null
+                const d = payload[0].payload
+                return <ChartTooltip><div className="font-medium">{d.label} words</div><div className="text-muted-foreground">{d.count} book{d.count !== 1 ? 's' : ''}</div></ChartTooltip>
+              }}
+            />
+            <Bar dataKey="count" fill={accent} radius={[4, 4, 0, 0]} isAnimationActive={false} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+      <p className="truncate text-[11px] text-muted-foreground">
+        avg <span className="font-medium text-foreground">{compact(data.avg_words)}</span> · median {compact(data.median_words)}
+        {data.longest && <> · longest <span className="text-foreground">{data.longest.title}</span> ({compact(data.longest.words)})</>}
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -8,7 +8,7 @@ import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import { Link } from 'react-router-dom'
 import { toPng } from 'html-to-image'
-import { ArrowLeft, Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, Trophy, Globe, Library as LibraryIcon, Clock3, Infinity as InfinityIcon, type LucideIcon } from 'lucide-react'
+import { ArrowLeft, Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, Trophy, Globe, Library as LibraryIcon, Clock3, Infinity as InfinityIcon, Type, Ruler, type LucideIcon } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { api } from '@/lib/api'
 import { SyncStatusBadge } from '@/components/SyncStatusBadge'
@@ -68,6 +68,11 @@ import {
   ReadingClock,
   ReadingByLanguage,
 } from '@/components/stats/widgets/insights'
+import {
+  WordsRead,
+  TrueWpm,
+  BookLength,
+} from '@/components/stats/widgets/wordstats'
 
 /**
  * Reading Stats — a fully customisable dashboard. Every chart is a tile on a
@@ -525,6 +530,35 @@ const WIDGETS: WidgetDef[] = [
     fixedWindow: 'all',
     render: ({ stats }) => <ReadingByLanguage data={stats.language} />,
   },
+  // Phase 4 — word-count powered (all-time)
+  {
+    id: 'words-read',
+    title: 'Words Read',
+    icon: Type,
+    size: { w: 6, h: 2, minW: 3, minH: 1 },
+    autoH: true,
+    fixedWindow: 'all',
+    defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
+    render: ({ stats }) => <WordsRead data={stats.words} />,
+  },
+  {
+    id: 'true-wpm',
+    title: 'Reading Speed',
+    icon: Gauge,
+    size: { w: 6, h: 3, minW: 3, minH: 2 },
+    autoH: true,
+    fixedWindow: 'all',
+    defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
+    render: ({ stats }) => <TrueWpm data={stats.wpm} />,
+  },
+  {
+    id: 'book-length',
+    title: 'Book Length',
+    icon: Ruler,
+    size: { w: 6, h: 3, minW: 3, minH: 2 },
+    fixedWindow: 'all',
+    render: ({ stats }) => <BookLength data={stats.book_lengths} />,
+  },
 ]
 
 const defById = (id: string) => WIDGETS.find((w) => w.id === id.replace(/--[a-z0-9]+$/, ''))!
@@ -577,6 +611,9 @@ const WIDGET_DESC: Record<string, string> = {
   'library-completion': 'How much of what you own you’ve read',
   'reading-clock': 'A 24-hour radial of when you read',
   'reading-by-language': 'Reading time split by language',
+  'words-read': 'Lifetime words read, by year',
+  'true-wpm': 'Your real reading speed — words ÷ time',
+  'book-length': 'How long the books you finish are',
 }
 
 // Widgets that are a number/short text — render their preview at natural size (no scale).
@@ -593,15 +630,15 @@ const SCROLL_IDS = new Set([
 const GALLERY_GROUPS: { label: string; ids: string[] }[] = [
   {
     label: 'Overview',
-    ids: ['stat-time', 'stat-sessions', 'stat-finished', 'stat-streak', 'stat-pages', 'stat-completion', 'stat-metric', 'goal', 'currently-reading', 'recently-finished', 'streak-calendar', 'daily', 'top-books', 'books-finished', 'activity-365', 'lifetime-totals', 'session-log'],
+    ids: ['stat-time', 'stat-sessions', 'stat-finished', 'stat-streak', 'stat-pages', 'stat-completion', 'stat-metric', 'goal', 'currently-reading', 'recently-finished', 'streak-calendar', 'daily', 'top-books', 'books-finished', 'activity-365', 'lifetime-totals', 'words-read', 'session-log'],
   },
   {
     label: 'Habits',
-    ids: ['hour-dow', 'reading-clock', 'session-timeline', 'reading-pace', 'pace-by-format', 'dow-bar', 'time-of-day', 'time-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'],
+    ids: ['hour-dow', 'reading-clock', 'session-timeline', 'reading-pace', 'pace-by-format', 'true-wpm', 'dow-bar', 'time-of-day', 'time-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'],
   },
   {
     label: 'Library',
-    ids: ['year-in-review', 'library-completion', 'series-completion', 'series-spotlight', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'per-book-table'],
+    ids: ['year-in-review', 'library-completion', 'series-completion', 'series-spotlight', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'book-length', 'per-book-table'],
   },
   {
     label: 'Taste',
@@ -658,6 +695,8 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
   'library-completion': { x: 0, y: 25, w: 4, h: 3 },   // Library
   'personal-records': { x: 4, y: 25, w: 4, h: 3 },     // Library
   'reading-by-language': { x: 8, y: 25, w: 4, h: 2 },  // Library
+  // (Phase 4 word-count tiles are gallery-only — no default placement; the gallery
+  // add-flow positions them from def.size, so they need no INITIAL_POS entry.)
 }
 
 // Each tab is its own board (own tiles + layout), independently customizable.
@@ -668,6 +707,8 @@ const TAB_DEFS: { id: string; label: string; ids: string[] }[] = [
   { id: 'habits', label: 'Habits', ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
   { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
   { id: 'taste', label: 'Taste', ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'] },
+  // Phase 4 word-count tiles (words-read / true-wpm / book-length) are gallery-only
+  // — addable from "Add tile" but on no default board, matching the batch-2 convention.
 ]
 
 function buildTab(def: { id: string; label: string; ids: string[] }): TabState {
@@ -1606,6 +1647,14 @@ export function StatsPage() {
   })
   const [activeTabId, setActiveTabId] = useState(() => loadPersisted()?.activeTabId ?? 'overview')
   const [renamingId, setRenamingId] = useState<string | null>(null)
+  // Keep the active board's tab scrolled into view — with many boards the tab
+  // strip scrolls, and the one you're on can sit off-screen otherwise. Re-run on
+  // edit toggle too, since the per-tab edit icons widen the strip enough to push
+  // the active tab out of view.
+  const activeTabRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({ inline: 'nearest', block: 'nearest' })
+  }, [activeTabId, editMode])
   const [tabMenuOpen, setTabMenuOpen] = useState(false)
   const [saveState, setSaveState] = useState<'idle' | 'saving' | 'saved' | 'error'>('idle')
   const [undo, setUndo] = useState<{ label: string; restore: () => void } | null>(null)
@@ -1953,11 +2002,15 @@ export function StatsPage() {
         </div>
 
         {/* board tabs (pills, like the Stats page) + board tools */}
-        <div className="overflow-x-auto border-t border-border/50">
+        <div className="border-t border-border/50">
           <div className={cn('flex items-center gap-1 py-1.5 transition-[padding] duration-200', PAD_X[pad])}>
+            {/* Only the tabs scroll horizontally; the + and board tools stay pinned
+                and reachable however many boards you add. */}
+            <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
             {tabs.map((t) => (
               <div
                 key={t.id}
+                ref={activeTabId === t.id ? activeTabRef : undefined}
                 className={cn(
                   'group/tab flex shrink-0 items-center rounded-md transition-all',
                   activeTabId === t.id ? 'bg-muted text-foreground shadow-sm' : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
@@ -2018,6 +2071,7 @@ export function StatsPage() {
                 )}
               </div>
             ))}
+            </div>
             {editMode && (
               <div className="relative shrink-0">
                 <button

--- a/tests/test_stats_word_count.py
+++ b/tests/test_stats_word_count.py
@@ -1,0 +1,74 @@
+"""Phase 4 word-count stats blocks: words / wpm / book_lengths on /api/stats."""
+from datetime import datetime
+
+from backend.models.tome_sync import ReadingSession
+from backend.models.user_book_status import UserBookStatus
+
+
+def _finish(db, user, book, when):
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="read", updated_at=when))
+
+
+def _session(db, user, book, secs, when):
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when,
+                          ended_at=when, duration_seconds=secs, pages_turned=10))
+
+
+def test_word_count_blocks(client, db, admin_user, make_book):
+    user, _ = admin_user
+
+    a = make_book(title="A"); a.word_count = 100_000
+    b = make_book(title="B"); b.word_count = 60_000
+    c = make_book(title="C"); c.word_count = 200_000
+    # finished but no word_count (e.g. a PDF) → excluded everywhere
+    d = make_book(title="D", file_format="pdf"); d.word_count = None
+    db.flush()
+
+    _finish(db, user, a, datetime(2025, 3, 1))
+    _finish(db, user, b, datetime(2026, 1, 1))
+    _finish(db, user, c, datetime(2026, 2, 1))
+    _finish(db, user, d, datetime(2026, 2, 2))
+    # read-time: A & C get enough to count for WPM; B is under the 5-min floor
+    _session(db, user, a, 6000, datetime(2025, 3, 1))   # 100k/6000s -> 1000 wpm
+    _session(db, user, c, 6000, datetime(2026, 2, 1))   # 200k/6000s -> 2000 wpm
+    _session(db, user, b, 120, datetime(2026, 1, 1))    # < 300s -> excluded from WPM
+    db.flush()
+
+    s = client.get("/api/stats?days=0").json()
+
+    # ── words ──
+    w = s["words"]
+    assert w["total_words"] == 360_000          # a + b + c (d has none)
+    assert w["books_counted"] == 3
+    assert w["by_year"] == [
+        {"year": 2025, "words": 100_000},
+        {"year": 2026, "words": 260_000},        # b + c
+    ]
+
+    # ── wpm ──
+    wpm = s["wpm"]
+    assert wpm["books_counted"] == 2             # a, c (b under floor)
+    assert wpm["overall"] == 1500.0             # (100k+200k)*60 / (6000+6000)
+    assert [bk["title"] for bk in wpm["books"]] == ["C", "A"]  # sorted wpm desc
+    assert wpm["books"][0]["wpm"] == 2000.0
+
+    # ── book_lengths ──
+    bl = s["book_lengths"]
+    assert bl["count"] == 3
+    assert bl["avg_words"] == 120_000           # (100k+60k+200k)/3
+    assert bl["median_words"] == 100_000
+    assert bl["longest"]["title"] == "C"
+    counts = {b["label"]: b["count"] for b in bl["buckets"]}
+    assert counts == {"<50k": 0, "50–100k": 1, "100–150k": 1, "150–250k": 1, "250k+": 0}
+
+
+def test_word_count_blocks_empty_user(client, db, admin_user, make_book):
+    # A user with no finished+counted books gets well-formed empty blocks.
+    make_book(title="Unread")  # exists but never finished
+    db.flush()
+    s = client.get("/api/stats?days=0").json()
+    assert s["words"] == {"total_words": 0, "books_counted": 0, "by_year": []}
+    assert s["wpm"] == {"overall": 0, "books_counted": 0, "books": []}
+    assert s["book_lengths"]["count"] == 0
+    assert s["book_lengths"]["avg_words"] == 0
+    assert s["book_lengths"]["longest"] is None

--- a/website/src/pages/docs/stats.astro
+++ b/website/src/pages/docs/stats.astro
@@ -24,12 +24,13 @@ import { withBase } from '../../lib/path'
   <p>
     Hit <strong>Edit</strong> and the grid opens up: drag tiles by their header, resize them by
     the corner handle, remove or duplicate them, and undo a removal straight from the toast.
-    <strong>Add tile</strong> opens a gallery of 35 widgets with live previews — everything
+    <strong>Add tile</strong> opens a gallery of 50 widgets with live previews — everything
     documented below, plus extras like a paginated session log, reading by weekday, a
-    time-of-day split, time by format, recently finished, and a monthly streak calendar.
+    time-of-day split, time by format, recently finished, a monthly streak calendar, and the
+    word-count tiles (words read, reading speed, book length).
   </p>
   <div class="docs-shot-bare">
-    <ThemedShot client:load name="stats-add-tile" alt="The add-widget gallery: live previews of all 35 widgets, with search and on-board filters" />
+    <ThemedShot client:load name="stats-add-tile" alt="The add-widget gallery: live previews of all 50 widgets, with search and on-board filters" />
   </div>
   <p>
     Tiles are individually configurable where it makes sense: chart tiles switch between bar,


### PR DESCRIPTION
## What

Phase 4 of the stats expansion — turns the per-book `word_count` (Phase 3, #72) into reader-facing insight with three new Reading Stats tiles:

- **Words Read** — lifetime word count, broken out by year once you've finished books across more than one.
- **Reading Speed** — your true words-per-minute: `word_count ÷` the time KOReader actually recorded (reconciled, idle-capped), with your fastest and slowest books. On real data this reads ~404 wpm overall, which is a believable pace.
- **Book Length** — how long the books you finish tend to be: a word-count distribution with average, median, and longest.

All three are **gallery-only** (no default board — addable from **Add tile** under Overview / Habits / Library), matching the batch-2 convention.

## How

- **Backend** (`backend/api/stats.py`): three new all-time blocks — `words`, `wpm`, `book_lengths` — computed in a single pass over the user's finished (`read`) books that have a `word_count`. Range-independent like `ratings`/`lifetime`. WPM uses a 5-minute read-time floor so a tiny session can't produce a garbage pace.
- **Frontend**: new `widgets/wordstats.tsx` (`WordsRead` / `TrueWpm` / `BookLength`) + `StatsResponse` types; registered in the widget catalog and the Add-tile gallery. Words Read and Reading Speed are **auto-fit height**; Reading Speed splits into **two columns** (Fastest | Slowest) when the tile is wide, via a **container query** (reacts to the tile's width, not the viewport).

## Dashboard chrome fixes (surfaced during review)

- The edit-mode toolbar put the tabs *and* the action buttons in one horizontal-scroll row, so with several boards the buttons (incl. **Done**) got pushed off-screen. Now **only the tab strip scrolls**; the `+` and the board tools stay pinned.
- The active board's tab now **auto-scrolls into view** on switch / edit-toggle, so you can always see which board you're on.

## Tests

- `tests/test_stats_word_count.py` — the three blocks on seeded data (per-year split, WPM floor + ordering, length buckets/avg/median/longest) and a well-formed empty-user case.
- Full backend suite green; frontend `npm run build` and the Astro website build both clean.
- Verified headless on the dev library against real data (0 console errors).

## Docs / changelog

- `CHANGELOG.md` `[Unreleased]`; website stats docs (corrected the stale widget count and listed the new tiles in the gallery).

## Notes

- Additive: a user with no finished+counted books gets well-formed empty blocks and the rest of `/api/stats` is unchanged.
- The **by-year** split only fills out as you finish books over calendar time — imported KOReader history all lands in the period it was marked read — but the tile is designed so that doesn't leave dead space.