### PR TITLE
release: v1.7.0 "Signature"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [1.7.0] — 2026-06-28 — "Signature"
+
 ### Added
 - **Per-page reading stats from your KOReader history.** Once you've imported your
   device's reading history, each book page gains a **Reading intensity** strip —
@@ -96,6 +98,12 @@ All notable changes to Tome are documented here. Format loosely follows
   survives reboots. Requires TomeSync plugin build 21. (KOReader plugin semver
   1.5.1.)
 
+### Changed
+- **Send to KOReader is now on by default.** Queue a book from the web straight to
+  your e-reader's TomeSync inbox — no email, no Amazon. It shipped as an off-by-
+  default beta; now that it's had real-hardware time it's on out of the box
+  (`TOME_SEND_TO_KOREADER`, still settable to `false` to disable).
+
 ### Fixed
 - **KOReader no longer syncs one book's reading progress onto another.** When the
   plugin had to match a book by filename (e.g. after a file was moved or "Re-resolve
@@ -118,6 +126,10 @@ All notable changes to Tome are documented here. Format loosely follows
   than the Stats page because it only counted live TomeSync sessions and ignored
   the imported page-stat days. Both now count reconciled reading, so a single,
   consistent streak shows everywhere.
+- **A Home link in the book-page breadcrumb.** The breadcrumb root let you jump to
+  the library but not back to the Home tab — and on a phone the lone house icon
+  confusingly went to the library. It's now a proper root: **Home** then
+  **Library**, both reachable (icon-only on mobile so neither is lost).
 
 ## [1.6.0] — 2026-06-21 — "Marginalia"
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -57,12 +57,11 @@ class Settings(BaseSettings):
     wishlist_enabled: bool = True   # env TOME_WISHLIST_ENABLED — kill switch, defaults on
     wishlist_max_open_per_user: int = 100  # env TOME_WISHLIST_MAX — soft cap per user
 
-    # Send-to-KOReader inbox (env TOME_SEND_TO_KOREADER) — BETA, default off.
-    # When on, the web UI can queue a book to be pulled onto KOReader by the
-    # TomeSync plugin's inbox (no email/Amazon). Default flips to True in the
-    # first release that ships it, once validated; the flag remains the kill
-    # switch thereafter.
-    send_to_koreader: bool = False
+    # Send-to-KOReader inbox (env TOME_SEND_TO_KOREADER). On by default since
+    # v1.7.0 ("Signature") after real-hardware validation; the web UI queues a
+    # book to be pulled onto KOReader by the TomeSync plugin's inbox (no
+    # email/Amazon). Set to false to disable — the flag remains the kill switch.
+    send_to_koreader: bool = True
 
     # JWT settings
     jwt_algorithm: str = "HS256"

--- a/backend/main.py
+++ b/backend/main.py
@@ -485,7 +485,7 @@ def create_app() -> FastAPI:
     app = FastAPI(
         title="Tome",
         description="Self-hosted ebook library",
-        version="0.1.0",
+        version="1.7.0",
         lifespan=lifespan,
         docs_url="/api/docs",
         redoc_url="/api/redoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tome"
-version = "1.6.0"
+version = "1.7.0"
 description = "Self-hosted ebook library"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/test_send_to_koreader.py
+++ b/tests/test_send_to_koreader.py
@@ -51,10 +51,20 @@ def koreader_on(monkeypatch):
     yield
 
 
+@pytest.fixture()
+def koreader_off(monkeypatch):
+    # On by default since v1.7.0 — explicitly disable to exercise the gate.
+    monkeypatch.setattr(settings, "send_to_koreader", False)
+    yield
+
+
 # ── Feature gate ──────────────────────────────────────────────────────────────
 
-def test_enqueue_404_when_disabled(client, db, make_book):
-    assert settings.send_to_koreader is False  # default off (beta)
+def test_default_is_on():
+    assert settings.send_to_koreader is True  # default on since v1.7.0
+
+
+def test_enqueue_404_when_disabled(client, db, make_book, koreader_off):
     user = _user(db)
     book = make_book(title="Gated")
     r = client.post("/api/send-to-device/koreader",
@@ -62,7 +72,7 @@ def test_enqueue_404_when_disabled(client, db, make_book):
     assert r.status_code == 404
 
 
-def test_inbox_404_when_disabled(client, db):
+def test_inbox_404_when_disabled(client, db, koreader_off):
     user = _user(db)
     r = client.get("/api/tome-sync/inbox", headers=_api_key(db, user.id))
     assert r.status_code == 404

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -13,6 +13,9 @@ export default defineConfig({
     // (createRoot/hydrateRoot) resolve in dev — otherwise island hydration
     // fails with "does not provide an export named 'createRoot'".
     optimizeDeps: { include: ['react', 'react-dom', 'react-dom/client', 'react/jsx-runtime'] },
+    // The changelog page ?raw-imports the repo-root CHANGELOG.md (one level up
+    // from the website root), so allow the dev server to read the parent dir.
+    server: { fs: { allow: ['..'] } },
   },
   // Bind to all interfaces so phones on the same wifi can hit the dev server.
   server: { host: true, port: 4321 },

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react-dom": "^19.0.0",
         "astro": "^6.4.7",
         "lucide-react": "^0.460.0",
+        "marked": "^18.0.5",
         "pagefind": "^1.5.2",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -4011,6 +4012,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdast-util-definitions": {

--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
     "@types/react-dom": "^19.0.0",
     "astro": "^6.4.7",
     "lucide-react": "^0.460.0",
+    "marked": "^18.0.5",
     "pagefind": "^1.5.2",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/website/src/pages/docs/changelog.astro
+++ b/website/src/pages/docs/changelog.astro
@@ -3,16 +3,23 @@ import DocsLayout from '../../layouts/DocsLayout.astro'
 import SectionHero from '../../components/SectionHero.astro'
 import DocsMeta from '../../components/DocsMeta.astro'
 import Callout from '../../components/Callout.astro'
-import { withBase } from '../../lib/path'
+import { marked } from 'marked'
+import changelogRaw from '../../../../CHANGELOG.md?raw'
+
+// Single source of truth: this page renders the repo's CHANGELOG.md directly at
+// build time. We drop the file's own "# Changelog" title + intro paragraph and
+// render from the first version section, so the site can never drift from the
+// canonical file again — update CHANGELOG.md and this page follows.
+const changelogHtml = marked.parse(changelogRaw.slice(changelogRaw.indexOf('## [')))
 ---
 <DocsLayout title="Changelog" description="Release history and notable changes for each Tome version.">
   <SectionHero section="reference" />
   <h1>Changelog</h1>
   <p>
-    Release notes per version, newest first. Tome's release codenames follow a "synonyms for
-    tome" theme — Codex, Grimoire, Atlas, Folio, and so on. The canonical source is
+    Release notes per version, newest first — generated straight from
     <a href="https://github.com/bndct-devops/tome/blob/main/CHANGELOG.md"><code>CHANGELOG.md</code></a>
-    in the repo; this page mirrors it.
+    in the repo, the single source of truth. Release codenames follow a book-craft theme
+    (Codex, Vellum, Marginalia, Signature&hellip;).
   </p>
   <DocsMeta />
 
@@ -22,251 +29,7 @@ import { withBase } from '../../lib/path'
     isn't a path anyone should be on; just upgrade to the latest 1.x.
   </Callout>
 
-  <h2>Unreleased</h2>
-  <h3>Added</h3>
-  <ul>
-    <li>
-      <strong>Word counts for your books.</strong> Tome parses each EPUB's text to record its word
-      count, shown in the <strong>Details</strong> panel on the book page (CJK titles are counted
-      per character). New uploads are counted automatically; admins can backfill older books from a
-      new <strong>Word Counts</strong> tab under Admin — a background run that only reads your files
-      and shows live progress. Groundwork for upcoming reading-speed and words-read stats. See
-      <a href={withBase("/docs/admin#word-counts")}>Admin tools</a>.
-    </li>
-    <li>
-      <strong>A "Taste" tab on Reading Stats.</strong> A fourth board next to Overview / Habits /
-      Library, built from your book ratings: a rating distribution, taste by genre (your average
-      per book type), highest &amp; lowest rated, a rating-vs-time scatter, best-rated series, and a
-      rating trend. Each tile is add/move/resize/removable like every other, and they ignore the
-      date-range picker since ratings are all-time. Existing custom dashboards get the new tab
-      appended without touching your current boards. See <a href={withBase("/docs/stats")}>Stats</a>.
-    </li>
-    <li>
-      <strong>Five new Reading Stats tiles.</strong> <strong>Lifetime Totals</strong> (all-time
-      hours / pages / books / streak), <strong>Personal Records</strong> (longest session, biggest
-      reading day, most pages in a day), <strong>Library Completion</strong> (how much of what you
-      own you've read, overall and per type), a <strong>Reading Clock</strong> (24-hour radial of
-      when you read), and <strong>Reading by Language</strong>. They're not on any board by default —
-      add the ones you want from <strong>Add tile</strong>.
-    </li>
-    <li>
-      <strong>Stats now include reading from before TomeSync.</strong> KOReader keeps its own
-      per-page reading log going back to whenever you started reading — often long before Tome
-      existed. TomeSync can now import that history, backfilling your reading-time charts, streaks,
-      heat-map, top books and pace. The first sync pushes your whole history (chunked, resumable,
-      survives the device sleeping or dropping Wi-Fi); later syncs send only new reading. It imports
-      reading time and pages only — it never changes your read/unread status. Enable it under
-      <strong>TomeSync → Auto-sync reading history on launch</strong>, or run it once from
-      <strong>Sync reading history</strong>. Requires TomeSync plugin build 22.
-    </li>
-    <li>
-      <strong>Ratings set offline now sync.</strong> A rating or review you set on KOReader while
-      offline is now remembered and pushed to Tome the next time the device is online — on resume,
-      on <strong>Sync now</strong>, or when you next close a book. Previously a rating could be
-      stranded on the device if you rated a finished book and never reopened it. It now rides a
-      small pending queue (like reading sessions) that survives reboots. Requires TomeSync plugin
-      build 21.
-    </li>
-    <li>
-      <strong>Send to KOReader (beta).</strong> Queue a book from the web straight to your
-      e-reader — no email, no Amazon. A split <strong>Send to KOReader</strong> button (the caret
-      keeps "Send via email…") queues to a per-user inbox the TomeSync plugin pulls via a new
-      <strong>Inbox (N)</strong> badge (plugin build 16). Off by default —
-      <code>TOME_SEND_TO_KOREADER=true</code>. See
-      <a href={withBase("/docs/koreader#send-to-koreader")}>Send to KOReader</a>.
-    </li>
-  </ul>
-  <h3>Fixed</h3>
-  <ul>
-    <li>
-      <strong>The Day-streak on the Home tab now matches your Stats page.</strong> After importing
-      your KOReader reading history, the Home summary kept showing a shorter streak because it only
-      counted live TomeSync sessions and ignored the imported page-stat days. Both now count
-      reconciled reading, so a single consistent streak shows everywhere.
-    </li>
-  </ul>
-
-  <h2>v1.2.1</h2>
-  <p>
-    A hotfix for reading-sync over HTTPS. If you run Tome behind a TLS-terminating reverse proxy,
-    the KOReader plugin was baking an <code>http://</code> server URL; when the proxy redirected to
-    HTTPS, KOReader couldn't follow the redirect on uploads, so reading sessions and progress
-    silently failed to sync (they queued as "pending" on the device). Plain HTTP, LAN, and localhost
-    setups were unaffected.
-  </p>
-  <h3>Fixed</h3>
-  <ul>
-    <li>
-      The server now honours <code>X-Forwarded-Proto</code> when baking the plugin's server URL, and
-      a new optional <code>TOME_PUBLIC_URL</code> setting pins the public origin explicitly. The
-      plugin build was bumped, so existing installs re-bake the corrected URL via
-      <strong>TomeSync → Check for updates</strong> — pending sessions then flush automatically. No
-      reading data is lost.
-    </li>
-  </ul>
-
-  <h2>v1.2.0 — "Press"</h2>
-  <p>
-    The release that gets out of its own way: the KOReader plugin now updates itself, and a single
-    command stands up a working instance. Less SSH, less ceremony.
-  </p>
-  <h3>Added</h3>
-  <ul>
-    <li>
-      <strong>TomeSync self-update:</strong> the KOReader plugin updates itself from the server —
-      <strong>Check for updates</strong> plus an opt-in <strong>Auto-check on launch</strong> —
-      replacing the SSH-into-every-device workflow. A bad update can't brick it: a frozen stable
-      shim wraps the replaceable implementation and runs an anti-brick rollback state machine
-      (syntax-broken updates roll back the same boot, init-crashing ones the next, corrupt downloads
-      are rejected before they're swapped in). Progress, book maps, and pending sessions are never
-      touched.
-    </li>
-    <li>
-      <strong>TomeSync gesture actions:</strong> <strong>Open menu</strong> and
-      <strong>Browse series</strong>, bindable from KOReader's Gesture manager in both the reader
-      and the file manager.
-    </li>
-    <li>
-      <strong>One-command installer:</strong> a <code>curl | bash</code> path for newcomers and
-      evals — checks Docker, writes <code>~/Tome</code>, auto-picks a free port, pulls, starts, and
-      waits until Tome answers. Re-running updates in place. Docker Compose stays the primary,
-      homelab-first path. See <a href={withBase("/docs/installation")}>Installation</a>.
-    </li>
-  </ul>
-  <h3>Fixed</h3>
-  <ul>
-    <li>
-      <strong>TomeSync series browser crash:</strong> browsing series no longer crashes the plugin
-      when a series' first book has no author (the server stopped sending JSON <code>null</code> for
-      the field, and the plugin now type-checks it).
-    </li>
-  </ul>
-
-  <h2>v1.1.0 — "Vellum"</h2>
-  <p>
-    The parchment a wanted text is written on — a release built around getting books to you and
-    knowing what you're still missing.
-  </p>
-  <h3>Added</h3>
-  <ul>
-    <li>
-      <strong>Send to device:</strong> email books to a Kindle, Kobo, or any address straight from
-      the web UI — single or bulk (max 25 per send). Per-user device list in Settings, admin Email
-      tab (SMTP status, test email, all devices, send history). SMTP via <code>TOME_SMTP_*</code>
-      env vars; 25&nbsp;MB attachment limit; 50/user/day rate limit. Members and admins only. See
-      <a href={withBase("/docs/send-to-device")}>Send to device</a>.
-    </li>
-    <li>
-      <strong>Wishlist:</strong> members and admins can wish for a single book or a whole series.
-      The matcher links wishes to library books both when a book is added and when a wish is created
-      against books already present, author-aware so same-named series don't cross-match.
-      Whole-series wishes are standing wants that show an "X of N" coverage strip and notify the
-      requester as each volume arrives. In-app notifications via a new top-bar bell, plus email on
-      fulfilment when SMTP is configured.
-    </li>
-    <li>
-      <strong>API token scopes:</strong> create tokens with <code>full</code> (default) or
-      <code>readonly</code> scope; read-only tokens are blocked from non-GET requests.
-    </li>
-    <li>
-      <strong>Parallel library scans:</strong> opt-in via <code>TOME_SCAN_WORKERS</code> to fan the
-      CPU-bound extract/hash phase across worker processes for large imports (database writes stay
-      single-process).
-    </li>
-  </ul>
-  <h3>Changed</h3>
-  <ul>
-    <li>
-      <strong>Performance:</strong> faster library scans (no per-book lazy-loads, one directory
-      walk, throughput-oriented SQLite pragmas) and a much faster book-list endpoint (eager-loaded
-      relationships, eliminating an N+1).
-    </li>
-    <li>Website: raster favicons for Google search results + Cloudflare Web Analytics.</li>
-  </ul>
-  <h3>Fixed</h3>
-  <ul>
-    <li>
-      Newly added books are searchable immediately — full-text search now indexes inline during
-      scan / upload / ingest instead of only at startup.
-    </li>
-    <li>
-      Bulk ZIP download now embeds Tome metadata like every other download path; cover-bearing files
-      are no longer hashed twice during ingest.
-    </li>
-  </ul>
-
-  <h2>v1.0 — "Codex"</h2>
-  <p>
-    The first release that calls itself done. Stable schema, opinionated defaults, a coherent
-    docs site. If you've been running Tome from <code>main</code>, this is where the floor stops
-    moving.
-  </p>
-
-  <h3>Highlights</h3>
-  <ul>
-    <li>
-      <strong>TomeSync KOReader plugin (v4):</strong> bidirectional position sync, reading-session
-      tracking, in-plugin series browser, series download. Zero-config install — download the
-      pre-baked <code>.koplugin</code> from Settings.
-    </li>
-    <li>
-      <strong>Web reader:</strong> EPUB (foliate-js) and CBZ (custom streaming) with themes, font
-      controls, RTL toggle, spread mode, position memory via CFI.
-    </li>
-    <li>
-      <strong>Reading stats:</strong> three tabs (Overview / Habits / Library), 4-hour streak
-      rollover, hour×DOW heatmap, period and monthly comparisons, completion estimates, per-book
-      time, library growth.
-    </li>
-    <li>
-      <strong>Series & arcs:</strong> SeriesMeta status badge, admin Arc CRUD, series-wide
-      progress aggregation, chapter vs volume detection for manga.
-    </li>
-    <li>
-      <strong>Roles & visibility:</strong> three-tier admin / member / guest model with
-      server-enforced per-book visibility rules. Quick Connect for new devices.
-    </li>
-    <li>
-      <strong>Bindery:</strong> drop-folder ingestion with manual review (default) or auto-import
-      on a timer. Content-hash dedup, filename-based series detection, metadata fetch from
-      Hardcover / Google Books / Open Library.
-    </li>
-    <li>
-      <strong>Scribe (alpha):</strong> Claude Code skill for bulk ingest, metadata audits, and
-      series-level annotation. <a href={withBase("/docs/scribe")}>Docs</a>.
-    </li>
-    <li>
-      <strong>API tokens:</strong> universal-scope <code>tome_*</code> bearer tokens for every
-      <code>/api/*</code> endpoint.
-    </li>
-    <li>
-      <strong>OPDS feed:</strong> standards-compliant Atom catalogue with per-user PINs.
-    </li>
-    <li>
-      <strong>Themes:</strong> light, dark, amber, plus user-defined 10-value palettes.
-    </li>
-    <li>
-      <strong>PWA:</strong> installable on iOS and Android with manifest + offline icons.
-    </li>
-  </ul>
-
-  <h3>Stable surfaces</h3>
-  <p>
-    The following are considered stable as of 1.0 — backwards-incompatible changes will get a
-    major-version bump:
-  </p>
-  <ul>
-    <li>The HTTP API at <code>/api/*</code>.</li>
-    <li>The OPDS feed at <code>/opds/</code>.</li>
-    <li>The TomeSync KOReader plugin protocol.</li>
-    <li>The environment variable names listed in <a href={withBase("/docs/configuration")}>Configuration</a>.</li>
-    <li>The on-disk library layout (<code>Series/</code> and <code>Author/</code> folders).</li>
-  </ul>
-
-  <h3>Things still labelled alpha</h3>
-  <ul>
-    <li><a href={withBase("/docs/scribe")}>Scribe</a> command surface — syntax and config format may change.</li>
-  </ul>
+  <Fragment set:html={changelogHtml} />
 
   <Callout variant="tip" title="Upgrading from 0.x">
     Pull the latest image and recreate the container. Migrations run on startup. Your data in


### PR DESCRIPTION
Cuts **v1.7.0 "Signature"** and sets up the single-source-of-truth changelog.

## Release
- `CHANGELOG.md [Unreleased] → [1.7.0]` (2026-06-28, codename "Signature") + the book-breadcrumb Home-link fix and a **Changed** entry for Send to KOReader.
- **Send to KOReader on by default** (`TOME_SEND_TO_KOREADER`) after real-hardware validation — still settable to `false` as the kill switch.
- Version bump **1.6.0 → 1.7.0** (`pyproject.toml` + FastAPI app).
- Tests updated: default-on assertion + an explicit `koreader_off` fixture for the gate tests.

## Single source of truth for the changelog
- The docs **Changelog page now renders `CHANGELOG.md` directly** at build time (`marked` + `?raw`), instead of a hand-maintained HTML mirror that kept drifting. Editorial intro + pre-1.0 / 0.x callouts stay; everything else generates from the canonical file.

After this merges I'll tag `v1.7.0` on the merge commit and publish the GitHub release (the full notes are drafted) — **on your go**, since the tag ships `:latest` to all users.