### PR TITLE
fix(stats): device-book progress uses reading position, not page coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Reading progress for device-read books is no longer understated.** A book you
+  were, say, 35% through could show as 11% — both in its **progress** figure and in
+  the **Completion Estimates** tile (which then wildly overestimated the time left).
+  The cause: progress was derived from how many distinct pages your KOReader history
+  had logged time on (coverage), not how far through you actually are (position).
+  Progress now uses your real reading position, falling back to the furthest page
+  reached, so it matches what your reader shows — and finished books read 100%.
 - **Per-book "all readers" totals now include device reading.** On a book read
   only through the KOReader plugin (imported page-stats, no live sessions), the
   admin "All readers" line showed 0m / 0 sessions / 0 readers; it now reflects that

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -1059,21 +1059,27 @@ def get_completion_estimates(
                 func.count(func.distinct(case((PageStat.start_time >= window_epoch, PageStat.page)))),
                 func.count(func.distinct(case((PageStat.start_time >= window_epoch,
                                                func.cast(PageStat.start_time / 86400, Integer))))),
+                func.max(PageStat.page),
             )
             .filter(PageStat.user_id == current_user.id, PageStat.book_id == row.id)
             .one()
         )
-        ps_pages, ps_total, ps_pages_30, ps_days_30 = (int(ps[0] or 0), int(ps[1] or 0),
-                                                       int(ps[2] or 0), int(ps[3] or 0))
+        ps_pages, ps_total, ps_pages_30, ps_days_30, ps_max_page = (
+            int(ps[0] or 0), int(ps[1] or 0), int(ps[2] or 0), int(ps[3] or 0), int(ps[4] or 0))
         ps_days_30 = max(ps_days_30 - (1 if ps_pages_30 else 0), 0)  # gained over the gaps, not the first day
-        if ps_total > 0:
-            progress = min(round(ps_pages / ps_total * 100, 1), 100.0)
+        # Progress = how far through: the best of the synced position (set above)
+        # and the furthest page reached. Page-stats are coverage, so use the
+        # furthest page, not the distinct-page count. max() covers a synced
+        # position ahead of the dwell history *and* a stale position behind it.
+        page_pct = round(ps_max_page / ps_total * 100, 1) if (ps_total > 0 and ps_max_page > 0) else 0.0
+        progress = min(max(progress, page_pct), 100.0)
 
         estimated_days: Optional[int] = None
         if session_count == 0 and ps_total > 0 and ps_pages_30 > 0 and ps_days_30 >= 1 and progress < 100:
             # Device-only: pages read per active-day → days to read the rest.
             pages_per_day = ps_pages_30 / ps_days_30
-            remaining_pages = max(ps_total - ps_pages, 0)
+            # Remaining measured from your position, not from uncovered pages.
+            remaining_pages = max(round((1 - progress / 100.0) * ps_total), 0)
             estimated_days = max(1, round(remaining_pages / pages_per_day)) if pages_per_day else None
         elif session_count > 0 and progress >= 5 and progress < 100:
             # Calculate progress gained during the window

--- a/backend/services/reading_stats.py
+++ b/backend/services/reading_stats.py
@@ -113,15 +113,19 @@ def compute_book_reading_stats(
             func.min(PageStat.start_time),
             func.max(PageStat.start_time),
             func.max(PageStat.total_pages),
+            func.max(PageStat.page),
         )
         .filter(PageStat.user_id == user_id, PageStat.book_id == book_id)
         .one()
     )
     ps_seconds = int(ps[0] or 0)
+    ps_total_pages = 0
+    ps_max_page = 0
     if ps_seconds > 0:
         total_seconds = ps_seconds
         pages_turned = int(ps[1] or 0)          # distinct pages genuinely read
         ps_total_pages = int(ps[4] or 0)
