### PR TITLE
fix(stats): show a current-progress bar on device books

### DIFF
--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1599,6 +1599,21 @@ function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps)
           <ActivityChart timeline={own.session_timeline} />
         </div>
       )}
+      {/* Current progress — only when there's no journey line (device books).
+          Web books already show their % in the journey line's header, so this
+          avoids two "Progress" rows saying the same thing. */}
+      {own.progress != null && own.progress > 0 &&
+        !own.session_timeline.some(d => d.progress_pct != null) && (
+        <div className="mt-4">
+          <div className="flex items-center justify-between mb-1.5">
+            <span className="text-xs text-muted-foreground/70">Progress</span>
+            <span className="text-xs font-medium tabular-nums text-foreground">{Math.round(own.progress * 100)}%</span>
+          </div>
+          <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+            <div className="h-full rounded-full bg-primary" style={{ width: `${Math.min(Math.round(own.progress * 100), 100)}%` }} />
+          </div>
+        </div>
+      )}
       <SourceSplit sources={own.by_source} />
       {/* Dates row — hairline-divided columns, no boxes */}
       {bottomStats.length > 0 && (


### PR DESCRIPTION
Follow-up to #85. That PR correctly stopped drawing the per-day **journey line** for device books (page dwell can't reconstruct a per-day position) — but it left device books with **no progress indicator at all**, even though we now compute the correct current %.

This adds a slim **current-progress bar** in the same slot, shown **only when there's no journey line** — web books already show their % in the line's header, so no book ever shows two "Progress" rows.

Verified with real renders before merging:
- **Device book** → activity bars + a Progress bar (e.g. 35%). ✅
- **Web book** → journey line only, no duplicate. ✅

Frontend-only; `tsc -b` clean.