### PR TITLE
fix(tomesync): stop filename resolver mapping later volumes onto volume 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ All notable changes to Tome are documented here. Format loosely follows
   1.5.1.)
 
 ### Fixed
+- **KOReader no longer syncs one book's reading progress onto another.** When the
+  plugin had to match a book by filename (e.g. after a file was moved or "Re-resolve
+  all books" was used), a series whose name matched its first book's title — combined
+  with a flat `{series} - 02 - {title}` download-naming template — could resolve every
+  volume back to volume 1, so later volumes overwrote volume 1's position. The matcher
+  now reads the volume number from all the filename shapes Tome produces, treats it as
+  authoritative, and refuses to resolve (rather than guess wrong) when a filename is
+  genuinely ambiguous.
 - **TomeSync no longer gets stuck "offline" after your Kindle wakes up.** When the
   device slept and Wi-Fi dropped, three failed sync attempts in a row used to latch
   TomeSync into a permanent back-off — it then skipped every request and never

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -87,18 +87,21 @@ def resolve_book(
 ):
     """Match a filename to a Tome book ID.
 
-    KOReader OPDS downloads save files as 'Author - Vol. X — Title.ext'.
-    We try multiple strategies, including volume number extraction.
+    Download paths name files differently — OPDS/single download use
+    '{title}.ext', the series browser uses 'Vol. X — Title.ext', and a user
+    naming template can produce e.g. '{series} - 02 - {title}.ext'. This is a
+    best-effort fallback used only when the plugin has no cached id for the file,
+    so it must never *guess* between two plausible books: a wrong guess silently
+    writes one book's reading progress onto another (issue: vol-2 mapped to
+    vol-1 because the series shared its name with its first book, so vol-1's
+    title appeared inside vol-2's filename).
     """
     import re
 
     stem = filename.rsplit(".", 1)[0] if "." in filename else filename
+    stem_l = stem.lower()
 
-    # Extract volume number from filename (e.g. "Vol. 1", "Vol. 12", "v01")
-    vol_match = re.search(r'[Vv]ol\.?\s*(\d+)', stem)
-    vol_num = float(vol_match.group(1)) if vol_match else None
-
-    # 1. Exact file path match in book_files
+    # 1. Exact file path match in book_files — the only unambiguous signal.
     book_file = (
         db.query(BookFile)
         .filter(BookFile.file_path.endswith("/" + filename) | (BookFile.file_path == filename))
@@ -109,44 +112,60 @@ def resolve_book(
         if book and book.status == "active":
             return {"book_id": book.id}
 
-    # 2. Extract title part and match with volume
-    title_part = None
-    if "\u2014" in stem:  # em dash: 'Author - Vol. X — Title'
-        title_part = stem.split("\u2014")[-1].strip()
-    elif " - " in stem:  # regular dash fallback
-        parts = stem.split(" - ", 1)
-        title_part = parts[-1].strip()
-        # Remove "Vol. X" prefix from title_part if present
-        title_part = re.sub(r'^[Vv]ol\.?\s*\d+\s*[-—]?\s*', '', title_part).strip()
+    # Volume number, in any of the shapes the download paths emit:
+    #   "Vol. 12", "v01", or a separator-delimited token "Series - 02 - Title".
+    vol_num = None
+    vol_match = (
+        re.search(r'[Vv]ol\.?\s*(\d+)', stem)
+        or re.search(r'\bv(\d{1,3})\b', stem)
+        or re.search(r'[-—]\s*0*(\d+)\s*[-—]', stem)
+    )
+    if vol_match:
+        vol_num = float(vol_match.group(1))
 
-    if title_part:
-        query = db.query(Book).filter(
-            Book.title.ilike(f"%{title_part}%"), Book.status == "active"
+    all_active = db.query(Book).filter(Book.status == "active").all()
+
+    # 2. Forward match: the book's title appears inside the filename. This is the
+    #    strong signal — the download paths all put the title into the name.
+    candidates = [b for b in all_active if b.title and b.title.lower() in stem_l]
+
+    # When the filename carries a volume number it is authoritative: it selects
+    # the right volume AND rejects any candidate whose series_index disagrees.
+    # This is what stops vol-2's filename (which contains vol-1's title when the
+    # series shares its name with its first book) from resolving to vol-1.
+    if vol_num is not None:
+        exact = [b for b in candidates if b.series_index == vol_num]
+        if len(exact) == 1:
+            return {"book_id": exact[0].id}
+        candidates = [
+            b for b in candidates
+            if b.series_index is None or b.series_index == vol_num
+        ]
+
+    if len(candidates) == 1:
+        return {"book_id": candidates[0].id}
+
+    if candidates:
+        # Most-specific title wins: the longest book title present in the filename
+        # (e.g. "Dune Messiah" beats the "Dune" nested inside it). A tie is
+        # genuinely ambiguous — refuse rather than clobber another book's progress.
+        candidates.sort(key=lambda b: len(b.title or ""), reverse=True)
+        if len(candidates[0].title) > len(candidates[1].title):
+            return {"book_id": candidates[0].id}
+        raise HTTPException(
+            status_code=404, detail="Ambiguous filename; could not resolve uniquely"
         )
-        if vol_num is not None:
-            # Prefer exact volume match
-            book = query.filter(Book.series_index == vol_num).first()
-            if book:
-                return {"book_id": book.id}
-        # Fall back to first match if no volume info
-        book = query.first()
-        if book:
-            return {"book_id": book.id}
 
-    # 3. Reverse match: book title contained in filename, with volume
-    books = db.query(Book).filter(Book.status == "active").all()
-    for book in books:
-        if book.title and book.title.lower() in stem.lower():
-            if vol_num is not None and book.series_index is not None:
-                if book.series_index == vol_num:
-                    return {"book_id": book.id}
-            else:
-                return {"book_id": book.id}
-
-    # 4. Reverse match without volume constraint (last resort)
-    for book in books:
-        if book.title and book.title.lower() in stem.lower():
-            return {"book_id": book.id}
+    # 3. Reverse fallback: the filename is a substring of exactly one title
+    #    (handles truncated/shortened names). Honour the volume here too.
+    reverse = [b for b in all_active if b.title and stem_l in b.title.lower()]
+    if vol_num is not None:
+        reverse = [
+            b for b in reverse
+            if b.series_index is None or b.series_index == vol_num
+        ]
+    if len(reverse) == 1:
+        return {"book_id": reverse[0].id}
 
     raise HTTPException(status_code=404, detail="No matching book found")
 

--- a/tests/test_tomesync_resolve.py
+++ b/tests/test_tomesync_resolve.py
@@ -1,0 +1,113 @@
+"""Tests for `GET /api/tome-sync/resolve` — the filename→book_id fallback the
+KOReader plugin uses when it has no cached id for an opened file.
+
+Regression anchor: a series named identically to its first book, downloaded with
+a flat `{series} - 02 - {title}` naming template, used to resolve *every* volume
+to vol 1 (vol 1's title is a substring of every volume's filename, and the bare
+"02" wasn't recognised as a volume). That silently overwrote vol 1's reading
+progress with later volumes'. The resolver must now refuse to guess.
+"""
+from backend.models.tome_sync import ApiKey
+
+
+def _api_key_for(db, user_id: int) -> str:
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(user_id=user_id, key_hash=ApiKey.hash_key(plaintext),
+                  key_prefix=plaintext[:11], label="test"))
+    db.flush()
+    return plaintext
+
+
+def _resolve(client, hdr, filename):
+    return client.get("/api/tome-sync/resolve", headers=hdr, params={"filename": filename})
+
+
+def test_flat_template_series_equals_vol1_title(client, db, admin_user, make_book):
+    """The reported bug: series name == vol-1 title, flat `{series} - NN - {title}`
+    filenames. Each volume must resolve to itself, never collapse onto vol 1."""
+    user, _ = admin_user
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+
+    v1 = make_book(title="Shield of Sparrows", series="Shield of Sparrows",
+                   series_index=1, file_path="/library/sos/v1.epub")
+    v2 = make_book(title="Shield of Sparrows - The Gathering", series="Shield of Sparrows",
+                   series_index=2, file_path="/library/sos/v2.epub")
+
+    # Filenames as the flat home-folder template renders them on the device.
+    r1 = _resolve(client, hdr, "Shield of Sparrows - 01 - Shield of Sparrows.epub")
+    r2 = _resolve(client, hdr, "Shield of Sparrows - 02 - Shield of Sparrows - The Gathering.epub")
+
+    assert r1.status_code == 200 and r1.json()["book_id"] == v1.id, r1.text
+    assert r2.status_code == 200 and r2.json()["book_id"] == v2.id, r2.text
+
+
+def test_duplicate_titles_disambiguated_by_volume(client, db, admin_user, make_book):
+    """Both volumes literally share the same title; only the volume number tells
+    them apart. The filename's volume must pick the right one."""
+    user, _ = admin_user
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+
+    v1 = make_book(title="Berserk", series="Berserk", series_index=1,
+                   file_path="/library/berserk/v1.epub")
+    v2 = make_book(title="Berserk", series="Berserk", series_index=2,
+                   file_path="/library/berserk/v2.epub")
+
+    assert _resolve(client, hdr, "Berserk - 01 - Berserk.epub").json()["book_id"] == v1.id
+    assert _resolve(client, hdr, "Berserk - 02 - Berserk.epub").json()["book_id"] == v2.id
+
+
+def test_builtin_vol_prefix_resolves(client, db, admin_user, make_book):
+    """Series-browser built-in layout: 'Vol. N — Title.ext'."""
+    user, _ = admin_user
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+
+    make_book(title="Sword Art Online", series="Sword Art Online", series_index=1,
+              file_path="/library/sao/v1.epub")
+    v2 = make_book(title="Sword Art Online", series="Sword Art Online", series_index=2,
+                   file_path="/library/sao/v2.epub")
+
+    r = _resolve(client, hdr, "Vol. 2 — Sword Art Online.epub")
+    assert r.status_code == 200 and r.json()["book_id"] == v2.id, r.text
+
+
+def test_most_specific_title_wins(client, db, admin_user, make_book):
+    """When one title is nested inside another and there's no volume, the longer
+    (more specific) match wins — and the shorter standalone still resolves."""
+    user, _ = admin_user
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+
+    dune = make_book(title="Dune", file_path="/library/dune/dune.epub")
+    messiah = make_book(title="Dune Messiah", file_path="/library/dune/messiah.epub")
+
+    assert _resolve(client, hdr, "Dune.epub").json()["book_id"] == dune.id
+    assert _resolve(client, hdr, "Dune Messiah.epub").json()["book_id"] == messiah.id
+
+
+def test_exact_path_match_short_circuits(client, db, admin_user, make_book):
+    """An exact on-disk path match is unambiguous and wins outright."""
+    user, _ = admin_user
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+
+    book = make_book(title="Whatever", file_path="/library/x/the-real-file.epub")
+    r = _resolve(client, hdr, "the-real-file.epub")
+    assert r.status_code == 200 and r.json()["book_id"] == book.id
+
+
+def test_volume_contradiction_refuses_rather_than_misresolve(client, db, admin_user, make_book):
+    """Filename says volume 2 but the only title-match is vol 1 (its title token
+    absent). Resolving to vol 1 would corrupt its progress — return 404 instead."""
+    user, _ = admin_user
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+
+    make_book(title="Shield of Sparrows", series="Shield of Sparrows", series_index=1,
+              file_path="/library/sos/v1.epub")
+    # No vol-2 book exists in the library yet.
+    r = _resolve(client, hdr, "Shield of Sparrows - 02 -.epub")
+    assert r.status_code == 404, r.text
+
+
+def test_no_match_returns_404(client, db, admin_user, make_book):
+    user, _ = admin_user
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    make_book(title="Something Else", file_path="/library/se/se.epub")
+    assert _resolve(client, hdr, "Totally Unrelated.epub").status_code == 404


### PR DESCRIPTION
## What

`GET /api/tome-sync/resolve` is the fallback the KOReader plugin uses when it has **no cached id** for an opened file (the file was moved, or the user ran "Re-resolve all books", which wipes the local path→id map). The old resolver matched a filename to a book by fuzzy title-in-filename containment and returned the **first** (lowest-id) book that matched.

That mis-resolves when a **series is named identically to its first book** and the file was downloaded with the **flat `{series} - 02 - {title}` naming template**: volume 1's title is a substring of every volume's filename, and the bare `02` wasn't recognised as a volume number (the old regex only matched `Vol. N`). So every volume resolved back to volume 1 — and later volumes' progress silently overwrote volume 1's reading position.

Reported via Reddit by a user with a "Shield of Sparrows" series whose vol 1 is titled "Shield of Sparrows".

## Fix

`resolve_book` now:
- parses the volume number from **all** filename shapes Tome emits — `Vol. 12`, `v01`, and the separator-delimited `… - 02 - …`;
- treats the volume as **authoritative** — an exact `series_index` match wins, and any candidate whose `series_index` *contradicts* the filename's volume is dropped (never returned);
- prefers the **most-specific (longest) title** among forward-containment matches;
- returns **404 rather than guessing** when a filename is genuinely ambiguous — a wrong guess corrupts another book's progress, whereas a 404 just lets the plugin keep its existing mapping.

Server-only; no plugin change. The durable follow-up (stamping `book_id` into the downloaded file's embedded metadata so resolution never depends on filename guessing) is a separate PR that needs a plugin build.

## Tests

New `tests/test_tomesync_resolve.py` (7 cases): the reported series-name-==-vol-1-title + flat-template shape, duplicate titles disambiguated by volume, the built-in `Vol. N — Title` layout, most-specific-title selection (`Dune` vs `Dune Messiah`), exact-path short-circuit, and the volume-contradiction / no-match → 404 paths. All green; adjacent tomesync + reading-progress suites unaffected.