### PR TITLE
feat(highlights): cross-library Highlights page + Home "on this day" card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **A Highlights page — your commonplace book.** Every highlight and note you make
+  in KOReader already syncs into Tome; now there's one place to read them all. The
+  new **Highlights** page (in the sidebar) gathers your highlights across the whole
+  library, grouped by book, each as a quote card with its chapter and note. Search
+  filters across everything at once — text, notes, chapter, and book title — with
+  the matches marked; collapse books to scan a big collection, or fold them all at
+  once. **On this day** resurfaces the highlights you made on today's date in past
+  years, and the Home tab shows a single "on this day" highlight as a quote card
+  (falling back to a random one). Each card shows when it was highlighted, with the
+  full detail (time, chapter, colour, when it synced) on hover. **Export** copies
+  your highlights as Markdown — per book or the whole set. Highlights stay read-only
+  on the web (KOReader owns them); this is the library-wide view of the same data
+  you already see per book on each book's page.
 - **Word counts for your books.** Tome now parses each EPUB's text to record its
   word count, shown in the **Details** panel on the book page. New uploads are
   counted automatically as they're added; CJK titles (Chinese / Japanese / Korean)

--- a/backend/api/annotations.py
+++ b/backend/api/annotations.py
@@ -1,0 +1,155 @@
+"""Annotations API — the cross-library Highlights / commonplace view.
+
+`GET /api/annotations` returns the current user's KOReader-synced highlights
+across *all* visible books (the per-book view lives at
+`GET /api/books/{id}/annotations`). Read-only: KOReader owns annotations; the
+plugin pushes them via `PUT /api/tome-sync/annotations/{id}`.
+
+Registered before `/api/books/{id}` is irrelevant here (distinct prefix), but the
+router is mounted at /api like the rest.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import or_, func
+from sqlalchemy.orm import Session
+
+from backend.core.database import get_db
+from backend.core.security import get_current_user
+from backend.core.permissions import book_visibility_filter
+from backend.models.book import Book
+from backend.models.tome_sync import Annotation
+from backend.models.user import User
+
+router = APIRouter(tags=["annotations"])
+
+
+def _to_item(a, b) -> dict:
+    """Shape one (Annotation, Book) row for the API, with book context."""
+    return {
+        "id": a.id,
+        "book_id": b.id,
+        "book_title": b.title,
+        "book_author": b.author,
+        "book_cover": f"/api/books/{b.id}/cover" if b.cover_path else None,
+        "highlighted_text": a.highlighted_text,
+        "note": a.note,
+        "chapter": a.chapter,
+        "color": a.color,
+        "datetime": a.koreader_datetime,  # when highlighted on the device
+        "synced_at": a.created_at.isoformat() + "Z",  # when Tome first stored it
+    }
+
+
+def _month_day(dt: Optional[str]) -> Optional[str]:
+    """Pull 'MM-DD' out of a KOReader datetime string like '2024-01-15 10:30:00'.
+
+    KOReader writes 'YYYY-MM-DD HH:MM:SS' (local wall-clock). We only need the
+    month-day for the 'on this day' filter, so a cheap slice is enough; return
+    None for anything that doesn't look like a date.
+    """
+    if not dt or len(dt) < 10 or dt[4] != "-" or dt[7] != "-":
+        return None
+    return dt[5:10]
+
+
+@router.get("/annotations")
+def list_annotations(
+    q: Optional[str] = Query(None, description="case-insensitive text search"),
+    on_this_day: bool = Query(False),
+    limit: int = Query(200, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """The current user's highlights across every book they can see."""
+    query = (
+        db.query(Annotation, Book)
+        .join(Book, Annotation.book_id == Book.id)
+        .filter(
+            Annotation.user_id == current_user.id,
+            Book.status == "active",
+            book_visibility_filter(db, current_user),
+        )
+    )
+
+    if q:
+        like = f"%{q.strip()}%"
+        query = query.filter(
+            or_(
+                Annotation.highlighted_text.ilike(like),
+                Annotation.note.ilike(like),
+                Annotation.chapter.ilike(like),
+                Book.title.ilike(like),
+            )
+        )
+
+    # Newest highlights first (KOReader's own timestamp, falling back to id).
+    rows = (
+        query.order_by(Annotation.koreader_datetime.desc().nullslast(), Annotation.id.desc())
+        .all()
+    )
+
+    if on_this_day:
+        today = _month_day(func_now_str())
+        rows = [(a, b) for (a, b) in rows if _month_day(a.koreader_datetime) == today]
+
+    total = len(rows)
+    book_ids = {b.id for (_, b) in rows}
+    page = rows[offset : offset + limit]
+
+    items = [_to_item(a, b) for (a, b) in page]
+
+    return {"total": total, "books": len(book_ids), "items": items}
+
+
+@router.get("/annotations/spotlight")
+def annotation_spotlight(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """One highlight for the Home tab: a random highlight made on this calendar
+    day in a past year, falling back to any random highlight so the card is never
+    empty. `on_this_day` tells the UI which case it got.
+    """
+    base = (
+        db.query(Annotation, Book)
+        .join(Book, Annotation.book_id == Book.id)
+        .filter(
+            Annotation.user_id == current_user.id,
+            Book.status == "active",
+            Annotation.highlighted_text.isnot(None),
+            Annotation.highlighted_text != "",
+            book_visibility_filter(db, current_user),
+        )
+    )
+
+    today_md = _month_day(func_now_str())
+    on_day_row = None
+    if today_md:
+        on_day_row = (
+            base.filter(
+                Annotation.koreader_datetime.isnot(None),
+                func.substr(Annotation.koreader_datetime, 6, 5) == today_md,
+            )
+            .order_by(func.random())
+            .first()
+        )
+
+    row = on_day_row or base.order_by(func.random()).first()
+    if not row:
+        return {"highlight": None, "on_this_day": False}
+    a, b = row
+    return {"highlight": _to_item(a, b), "on_this_day": on_day_row is not None}
+
+
+def func_now_str() -> str:
+    """Today's local date as 'YYYY-MM-DD HH:MM:SS' so _month_day can slice it.
+
+    Wrapped in a helper (not inlined) so tests can monkeypatch 'today'.
+    """
+    from datetime import datetime
+
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,6 +32,7 @@ from backend.api import wishlist as wishlist_api
 from backend.api import notifications as notifications_api
 from backend.api import oidc as oidc_api
 from backend.api import goals as goals_api
+from backend.api import annotations as annotations_api
 from backend.models.kosync import KOSyncUser, KOSyncProgress, OPDSPendingLink, ReadingHistory  # noqa: F401
 from backend.models.opds_pin import OpdsPin  # noqa: F401
 from backend.models.tome_sync import ApiKey, ReadingSession, TomeSyncPosition  # noqa: F401
@@ -542,6 +543,7 @@ def create_app() -> FastAPI:
     app.include_router(notifications_api.router, prefix="/api")
     app.include_router(oidc_api.router, prefix="/api")
     app.include_router(goals_api.router, prefix="/api")
+    app.include_router(annotations_api.router, prefix="/api")
 
     # Serve frontend static files in production (SPA fallback)
     frontend_dist = Path(__file__).parent.parent / "frontend" / "dist"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { SettingsPage } from '@/pages/SettingsPage'
 import { StatsPage } from '@/pages/StatsPage'
 import { BinderyPage } from '@/pages/BinderyPage'
 import { WishlistPage } from '@/pages/WishlistPage'
+import { HighlightsPage } from '@/pages/HighlightsPage'
 import { api } from '@/lib/api'
 import { applyTheme, getStoredTheme } from '@/lib/theme'
 
@@ -120,6 +121,14 @@ function AppRoutes() {
           }
         />
         <Route path="/stats-lab" element={<Navigate to="/stats" replace />} />
+        <Route
+          path="/highlights"
+          element={
+            <ProtectedRoute>
+              <HighlightsPage />
+            </ProtectedRoute>
+          }
+        />
         <Route
           path="/reader/:bookId"
           element={

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import {
   BookOpen, Plus, Pencil, Trash2,
   ChevronLeft, ChevronRight, Bookmark, Library as LibraryIcon, Layers, Home, BarChart3,
   Settings, Shield, LogOut, ChevronsUpDown, Lock, X, BookPlus, ExternalLink,
-  Sun, Moon, MoonStar, Flame, Coffee, Check, Sparkles, Users,
+  Sun, Moon, MoonStar, Flame, Coffee, Check, Sparkles, Users, Quote,
   type LucideIcon,
 } from 'lucide-react'
 import { api } from '@/lib/api'
@@ -338,6 +338,19 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
             >
               <BarChart3 className="w-4 h-4 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
             </Link>
+            <Link
+              to="/highlights"
+              title="Highlights"
+              aria-label="Highlights"
+              className={cn(
+                'group relative flex items-center justify-center w-9 h-9 rounded-lg transition-all',
+                location.pathname === '/highlights'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+              )}
+            >
+              <Quote className="w-4 h-4 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
+            </Link>
             {isMember(user) && (
               <Link
                 to="/wishlist"
@@ -466,6 +479,18 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
               >
                 <BarChart3 className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
                 <span className="truncate">Stats</span>
+              </Link>
+              <Link
+                to="/highlights"
+                className={cn(
+                  'group flex items-center gap-2 w-full px-2 py-1.5 rounded-lg text-sm transition-all touch-feedback',
+                  location.pathname === '/highlights'
+                    ? 'bg-primary/10 text-primary font-medium'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                )}
+              >
+                <Quote className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
+                <span className="truncate">Highlights</span>
               </Link>
               {isMember(user) && (
                 <Link
@@ -646,6 +671,19 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                 >
                   <BarChart3 className="w-5 h-5 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
                   <span className="truncate">Stats</span>
+                </Link>
+                <Link
+                  to="/highlights"
+                  onClick={onMobileClose}
+                  className={cn(
+                    'group flex items-center gap-2 w-full px-2 py-2.5 rounded-lg text-sm transition-all touch-feedback',
+                    location.pathname === '/highlights'
+                      ? 'bg-primary/10 text-primary font-medium'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                  )}
+                >
+                  <Quote className="w-5 h-5 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
+                  <span className="truncate">Highlights</span>
                 </Link>
                 {isMember(user) && (
                   <Link

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,7 +5,7 @@ import {
   LayoutGrid, List,
   ChevronUp, ChevronDown, SlidersHorizontal, Loader2,
   Library as LibraryIcon, CheckSquare, XSquare, Download, Pencil, Menu,
-  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star,
+  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star, Quote,
 } from 'lucide-react'
 import { TomeMark } from '@/components/TomeMark'
 import { useAuth, isMember, isAdmin } from '@/contexts/AuthContext'
@@ -93,6 +93,16 @@ interface ForgottenBook {
   has_cover: boolean
   last_read: string | null
   days_ago: number | null
+}
+
+interface HighlightSpotlight {
+  on_this_day: boolean
+  highlight: {
+    book_id: number
+    book_title: string
+    book_author: string | null
+    highlighted_text: string | null
+  } | null
 }
 
 const SORT_LABELS: Record<SortField, string> = {
@@ -707,6 +717,7 @@ export function DashboardPage() {
   const [recentlyAdded, setRecentlyAdded] = useState<Book[]>([])
   const [activityLog, setActivityLog] = useState<ActivityEntry[]>([])
   const [forgottenBooks, setForgottenBooks] = useState<ForgottenBook[]>([])
+  const [spotlight, setSpotlight] = useState<HighlightSpotlight | null>(null)
   // Persisted dismissal: store the signature of the dismissed book set so the
   // panel stays hidden across refreshes, but resurfaces if a new set appears.
   const [forgottenDismissedSig, setForgottenDismissedSig] = useState<string>(
@@ -907,6 +918,7 @@ export function DashboardPage() {
     api.get<Book[]>('/books?sort=added_at&order=desc&limit=6').then(setRecentlyAdded).catch(() => {})
     api.get<ActivityEntry[]>('/home/activity').then(setActivityLog).catch(() => {})
     api.get<ForgottenBook[]>('/home/forgotten-books').then(setForgottenBooks).catch(() => {})
+    api.get<HighlightSpotlight>('/annotations/spotlight').then(setSpotlight).catch(() => {})
     api.get<SeriesItem[]>('/books/series').then(setSeriesList).catch(() => {})
   }, [])
 
@@ -1141,6 +1153,30 @@ export function DashboardPage() {
                   </section>
                 )
               })()}
+
+              {/* ── Highlight spotlight (on this day) ──────────────────────── */}
+              {spotlight?.highlight?.highlighted_text && (
+                <section className="rounded-lg border border-border bg-muted/30 px-4 py-3.5">
+                  <header className="flex items-center justify-between mb-2.5">
+                    <h2 className="flex items-center gap-1.5 text-base text-foreground">
+                      <Quote className="w-4 h-4 text-primary/60" />
+                      {spotlight.on_this_day ? 'On this day you highlighted' : 'From your highlights'}
+                    </h2>
+                    <a href="/highlights" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+                      All highlights
+                    </a>
+                  </header>
+                  <a href={`/books/${spotlight.highlight.book_id}`} className="block group">
+                    <p className="text-sm text-foreground leading-relaxed border-l-2 border-primary/40 pl-3 italic line-clamp-4">
+                      {spotlight.highlight.highlighted_text}
+                    </p>
+                    <p className="mt-2 pl-3 text-xs text-muted-foreground group-hover:text-primary transition-colors">
+                      — {spotlight.highlight.book_title}
+                      {spotlight.highlight.book_author ? `, ${spotlight.highlight.book_author}` : ''}
+                    </p>
+                  </a>
+                </section>
+              )}
 
               {/* ── Continue Reading ──────────────────────────────────────── */}
               <div className="flex flex-col gap-3">

--- a/frontend/src/pages/HighlightsPage.tsx
+++ b/frontend/src/pages/HighlightsPage.tsx
@@ -1,0 +1,422 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  ArrowLeft, Search, Quote, StickyNote, Loader2, BookOpen,
+  CalendarHeart, Copy, X, ChevronDown, Info, ChevronsDownUp, ChevronsUpDown,
+} from 'lucide-react'
+import { api } from '@/lib/api'
+import { useToast } from '@/contexts/ToastContext'
+import { cn } from '@/lib/utils'
+
+interface Highlight {
+  id: number
+  book_id: number
+  book_title: string
+  book_author: string | null
+  book_cover: string | null
+  highlighted_text: string | null
+  note: string | null
+  chapter: string | null
+  color: string | null
+  datetime: string | null
+  synced_at: string | null
+}
+
+interface HighlightsResponse {
+  total: number
+  books: number
+  items: Highlight[]
+}
+
+interface BookGroup {
+  book_id: number
+  title: string
+  author: string | null
+  cover: string | null
+  items: Highlight[]
+}
+
+const PAGE_SIZE = 15
+
+// KOReader highlight colours → a dot tint. Unknown colours fall back to the
+// primary accent. Dots only render when the library actually uses more than one
+// colour (see `showDots`), so single-colour readers don't get noise.
+const COLOR_TINT: Record<string, string> = {
+  red: 'bg-red-500', orange: 'bg-orange-500', yellow: 'bg-yellow-500',
+  green: 'bg-green-500', blue: 'bg-blue-500', purple: 'bg-purple-500',
+  gray: 'bg-gray-400', grey: 'bg-gray-400',
+}
+
+function groupByBook(items: Highlight[]): BookGroup[] {
+  const order: number[] = []
+  const map = new Map<number, BookGroup>()
+  for (const h of items) {
+    let g = map.get(h.book_id)
+    if (!g) {
+      g = { book_id: h.book_id, title: h.book_title, author: h.book_author, cover: h.book_cover, items: [] }
+      map.set(h.book_id, g)
+      order.push(h.book_id)
+    }
+    g.items.push(h)
+  }
+  return order.map(id => map.get(id)!)
+}
+
+function groupToMarkdown(g: BookGroup): string {
+  const lines = [`## ${g.title}${g.author ? ` — ${g.author}` : ''}`, '']
+  for (const h of g.items) {
+    if (h.chapter) lines.push(`*${h.chapter}*`)
+    if (h.highlighted_text) lines.push(`> ${h.highlighted_text}`)
+    if (h.note) lines.push('', `Note: ${h.note}`)
+    lines.push('')
+  }
+  return lines.join('\n').trimEnd()
+}
+
+// Wrap case-insensitive matches of `q` in <mark>, leaving the rest as text.
+function mark(text: string, q: string): ReactNode {
+  if (!q) return text
+  const esc = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const parts = text.split(new RegExp(`(${esc})`, 'ig'))
+  return parts.map((p, i) =>
+    p.toLowerCase() === q.toLowerCase()
+      ? <mark key={i} className="bg-primary/25 text-foreground rounded px-0.5">{p}</mark>
+      : <span key={i}>{p}</span>
+  )
+}
+
+function parseKo(dt: string | null): Date | null {
+  if (!dt) return null
+  const d = new Date(dt.replace(' ', 'T'))
+  return isNaN(d.getTime()) ? null : d
+}
+
+function shortDate(dt: string | null): string | null {
+  const d = parseKo(dt)
+  return d ? d.toLocaleDateString(undefined, { month: 'short', year: 'numeric' }) : null
+}
+
+function fullInfo(h: Highlight): string {
+  const parts: string[] = []
+  const d = parseKo(h.datetime)
+  if (d) parts.push(`Highlighted ${d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}`)
+  if (h.chapter) parts.push(h.chapter)
+  if (h.color) parts.push(`${h.color} highlight`)
+  if (h.synced_at) {
+    const s = new Date(h.synced_at)
+    if (!isNaN(s.getTime())) parts.push(`Synced to Tome ${s.toLocaleDateString(undefined, { dateStyle: 'medium' })}`)
+  }
+  return parts.join('  ·  ')
+}
+
+function HighlightCard({ h, q, showDot }: { h: Highlight; q: string; showDot: boolean }) {
+  const tint = h.color ? (COLOR_TINT[h.color.toLowerCase()] ?? 'bg-primary/50') : 'bg-primary/40'
+  const date = shortDate(h.datetime)
+  return (
+    <li className="rounded-lg border border-border bg-muted/40 px-3.5 py-3">
+      <div className="flex items-start justify-between gap-3 mb-1.5">
+        <div className="flex items-center gap-1.5 min-w-0">
+          {showDot && <span className={cn('w-2 h-2 rounded-full shrink-0', tint)} />}
+          {h.chapter && (
+            <p className="text-xs text-muted-foreground/70 truncate">{q ? mark(h.chapter, q) : h.chapter}</p>
+          )}
+        </div>
+        {date && (
+          <span
+            className="flex items-center gap-1 text-[11px] text-muted-foreground/50 shrink-0 cursor-help"
+            title={fullInfo(h)}
+          >
+            {date}
+            <Info className="w-3 h-3" />
+          </span>
+        )}
+      </div>
+      {h.highlighted_text && (
+        <p className="text-sm text-foreground leading-relaxed border-l-2 border-primary/40 pl-2.5">
+          {q ? mark(h.highlighted_text, q) : h.highlighted_text}
+        </p>
+      )}
+      {h.note && (
+        <p className="mt-2 flex items-start gap-1.5 text-sm text-muted-foreground">
+          <StickyNote className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+          <span className="leading-relaxed">{q ? mark(h.note, q) : h.note}</span>
+        </p>
+      )}
+    </li>
+  )
+}
+
+export function HighlightsPage() {
+  const { toast } = useToast()
+  const [items, setItems] = useState<Highlight[]>([])
+  const [total, setTotal] = useState(0)
+  const [books, setBooks] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+  const [debounced, setDebounced] = useState('')
+  const [onThisDay, setOnThisDay] = useState(false)
+  const [collapsed, setCollapsed] = useState<Set<number>>(new Set())
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebounced(search.trim()), 250)
+    return () => clearTimeout(t)
+  }, [search])
+
+  const buildParams = useCallback((offset: number) => {
+    const p = new URLSearchParams()
+    if (debounced) p.set('q', debounced)
+    if (onThisDay) p.set('on_this_day', '1')
+    p.set('limit', String(PAGE_SIZE))
+    p.set('offset', String(offset))
+    return p
+  }, [debounced, onThisDay])
+
+  // Reset + first page whenever the query/filter changes.
+  useEffect(() => {
+    const ctrl = new AbortController()
+    setLoading(true)
+    setError(null)
+    api.get<HighlightsResponse>(`/annotations?${buildParams(0).toString()}`, ctrl.signal)
+      .then(d => { setItems(d.items); setTotal(d.total); setBooks(d.books) })
+      .catch(e => { if (e.name !== 'AbortError') setError(e.message ?? 'Failed to load') })
+      .finally(() => setLoading(false))
+    return () => ctrl.abort()
+  }, [buildParams])
+
+  async function loadMore() {
+    setLoadingMore(true)
+    try {
+      const d = await api.get<HighlightsResponse>(`/annotations?${buildParams(items.length).toString()}`)
+      setItems(prev => [...prev, ...d.items])
+      setTotal(d.total)
+    } catch (e) {
+      toast.error((e as Error).message ?? 'Failed to load more')
+    } finally {
+      setLoadingMore(false)
+    }
+  }
+
+  const groups = useMemo(() => groupByBook(items), [items])
+  const hasMore = items.length < total
+  // While searching, force every book open so matches are never hidden behind a
+  // collapsed header. Manual collapse state is preserved and returns on clear.
+  const searching = debounced.length > 0
+  // Only show colour dots when the loaded highlights actually use >1 colour.
+  const showDots = useMemo(
+    () => new Set(items.map(i => i.color).filter(Boolean)).size >= 2,
+    [items],
+  )
+  const allCollapsed = groups.length > 0 && groups.every(g => collapsed.has(g.book_id))
+
+  function toggleBook(id: number) {
+    setCollapsed(prev => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+  function toggleAll() {
+    setCollapsed(allCollapsed ? new Set() : new Set(groups.map(g => g.book_id)))
+  }
+
+  async function copyAll() {
+    // Export everything that matches, not just the loaded pages.
+    const p = new URLSearchParams()
+    if (debounced) p.set('q', debounced)
+    if (onThisDay) p.set('on_this_day', '1')
+    p.set('limit', '2000')
+    const d = await api.get<HighlightsResponse>(`/annotations?${p.toString()}`)
+    const md = groupByBook(d.items).map(groupToMarkdown).join('\n\n')
+    await navigator.clipboard.writeText(md)
+    toast.success(`Copied ${d.items.length} highlights as Markdown`)
+  }
+
+  async function copyGroup(g: BookGroup) {
+    await navigator.clipboard.writeText(groupToMarkdown(g))
+    toast.success(`Copied ${g.items.length} from “${g.title}”`)
+  }
+
+  const isEmpty = !loading && !error && groups.length === 0
+  const neverSynced = isEmpty && !debounced && !onThisDay
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-sm safe-top">
+        <div className="flex items-center gap-3 px-4 h-14 max-w-3xl mx-auto">
+          <Link
+            to="/"
+            className="p-2 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
+          >
+            <ArrowLeft className="w-4 h-4" />
+          </Link>
+          <div className="flex items-center gap-2 flex-1 min-w-0">
+            <Quote className="w-4 h-4 text-muted-foreground shrink-0" />
+            <span className="text-sm font-semibold">Highlights</span>
+            {total > 0 && (
+              <span className="text-xs text-muted-foreground/60 truncate">
+                {total} from {books} book{books === 1 ? '' : 's'}
+              </span>
+            )}
+          </div>
+          {groups.length > 0 && (
+            <button
+              onClick={copyAll}
+              title="Copy all as Markdown"
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border hover:bg-muted transition-all"
+            >
+              <Copy className="w-3.5 h-3.5" />
+              Export
+            </button>
+          )}
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-4 py-6 space-y-5">
+        {/* Controls */}
+        <div className="flex items-center gap-2">
+          <div className="relative flex-1">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/60" />
+            <input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Search your highlights…"
+              className="w-full pl-9 pr-9 py-2 rounded-lg bg-muted/50 border border-border text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+            />
+            {search && (
+              <button
+                onClick={() => setSearch('')}
+                className="absolute right-2.5 top-1/2 -translate-y-1/2 p-1 rounded text-muted-foreground hover:text-foreground"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </div>
+          <button
+            onClick={() => setOnThisDay(v => !v)}
+            title="Highlights you made on this day in past years"
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium border transition-all whitespace-nowrap',
+              onThisDay
+                ? 'bg-primary/10 border-primary/30 text-primary'
+                : 'border-border text-muted-foreground hover:bg-muted'
+            )}
+          >
+            <CalendarHeart className="w-3.5 h-3.5" />
+            On this day
+          </button>
+          {groups.length > 0 && !searching && (
+            <button
+              onClick={toggleAll}
+              title={allCollapsed ? 'Expand all' : 'Collapse all'}
+              className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium border border-border text-muted-foreground hover:bg-muted transition-all whitespace-nowrap"
+            >
+              {allCollapsed ? <ChevronsUpDown className="w-3.5 h-3.5" /> : <ChevronsDownUp className="w-3.5 h-3.5" />}
+              {allCollapsed ? 'Expand' : 'Collapse'}
+            </button>
+          )}
+        </div>
+
+        {loading ? (
+          <div className="flex justify-center py-16">
+            <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : error ? (
+          <div className="px-3 py-2 rounded-lg bg-destructive/10 border border-destructive/20 text-sm text-destructive">
+            {error}
+          </div>
+        ) : isEmpty ? (
+          <div className="flex flex-col items-center justify-center text-center py-20 gap-3 text-muted-foreground">
+            <Quote className="w-8 h-8 opacity-40" />
+            {neverSynced ? (
+              <>
+                <p className="text-sm font-medium text-foreground">No highlights yet</p>
+                <p className="text-xs max-w-xs leading-relaxed">
+                  Highlights and notes you make in KOReader sync here automatically.
+                  Highlight a passage on your device, then sync — it’ll show up in this
+                  commonplace book.
+                </p>
+              </>
+            ) : (
+              <p className="text-sm">
+                {onThisDay ? 'Nothing highlighted on this day — yet.' : 'No highlights match your search.'}
+              </p>
+            )}
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {groups.map(g => {
+              const isCollapsed = !searching && collapsed.has(g.book_id)
+              return (
+                <section key={g.book_id} className="animate-card-appear">
+                  <div className="flex items-center gap-3 mb-3">
+                    <Link to={`/books/${g.book_id}`} className="shrink-0">
+                      <div className="w-10 h-14 rounded bg-muted overflow-hidden flex items-center justify-center">
+                        {g.cover ? (
+                          <img
+                            src={g.cover}
+                            alt=""
+                            className="w-full h-full object-cover"
+                            onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+                          />
+                        ) : (
+                          <BookOpen className="w-4 h-4 text-muted-foreground" />
+                        )}
+                      </div>
+                    </Link>
+                    <button
+                      onClick={() => toggleBook(g.book_id)}
+                      className="flex-1 min-w-0 flex items-center gap-2 text-left group"
+                    >
+                      <ChevronDown
+                        className={cn('w-4 h-4 text-muted-foreground/60 shrink-0 transition-transform', isCollapsed && '-rotate-90')}
+                      />
+                      <span className="min-w-0">
+                        <span className="block font-display text-base text-foreground group-hover:text-primary transition-colors line-clamp-1">
+                          {g.title}
+                        </span>
+                        {g.author && <span className="block text-xs text-muted-foreground truncate">{g.author}</span>}
+                      </span>
+                      <span className="text-xs text-muted-foreground/60 shrink-0 ml-auto">
+                        {g.items.length}
+                      </span>
+                    </button>
+                    <button
+                      onClick={() => copyGroup(g)}
+                      title="Copy this book’s highlights as Markdown"
+                      className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
+                    >
+                      <Copy className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                  {/* grid-rows 1fr↔0fr gives a smooth height collapse without measuring. */}
+                  <div className={cn('grid transition-[grid-template-rows] duration-300 ease-out', isCollapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]')}>
+                    <div className="overflow-hidden">
+                      <ul className="space-y-2.5">
+                        {g.items.map(h => <HighlightCard key={h.id} h={h} q={debounced} showDot={showDots} />)}
+                      </ul>
+                    </div>
+                  </div>
+                </section>
+              )
+            })}
+
+            {hasMore && (
+              <div className="flex justify-center pt-1">
+                <button
+                  onClick={loadMore}
+                  disabled={loadingMore}
+                  className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border border-border hover:bg-muted transition-all disabled:opacity-60"
+                >
+                  {loadingMore ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
+                  Load more ({total - items.length} left)
+                </button>
+              </div>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/tests/test_annotations_aggregate.py
+++ b/tests/test_annotations_aggregate.py
@@ -1,0 +1,122 @@
+"""Tests for the cross-library Highlights endpoint `GET /api/annotations`.
+
+The per-book view (`/api/books/{id}/annotations`) is covered elsewhere; this
+exercises the aggregate: search, grouping context, on-this-day, and that it only
+returns the caller's own highlights on books they can see.
+"""
+from backend.core.security import create_access_token, hash_password
+from backend.models.tome_sync import Annotation
+from backend.models.user import User
+
+
+def _hdr(user):
+    return {"Authorization": f"Bearer {create_access_token(subject=user.id)}"}
+
+
+def _anno(db, user, book, text, anchor, note=None, chapter=None, when="2024-03-10 09:00:00"):
+    db.add(Annotation(
+        user_id=user.id, book_id=book.id, anchor=anchor,
+        highlighted_text=text, note=note, chapter=chapter, koreader_datetime=when,
+    ))
+    db.flush()
+
+
+def test_aggregates_across_books_with_context(client, db, admin_user, make_book):
+    user, _ = admin_user
+    b1 = make_book(title="Dune")
+    b2 = make_book(title="Hyperion")
+    _anno(db, user, b1, "Fear is the mind-killer", "a1", chapter="Book One")
+    _anno(db, user, b1, "The spice must flow", "a2")
+    _anno(db, user, b2, "The Time Tombs", "a3", note="eerie")
+    db.commit()
+
+    r = client.get("/api/annotations", headers=_hdr(user))
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data["total"] == 3
+    assert data["books"] == 2
+    # Context travels with each item so the page can group + link.
+    item = next(i for i in data["items"] if i["highlighted_text"] == "The Time Tombs")
+    assert item["book_id"] == b2.id and item["book_title"] == "Hyperion"
+    assert item["note"] == "eerie"
+
+
+def test_search_matches_text_note_and_title(client, db, admin_user, make_book):
+    user, _ = admin_user
+    b1 = make_book(title="Dune")
+    b2 = make_book(title="Hyperion")
+    _anno(db, user, b1, "Fear is the mind-killer", "a1")
+    _anno(db, user, b2, "The Time Tombs", "a3", note="eerie cathedral")
+    db.commit()
+
+    assert client.get("/api/annotations?q=mind-killer", headers=_hdr(user)).json()["total"] == 1
+    assert client.get("/api/annotations?q=cathedral", headers=_hdr(user)).json()["total"] == 1  # note
+    assert client.get("/api/annotations?q=hyperion", headers=_hdr(user)).json()["total"] == 1   # title
+    assert client.get("/api/annotations?q=nothinghere", headers=_hdr(user)).json()["total"] == 0
+
+
+def test_on_this_day_filters_by_month_day(client, db, admin_user, make_book, monkeypatch):
+    user, _ = admin_user
+    b1 = make_book(title="Dune")
+    _anno(db, user, b1, "kept — same day, prior year", "a1", when="2022-03-10 08:00:00")
+    _anno(db, user, b1, "dropped — different day", "a2", when="2022-07-01 08:00:00")
+    db.commit()
+
+    import backend.api.annotations as mod
+    monkeypatch.setattr(mod, "func_now_str", lambda: "2024-03-10 12:00:00")
+
+    data = client.get("/api/annotations?on_this_day=1", headers=_hdr(user)).json()
+    assert data["total"] == 1
+    assert data["items"][0]["highlighted_text"].startswith("kept")
+
+
+def test_spotlight_prefers_on_this_day(client, db, admin_user, make_book, monkeypatch):
+    user, _ = admin_user
+    book = make_book(title="Dune")
+    _anno(db, user, book, "today, a past year", "a1", when="2021-03-10 08:00:00")
+    _anno(db, user, book, "some other day", "a2", when="2021-09-01 08:00:00")
+    db.commit()
+
+    import backend.api.annotations as mod
+    monkeypatch.setattr(mod, "func_now_str", lambda: "2024-03-10 12:00:00")
+
+    data = client.get("/api/annotations/spotlight", headers=_hdr(user)).json()
+    assert data["on_this_day"] is True
+    assert data["highlight"]["highlighted_text"] == "today, a past year"
+
+
+def test_spotlight_falls_back_to_random(client, db, admin_user, make_book, monkeypatch):
+    user, _ = admin_user
+    book = make_book(title="Dune")
+    _anno(db, user, book, "only highlight", "a1", when="2021-09-01 08:00:00")
+    db.commit()
+
+    import backend.api.annotations as mod
+    monkeypatch.setattr(mod, "func_now_str", lambda: "2024-03-10 12:00:00")  # nothing on 03-10
+
+    data = client.get("/api/annotations/spotlight", headers=_hdr(user)).json()
+    assert data["on_this_day"] is False
+    assert data["highlight"]["highlighted_text"] == "only highlight"
+
+
+def test_spotlight_null_when_no_highlights(client, db, admin_user, make_book):
+    user, _ = admin_user
+    make_book(title="Dune")  # book but no highlights
+    data = client.get("/api/annotations/spotlight", headers=_hdr(user)).json()
+    assert data == {"highlight": None, "on_this_day": False}
+
+
+def test_only_own_highlights(client, db, admin_user, make_book):
+    user, _ = admin_user
+    other = User(username="other", email="other@x.io",
+                 hashed_password=hash_password("x"), is_admin=True, role="admin")
+    db.add(other)
+    db.flush()
+    book = make_book(title="Shared")
+    _anno(db, user, book, "mine", "a1")
+    _anno(db, other, book, "theirs", "a2")
+    db.commit()
+
+    data = client.get("/api/annotations", headers=_hdr(user)).json()
+    assert data["total"] == 1
+    assert data["items"][0]["highlighted_text"] == "mine"

--- a/website/src/components/docs-nav.ts
+++ b/website/src/components/docs-nav.ts
@@ -20,6 +20,7 @@ export const DOCS_NAV: DocGroup[] = [
       { href: '/docs/reader',             title: 'Built-in reader' },
       { href: '/docs/series',             title: 'Series & arcs' },
       { href: '/docs/stats',              title: 'Reading stats' },
+      { href: '/docs/highlights',         title: 'Highlights' },
       { href: '/docs/bindery',            title: 'Bindery (auto-import)' },
       { href: '/docs/send-to-device',     title: 'Send to device' },
       { href: '/docs/wishlist',           title: 'Wishlist' },

--- a/website/src/pages/docs/highlights.astro
+++ b/website/src/pages/docs/highlights.astro
@@ -1,0 +1,81 @@
+---
+import DocsLayout from '../../layouts/DocsLayout.astro'
+import SectionHero from '../../components/SectionHero.astro'
+import DocsMeta from '../../components/DocsMeta.astro'
+import Callout from '../../components/Callout.astro'
+import { withBase } from '../../lib/path'
+---
+<DocsLayout title="Highlights" description="Every highlight and note you make in KOReader, gathered into one searchable commonplace book — grouped by book, exportable, with an 'on this day' resurfacing.">
+  <SectionHero section="features" />
+  <h1>Highlights</h1>
+  <p>
+    The passages you highlight while reading in KOReader sync into Tome, and the
+    <strong>Highlights</strong> page gathers all of them into one place — a personal commonplace
+    book you can search, browse by book, and export. Nothing to set up beyond
+    <a href={withBase("/docs/koreader")}>the KOReader plugin</a>: highlight a passage on your
+    device, sync, and it shows up here.
+  </p>
+  <DocsMeta />
+
+  <Callout variant="info" title="Highlights come from KOReader">
+    Highlights and notes are made on your device and synced up by the
+    <a href={withBase("/docs/koreader")}>TomeSync plugin</a> — KOReader owns them, so the Highlights
+    page is read-only (you browse, search, and export here; you create and edit on the device). They
+    sync <strong>bidirectionally across devices</strong>, so a passage highlighted on two readers is
+    one entry. The web reader doesn't create highlights yet.
+  </Callout>
+
+
+  <h2>Browsing by book</h2>
+  <p>
+    Open <strong>Highlights</strong> from the sidebar. Your highlights are grouped under the book
+    they came from — cover, title, author, and a count — with each highlight shown as a quote card,
+    along with its chapter and the note you attached, if any. Click a book's title to jump to its
+    detail page. Each book can be <strong>collapsed</strong> to its header so you can scan a large
+    collection quickly, and <strong>Collapse all</strong> / <strong>Expand all</strong> in the
+    toolbar folds the whole list at once.
+  </p>
+
+  <h2>Searching</h2>
+  <p>
+    The search box filters across <strong>every</strong> highlight in your library at once — matching
+    the highlighted text, your notes, the chapter, and the book title — and the matching words are
+    marked in the results. Searching automatically opens any collapsed books so nothing is hidden,
+    and restores your collapsed view when you clear it.
+  </p>
+
+
+  <h2>On this day</h2>
+  <p>
+    Toggle <strong>On this day</strong> to see only the highlights you made on today's date in
+    previous years — a small, pleasant way to rediscover what struck you a year or two ago. The
+    <a href={withBase("/docs/books")}>Home tab</a> also surfaces a single "on this day" highlight as
+    a quote card; on a day with none, it shows a random highlight instead.
+  </p>
+
+  <h2>Dates &amp; details</h2>
+  <p>
+    Each card shows when the highlight was made, with a hover for the full detail — the exact time,
+    the chapter, the highlight colour, and when it first synced to Tome. When your highlights use
+    more than one KOReader colour, a small coloured dot on each card reflects the colour you chose on
+    the device; if you only ever use one colour, the dots are hidden so they don't add noise.
+  </p>
+
+  <h2>Exporting</h2>
+  <p>
+    <strong>Export</strong> copies your highlights as Markdown — a heading per book, each passage as
+    a block quote with its note — ready to paste into your notes app, a wiki, or a journal. The copy
+    icon on each book exports just that book's highlights. Export reflects whatever you're currently
+    viewing, so an active search exports only the matching highlights.
+  </p>
+
+
+  <h2>Per-book highlights</h2>
+  <p>
+    Every book's detail page also has its own <strong>Highlights &amp; Notes</strong> section showing
+    just that book's highlights — handy when you're looking at one title. The Highlights page is the
+    library-wide view of the same data. See <a href={withBase("/docs/koreader")}>KOReader plugin</a>
+    for how syncing works and <a href={withBase("/docs/reader")}>the reader</a> for reading inside
+    Tome.
+  </p>
+</DocsLayout>


### PR DESCRIPTION
## What

Tome already syncs KOReader highlights/notes into the `Annotation` model and shows them **per book** on `BookDetailPage`. This adds the **library-wide view** of that same data — a commonplace book — plus a Home-tab resurfacing card. It's a read/search/export surface; annotations stay read-only (KOReader owns them).

## Highlights page (`/highlights`, new sidebar item)

- **Grouped by book** — cover, title, author, count; each highlight a quote card with chapter + note.
- **Collapsible** books (+ collapse-all in the toolbar); **search force-expands** so matches are never hidden, and restores your view on clear.
- **Search** across the whole library at once (text, note, chapter, book title) with matched terms `<mark>`ed.
- **On this day** toggle — highlights you made on today's date in past years.
- **Per-card date + info** tooltip (exact time, chapter, colour, when it synced).
- **Colour dots** only render when your highlights actually use more than one KOReader colour.
- **Load more** (search-safe — search always queries the full library server-side) and **Markdown export** (whole set or per book).

## Home tab

- An **"On this day you highlighted"** spotlight quote card — a random highlight from today's date in past years, falling back to a random one so it's never empty.

## Backend (`backend/api/annotations.py`)

- `GET /api/annotations` — visibility-gated (`book_visibility_filter`), `q` search, `on_this_day`, `limit`/`offset`.
- `GET /api/annotations/spotlight` — random on-this-day highlight, random fallback.

## Docs / tests

- New `website/docs/highlights` page (nav-registered) + CHANGELOG entry.
- `tests/test_annotations_aggregate.py` — aggregate search/grouping/visibility + spotlight (on-this-day-preferred / random-fallback / null-when-empty). All green; frontend builds clean.

## Notes

- Builds on existing synced data; no migration. Per-book "Highlights & Notes" section on `BookDetailPage` is unchanged (same data, single-book scope).
- The website docs deploy on merge to `main` (auto), so the docs go live with the feature landing on `main`.