+        ps_max_page = int(ps[5] or 0)           # furthest page reached (position fallback)
         # Daily buckets from page-stats (local-day = start_time // 86400, UTC).
         day_rows = (
             db.query(
@@ -151,30 +155,17 @@ def compute_book_reading_stats(
         total_minutes = total_seconds / 60.0
         if total_minutes > 0 and pages_turned > 0:
             pace_pages_per_min = round(pages_turned / total_minutes, 2)
-        # Real page-based progress beats a stale stored progress_pct.
-        if ps_total_pages > 0:
-            progress = min(pages_turned / ps_total_pages, 1.0)
 
     # ── Journey: cumulative progress per reading day (the progress line) ──────
     # Augments each session_timeline day with the furthest-progress reached, so
     # the frontend can plot a progress arc over the minutes-per-day bars.
     day_progress: dict[str, float] = {}
     if ps_seconds > 0:
-        # Covered book: cumulative distinct pages read through each day ÷ total.
-        pg_pairs = (
-            db.query(
-                func.cast(PageStat.start_time / 86400, Integer).label("day"),
-                PageStat.page,
-            )
-            .filter(PageStat.user_id == user_id, PageStat.book_id == book_id)
-            .all()
-        )
-        seen: set[int] = set()
-        for day, page in sorted(pg_pairs, key=lambda r: int(r[0])):
-            seen.add(int(page))
-            dstr = datetime.fromtimestamp(int(day) * 86400, timezone.utc).strftime("%Y-%m-%d")
-            if ps_total_pages > 0:
-                day_progress[dstr] = min(len(seen) / ps_total_pages, 1.0)
+        # Covered (device) book: a per-day position can't be reconstructed from
+        # page dwell — that's *coverage*, not position (you can be 35% in having
+        # dwelled on only 11% of pages). So draw no progress line here; the
+        # headline % (synced position) and the intensity chart tell that story.
+        pass
     else:
         # Web sessions: the furthest progress_end reached on each day.
         prog_rows = (
@@ -261,6 +252,21 @@ def compute_book_reading_stats(
     finished_at: Optional[str] = None
     if status_row and status_row.status == "read" and status_row.updated_at:
         finished_at = status_row.updated_at.isoformat() + "Z"
+
+    # ── Progress = how far through the book ──────────────────────────────────
+    # Best available evidence of position: the synced reading position OR the
+    # furthest page reached. Page-stats are *coverage*, so use the furthest page,
+    # never the distinct-page count (which trails position when pages are
+    # skimmed). max() handles both directions: a synced position ahead of the
+    # dwell history (you skimmed/jumped), and a stale-low position behind pages
+    # you've since read. A finished book is always 100%.
+    page_progress = (ps_max_page / ps_total_pages) if (ps_total_pages and ps_max_page) else 0.0
+    if book_status == "read":
+        progress = 1.0
+    else:
+        candidates = [p for p in (progress, page_progress) if p and p > 0]
+        if candidates:
+            progress = min(max(candidates), 1.0)
 
     # ── Estimated time to finish ─────────────────────────────────────────────
     estimated_finish_seconds: Optional[int] = None

--- a/tests/test_book_reading_stats.py
+++ b/tests/test_book_reading_stats.py
@@ -303,3 +303,58 @@ def test_manual_session_completion_is_sticky(client: TestClient, make_book, admi
     resp = client.post(f"/api/books/{book.id}/sessions", json={"duration_minutes": 10, "end_progress": 0.3})
     assert resp.status_code == 201
     assert resp.json()["own"]["status"] == "read"
+
+
+# ── Progress = synced position, not page coverage (device-book regression) ─────
+
+def _page_run(db, user_id, book_id, *, pages, total_pages, device="Kindle", base=1_700_000_000):
+    """Add a 1-minute dwell row for each page in `pages` (distinct start_times)."""
+    from backend.models.ko_stats import PageStat
+    for i, pg in enumerate(pages):
+        db.add(PageStat(user_id=user_id, book_id=book_id, page=pg, total_pages=total_pages,
+                        start_time=base + i * 60, duration_seconds=60, device=device))
+    db.flush()
+
+
+def test_progress_uses_synced_position_not_coverage(client: TestClient, make_book, admin_user, db: Session):
+    """Regression: a device book showed 11% (coverage) while the reader was at 35% (position)."""
+    user, _ = admin_user
+    book = make_book(title="Position Book")
+    # dwelled on only the first 123 pages of a 1008-page book…
+    _page_run(db, user.id, book.id, pages=range(1, 124), total_pages=1008)
+    # …but the reader synced its position at 34.8%.
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="reading", progress_pct=0.348))
+    db.flush()
+
+    own = _get_stats(client, book.id)["own"]
+    assert own["progress"] == pytest.approx(0.348)             # synced position, not 0.122 coverage
+    # Device book: no progress line — per-day position can't come from dwell.
+    assert all(d["progress_pct"] is None for d in own["session_timeline"])
+
+
+def test_progress_finished_device_book_is_full(client: TestClient, make_book, admin_user, db: Session):
+    """A finished book with no synced position still reads 100%, not coverage."""
+    user, _ = admin_user
+    book = make_book(title="Finished Device Book")
+    # read to the end but missed a few pages → distinct < total
+    _page_run(db, user.id, book.id, pages=[p for p in range(1, 477) if p % 50 != 0], total_pages=476)
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="read", progress_pct=0.0))
+    db.flush()
+
+    own = _get_stats(client, book.id)["own"]
+    assert own["status"] == "read"
+    assert own["progress"] == pytest.approx(1.0)
+
+
+def test_progress_fallback_uses_furthest_page_not_distinct(client: TestClient, make_book, admin_user, db: Session):
+    """No synced position: progress = furthest page reached, not distinct-page count."""
+    user, _ = admin_user
+    book = make_book(title="Skimmed Book")
+    # dwelled on 50 pages but reached page 500 of 1000
+    pages = list(range(1, 41)) + list(range(491, 501))        # 50 distinct, max 500
+    _page_run(db, user.id, book.id, pages=pages, total_pages=1000)
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="reading", progress_pct=0.0))
+    db.flush()
+
+    own = _get_stats(client, book.id)["own"]
+    assert own["progress"] == pytest.approx(0.5)              # 500/1000, not 50/1000


