### PR TITLE
feat(highlights): delete a highlight from the web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@ All notable changes to Tome are documented here. Format loosely follows
   years, and the Home tab shows a single "on this day" highlight as a quote card
   (falling back to a random one). Each card shows when it was highlighted, with the
   full detail (time, chapter, colour, when it synced) on hover. **Export** copies
-  your highlights as Markdown — per book or the whole set. Highlights stay read-only
-  on the web (KOReader owns them); this is the library-wide view of the same data
-  you already see per book on each book's page.
+  your highlights as Markdown — per book or the whole set. This is the library-wide
+  view of the same data you already see per book on each book's page. KOReader still
+  owns your highlights, but you can now **delete** one from the web — handy for an
+  accidental highlight you'd otherwise have to reopen the book to clear. Deleting
+  here removes it everywhere: Tome records the deletion and your KOReader devices
+  drop it on their next sync (a hover trash button with a quick confirm, on both the
+  Highlights page and each book's Highlights & Notes panel).
 - **Word counts for your books.** Tome now parses each EPUB's text to record its
   word count, shown in the **Details** panel on the book page. New uploads are
   counted automatically as they're added; CJK titles (Chinese / Japanese / Korean)

--- a/backend/api/annotations.py
+++ b/backend/api/annotations.py
@@ -2,8 +2,10 @@
 
 `GET /api/annotations` returns the current user's KOReader-synced highlights
 across *all* visible books (the per-book view lives at
-`GET /api/books/{id}/annotations`). Read-only: KOReader owns annotations; the
-plugin pushes them via `PUT /api/tome-sync/annotations/{id}`.
+`GET /api/books/{id}/annotations`). KOReader owns annotations and pushes them via
+the TomeSync plugin; the one write the web offers is `DELETE /api/annotations/{id}`,
+which drops the row and leaves a tombstone so the deletion propagates back to the
+device (and stale devices can't resurrect it) — mirroring the plugin's own deletes.
 
 Registered before `/api/books/{id}` is irrelevant here (distinct prefix), but the
 router is mounted at /api like the rest.
@@ -12,7 +14,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import or_, func
 from sqlalchemy.orm import Session
 
@@ -20,7 +22,7 @@ from backend.core.database import get_db
 from backend.core.security import get_current_user
 from backend.core.permissions import book_visibility_filter
 from backend.models.book import Book
-from backend.models.tome_sync import Annotation
+from backend.models.tome_sync import Annotation, AnnotationTombstone
 from backend.models.user import User
 
 router = APIRouter(tags=["annotations"])
@@ -103,6 +105,57 @@ def list_annotations(
     items = [_to_item(a, b) for (a, b) in page]
 
     return {"total": total, "books": len(book_ids), "items": items}
+
+
+@router.delete("/annotations/{annotation_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_annotation(
+    annotation_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Delete one of the current user's highlights (e.g. an accidental one).
+
+    Mirrors the TomeSync delete path: we remove the `Annotation` row *and* write an
+    `AnnotationTombstone` stamped with the current wall-clock time. On its next sync
+    the device sees the tombstone, finds its local copy older, and drops it too — so
+    the deletion sticks instead of being re-uploaded. A later, genuinely-newer re-add
+    of the same passage (strictly newer mtime) still wins and clears the tombstone,
+    exactly as it would for a device-originated delete.
+    """
+    annotation = (
+        db.query(Annotation)
+        .filter(Annotation.id == annotation_id, Annotation.user_id == current_user.id)
+        .first()
+    )
+    if annotation is None:
+        raise HTTPException(status_code=404, detail="Highlight not found")
+
+    book_id = annotation.book_id
+    anchor = annotation.anchor
+    now = func_now_str()
+
+    db.delete(annotation)
+
+    tomb = (
+        db.query(AnnotationTombstone)
+        .filter(
+            AnnotationTombstone.user_id == current_user.id,
+            AnnotationTombstone.book_id == book_id,
+            AnnotationTombstone.anchor == anchor,
+        )
+        .first()
+    )
+    if tomb:
+        # Keep the latest deletion time so a stale re-add can't slip under it.
+        if now > (tomb.client_deleted_at or ""):
+            tomb.client_deleted_at = now
+    else:
+        db.add(AnnotationTombstone(
+            user_id=current_user.id, book_id=book_id, anchor=anchor,
+            client_deleted_at=now,
+        ))
+
+    db.commit()
 
 
 @router.get("/annotations/spotlight")

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1040,9 +1040,9 @@ def get_book_annotations(
 ):
     """Highlights/notes the current user has synced from KOReader for this book.
 
-    Read-only: KOReader owns annotations; the plugin pushes them via
-    PUT /api/tome-sync/annotations/{book_id}. Web reader (foliate) inline
-    rendering is a separate, later phase.
+    KOReader owns annotations and pushes them via the TomeSync plugin; the web's
+    only write is DELETE /api/annotations/{id} (drops the row + tombstones it so the
+    deletion syncs back). Web reader (foliate) inline rendering is a later phase.
     """
     from backend.models.tome_sync import Annotation
 

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -116,6 +116,7 @@ export function BookDetailPage() {
   const [editingReview, setEditingReview] = useState(false)
   const [kosyncDevice, setKosyncDevice] = useState<string | null>(null)
   const [annotations, setAnnotations] = useState<Annotation[]>([])
+  const [confirmingHighlight, setConfirmingHighlight] = useState<number | null>(null)
   const [highlightsOpen, setHighlightsOpen] = useState(true)
   const [readingStats, setReadingStats] = useState<ReadingStatsResponse | null>(null)
   const [statsOpen, setStatsOpen] = useState(true)
@@ -861,6 +862,17 @@ export function BookDetailPage() {
     </div>
   )
 
+  async function deleteHighlight(annotationId: number) {
+    try {
+      await api.delete(`/annotations/${annotationId}`)
+      setAnnotations(prev => prev.filter(a => a.id !== annotationId))
+      setConfirmingHighlight(null)
+      toast.success('Highlight deleted')
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Failed to delete highlight')
+    }
+  }
+
   const highlightsBlock = annotations.length > 0 ? (
     <div className="mt-6">
       <button
@@ -876,10 +888,31 @@ export function BookDetailPage() {
       {highlightsOpen && (
         <ul className="space-y-3 max-h-[28rem] overflow-y-auto pr-1">
           {annotations.map(a => (
-            <li key={a.id} className="rounded-lg border border-border bg-muted/40 px-3 py-2.5">
-              {a.chapter && (
-                <p className="text-xs text-muted-foreground/70 mb-1.5 truncate">{a.chapter}</p>
-              )}
+            <li key={a.id} className="group rounded-lg border border-border bg-muted/40 px-3 py-2.5">
+              <div className="flex items-start justify-between gap-2">
+                {a.chapter ? (
+                  <p className="text-xs text-muted-foreground/70 mb-1.5 truncate">{a.chapter}</p>
+                ) : <span />}
+                {confirmingHighlight === a.id ? (
+                  <span className="flex items-center gap-1.5 text-[11px] shrink-0">
+                    <button onClick={() => deleteHighlight(a.id)} className="font-medium text-destructive hover:underline">
+                      Delete
+                    </button>
+                    <button onClick={() => setConfirmingHighlight(null)} className="text-muted-foreground hover:text-foreground">
+                      Cancel
+                    </button>
+                  </span>
+                ) : (
+                  <button
+                    onClick={() => setConfirmingHighlight(a.id)}
+                    title="Delete this highlight"
+                    aria-label="Delete this highlight"
+                    className="p-1 -mt-1 -mr-1 rounded text-muted-foreground/50 hover:text-destructive transition-all opacity-60 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100 shrink-0"
+                  >
+                    <Trash2 className="w-3.5 h-3.5" />
+                  </button>
+                )}
+              </div>
               {a.highlighted_text && (
                 <p className="text-sm text-foreground leading-relaxed border-l-2 border-primary/40 pl-2.5">
                   {a.highlighted_text}

--- a/frontend/src/pages/HighlightsPage.tsx
+++ b/frontend/src/pages/HighlightsPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react
 import { Link } from 'react-router-dom'
 import {
   ArrowLeft, Search, Quote, StickyNote, Loader2, BookOpen,
-  CalendarHeart, Copy, X, ChevronDown, Info, ChevronsDownUp, ChevronsUpDown,
+  CalendarHeart, Copy, X, ChevronDown, Info, ChevronsDownUp, ChevronsUpDown, Trash2,
 } from 'lucide-react'
 import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
@@ -109,11 +109,12 @@ function fullInfo(h: Highlight): string {
   return parts.join('  ·  ')
 }
 
-function HighlightCard({ h, q, showDot }: { h: Highlight; q: string; showDot: boolean }) {
+function HighlightCard({ h, q, showDot, onDelete }: { h: Highlight; q: string; showDot: boolean; onDelete: (h: Highlight) => void }) {
   const tint = h.color ? (COLOR_TINT[h.color.toLowerCase()] ?? 'bg-primary/50') : 'bg-primary/40'
   const date = shortDate(h.datetime)
+  const [confirming, setConfirming] = useState(false)
   return (
-    <li className="rounded-lg border border-border bg-muted/40 px-3.5 py-3">
+    <li className="group rounded-lg border border-border bg-muted/40 px-3.5 py-3">
       <div className="flex items-start justify-between gap-3 mb-1.5">
         <div className="flex items-center gap-1.5 min-w-0">
           {showDot && <span className={cn('w-2 h-2 rounded-full shrink-0', tint)} />}
@@ -121,15 +122,42 @@ function HighlightCard({ h, q, showDot }: { h: Highlight; q: string; showDot: bo
             <p className="text-xs text-muted-foreground/70 truncate">{q ? mark(h.chapter, q) : h.chapter}</p>
           )}
         </div>
-        {date && (
-          <span
-            className="flex items-center gap-1 text-[11px] text-muted-foreground/50 shrink-0 cursor-help"
-            title={fullInfo(h)}
-          >
-            {date}
-            <Info className="w-3 h-3" />
-          </span>
-        )}
+        <div className="flex items-center gap-2 shrink-0">
+          {date && (
+            <span
+              className="flex items-center gap-1 text-[11px] text-muted-foreground/50 cursor-help"
+              title={fullInfo(h)}
+            >
+              {date}
+              <Info className="w-3 h-3" />
+            </span>
+          )}
+          {confirming ? (
+            <span className="flex items-center gap-1.5 text-[11px]">
+              <button
+                onClick={() => onDelete(h)}
+                className="font-medium text-destructive hover:underline"
+              >
+                Delete
+              </button>
+              <button
+                onClick={() => setConfirming(false)}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                Cancel
+              </button>
+            </span>
+          ) : (
+            <button
+              onClick={() => setConfirming(true)}
+              title="Delete this highlight"
+              aria-label="Delete this highlight"
+              className="p-1 -m-1 rounded text-muted-foreground/50 hover:text-destructive transition-all opacity-60 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
+            >
+              <Trash2 className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
       </div>
       {h.highlighted_text && (
         <p className="text-sm text-foreground leading-relaxed border-l-2 border-primary/40 pl-2.5">
@@ -236,6 +264,20 @@ export function HighlightsPage() {
   async function copyGroup(g: BookGroup) {
     await navigator.clipboard.writeText(groupToMarkdown(g))
     toast.success(`Copied ${g.items.length} from “${g.title}”`)
+  }
+
+  async function deleteHighlight(h: Highlight) {
+    // Was this the last loaded highlight for its book? If so the book drops off too.
+    const lastOfBook = !items.some(x => x.book_id === h.book_id && x.id !== h.id)
+    try {
+      await api.delete(`/annotations/${h.id}`)
+      setItems(prev => prev.filter(x => x.id !== h.id))
+      setTotal(t => Math.max(0, t - 1))
+      if (lastOfBook) setBooks(b => Math.max(0, b - 1))
+      toast.success('Highlight deleted')
+    } catch (e) {
+      toast.error((e as Error).message ?? 'Failed to delete highlight')
+    }
   }
 
   const isEmpty = !loading && !error && groups.length === 0
@@ -394,7 +436,7 @@ export function HighlightsPage() {
                   <div className={cn('grid transition-[grid-template-rows] duration-300 ease-out', isCollapsed ? 'grid-rows-[0fr]' : 'grid-rows-[1fr]')}>
                     <div className="overflow-hidden">
                       <ul className="space-y-2.5">
-                        {g.items.map(h => <HighlightCard key={h.id} h={h} q={debounced} showDot={showDots} />)}
+                        {g.items.map(h => <HighlightCard key={h.id} h={h} q={debounced} showDot={showDots} onDelete={deleteHighlight} />)}
                       </ul>
                     </div>
                   </div>

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -166,6 +166,61 @@ def test_empty_object_payload_coerced(client, db, admin_user, make_book):
     assert r.json()["annotations"] == []
 
 
+def test_web_delete_removes_and_tombstones(client, db, admin_user, make_book):
+    """Deleting a highlight from the web drops the row and leaves a tombstone,
+    so the deletion can propagate back to KOReader like a device-side delete."""
+    user, _ = admin_user
+    book = make_book()
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    _sync(client, hdr, book.id, upserts=[_hl(A1, "oops", dtu="2026-06-03 10:00:00")])
+
+    aid = client.get(f"/api/books/{book.id}/annotations").json()[0]["id"]
+    r = client.delete(f"/api/annotations/{aid}")
+    assert r.status_code == 204, r.text
+
+    assert db.query(Annotation).filter(Annotation.book_id == book.id).count() == 0
+    tombs = db.query(AnnotationTombstone).filter(AnnotationTombstone.book_id == book.id).all()
+    assert [t.anchor for t in tombs] == [A1]
+    assert tombs[0].client_deleted_at  # stamped with the deletion wall-clock
+
+
+def test_web_delete_propagates_and_holds_against_stale_device(client, db, admin_user, make_book):
+    """After a web delete the plugin pull returns the tombstone and no live row;
+    a stale device re-add (older mtime) cannot resurrect it."""
+    user, _ = admin_user
+    book = make_book()
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    _sync(client, hdr, book.id, upserts=[_hl(A1, dtu="2026-06-03 10:00:00")])
+    aid = client.get(f"/api/books/{book.id}/annotations").json()[0]["id"]
+    client.delete(f"/api/annotations/{aid}")
+
+    g = client.get(f"/api/tome-sync/annotations/{book.id}", headers=hdr).json()
+    assert g["annotations"] == []
+    assert [t["anchor"] for t in g["tombstones"]] == [A1]
+
+    r = _sync(client, hdr, book.id, upserts=[_hl(A1, dtu="2026-06-03 10:00:00")])
+    assert r.json()["applied"]["skipped"] == 1
+    assert r.json()["annotations"] == []
+
+
+def test_web_delete_scoped_to_owner(client, db, admin_user, make_book):
+    """You can only delete your own highlights; another user's id (or a missing one) 404s."""
+    user, _ = admin_user
+    book = make_book()
+    other = User(username="other2", email="o2@x.com", hashed_password=hash_password("pw"),
+                 is_active=True, is_admin=False, role="member")
+    db.add(other); db.flush()
+    hdr_other = {"Authorization": f"Bearer {_api_key_for(db, other.id)}"}
+    _sync(client, hdr_other, book.id, upserts=[_hl(A1, dtu="2026-06-03 10:00:00")])
+    other_aid = db.query(Annotation).filter(Annotation.user_id == other.id).first().id
+
+    # default client JWT is the admin user — must not reach another user's highlight
+    assert client.delete(f"/api/annotations/{other_aid}").status_code == 404
+    assert client.delete("/api/annotations/999999").status_code == 404
+    # the other user's highlight is untouched
+    assert db.query(Annotation).filter(Annotation.id == other_aid).count() == 1
+
+
 def test_auth_and_404(client, db, admin_user, make_book):
     user, _ = admin_user
     book = make_book()


### PR DESCRIPTION
## What

Lets you delete a synced KOReader highlight from Tome's web UI — handy for an accidental highlight you'd otherwise have to reopen the book to clear.

## How

New `DELETE /api/annotations/{id}`:
- Removes the `Annotation` row **and** writes an `AnnotationTombstone` stamped with the current wall-clock time — mirroring the TomeSync plugin's own delete path.
- On its next sync the device sees the tombstone, finds its local copy older, and drops the highlight too. So the delete actually sticks instead of being re-uploaded by a stale device.
- A genuinely-newer re-highlight of the same passage still wins and clears the tombstone, exactly as for a device-originated delete.
- Scoped to `user_id == current_user.id` — you can only delete your own highlights (another user's id or a missing one → 404).

Web UI: hover-revealed trash button with a two-step inline confirm, on both the **Highlights** page and each book's **Highlights & Notes** panel. Optimistic removal.

## Tests

3 new cases in `tests/test_annotations.py` (delete removes row + writes tombstone; deletion holds against a stale device re-add; owner-scoping/404). Full annotation suite: 14 passed. Frontend `tsc -b` clean.

## Caveats

- **True delete** — gone on every device, not a Tome-only hide.
- **Clock skew**: tombstone uses server wall-clock; deleting a *very* freshly-made highlight while a device clock runs behind could resurrect it (same LWW model the whole sync already uses).
- **PDF** anchors fall back to a timestamp rather than a stable xPointer, so a tombstone may not match across two devices; EPUB is fine.
- Device round-trip not yet verified on hardware/emulator.