### PR TITLE
fix(tomesync): self-heal sync back-off instead of latching offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ All notable changes to Tome are documented here. Format loosely follows
   1.5.1.)
 
 ### Fixed
+- **TomeSync no longer gets stuck "offline" after your Kindle wakes up.** When the
+  device slept and Wi-Fi dropped, three failed sync attempts in a row used to latch
+  TomeSync into a permanent back-off — it then skipped every request and never
+  recovered until KOReader was fully restarted, even once the network was back.
+  Back-off is now time-based: it goes quiet for a minute, then quietly retries, and
+  also clears the moment Wi-Fi reconnects, so reading sessions and positions resume
+  syncing on their own. (Requires updating the KOReader plugin to build 23 via
+  **TomeSync → Check for updates**.)
 - **The Day-streak on the Home tab now matches your stats page.** After importing
   your KOReader reading history, the Home summary kept showing a shorter streak
   than the Stats page because it only counted live TomeSync sessions and ignored

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 22
-TOMESYNC_PLUGIN_SEMVER = "1.6.0"
+TOMESYNC_PLUGIN_BUILD = 23
+TOMESYNC_PLUGIN_SEMVER = "1.6.1"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1219,9 +1219,16 @@ local USERNAME   = "{username}"
 -- Short timeout so unreachable server doesn't freeze the UI
 http.TIMEOUT = 5
 
--- Track consecutive failures for backoff
+-- Track consecutive failures for backoff. Time-based so it self-heals:
+-- once we hit the threshold we go quiet for BACKOFF_COOLDOWN seconds, then
+-- let a single probe through. A success clears the latch; a failure re-arms
+-- it. Without the time window this was a one-way latch — three failures while
+-- the device slept (no WiFi) wedged it permanently until a KOReader restart,
+-- because the only reset path (a successful request) was gated behind the latch.
 local consecutive_failures = 0
 local MAX_BACKOFF_FAILURES = 3
+local BACKOFF_COOLDOWN     = 60   -- seconds to stay quiet before re-probing
+local backoff_until        = 0    -- os.time() before which requests are skipped
 
 -- Chunk-local (shared across plugin instances): dedupes _initSession when the
 -- ReaderReady event reaches more than one live TomeSync instance for the same
@@ -1259,8 +1266,10 @@ local function apiRequest(method, path, body)
         return nil, "offline"
     end
 
-    -- Skip requests if server has been unreachable repeatedly (backoff)
-    if consecutive_failures >= MAX_BACKOFF_FAILURES then
+    -- Skip requests while the backoff window is open. Once it expires we fall
+    -- through and let one probe attempt the request, so connectivity recovery
+    -- is detected automatically rather than only on a KOReader restart.
+    if consecutive_failures >= MAX_BACKOFF_FAILURES and os.time() < backoff_until then
         logger.warn("TomeSync: skipping request (server unreachable, backing off)")
         return nil, "backoff"
     end
@@ -1288,13 +1297,15 @@ local function apiRequest(method, path, body)
 
     if not ok then
         consecutive_failures = consecutive_failures + 1
+        backoff_until = os.time() + BACKOFF_COOLDOWN
         logger.warn("TomeSync: request failed:", tostring(code),
                      "(" .. consecutive_failures .. "/" .. MAX_BACKOFF_FAILURES .. ")")
         return nil, code
     end
 
-    -- Server reachable — reset backoff counter
+    -- Server reachable — clear the backoff latch
     consecutive_failures = 0
+    backoff_until = 0
 
     local resp_body = table.concat(resp_chunks)
     if code == 404 then return nil, 404 end
@@ -1746,6 +1757,17 @@ function TomeSync:onResume()
     self:_pushPosition()
 
     -- Flush any pending sessions / ratings from offline periods
+    self:_flushPendingSessions()
+    self:_flushPendingRatings()
+end
+
+-- WiFi just came back: drop the backoff latch immediately so we don't sit out
+-- the cooldown, then catch up anything queued while we were offline. The latch
+-- is chunk-local, so clearing it here unblocks every TomeSync instance at once.
+function TomeSync:onNetworkConnected()
+    consecutive_failures = 0
+    backoff_until = 0
+    if not self.enabled or not self.book_id then return end
     self:_flushPendingSessions()
     self:_flushPendingRatings()
 end

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -150,5 +150,7 @@ def test_build_bumped_for_rebake():
     # reopen still syncs its rating (the per-book open/close push alone missed it).
     # 1.6.0 / build 22 imports KOReader's statistics.sqlite3 (per-page reading
     # history) so stats backfill reading from before TomeSync (time & pages only).
-    assert TOMESYNC_PLUGIN_BUILD >= 22
-    assert TOMESYNC_PLUGIN_SEMVER == "1.6.0"
+    # 1.6.1 / build 23 makes the sync back-off time-based (+ clears on
+    # NetworkConnected) so it self-heals instead of latching offline after sleep.
+    assert TOMESYNC_PLUGIN_BUILD >= 23
+    assert TOMESYNC_PLUGIN_SEMVER == "1.6.1"


### PR DESCRIPTION
## Problem

A user's Kindle silently stopped syncing with Tome despite being on the network. The KOReader crashlog showed every request being skipped with `skipping request (server unreachable, backing off)` — even after `Wi-Fi successfully restored` and with the server confirmed reachable from the device (`curl /api/health` → 200).

Root cause: the plugin's back-off was a **one-way latch**. Three consecutive request failures (e.g. while the device slept with Wi-Fi down → `Network is unreachable`) pinned `consecutive_failures` at the threshold. After that the guard short-circuited *every* `apiRequest`, and the only reset path — a successful request — was gated behind that same guard. The latch only cleared on a full KOReader restart, so sync stayed dead even once the network and server were back.

## Fix

Make back-off **time-based** so it self-heals:
- After hitting the threshold we stay quiet for `BACKOFF_COOLDOWN` (60s) via `backoff_until`, then let a single probe through. A success clears the latch; a failure re-arms it.
- Also clear the latch on the `NetworkConnected` event, so recovery is **instant** when Wi-Fi reconnects rather than waiting out the cooldown.

Plugin **build 22 → 23** (semver 1.6.1). The fix is contained in the baked plugin impl in `backend/api/tome_sync.py`.

## Verification

Ran the actual build-23 plugin in the KOReader emulator against a live Tome backend and exercised the real `apiRequest` gate + `onNetworkConnected` handler via their shared upvalues:

| Check | Result |
|---|---|
| Rendered impl parses under luajit | pass |
| Back-off control-flow harness (latch → cooldown → re-probe → reconnect) | 9/9 |
| Plugin loads in emulator at build 23 | pass |
| Real `NetworkConnected` broadcast clears a wedged latch (`cf 3→0`, `bu→0`) | pass |
| Latched + cooldown open → request skipped (`backoff`) | pass |
| Latched + cooldown expired → request attempted → `200` → latch self-clears | pass |

The old code returned `backoff` in the last two cases forever; now it self-heals.

## Upgrade note

Devices pick this up via **TomeSync → Check for updates** (build 23 > 22). Graceful update — no manual reinstall.