### PR DESCRIPTION
## The bug
A book you were ~35% through could show **11%** — in its per-book **Progress**, and in the dashboard **Completion Estimates** tile (which then badly over-estimated time remaining).

Cause: for device-read books, progress was derived from **coverage** — the count of distinct pages your KOReader history logged dwell time on ÷ total pages — instead of your **position** (how far through you actually are). Whenever the imported page-stats lag the synced position (you skim, jump ahead, or stats import only part of your reading), coverage trails position.

**Verified on prod** (read-only), book *"2 Lies, 2 Thrones"*:
| synced position | coverage (115/1008) | furthest page (123/1008) |
|---|---|---|
| **34.8%** | 11.4% | 12.2% |

It was showing 11.4%. It should show 34.8%.

## Scope
This is a **pre-existing bug from the KOReader `statistics.db` import feature** — the new per-book progress lane just made it visible. It lived in two places, both with the same override:
- `reading_stats.py` — per-book progress % + "Est. remaining"
- `stats.py:get_completion_estimates` — the dashboard tile (% and days-remaining)

Across prod, **56 of 77** device books have no synced position at all (mostly finished books read entirely on-device), so a naive "just use position" would regress those to 0%.

## The fix
Progress = **`max(synced position, furthest page reached)`**, never the distinct-page count.
- `max()` handles a position **ahead** of the dwell history (skim/jump — the reported case) **and** a stale position **behind** pages you've since read.
- Furthest page (not distinct count) is the right page-based floor.
- **Finished books read 100%.**
- "Days remaining" in the estimates tile now measures from position, not uncovered pages.
- The per-book **journey line is no longer drawn for device books** — a per-day position genuinely can't be reconstructed from page dwell; the headline % + the intensity chart cover it. (Web-reader books, which record real per-day position, still get the line.)

## Tests
4 prod-shaped regression tests (the 35%-vs-11% case, finished-no-position → 100%, skimmed → furthest-page not distinct-count, and no journey line for device books). Full stats suite green (29 passed). The existing `test_completion_uses_page_denominator` (stale-position case) still passes — `max()` covers it.