### PR TITLE
feat(nav): one shared sidebar on every page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **The sidebar now follows you onto every page.** Stats, Highlights, Wishlist and
+  the Bindery used to drop you onto a bare screen with only a back-arrow — to get
+  from your stats to your highlights you had to bounce back through Home first.
+  They now carry the same sidebar as the rest of Tome (your libraries and shelves,
+  the full nav, your profile), so you can jump straight between any section and the
+  whole app feels like one place instead of a handful of detached screens. The
+  active section highlights itself, and on phones it's the same slide-in drawer.
 - **A Highlights page — your commonplace book.** Every highlight and note you make
   in KOReader already syncs into Tome; now there's one place to read them all. The
   new **Highlights** page (in the sidebar) gathers your highlights across the whole

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Menu } from 'lucide-react'
+import { useAuth, isMember } from '@/contexts/AuthContext'
+import { api } from '@/lib/api'
+import type { Library, SavedFilter } from '@/lib/books'
+import { Sidebar } from '@/components/Sidebar'
+import { TomeMark } from '@/components/TomeMark'
+import { SyncStatusBadge } from '@/components/SyncStatusBadge'
+import { NotificationBell } from '@/components/NotificationBell'
+import { UploadModal } from '@/components/UploadModal'
+
+/**
+ * The shared application shell — the same top navbar (Tome wordmark) + persistent
+ * Sidebar (docked on desktop, drawer on mobile) that the dashboard uses, so the
+ * standalone pages (Stats, Highlights, Wishlist, Bindery) get the *real* nav
+ * instead of a stripped-down clone. The page renders its own content as children;
+ * `actions` slots page-specific controls into the navbar's right side.
+ *
+ * Home / All Books / Series in the sidebar navigate back to the dashboard; the
+ * active section item (Stats/Highlights/…) highlights itself by route.
+ */
+export function AppShell({
+  children,
+  actions,
+}: {
+  children: ReactNode
+  actions?: ReactNode
+}) {
+  const navigate = useNavigate()
+  const { user } = useAuth()
+  const [libraries, setLibraries] = useState<Library[]>([])
+  const [savedFilters, setSavedFilters] = useState<SavedFilter[]>([])
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
+  const [uploadOpen, setUploadOpen] = useState(false)
+
+  const loadLibraries = () => { api.get<Library[]>('/libraries').then(setLibraries).catch(() => {}) }
+  const loadSavedFilters = () => { api.get<SavedFilter[]>('/saved-filters').then(setSavedFilters).catch(() => {}) }
+  useEffect(() => { loadLibraries(); loadSavedFilters() }, [])
+
+  return (
+    <div className="h-screen bg-background flex flex-col overflow-hidden">
+      <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-20 shrink-0 safe-top">
+        <div className="px-4 h-14 flex items-center gap-3">
+          <button
+            className="md:hidden flex items-center justify-center w-8 h-8 text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-muted shrink-0"
+            onClick={() => setMobileSidebarOpen(true)}
+            aria-label="Open navigation"
+          >
+            <Menu className="w-5 h-5" />
+          </button>
+          <div className="flex items-center gap-2 mr-2 shrink-0 group cursor-default">
+            <TomeMark className="w-5 h-5 text-primary logo-bob" strokeWidth={7} />
+            <span className="font-semibold text-sm">Tome</span>
+          </div>
+          <div className="flex items-center gap-1.5 ml-auto">
+            {actions}
+            <SyncStatusBadge />
+            <NotificationBell />
+            {isMember(user) && (
+              <button
+                onClick={() => setUploadOpen(true)}
+                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card hover:bg-muted transition-all touch-feedback"
+              >
+                <span className="hidden sm:inline">Upload</span>
+              </button>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <UploadModal
+        isOpen={uploadOpen}
+        onClose={() => setUploadOpen(false)}
+        onDone={() => {}}
+        onWishMatches={() => {}}
+      />
+
+      <div className="flex flex-1 overflow-hidden">
+        <Sidebar
+          libraries={libraries}
+          savedFilters={savedFilters}
+          activeTab="none"
+          onLibrariesChange={loadLibraries}
+          onSavedFiltersChange={loadSavedFilters}
+          onOpenSeriesView={() => navigate('/?tab=series')}
+          onOpenHomeView={() => navigate('/')}
+          mobileOpen={mobileSidebarOpen}
+          onMobileClose={() => setMobileSidebarOpen(false)}
+        />
+        <main className="flex-1 overflow-y-auto min-w-0">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Menu } from 'lucide-react'
+import { Menu, Search, X } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { api } from '@/lib/api'
 import type { Library, SavedFilter } from '@/lib/books'
@@ -33,6 +33,15 @@ export function AppShell({
   const [savedFilters, setSavedFilters] = useState<SavedFilter[]>([])
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [uploadOpen, setUploadOpen] = useState(false)
+  const [searchInput, setSearchInput] = useState('')
+
+  // Global library search from any page: Enter jumps to the dashboard's book
+  // results (it never live-yanks you off the current page mid-type).
+  function submitSearch(e: React.FormEvent) {
+    e.preventDefault()
+    const q = searchInput.trim()
+    navigate(q ? `/?tab=books&q=${encodeURIComponent(q)}` : '/?tab=books')
+  }
 
   const loadLibraries = () => { api.get<Library[]>('/libraries').then(setLibraries).catch(() => {}) }
   const loadSavedFilters = () => { api.get<SavedFilter[]>('/saved-filters').then(setSavedFilters).catch(() => {}) }
@@ -53,6 +62,25 @@ export function AppShell({
             <TomeMark className="w-5 h-5 text-primary logo-bob" strokeWidth={7} />
             <span className="font-semibold text-sm">Tome</span>
           </div>
+          <form onSubmit={submitSearch} className="relative flex-1 sm:max-w-md">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+            <input
+              className="w-full h-8 pl-9 pr-8 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+              placeholder="Search books…"
+              value={searchInput}
+              onChange={e => setSearchInput(e.target.value)}
+            />
+            {searchInput && (
+              <button
+                type="button"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                aria-label="Clear search"
+                onClick={() => setSearchInput('')}
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </form>
           <div className="flex items-center gap-1.5 ml-auto">
             {actions}
             <SyncStatusBadge />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useState, useRef, useEffect, useMemo } from 'react'
-import { useSearchParams, useLocation, Link } from 'react-router-dom'
+import { useSearchParams, useLocation, useNavigate, Link } from 'react-router-dom'
 import * as LucideIcons from 'lucide-react'
 import {
   BookOpen, Plus, Pencil, Trash2,
@@ -107,7 +107,9 @@ export function IconPicker({ value, onChange }: { value: string; onChange: (v: s
 interface Props {
   libraries: Library[]
   savedFilters: SavedFilter[]
-  activeTab: 'home' | 'books' | 'series'
+  // 'none' = a non-dashboard page (Stats/Highlights/…) is open, so none of the
+  // Home/All Books/Series items highlight — the active route item does instead.
+  activeTab: 'home' | 'books' | 'series' | 'none'
   onLibrariesChange: () => void
   onSavedFiltersChange: () => void
   onOpenSeriesView: () => void
@@ -118,7 +120,8 @@ interface Props {
 
 export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange, onSavedFiltersChange, onOpenSeriesView, onOpenHomeView, mobileOpen, onMobileClose }: Props) {
   const [open, setOpen] = useState(() => localStorage.getItem(SIDEBAR_KEY) !== 'closed')
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
   const { user, logout } = useAuth()
 
   // Generic filter modal (for saved filters only)
@@ -189,12 +192,19 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
     localStorage.setItem(SIDEBAR_KEY, next ? 'open' : 'closed')
   }
 
-  function selectAllBooks() { setSearchParams({ tab: 'books' }) }
-  function selectLibrary(id: number) { setSearchParams({ tab: 'books', library_id: String(id) }) }
+  // Navigate to the dashboard (pathname '/') with these params. Using navigate
+  // (not setSearchParams) means these work from a non-dashboard page too — the
+  // sidebar is now shared by Stats/Highlights/… via AppShell. On the dashboard
+  // itself the resulting URL is identical, so behaviour there is unchanged.
+  function goToBooks(params: Record<string, string>) {
+    navigate({ pathname: '/', search: '?' + new URLSearchParams(params).toString() })
+  }
+  function selectAllBooks() { goToBooks({ tab: 'books' }) }
+  function selectLibrary(id: number) { goToBooks({ tab: 'books', library_id: String(id) }) }
   function selectSavedFilter(sf: SavedFilter) {
     const params: Record<string, string> = { tab: 'books', saved_filter: String(sf.id) }
     Object.entries(sf.params).forEach(([k, v]) => { if (v) params[k] = v })
-    setSearchParams(params)
+    goToBooks(params)
   }
 
   function openCreateLibModal() {

--- a/frontend/src/pages/BinderyPage.tsx
+++ b/frontend/src/pages/BinderyPage.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState, useCallback } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import {
   RefreshCw, Loader2, BookOpen, Check, X, Trash2, Search,
   ChevronRight, ChevronDown, ArrowLeft, FolderOpen,
-  Inbox, Zap, Eye, BookPlus, HelpCircle,
+  Inbox, Zap, Eye, HelpCircle,
 } from 'lucide-react'
+import { AppShell } from '@/components/AppShell'
 import { DOCS, docsLink } from '@/lib/docs'
 import { api } from '@/lib/api'
 import { useBookTypes } from '@/lib/bookTypes'
@@ -1105,7 +1106,19 @@ export function BinderyPage() {
     let rowCounter = 0
 
     return (
-      <div className={cn('flex flex-col h-full min-h-screen bg-background transition-opacity duration-150', viewTransition ? 'opacity-0' : 'opacity-100')}>
+      <AppShell
+        actions={
+          <button
+            onClick={fetchAll}
+            disabled={loading || unreviewedLoading}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50"
+          >
+            <RefreshCw className={cn('h-3.5 w-3.5', (loading || unreviewedLoading) && 'animate-spin')} />
+            <span className="hidden sm:inline">Refresh</span>
+          </button>
+        }
+      >
+      <div className={cn('flex flex-col h-full transition-opacity duration-150', viewTransition ? 'opacity-0' : 'opacity-100')}>
         <style>{`
           @keyframes fade-in-up {
             from { opacity: 0; transform: translateY(8px); }
@@ -1118,41 +1131,25 @@ export function BinderyPage() {
           }
         `}</style>
         {/* Header */}
-        <div className="sticky top-0 z-10 bg-background/80 backdrop-blur-sm border-b border-border px-6 pt-6 pb-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center gap-3">
-              <Link to="/" className="p-2 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground">
-                <ArrowLeft className="w-4 h-4" />
-              </Link>
-              <BookPlus className="w-4 h-4 text-muted-foreground" />
-              <div>
-                <h1 className="text-sm font-semibold">Bindery</h1>
-                <p className="text-xs text-muted-foreground">
-                  {loading || unreviewedLoading
-                    ? 'Loading...'
-                    : unreviewed.length > 0
-                      ? `${unreviewed.length} imported + ${items.length} incoming`
-                      : `${items.length} file${items.length !== 1 ? 's' : ''} waiting for review`}
-                </p>
-              </div>
-              <a
-                href={docsLink(DOCS.bindery)}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Bindery flow explained — open docs"
-                className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              >
-                <HelpCircle className="w-3.5 h-3.5" />
-              </a>
-            </div>
-            <button
-              onClick={fetchAll}
-              disabled={loading || unreviewedLoading}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50"
+        <div className="sticky top-0 z-20 bg-background/80 backdrop-blur-sm border-b border-border px-4 pt-4 pb-4">
+          <div className="flex items-center gap-3">
+            <h1 className="font-display text-xl text-foreground">Bindery</h1>
+            <p className="text-xs text-muted-foreground hidden md:block">
+              {loading || unreviewedLoading
+                ? 'Loading...'
+                : unreviewed.length > 0
+                  ? `${unreviewed.length} imported + ${items.length} incoming`
+                  : `${items.length} file${items.length !== 1 ? 's' : ''} waiting for review`}
+            </p>
+            <a
+              href={docsLink(DOCS.bindery)}
+              target="_blank"
+              rel="noopener noreferrer"
+              title="Bindery flow explained — open docs"
+              className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
             >
-              <RefreshCw className={cn('h-3.5 w-3.5', (loading || unreviewedLoading) && 'animate-spin')} />
-              Refresh
-            </button>
+              <HelpCircle className="w-3.5 h-3.5" />
+            </a>
           </div>
 
           {/* Toolbar — always visible when there are items */}
@@ -1489,6 +1486,7 @@ export function BinderyPage() {
           onCancel={() => setConfirmRejectUnreviewed(null)}
         />
       </div>
+      </AppShell>
     )
   }
 
@@ -1501,7 +1499,8 @@ export function BinderyPage() {
   const currentForm = currentItem ? formData[currentItem.path] : null
 
   return (
-    <div className={cn('flex flex-col h-full min-h-screen bg-background transition-opacity duration-150', viewTransition ? 'opacity-0' : 'opacity-100')}>
+    <AppShell>
+    <div className={cn('flex flex-col h-full transition-opacity duration-150', viewTransition ? 'opacity-0' : 'opacity-100')}>
       {/* Header */}
       <div className="sticky top-0 z-10 bg-background border-b border-border px-6 pt-5 pb-3">
         <div className="flex items-center gap-3">
@@ -1776,5 +1775,6 @@ export function BinderyPage() {
         onCancel={() => setConfirmReject(null)}
       />
     </div>
+    </AppShell>
   )
 }

--- a/frontend/src/pages/HighlightsPage.tsx
+++ b/frontend/src/pages/HighlightsPage.tsx
@@ -1,12 +1,13 @@
 import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import {
-  ArrowLeft, Search, Quote, StickyNote, Loader2, BookOpen,
+  Search, Quote, StickyNote, Loader2, BookOpen,
   CalendarHeart, Copy, X, ChevronDown, Info, ChevronsDownUp, ChevronsUpDown,
 } from 'lucide-react'
 import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
 import { cn } from '@/lib/utils'
+import { AppShell } from '@/components/AppShell'
 
 interface Highlight {
   id: number
@@ -242,38 +243,27 @@ export function HighlightsPage() {
   const neverSynced = isEmpty && !debounced && !onThisDay
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-sm safe-top">
-        <div className="flex items-center gap-3 px-4 h-14 max-w-3xl mx-auto">
-          <Link
-            to="/"
-            className="p-2 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
-          >
-            <ArrowLeft className="w-4 h-4" />
-          </Link>
-          <div className="flex items-center gap-2 flex-1 min-w-0">
-            <Quote className="w-4 h-4 text-muted-foreground shrink-0" />
-            <span className="text-sm font-semibold">Highlights</span>
-            {total > 0 && (
-              <span className="text-xs text-muted-foreground/60 truncate">
-                {total} from {books} book{books === 1 ? '' : 's'}
-              </span>
-            )}
-          </div>
-          {groups.length > 0 && (
-            <button
-              onClick={copyAll}
-              title="Copy all as Markdown"
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border hover:bg-muted transition-all"
-            >
-              <Copy className="w-3.5 h-3.5" />
-              Export
-            </button>
+    <AppShell
+      actions={groups.length > 0 ? (
+        <button
+          onClick={copyAll}
+          title="Copy all as Markdown"
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border hover:bg-muted transition-all"
+        >
+          <Copy className="w-3.5 h-3.5" />
+          <span className="hidden sm:inline">Export</span>
+        </button>
+      ) : undefined}
+    >
+      <div className="max-w-3xl mx-auto px-4 py-6 space-y-5">
+        <div className="flex items-baseline justify-between gap-3">
+          <h1 className="font-display text-xl text-foreground">Highlights</h1>
+          {total > 0 && (
+            <span className="text-xs text-muted-foreground/60">
+              {total} from {books} book{books === 1 ? '' : 's'}
+            </span>
           )}
         </div>
-      </header>
-
-      <main className="max-w-3xl mx-auto px-4 py-6 space-y-5">
         {/* Controls */}
         <div className="flex items-center gap-2">
           <div className="relative flex-1">
@@ -416,7 +406,7 @@ export function HighlightsPage() {
             )}
           </div>
         )}
-      </main>
-    </div>
+      </div>
+    </AppShell>
   )
 }

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -7,11 +7,11 @@ import ReactGridLayout, {
 import 'react-grid-layout/css/styles.css'
 import 'react-resizable/css/styles.css'
 import { Link } from 'react-router-dom'
+import { AppShell } from '@/components/AppShell'
 import { toPng } from 'html-to-image'
-import { ArrowLeft, Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, Trophy, Globe, Library as LibraryIcon, Clock3, Infinity as InfinityIcon, Type, Ruler, type LucideIcon } from 'lucide-react'
+import { Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, Trophy, Globe, Library as LibraryIcon, Clock3, Infinity as InfinityIcon, Type, Ruler, type LucideIcon } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { api } from '@/lib/api'
-import { SyncStatusBadge } from '@/components/SyncStatusBadge'
 import { BookAnimation } from '@/components/BookAnimation'
 import { DOCS, docsLink } from '@/lib/docs'
 import { type StatsResponse, type CompletionEstimate } from '@/components/stats/shared'
@@ -1944,7 +1944,7 @@ export function StatsPage() {
   }, [editMode, addOpen, tabMenuOpen])
 
   return (
-    <div className="min-h-screen bg-background">
+    <AppShell>
       <style>{`
         .react-grid-item.react-grid-placeholder {
           background: var(--primary, #6366f1) !important;
@@ -1971,12 +1971,8 @@ export function StatsPage() {
       <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-sm safe-top">
         {/* min-h + wrap: on phones the range pills don't fit beside the title row,
             so they wrap to a second line instead of overflowing the viewport */}
-        <div className={cn('flex min-h-14 flex-wrap items-center gap-x-3 py-1.5 transition-[padding] duration-200', PAD_X[pad])}>
-          <Link to="/" className="-ml-2 rounded-lg p-2 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-          <BarChart3 className="h-4 w-4 text-muted-foreground" />
-          <span className="hidden text-base font-bold sm:inline">Reading Stats</span>
+        <div className={cn('flex min-h-14 flex-wrap items-center gap-x-3 py-1.5 px-4')}>
+          <h1 className="font-display text-xl text-foreground">Reading Stats</h1>
           <a
             href={docsLink(DOCS.stats)}
             target="_blank"
@@ -1987,7 +1983,6 @@ export function StatsPage() {
             <HelpCircle className="h-3.5 w-3.5" />
           </a>
           <div className="ml-auto flex items-center gap-2">
-            <SyncStatusBadge />
             {/* range selector — presets + custom date range; refetches /stats */}
             <RangeControl
               days={days}
@@ -2003,7 +1998,7 @@ export function StatsPage() {
 
         {/* board tabs (pills, like the Stats page) + board tools */}
         <div className="border-t border-border/50">
-          <div className={cn('flex items-center gap-1 py-1.5 transition-[padding] duration-200', PAD_X[pad])}>
+          <div className={cn('flex items-center gap-1 py-1.5 px-4')}>
             {/* Only the tabs scroll horizontally; the + and board tools stay pinned
                 and reachable however many boards you add. */}
             <div className="flex min-w-0 items-center gap-1 overflow-x-auto">
@@ -2216,7 +2211,7 @@ export function StatsPage() {
 
       {/* edit mode gets extra bottom room so the last tile's resize handles have
           somewhere to scroll to */}
-      <main className={cn('py-6 transition-[padding] duration-200', PAD_X[pad], editMode && 'pb-[35vh]')}>
+      <div className={cn('py-6 transition-[padding] duration-200', PAD_X[pad], editMode && 'pb-[35vh]')}>
       {/* one-time hint that the page is editable */}
       {stats && !neverRead && !hintDismissed && !editMode && (
         <div className="mb-4 flex items-center gap-2 rounded-lg border border-primary/30 bg-primary/5 px-3 py-2 text-xs">
@@ -2280,7 +2275,7 @@ export function StatsPage() {
       ) : (
         <p className="py-32 text-center text-sm text-muted-foreground">Couldn’t load stats.</p>
       )}
-      </main>
+      </div>
 
       {addOpen && stats && (
         <AddWidgetModal ctx={{ stats, estimates, goals, reloadGoals }} present={new Set(active.tiles.map((t) => t.defId))} onAdd={addWidget} onClose={() => setAddOpen(false)} />
@@ -2305,7 +2300,7 @@ export function StatsPage() {
           </button>
         </div>
       )}
-    </div>
+    </AppShell>
   )
 }
 

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {
-  ArrowLeft, Plus, Trash2, ChevronDown, ChevronUp,
+  Plus, Trash2, ChevronDown, ChevronUp,
   BookOpen, Loader2, Sparkles, Layers, ExternalLink,
 } from 'lucide-react'
+import { AppShell } from '@/components/AppShell'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
 import { listWishes, deleteWish, type WishOut } from '@/lib/wishlist'
@@ -92,41 +93,30 @@ export function WishlistPage() {
 
   if (!canWish) {
     return (
-      <div className="min-h-screen bg-background flex flex-col items-center justify-center gap-3">
-        <Sparkles className="w-10 h-10 text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">Members can add books to their wishlist.</p>
-        <Link to="/" className="text-sm text-primary hover:underline">Go back</Link>
-      </div>
+      <AppShell>
+        <div className="flex flex-col items-center justify-center gap-3 py-24 text-center">
+          <Sparkles className="w-10 h-10 text-muted-foreground" />
+          <p className="text-sm text-muted-foreground">Members can add books to their wishlist.</p>
+          <Link to="/" className="text-sm text-primary hover:underline">Go back</Link>
+        </div>
+      </AppShell>
     )
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-sm safe-top">
-        <div className="flex items-center gap-3 px-4 h-14 max-w-3xl mx-auto">
-          <Link
-            to="/"
-            className="p-2 rounded-lg hover:bg-accent transition-colors text-muted-foreground hover:text-foreground"
-          >
-            <ArrowLeft className="w-4 h-4" />
-          </Link>
-          <div className="flex items-center gap-2 flex-1">
-            <Sparkles className="w-4 h-4 text-muted-foreground" />
-            <span className="text-sm font-semibold">Wishlist</span>
-          </div>
-          {canWish && (
-            <button
-              onClick={() => setAddOpen(true)}
-              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
-            >
-              <Plus className="w-3.5 h-3.5" />
-              Wish
-            </button>
-          )}
-        </div>
-      </header>
-
-      <main className="max-w-3xl mx-auto px-4 py-6 space-y-6">
+    <AppShell
+      actions={
+        <button
+          onClick={() => setAddOpen(true)}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
+        >
+          <Plus className="w-3.5 h-3.5" />
+          <span className="hidden sm:inline">Wish</span>
+        </button>
+      }
+    >
+      <div className="max-w-3xl mx-auto px-4 py-6 space-y-6">
+        <h1 className="font-display text-xl text-foreground">Wishlist</h1>
         {loading ? (
           <div className="flex justify-center py-16">
             <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
@@ -272,7 +262,7 @@ export function WishlistPage() {
             )}
           </>
         )}
-      </main>
+      </div>
 
       {addOpen && (
         <WishlistModal
@@ -283,6 +273,6 @@ export function WishlistPage() {
           }}
         />
       )}
-    </div>
+    </AppShell>
   )
 }


### PR DESCRIPTION
## What

The standalone pages — **Stats, Highlights, Wishlist, Bindery** — used to drop you onto a bare screen with a stripped-down clone drawer (five links, no logo, no search, no libraries/shelves), and each page hand-rolled its own header. Switching between them was jarring: the nav control jumped position and the chrome changed shape, and the nav itself felt like a lesser, different app.

Now they all render inside the **real** application shell — the same navbar and sidebar the dashboard uses.

## How

- New **`AppShell`** = the genuine top navbar (Tome wordmark + global book search) + the real `Sidebar` (docked on desktop, slide-in drawer on mobile). All four standalone pages render their content inside it.
- The sidebar is the actual component, so these pages get the full nav: Home / All Books / Series / Stats / Highlights / Wishlist / Bindery, your **libraries** (with counts), your **shelves**, and your **profile**. The active section highlights itself by route; only the content area changes when you switch.
- `Sidebar` made route-safe — All Books / library / shelf clicks navigate to the dashboard explicitly so they work from any page (dashboard behaviour unchanged).
- **Global library search** in the shared navbar: Enter jumps to the library results; it never live-navigates mid-type.
- Deleted the `SectionDrawer` / `SectionNav` clones — there is now exactly one navigation component in the codebase.

## Verification

- Captured every page against the showcase stack: Home, Stats, Highlights, Wishlist, Bindery (incl. the Bindery file-review view with a seeded file) — all render correctly inside the shell, dashboard unaffected.
- `tsc -b` clean; `test_annotations.py` 14 passed.

## Notes

- Per-page actions preserved: Export (Highlights), Wish (Wishlist), Refresh (Bindery), and the Overview/Habits/Library/Taste tabs + range picker (Stats) now sit as a sub-toolbar under the shared navbar.
- Includes a merge of `main` (the #77 highlight-delete work); the Highlights page carries both the new shell and the per-highlight delete button.