### PR TITLE
fix(stats): reading streak drops covered-book session days

### DIFF
--- a/backend/services/reconciled_reading.py
+++ b/backend/services/reconciled_reading.py
@@ -249,9 +249,16 @@ def monthly_map(db, user_id, tzm, covered, start_dt) -> dict[str, tuple[int, int
 
 def active_days(db, user_id, tzm, covered) -> set:
     from datetime import date as _date
+    # A day is "active" if the user read at all that day — page-stat OR session,
+    # covered book or not. We deliberately do NOT exclude covered-book sessions
+    # here (unlike the time/count reconciliation, where the exclusion avoids
+    # double-counting): for the active-DAY set, excluding them drops days you read
+    # on a book that merely *has* imported history but whose page-stats don't (yet)
+    # cover that day — e.g. recent web-reader reading, or reading synced before the
+    # history sync caught up. That silently broke the streak after a first import.
     rs_days = {
         r[0] for r in
-        _rs_filtered(db, user_id, covered, None, None)
+        _rs_filtered(db, user_id, [], None, None)
         .with_entities(func.date(ReadingSession.started_at, tzm)).distinct().all()
         if r[0]
     }

--- a/tests/test_home_streak_reconciliation.py
+++ b/tests/test_home_streak_reconciliation.py
@@ -7,6 +7,7 @@ endpoints now route through ``reconciled_user_streaks``.
 from datetime import datetime, timedelta, timezone
 
 from backend.models.ko_stats import PageStat
+from backend.models.tome_sync import ReadingSession
 from backend.services.streaks import effective_today
 
 
@@ -33,4 +34,34 @@ def test_home_streak_counts_pagestat_days_and_matches_stats(client, db, admin_us
     # Page-stat days feed the home streak (session-only would be 0 here)...
     assert home["current_streak_days"] == 3
     # ...and the two endpoints never disagree.
+    assert home["current_streak_days"] == stats["current_streak_days"]
+
+
+def _add_session_day(db, user, book, eff_day):
+    """A live reading session at 12:00 UTC on eff_day (no page-stat)."""
+    when = datetime(eff_day.year, eff_day.month, eff_day.day, 12)  # naive UTC
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when,
+                          ended_at=when, duration_seconds=600, pages_turned=10))
+
+
+def test_streak_counts_recent_sessions_on_a_covered_book(client, db, admin_user, make_book):
+    """Regression (v1.7.0): a book with imported history became 'covered', which
+    suppressed its live sessions in the reconciled active-day set — so reading it
+    today/yesterday (web reader, or before the history sync caught up) dropped off
+    the streak entirely. A day is active if you read at all, page-stat or session.
+    """
+    user, _ = admin_user
+    book = make_book(title="Covered but read recently")
+    today = effective_today(0)
+
+    # Old imported history makes the book 'covered'.
+    _add_pagestat_day(db, user, book, today - timedelta(days=20))
+    # Read it today and yesterday — live sessions only, not yet in page-stats.
+    _add_session_day(db, user, book, today)
+    _add_session_day(db, user, book, today - timedelta(days=1))
+    db.flush()
+
+    home = client.get("/api/home/stats?tz_offset=0").json()
+    stats = client.get("/api/stats?days=0&tz_offset=0").json()["headline"]
+    assert home["current_streak_days"] == 2          # today + yesterday
     assert home["current_streak_days"] == stats["current_streak_days"]


### PR DESCRIPTION
**Regression in v1.7.0** found on real prod data right after release.

The reconciled active-day set (used for the home + stats streak) excluded a covered book's live sessions — correct for not double-counting *time*, but wrong for the active-**day** set. A day you read on a book that merely *has* imported history vanished from the streak unless that day was also present in the page-stats. So reading on the device the day before the history sync caught up — or in the web reader — silently broke the entire streak.

**Verified on prod:** a session on `2026-06-27` (covered book 42, no page-stat for that day yet) collapsed a **170-day streak to 0**. With this fix the day counts and the streak is restored (computed both ways against the live DB).

Fix: `active_days` now counts *all* reading days — covered-book sessions included. A day is active if you read at all. Regression test added (covered book + recent session-only days).

This will be folded into a re-cut **v1.7.0** (replacing the tag), not shipped as a separate hotfix.