### PR TITLE
feat(stats): per-page reading insights from imported KOReader history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Per-page reading stats from your KOReader history.** Once you've imported your
+  device's reading history, each book page gains a **Reading intensity** strip —
+  where your time actually went across the book, page by page — plus an honest
+  **"X of Y pages"** read (from the real page count, not a guess) and a note when
+  you've re-read stretches. A book's reading stats (time, pages, dates, pace) now
+  also reflect that imported history, so books you only ever read on the device
+  are no longer shown as blank. On the dashboard, a new **Re-reads** tile (from the
+  tile gallery) ranks the books whose pages you keep coming back to, and the
+  **Completion Estimates** tile now measures progress by real pages turned — so it
+  works for device reading too, not just the web reader.
 - **The sidebar now follows you onto every page.** Stats, Highlights, Wishlist and
   the Bindery used to drop you onto a bare screen with only a back-arrow — to get
   from your stats to your highlights you had to bounce back through Home first.

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1089,6 +1089,7 @@ def get_book_reading_stats(
     from backend.services.reading_stats import (
         compute_book_reading_stats,
         compute_book_aggregate_stats,
+        compute_book_page_intensity,
     )
 
     book = db.get(Book, book_id)
@@ -1103,8 +1104,10 @@ def get_book_reading_stats(
         if _is_admin(current_user)
         else None
     )
+    # Per-page intensity from imported KOReader page-stats (None if web-only reading)
+    intensity = compute_book_page_intensity(db, user_id=current_user.id, book_id=book_id)
 
-    return {"own": own, "aggregate": aggregate}
+    return {"own": own, "aggregate": aggregate, "intensity": intensity}
 
 
 # ── Single book ───────────────────────────────────────────────────────────────

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -1,11 +1,11 @@
 """Personal reading statistics endpoint. TomeSync data only."""
 import json
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, HTTPException
-from sqlalchemy import func, case
+from sqlalchemy import func, case, Integer
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -900,6 +900,54 @@ def get_stats(
         "books": length_books,
     }
 
+    # ── Re-reads (all-time) — books with pages revisited on a later day ─────────
+    # A page read on 2+ distinct local-days is a re-read. We rank books by how
+    # many of their pages got revisited. Pure page-stats, no plugin work.
+    from backend.models.ko_stats import PageStat as _PageStat
+    _day = func.cast(_PageStat.start_time / 86400, Integer)
+    _reread_pages_sq = (
+        db.query(
+            _PageStat.book_id.label("book_id"),
+            _PageStat.page.label("page"),
+        )
+        .filter(_PageStat.user_id == current_user.id)
+        .group_by(_PageStat.book_id, _PageStat.page)
+        .having(func.count(func.distinct(_day)) > 1)
+        .subquery()
+    )
+    reread_counts = dict(
+        db.query(_reread_pages_sq.c.book_id, func.count())
+        .group_by(_reread_pages_sq.c.book_id)
+        .all()
+    )
+    reread_books: list[dict] = []
+    if reread_counts:
+        rr_ids = list(reread_counts.keys())
+        rr_totals = dict(
+            db.query(_PageStat.book_id, func.max(_PageStat.total_pages))
+            .filter(_PageStat.user_id == current_user.id, _PageStat.book_id.in_(rr_ids))
+            .group_by(_PageStat.book_id).all()
+        )
+        rr_meta = {
+            b.id: b for b in db.query(Book).filter(
+                Book.id.in_(rr_ids), Book.status == "active",
+                book_visibility_filter(db, current_user),
+            )
+        }
+        for bid, n in reread_counts.items():
+            bk = rr_meta.get(bid)
+            if not bk or int(n) < 3:          # ignore 1–2 stray revisited pages
+                continue
+            total = int(rr_totals.get(bid) or 0)
+            reread_books.append({
+                "book_id": bid, "title": bk.title, "author": bk.author,
+                "has_cover": bool(bk.cover_path),
+                "reread_pages": int(n), "total_pages": total,
+                "pct": round(int(n) / total * 100, 1) if total else 0,
+            })
+        reread_books.sort(key=lambda b: b["reread_pages"], reverse=True)
+    rereads = {"books": reread_books}
+
     return {
         "range_days": effective_days,
         "headline": {
@@ -939,6 +987,7 @@ def get_stats(
         "words": words,
         "wpm": wpm,
         "book_lengths": book_lengths,
+        "rereads": rereads,
     }
 
 
@@ -971,6 +1020,9 @@ def get_completion_estimates(
         .all()
     )
 
+    from backend.models.ko_stats import PageStat
+    window_epoch = int(window_start.replace(tzinfo=timezone.utc).timestamp())
+
     result = []
     for row in in_progress:
         # Normalise progress to 0–100
@@ -997,8 +1049,33 @@ def get_completion_estimates(
         total_secs_30 = int(session_rows.total_secs) if session_rows and session_rows.total_secs else 0
         session_count = int(session_rows.session_count) if session_rows and session_rows.session_count else 0
 
+        # Honest progress + pace from imported KOReader page-stats, when present:
+        # distinct pages read ÷ real total_pages, and a page-stats reading-day
+        # count so device-only books (no live sessions) still get an estimate.
+        ps = (
+            db.query(
+                func.count(func.distinct(PageStat.page)),
+                func.max(PageStat.total_pages),
+                func.count(func.distinct(case((PageStat.start_time >= window_epoch, PageStat.page)))),
+                func.count(func.distinct(case((PageStat.start_time >= window_epoch,
+                                               func.cast(PageStat.start_time / 86400, Integer))))),
+            )
+            .filter(PageStat.user_id == current_user.id, PageStat.book_id == row.id)
+            .one()
+        )
+        ps_pages, ps_total, ps_pages_30, ps_days_30 = (int(ps[0] or 0), int(ps[1] or 0),
+                                                       int(ps[2] or 0), int(ps[3] or 0))
+        ps_days_30 = max(ps_days_30 - (1 if ps_pages_30 else 0), 0)  # gained over the gaps, not the first day
+        if ps_total > 0:
+            progress = min(round(ps_pages / ps_total * 100, 1), 100.0)
+
         estimated_days: Optional[int] = None
-        if session_count > 0 and progress >= 5 and progress < 100:
+        if session_count == 0 and ps_total > 0 and ps_pages_30 > 0 and ps_days_30 >= 1 and progress < 100:
+            # Device-only: pages read per active-day → days to read the rest.
+            pages_per_day = ps_pages_30 / ps_days_30
+            remaining_pages = max(ps_total - ps_pages, 0)
+            estimated_days = max(1, round(remaining_pages / pages_per_day)) if pages_per_day else None
+        elif session_count > 0 and progress >= 5 and progress < 100:
             # Calculate progress gained during the window
             earliest_pct = session_rows.earliest_progress or 0.0
             # Normalise earliest_pct the same way as progress (0-1 → 0-100)
@@ -1011,9 +1088,12 @@ def get_completion_estimates(
             remaining = 100.0 - progress
             estimated_days = max(1, round(remaining / progress_per_day))
 
-        if session_count >= 5:
+        # Confidence from whichever signal drove the estimate (live sessions or
+        # page-stat reading-days for device-only books).
+        evidence = max(session_count, ps_days_30)
+        if evidence >= 5:
             confidence = "high"
-        elif session_count >= 2:
+        elif evidence >= 2:
             confidence = "medium"
         else:
             confidence = "low"

--- a/backend/services/reading_stats.py
+++ b/backend/services/reading_stats.py
@@ -125,6 +125,84 @@ def compute_book_reading_stats(
     }
 
 
+# ── Per-book reading intensity (imported KOReader page-stats) ─────────────────
+
+def compute_book_page_intensity(
+    db: Session,
+    *,
+    user_id: int,
+    book_id: int,
+    bins: int = 50,
+) -> Optional[dict]:
+    """Per-page reading intensity for one book, from imported KOReader page-stats.
+
+    Returns None when the user has no page-stats for this book (e.g. it was only
+    ever read in the web reader) — the caller hides the section in that case.
+
+    KOReader re-paginates whenever font/margins change, so a row's absolute page
+    number is only meaningful against its own ``total_pages``. We map each dwell
+    row to a fraction-of-book (``page / total_pages``) and bucket into ``bins``
+    slots — pagination-robust, and exactly the "where did the time go across the
+    book" curve we want. Distinct pages read (against the latest pagination) gives
+    an honest "X of Y pages" denominator without needing an intrinsic page count.
+    """
+    from backend.models.ko_stats import PageStat
+
+    rows = (
+        db.query(
+            PageStat.page,
+            PageStat.total_pages,
+            PageStat.duration_seconds,
+            PageStat.start_time,
+        )
+        .filter(
+            PageStat.user_id == user_id,
+            PageStat.book_id == book_id,
+            PageStat.total_pages > 0,
+        )
+        .all()
+    )
+    if not rows:
+        return None
+
+    curve = [0] * bins
+    bin_days: dict[int, set] = defaultdict(set)
+    distinct_pages: set[int] = set()
+    total_seconds = 0
+    latest_total_pages = 0
+
+    for page, total_pages, dur, start_time in rows:
+        if not total_pages or total_pages <= 0:
+            continue
+        frac = (page - 1) / total_pages          # page is 1-based
+        frac = min(max(frac, 0.0), 0.99999)
+        b = min(int(frac * bins), bins - 1)
+        dur = int(dur or 0)
+        curve[b] += dur
+        total_seconds += dur
+        distinct_pages.add(int(page))
+        latest_total_pages = max(latest_total_pages, int(total_pages))
+        # local-day bucket (page revisited on a different day ⇒ a re-read)
+        bin_days[b].add(int(start_time) // 86400 if start_time else 0)
+
+    pages_read = len(distinct_pages)
+    pct_read = (
+        min(round(pages_read / latest_total_pages * 100, 1), 100.0)
+        if latest_total_pages else 0.0
+    )
+    reread_bins = sum(1 for days in bin_days.values() if len(days) > 1)
+
+    return {
+        "bins": bins,
+        "curve": curve,                 # seconds of dwell per fraction-bin (0..bins-1)
+        "total_seconds": total_seconds,
+        "total_pages": latest_total_pages,
+        "pages_read": pages_read,
+        "pct_read": pct_read,           # distinct pages read ÷ total (capped 100)
+        "reread_bins": reread_bins,     # bins revisited on a later day
+    }
+
+
 # ── Admin aggregate — all users, one book ────────────────────────────────────
 
 def compute_book_aggregate_stats(

--- a/backend/services/reading_stats.py
+++ b/backend/services/reading_stats.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import func
+from sqlalchemy import func, Integer
 from sqlalchemy.orm import Session
 
 from backend.models.book import Book
@@ -99,6 +99,61 @@ def compute_book_reading_stats(
         {"date": row.date, "seconds": int(row.seconds), "pages": int(row.pages)}
         for row in timeline_rows
     ]
+
+    # ── Reconcile with imported KOReader page-stats ──────────────────────────
+    # Page-stats win per book (same rule as the dashboard's reconciled_reading),
+    # so a book read only on the device isn't shown empty. Untouched when the
+    # book has no page-stats — ps_seconds is 0 and this whole block is skipped.
+    from backend.models.ko_stats import PageStat
+
+    ps = (
+        db.query(
+            func.coalesce(func.sum(PageStat.duration_seconds), 0),
+            func.count(func.distinct(PageStat.page)),
+            func.min(PageStat.start_time),
+            func.max(PageStat.start_time),
+            func.max(PageStat.total_pages),
+        )
+        .filter(PageStat.user_id == user_id, PageStat.book_id == book_id)
+        .one()
+    )
+    ps_seconds = int(ps[0] or 0)
+    if ps_seconds > 0:
+        total_seconds = ps_seconds
+        pages_turned = int(ps[1] or 0)          # distinct pages genuinely read
+        ps_total_pages = int(ps[4] or 0)
+        # Daily buckets from page-stats (local-day = start_time // 86400, UTC).
+        day_rows = (
+            db.query(
+                func.cast(PageStat.start_time / 86400, Integer).label("day"),
+                func.coalesce(func.sum(PageStat.duration_seconds), 0).label("seconds"),
+                func.count(func.distinct(PageStat.page)).label("pages"),
+            )
+            .filter(PageStat.user_id == user_id, PageStat.book_id == book_id)
+            .group_by("day")
+            .order_by("day")
+            .all()
+        )
+        session_timeline = [
+            {
+                "date": datetime.fromtimestamp(int(r.day) * 86400, timezone.utc).strftime("%Y-%m-%d"),
+                "seconds": int(r.seconds),
+                "pages": int(r.pages),
+            }
+            for r in day_rows
+        ]
+        sessions = len(session_timeline)        # one "session" per reading day
+        avg_session_seconds = round(total_seconds / sessions) if sessions else 0
+        if ps[2]:
+            first_read = datetime.fromtimestamp(int(ps[2]), timezone.utc).isoformat()
+        if ps[3]:
+            last_read = datetime.fromtimestamp(int(ps[3]), timezone.utc).isoformat()
+        total_minutes = total_seconds / 60.0
+        if total_minutes > 0 and pages_turned > 0:
+            pace_pages_per_min = round(pages_turned / total_minutes, 2)
+        # Real page-based progress beats a stale stored progress_pct.
+        if ps_total_pages > 0:
+            progress = min(pages_turned / ps_total_pages, 1.0)
 
     # ── Estimated time to finish ─────────────────────────────────────────────
     estimated_finish_seconds: Optional[int] = None

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -76,6 +76,9 @@ export interface StatsResponse {
     by_year: { year: number; avg_words: number; count: number }[]
     books: { book_id: number; title: string; has_cover: boolean; words: number; finished: string | null }[]
   }
+  rereads: {
+    books: { book_id: number; title: string; author: string | null; has_cover: boolean; reread_pages: number; total_pages: number; pct: number }[]
+  }
 }
 
 export interface CompletionEstimate {

--- a/frontend/src/components/stats/widgets/wordstats.tsx
+++ b/frontend/src/components/stats/widgets/wordstats.tsx
@@ -107,6 +107,28 @@ export function TrueWpm({ data }: { data: StatsResponse['wpm'] }) {
   )
 }
 
+// 4 ── Re-reads: books whose pages you've revisited on a later day ──────────────
+export function ReReads({ data }: { data: StatsResponse['rereads'] }) {
+  if (!data || data.books.length === 0) return <Empty text="No re-reads yet — pages you revisit on a later day show up here." />
+  return (
+    <div className="flex flex-col gap-2.5">
+      {data.books.slice(0, 8).map((b) => (
+        <div key={b.book_id} className="flex items-center gap-2.5">
+          <Cover id={b.book_id} has={b.has_cover} alt="" />
+          <div className="min-w-0 flex-1">
+            <a href={`/books/${b.book_id}`} className="line-clamp-1 text-sm font-medium text-foreground transition-colors hover:text-primary">{b.title}</a>
+            {b.author && <p className="truncate text-xs text-muted-foreground">{b.author}</p>}
+          </div>
+          <span className="shrink-0 text-right text-sm font-bold tabular-nums text-foreground">
+            {b.reread_pages.toLocaleString()}
+            <span className="ml-0.5 text-[10px] font-normal text-muted-foreground">pages{b.pct ? ` · ${b.pct}%` : ''}</span>
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 // 3 ── Book Length: word-count distribution of finished books + avg/median ───────
 export function BookLength({ data }: { data: StatsResponse['book_lengths'] }) {
   const { accent, tick, cursor } = useChartColors()

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -53,6 +53,16 @@ interface BookReadingStats {
   estimated_finish_seconds: number | null
 }
 
+interface BookIntensity {
+  bins: number
+  curve: number[]
+  total_seconds: number
+  total_pages: number
+  pages_read: number
+  pct_read: number
+  reread_bins: number
+}
+
 interface ReadingStatsResponse {
   own: BookReadingStats
   aggregate: {
@@ -60,6 +70,7 @@ interface ReadingStatsResponse {
     total_sessions: number
     distinct_readers: number
   } | null
+  intensity: BookIntensity | null
 }
 
 async function downloadFile(book: BookDetail, f: BookFile) {
@@ -685,8 +696,10 @@ export function BookDetailPage() {
     </div>
   )
 
-  // Full collapsible stats hero block
-  const statsFull = readingStats && readingStats.own.sessions > 0 ? (
+  // Full collapsible stats hero block. Shows when there are live sessions OR
+  // imported KOReader page-stats (a book read only on the device has no sessions
+  // but does have an intensity curve).
+  const statsFull = readingStats && (readingStats.own.sessions > 0 || readingStats.intensity) ? (
     <div className="mt-1 mb-5">
       <div className="flex items-center gap-2 mb-2.5">
         <button
@@ -700,7 +713,12 @@ export function BookDetailPage() {
         </button>
       </div>
       {statsOpen && (
-        <StatsLayoutHero own={readingStats.own} aggregate={readingStats.aggregate} />
+        <div className="flex flex-col gap-3">
+          {readingStats.own.sessions > 0 && (
+            <StatsLayoutHero own={readingStats.own} aggregate={readingStats.aggregate} />
+          )}
+          {readingStats.intensity && <IntensityBlock data={readingStats.intensity} />}
+        </div>
       )}
     </div>
   ) : null
@@ -1210,6 +1228,52 @@ function ActivityChart({ timeline }: { timeline: { date: string; seconds: number
       <div className="flex justify-between text-xs text-muted-foreground/50 mt-1 shrink-0">
         <span>{first?.date ? fmtDay(first.date) : ''}</span>
         <span>{last?.date ? fmtDay(last.date) : ''}</span>
+      </div>
+    </div>
+  )
+}
+
+// ── Reading intensity: per-page dwell across the book, from imported KOReader page-stats ─────
+
+function IntensityBlock({ data }: { data: BookIntensity }) {
+  const max = Math.max(...data.curve, 1)
+  const finished = data.pct_read >= 99
+  return (
+    <div className="rounded-xl border border-border bg-card px-5 py-4">
+      <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+        <p className="font-display text-sm text-foreground">Reading intensity</p>
+        <p className="text-xs text-muted-foreground">
+          <span className="font-medium tabular-nums text-foreground">{data.pages_read.toLocaleString()}</span>
+          {' '}of {data.total_pages.toLocaleString()} pages
+          {!finished && <span className="tabular-nums"> · {data.pct_read}%</span>}
+          {' · '}{formatDuration(data.total_seconds)} on device
+        </p>
+      </div>
+      {/* Dwell across the book, 0% → 100%. Taller bar = more time spent there. */}
+      <div className="mt-3 relative h-16">
+        <div className="absolute bottom-0 left-0 right-0 h-px bg-border/40" />
+        <div className="absolute inset-0 flex items-end gap-px">
+          {data.curve.map((secs, i) => {
+            const pct = secs > 0 ? Math.max(secs / max, 0.04) : 0
+            const at = Math.round((i / data.curve.length) * 100)
+            const tip = secs > 0 ? `~${at}% in · ${formatDuration(secs)}` : `~${at}% in · not read`
+            return (
+              <div
+                key={i}
+                className="flex-1 min-w-px bg-primary/60 hover:bg-primary transition-colors rounded-t-[1px]"
+                style={{ height: pct > 0 ? `${Math.round(pct * 100)}%` : '0%' }}
+                title={tip}
+              />
+            )
+          })}
+        </div>
+      </div>
+      <div className="flex justify-between text-xs text-muted-foreground/50 mt-1">
+        <span>start</span>
+        {data.reread_bins > 0 && (
+          <span className="text-muted-foreground/70">{data.reread_bins} stretch{data.reread_bins !== 1 ? 'es' : ''} re-read</span>
+        )}
+        <span>end</span>
       </div>
     </div>
   )

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -9,7 +9,7 @@ import 'react-resizable/css/styles.css'
 import { Link } from 'react-router-dom'
 import { AppShell } from '@/components/AppShell'
 import { toPng } from 'html-to-image'
-import { Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, Trophy, Globe, Library as LibraryIcon, Clock3, Infinity as InfinityIcon, Type, Ruler, type LucideIcon } from 'lucide-react'
+import { Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, Trophy, Globe, Library as LibraryIcon, Clock3, Infinity as InfinityIcon, Type, Ruler, Repeat, type LucideIcon } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { api } from '@/lib/api'
 import { BookAnimation } from '@/components/BookAnimation'
@@ -72,6 +72,7 @@ import {
   WordsRead,
   TrueWpm,
   BookLength,
+  ReReads,
 } from '@/components/stats/widgets/wordstats'
 
 /**
@@ -559,6 +560,16 @@ const WIDGETS: WidgetDef[] = [
     fixedWindow: 'all',
     render: ({ stats }) => <BookLength data={stats.book_lengths} />,
   },
+  {
+    id: 'rereads',
+    title: 'Re-reads',
+    icon: Repeat,
+    size: { w: 4, h: 3, minW: 3, minH: 2 },
+    autoH: true,
+    fixedWindow: 'all',
+    defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
+    render: ({ stats }) => <ReReads data={stats.rereads} />,
+  },
 ]
 
 const defById = (id: string) => WIDGETS.find((w) => w.id === id.replace(/--[a-z0-9]+$/, ''))!
@@ -614,6 +625,7 @@ const WIDGET_DESC: Record<string, string> = {
   'words-read': 'Lifetime words read, by year',
   'true-wpm': 'Your real reading speed — words ÷ time',
   'book-length': 'How long the books you finish are',
+  'rereads': 'Books whose pages you revisit',
 }
 
 // Widgets that are a number/short text — render their preview at natural size (no scale).
@@ -638,7 +650,7 @@ const GALLERY_GROUPS: { label: string; ids: string[] }[] = [
   },
   {
     label: 'Library',
-    ids: ['year-in-review', 'library-completion', 'series-completion', 'series-spotlight', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'book-length', 'per-book-table'],
+    ids: ['year-in-review', 'library-completion', 'series-completion', 'series-spotlight', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'book-length', 'rereads', 'per-book-table'],
   },
   {
     label: 'Taste',

--- a/tests/test_book_page_intensity.py
+++ b/tests/test_book_page_intensity.py
@@ -1,0 +1,52 @@
+"""Per-book reading intensity from imported KOReader page-stats."""
+from backend.models.ko_stats import PageStat
+from backend.services.reading_stats import compute_book_page_intensity
+
+BASE = 1_700_000_000  # fixed epoch so day-bucketing is deterministic
+
+
+def test_none_without_pagestats(db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book()
+    assert compute_book_page_intensity(db, user_id=user.id, book_id=book.id) is None
+
+
+def test_curve_completion_and_reread(db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book()
+    # 10-page book: dwell 60s on pages 1–5 (first half); page 1 revisited next day.
+    for page in range(1, 6):
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=page, total_pages=10,
+                        start_time=BASE + page * 60, duration_seconds=60, device="Kindle"))
+    db.add(PageStat(user_id=user.id, book_id=book.id, page=1, total_pages=10,
+                    start_time=BASE + 90_000, duration_seconds=30, device="Kindle"))  # +1 day
+    db.flush()
+
+    it = compute_book_page_intensity(db, user_id=user.id, book_id=book.id, bins=10)
+    assert it is not None
+    assert it["total_pages"] == 10
+    assert it["pages_read"] == 5            # distinct pages 1–5
+    assert it["pct_read"] == 50.0           # 5 of 10
+    assert it["total_seconds"] == 60 * 5 + 30
+    assert len(it["curve"]) == 10
+    # page 1 (bin 0) = 60 + 30; pages 2–5 = 60 each in bins 1–4; second half empty.
+    assert it["curve"][0] == 90
+    assert it["curve"][1:5] == [60, 60, 60, 60]
+    assert sum(it["curve"][5:]) == 0
+    assert it["reread_bins"] == 1           # bin 0 read on two different days
+
+
+def test_pagination_change_is_robust(db, admin_user, make_book):
+    # Same book read at two different paginations (KOReader re-paginates). Both
+    # halves map to the right fraction-of-book regardless of absolute page count.
+    user, _ = admin_user
+    book = make_book()
+    db.add(PageStat(user_id=user.id, book_id=book.id, page=1, total_pages=4,
+                    start_time=BASE, duration_seconds=100, device="Kindle"))        # ~0%
+    db.add(PageStat(user_id=user.id, book_id=book.id, page=80, total_pages=100,
+                    start_time=BASE + 60, duration_seconds=100, device="Kindle"))   # ~79%
+    db.flush()
+    it = compute_book_page_intensity(db, user_id=user.id, book_id=book.id, bins=100)
+    assert it["curve"][0] == 100            # start of book
+    assert it["curve"][79] == 100           # ~80% through
+    assert it["total_pages"] == 100         # latest pagination wins as the denominator

--- a/tests/test_stats_pagestat.py
+++ b/tests/test_stats_pagestat.py
@@ -1,0 +1,55 @@
+"""Page-stat-powered stats: re-reads block + page-based completion estimates."""
+from datetime import datetime, timezone
+
+from backend.models.ko_stats import PageStat
+from backend.models.user_book_status import UserBookStatus
+
+DAY = 86_400
+BASE = 1_700_000_000
+NOW = int(datetime.utcnow().replace(tzinfo=timezone.utc).timestamp())
+
+
+def _page(db, user, book, page, total, day, dur=60):
+    db.add(PageStat(user_id=user.id, book_id=book.id, page=page, total_pages=total,
+                    start_time=BASE + day * DAY + page, duration_seconds=dur, device="Kindle"))
+
+
+def test_rereads_block(client, db, admin_user, make_book):
+    user, _ = admin_user
+    reread = make_book(title="Reread Me")
+    once = make_book(title="Read Once")
+    # `reread`: pages 1–5 read on day 0, then 1–4 again on day 10 → 4 re-read pages
+    for p in range(1, 6):
+        _page(db, user, reread, p, 100, 0)
+    for p in range(1, 5):
+        _page(db, user, reread, p, 100, 10)
+    # `once`: each page read a single day → no re-reads
+    for p in range(1, 6):
+        _page(db, user, once, p, 100, 0)
+    db.flush()
+
+    rr = client.get("/api/stats?days=0").json()["rereads"]["books"]
+    ids = {b["book_id"]: b for b in rr}
+    assert reread.id in ids
+    assert ids[reread.id]["reread_pages"] == 4
+    assert ids[reread.id]["total_pages"] == 100
+    assert once.id not in ids                      # nothing revisited
+
+
+def test_completion_uses_page_denominator(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="In Progress")
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="reading", progress_pct=0.02))
+    # 200-page book, 40 distinct pages over the last 4 days → 20% done by real pages.
+    # Timestamps must fall inside the estimate's 30-day window, so anchor on NOW.
+    for day in range(4):
+        ts = NOW - (3 - day) * DAY
+        for p in range(day * 10 + 1, day * 10 + 11):
+            db.add(PageStat(user_id=user.id, book_id=book.id, page=p, total_pages=200,
+                            start_time=ts + p, duration_seconds=60, device="Kindle"))
+    db.flush()
+
+    rows = client.get("/api/stats/completion-estimates").json()
+    row = next(r for r in rows if r["book_id"] == book.id)
+    assert row["progress"] == 20.0                 # 40/200, not the stale 2%
+    assert row["estimated_days"] is not None       # device-only book still gets an estimate


### PR DESCRIPTION
## What

Turns the per-page KOReader history (imported in #69) into reader-facing insight — three PageStat-powered surfaces plus a reconciliation fix. **No new plumbing, no plugin/emulator work** (it all reads data already imported).

- **Reading intensity** (per-book) — a strip on the book page showing where your time went across the book (per-page dwell), a real **"X of Y pages"** read, and a re-read note.
- **Re-reads** — a gallery-only dashboard tile ranking books whose pages you revisit on a later day.
- **Honest completion** — Completion Estimates now derives progress from the real page denominator (distinct pages ÷ total_pages) and can estimate device-only books from page-stat reading-days, not just web-reader sessions.
- **Bonus fix:** per-book `compute_book_reading_stats` now **reconciles with page-stats** (page-stats win per book, same rule as the dashboard), so a book read only on the device shows real time/pages/dates/pace/progress instead of a blank session hero.

## How

- `compute_book_page_intensity()` maps each dwell row to a fraction-of-book (`page / total_pages`) and buckets into bins — robust to KOReader re-pagination; distinct pages ÷ latest total_pages gives the honest completion denominator. Exposed as `intensity` on `GET /books/{id}/reading-stats` (null for web-only books).
- New all-time `rereads` block on `/api/stats` (pages read on 2+ distinct days, ranked) + a `Re-reads` gallery tile (auto-fit).
- `/stats/completion-estimates` prefers the page-based progress and adds a page-stat pace path.
- Per-book reconciliation appended to `compute_book_reading_stats` — the no-page-stats path is byte-for-byte unchanged (existing tests pass).

## Tests

- `tests/test_book_page_intensity.py` (3, incl. pagination-change robustness) and `tests/test_stats_pagestat.py` (re-reads + page-based completion).
- Full backend suite green (**645**); frontend `npm run build` clean.
- Verified end-to-end on real imported Kindle data — *High Gloom: 6h 43m / 1,499 of 1,571 pages reconciled; 9 re-read books*, 0 console errors.

## Notes

- Additive: a user with no imported page-stats sees identical behaviour (intensity null, rereads empty, per-book stats unchanged).
- Part of the pre-v1.7.0 stats batch; time-per-chapter and the `BookChapter`/`page_count` plumbing stay deferred to v1.8.0.