### PR TITLE
polish(stats): fix KPI label truncation + richer chart tooltips

### DIFF
--- a/frontend/src/components/stats/widgets/overview.tsx
+++ b/frontend/src/components/stats/widgets/overview.tsx
@@ -104,7 +104,10 @@ export function ReadingTimePerDay({ daily, chartType = 'bar' }: { daily: StatsRe
               <ChartTooltip>
                 <div className="font-medium">{formatDate(d.date)}</div>
                 <div>{formatDuration(d.seconds)}</div>
-                <div className="text-muted-foreground">{d.sessions} session{d.sessions !== 1 ? 's' : ''}</div>
+                <div className="text-muted-foreground">
+                  {d.sessions} session{d.sessions !== 1 ? 's' : ''}
+                  {d.pages > 0 ? ` · ${d.pages.toLocaleString()} pages` : ''}
+                </div>
               </ChartTooltip>
             )
           }}
@@ -150,7 +153,10 @@ export function TopBooksByTime({ topBooks }: { topBooks: StatsResponse['top_book
               <ChartTooltip>
                 <div className="font-medium">{d.title}</div>
                 <div>{formatDuration(d.seconds)}</div>
-                <div className="text-muted-foreground">{d.sessions} session{d.sessions !== 1 ? 's' : ''}</div>
+                <div className="text-muted-foreground">
+                  {d.sessions} session{d.sessions !== 1 ? 's' : ''}
+                  {d.sessions > 0 ? ` · avg ${formatDuration(Math.round(d.seconds / d.sessions))}` : ''}
+                </div>
               </ChartTooltip>
             )
           }}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -182,7 +182,7 @@ const WIDGETS: WidgetDef[] = [
     icon: Clock,
     size: STAT_SIZE,
     render: ({ stats }) => (
-      <HeadlineStatBody value={formatDuration(stats.headline.total_reading_seconds)} sub={`avg ${formatDuration(stats.headline.avg_session_seconds)} / session`} />
+      <HeadlineStatBody value={formatDuration(stats.headline.total_reading_seconds)} sub={`avg ${formatDuration(stats.headline.avg_session_seconds)}`} />
     ),
   },
   {
@@ -1150,9 +1150,11 @@ function TileShell({
         className={cn('mb-3 flex items-center gap-1.5', editMode && !stacked && 'tile-drag-handle cursor-grab active:cursor-grabbing')}
       >
         {editMode && !stacked && <GripVertical className="h-3.5 w-3.5 shrink-0 text-muted-foreground/50" />}
-        {def.icon && <def.icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" />}
-        {/* truncate, don't wrap — a wrapped title pushes the body out of 1-row tiles */}
-        <h3 className="min-w-0 truncate font-display text-[13px] font-medium text-muted-foreground">{def.titleFor?.(config) ?? def.title}</h3>
+        {def.icon && <def.icon className="h-3 w-3 shrink-0 text-muted-foreground/70" />}
+        {/* truncate, don't wrap — a wrapped title pushes the body out of 1-row tiles.
+            12px + a 12px icon keeps long labels ("Reading Time") on one line in a
+            narrow ~126px stat tile instead of clipping to "Reading Ti…". */}
+        <h3 className="min-w-0 truncate font-display text-xs font-medium text-muted-foreground">{def.titleFor?.(config) ?? def.title}</h3>
         {def.fixedWindow && (
           <span title="This tile uses a fixed window and ignores the range picker" className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
             {def.fixedWindow}


### PR DESCRIPTION
Small, verified polish on the Reading Stats dashboard.

- **Fixed KPI label truncation.** "Reading Time" / "Pages Turned" were clipping to "Reading Ti…" in the narrow (~126px) stat tiles. Tightened the tile header (12px text + 12px icon) so the full labels fit; verified by measuring rendered widths. Time sub shortened to "avg 54m".
- **Richer chart tooltips** where the data already supports it: the daily reading chart now shows pages alongside sessions; Top Books shows average-per-session. Both go through the existing shared tooltip, so styling stays consistent.

Note: deliberately did **not** add loading skeletons (would break consistency with the app-wide `BookAnimation` loader) or entrance animation (against the restrained aesthetic). The dashboard chrome was already well-built — this is just two papercuts.