### PR TITLE
Home: Focus mode + Reading DNA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Focus mode on the Home page.** A new minimalist Home view that surfaces the one
+  book you're most likely to pick up next — your most-recently-synced in-progress
+  title — as a large cover with the upcoming volumes of its series fanned behind it
+  in a rotating "coverflow" display. Alongside it: the series, your progress and
+  where you last synced from, a one-click **Resume reading**, and a quiet
+  **Currently reading** strip to switch the spotlight to any other in-progress book.
+  Clicking the cover or series name jumps to the series. Toggle between **Focus** and
+  the full **Dashboard** from the Home header; your choice is remembered.
+- **Your Reading DNA.** The Home dashboard and Stats page now show a reading-personality
+  card — an archetype (e.g. "Night-Owl Epic Specialist") distilled from a few traits
+  like when you read, how long your sessions run, and how widely you range across the
+  library — computed over a recent trailing window.
 - **A richer reading log on every book.** A book's Reading Stats now show more of
   its story: a **progress line** traced over the activity bars so you can see how
   far you got on each reading day, a **momentum** indicator comparing the last week

--- a/backend/api/home.py
+++ b/backend/api/home.py
@@ -6,14 +6,152 @@ from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from backend.core.database import get_db
+from backend.core.permissions import book_visibility_filter
 from backend.core.security import get_current_user
 from backend.models.user import User
-from backend.models.tome_sync import ReadingSession
+from backend.models.tome_sync import ReadingSession, TomeSyncPosition
 from backend.models.book import Book
 from backend.models.user_book_status import UserBookStatus
 from backend.services.streaks import reconciled_user_streaks
 
 router = APIRouter(prefix="/home", tags=["home"])
+
+
+def _norm_pct(raw: float | None) -> float:
+    """Normalise a progress value (KOReader 0–1 or legacy 0–100) to 0–100."""
+    if not raw:
+        return 0.0
+    return round(raw * 100, 1) if raw <= 1.0 else round(raw, 1)
+
+
+@router.get("/focus")
+def get_focus(
+    book_id: int | None = Query(None, description="Focus a specific in-progress book instead of the latest-synced one"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """The single book to surface in Home's Focus mode: the user's most-recently
+    active in-progress title (latest sync wins), plus the upcoming volumes of its
+    series fanned behind it, and the rest of the in-progress set as a switcher.
+
+    When ``book_id`` is given and it's one of the user's visible in-progress books,
+    that book becomes the hero instead (used by the "Also reading" switcher).
+    """
+    visible = book_visibility_filter(db, current_user)
+
+    rows = (
+        db.query(UserBookStatus)
+        .filter(
+            UserBookStatus.user_id == current_user.id,
+            UserBookStatus.status == "reading",
+        )
+        .join(Book, Book.id == UserBookStatus.book_id)
+        .filter(Book.status == "active", visible)
+        .outerjoin(
+            TomeSyncPosition,
+            (TomeSyncPosition.book_id == Book.id)
+            & (TomeSyncPosition.user_id == current_user.id),
+        )
+        .with_entities(
+            Book.id,
+            Book.title,
+            Book.author,
+            Book.series,
+            Book.series_index,
+            Book.description,
+            Book.cover_path,
+            TomeSyncPosition.percentage.label("sync_pct"),
+            TomeSyncPosition.device.label("device"),
+            TomeSyncPosition.updated_at.label("synced_at"),
+            UserBookStatus.progress_pct,
+            UserBookStatus.updated_at.label("status_at"),
+        )
+        .all()
+    )
+
+    if not rows:
+        return {"ready": False, "book": None, "upcoming": [], "ahead_count": 0, "reading": []}
+
+    # Most-recent activity = the newer of (last sync, last status change).
+    def last_active(r):
+        candidates = [t for t in (r.synced_at, r.status_at) if t is not None]
+        return max(candidates) if candidates else datetime.min
+
+    # Canonical, stable order (latest activity first). This order does NOT depend
+    # on which book is focused, so the "Currently reading" strip stays static when
+    # the user switches the hero — only the active highlight moves.
+    ordered = sorted(rows, key=last_active, reverse=True)
+    # The switcher can pin a specific book as hero; otherwise latest activity wins.
+    hero = ordered[0]
+    if book_id is not None:
+        hero = next((r for r in ordered if r.id == book_id), ordered[0])
+
+    progress = _norm_pct(hero.sync_pct if hero.sync_pct is not None else hero.progress_pct)
+    synced_at = hero.synced_at or hero.status_at
+
+    # Upcoming volumes of this series the user can see (only if it's a real series).
+    upcoming: list[dict] = []
+    ahead_count = 0
+    if hero.series and hero.series_index is not None:
+        vol_rows = (
+            db.query(Book)
+            .filter(
+                Book.status == "active",
+                Book.series == hero.series,
+                Book.series_index > hero.series_index,
+                visible,
+            )
+            .order_by(Book.series_index.asc())
+            .with_entities(Book.id, Book.title, Book.series_index, Book.cover_path, Book.description)
+            .all()
+        )
+        # Whole volumes only — exclude side-story / fractional indices (e.g. 13.5)
+        # so "N ahead" counts the main line, not bonus material.
+        vol_rows = [v for v in vol_rows if v.series_index is not None and float(v.series_index).is_integer()]
+        ahead_count = len(vol_rows)
+        upcoming = [
+            {
+                "book_id": v.id,
+                "title": v.title,
+                "series_index": v.series_index,
+                "has_cover": bool(v.cover_path),
+                "description": v.description,
+            }
+            for v in vol_rows[:5]
+        ]
+
+    # The full in-progress set, in stable order, INCLUDING the current hero — the
+    # strip is a static filmstrip; the frontend just highlights whichever is active.
+    reading = [
+        {
+            "book_id": r.id,
+            "title": r.title,
+            "author": r.author,
+            "has_cover": bool(r.cover_path),
+            "progress": _norm_pct(r.sync_pct if r.sync_pct is not None else r.progress_pct),
+        }
+        for r in ordered[:12]
+    ]
+
+    return {
+        "ready": True,
+        "book": {
+            "book_id": hero.id,
+            "title": hero.title,
+            "author": hero.author,
+            "series": hero.series,
+            "series_index": hero.series_index,
+            "description": hero.description,
+            "has_cover": bool(hero.cover_path),
+            "progress": progress,
+            "device": hero.device,
+            "synced": hero.synced_at is not None,
+            "last_sync": synced_at.isoformat() + "Z" if synced_at else None,
+        },
+        "upcoming": upcoming,
+        "ahead_count": ahead_count,
+        "reading": reading,
+    }
 
 
 @router.get("/stats")
@@ -61,6 +199,18 @@ def get_home_stats(
         "reading_seconds_30d": reading_seconds_30d,
         "pages_turned_30d": pages_turned_30d,
     }
+
+
+@router.get("/reading-dna")
+def get_home_reading_dna(
+    tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Reading-personality summary for the Home rail (see services.reading_dna)."""
+    from backend.services.reading_dna import compute_reading_dna
+
+    return compute_reading_dna(db, current_user, tz_offset)
 
 
 @router.get("/activity")

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -948,6 +948,10 @@ def get_stats(
         reread_books.sort(key=lambda b: b["reread_pages"], reverse=True)
     rereads = {"books": reread_books}
 
+    # ── Reading DNA — fixed trailing window, independent of the range selector ──
+    from backend.services.reading_dna import compute_reading_dna
+    reading_dna = compute_reading_dna(db, current_user, tz_offset)
+
     return {
         "range_days": effective_days,
         "headline": {
@@ -988,6 +992,7 @@ def get_stats(
         "wpm": wpm,
         "book_lengths": book_lengths,
         "rereads": rereads,
+        "reading_dna": reading_dna,
     }
 
 

--- a/backend/services/reading_dna.py
+++ b/backend/services/reading_dna.py
@@ -1,0 +1,205 @@
+"""Reading DNA — a reader-personality summary derived from existing aggregates.
+
+Five 0–100 trait scores (Length, Variety, Rhythm, Time, Pace), each over a
+trailing window, plus a named archetype assembled from the two most-defining
+traits. No new tables, no migration — pure computation over the same
+reconciled reading data the stats page already uses.
+
+Trait scoring convention: 0 = the "low" pole, 100 = the "high" pole, 50 =
+neutral. The archetype's NOUN comes from the single most extreme trait, the
+MODIFIER from the second; they always come from different axes so the name can
+never contradict itself (no "Savorer Devourer"). Tone is calibrated so the low
+pole flatters as much as the high pole — reading one author for a year is
+"loyal devotion", not "narrow".
+"""
+from __future__ import annotations
+
+import statistics
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from backend.core.permissions import book_visibility_filter
+from backend.models.book import Book
+from backend.models.user import User
+from backend.models.user_book_status import UserBookStatus
+from backend.services import reconciled_reading as rr
+
+# Per-axis vocabulary, tone-checked. Tuple is (low-pole word, high-pole word).
+_NOUN = {
+    "length":  ("Sprinter", "Epic Specialist"),
+    "variety": ("Devotee", "Wanderer"),
+    "rhythm":  ("Spree Reader", "Constant Reader"),
+    "time":    ("Dawn Reader", "Night Owl"),
+    "pace":    ("Savorer", "Devourer"),
+}
+_MOD = {
+    "length":  ("Bite-size", "Marathon"),
+    "variety": ("Loyal", "Roving"),
+    "rhythm":  ("Seasonal", "Steady"),
+    "time":    ("Early-Bird", "Night-Owl"),
+    "pace":    ("Slow-Burn", "Voracious"),
+}
+# Bar pole labels shown in the UI (low, high).
+_LABELS = {
+    "length":  ("Short reads", "Long epics"),
+    "variety": ("Focused", "Eclectic"),
+    "rhythm":  ("Sporadic", "Consistent"),
+    "time":    ("Early bird", "Night owl"),
+    "pace":    ("Savorer", "Speed demon"),
+}
+# Short tag for the one-line summary (low, high).
+_PHRASE = {
+    "length":  ("short reads", "long epics"),
+    "variety": ("focused taste", "eclectic taste"),
+    "rhythm":  ("reads in bursts", "consistent"),
+    "time":    ("early bird", "night owl"),
+    "pace":    ("savoured", "fast-paced"),
+}
+_ORDER = ["length", "variety", "rhythm", "time", "pace"]
+
+# An axis must sit at least this far from neutral (out of 50) to name the reader.
+_EXTREME_MIN = 12
+_WPM_MIN_SECONDS = 300  # below ~5 min of read-time on a book, pace is just noise
+
+
+def _clamp(x: float, lo: float = 0.0, hi: float = 100.0) -> float:
+    return max(lo, min(hi, x))
+
+
+def _lerp_score(v: float, lo: float, hi: float) -> float:
+    """Map v in [lo, hi] onto 0..100, clamped."""
+    if hi == lo:
+        return 50.0
+    return _clamp((v - lo) / (hi - lo) * 100.0)
+
+
+def compute_reading_dna(db: Session, user: User, tz_offset: int) -> dict:
+    now = datetime.utcnow()
+    offset_hours = -(tz_offset // 60)
+    tzm = f"{offset_hours:+d} hours"
+    covered = rr.covered_book_ids(db, user.id)
+
+    traits: dict[str, float] = {}
+
+    # ── Time (early bird ↔ night owl) — trailing 365d hour distribution ──────────
+    hour_dow = rr.hour_dow(db, user.id, tzm, covered, now - timedelta(days=365), None)
+    hour_secs: dict[int, int] = {}
+    for (_d, h), (secs, _sess) in hour_dow.items():
+        hour_secs[h] = hour_secs.get(h, 0) + secs
+    total_t = sum(hour_secs.values())
+    if total_t > 0:
+        # Circular mean with a 4am reading-day boundary (hours 0–3 roll to 24–27),
+        # so a 1am session reads as "late", not "early morning".
+        num = sum((h if h >= 4 else h + 24) * s for h, s in hour_secs.items())
+        mean_hour = num / total_t
+        traits["time"] = _lerp_score(mean_hour, 8, 24)  # 8am→early, midnight→night
+
+    # ── Rhythm (sporadic ↔ consistent) — active-day density, last 120d ───────────
+    adays = rr.active_days(db, user.id, tzm, covered)
+    if adays:
+        today = now.date()
+        window = 120
+        first = min(adays)
+        span = min(window, (today - first).days + 1)
+        if span >= 14:  # need a couple of weeks before judging consistency
+            recent = sum(1 for d in adays if 0 <= (today - d).days < window)
+            traits["rhythm"] = _clamp(recent / span * 100)
+
+    # ── Finished books power Length, Pace, Variety ───────────────────────────────
+    finished = (
+        db.query(Book.id, Book.author, Book.book_type_id, Book.word_count)
+        .join(UserBookStatus, UserBookStatus.book_id == Book.id)
+        .filter(
+            UserBookStatus.user_id == user.id,
+            UserBookStatus.status == "read",
+            Book.status == "active",
+            book_visibility_filter(db, user),
+        )
+        .all()
+    )
+
+    # Length (short ↔ long) — median finished-book word count.
+    word_counts = [int(r.word_count) for r in finished if r.word_count]
+    if len(word_counts) >= 3:
+        # Calibrated to human norms: ~50k light novel → short, ~90k novel → neutral,
+        # 150k+ → long epic. (Not to any one library's data.)
+        traits["length"] = _lerp_score(statistics.median(word_counts), 30_000, 150_000)
+
+    # Pace (savorer ↔ speed demon) — true WPM = words ÷ reconciled read-time.
+    if word_counts:
+        book_secs = rr.book_seconds(db, user.id, tzm, covered, None, None)
+        words_sum = secs_sum = counted = 0
+        for r in finished:
+            if not r.word_count:
+                continue
+            secs = int(book_secs.get(r.id, (0, 0, 0))[0])
+            if secs >= _WPM_MIN_SECONDS:
+                words_sum += int(r.word_count)
+                secs_sum += secs
+                counted += 1
+        if counted >= 3 and secs_sum > 0:
+            # ~250 reconciled WPM is an average reader (→ neutral); 140 savours,
+            # 360+ is a speed demon. Human-calibrated, not seed-calibrated.
+            traits["pace"] = _lerp_score(words_sum * 60 / secs_sum, 140, 360)
+
+    # Variety (focused ↔ eclectic) — spread across authors & book types.
+    if len(finished) >= 4:
+        authors: dict[str, int] = {}
+        types: dict[int, int] = {}
+        for r in finished:
+            a = (r.author or "").strip().lower()
+            if a:
+                authors[a] = authors.get(a, 0) + 1
+            if r.book_type_id is not None:
+                types[r.book_type_id] = types.get(r.book_type_id, 0) + 1
+
+        def _spread(counts: dict) -> float | None:
+            tot = sum(counts.values())
+            if tot == 0:
+                return None
+            hhi = sum((c / tot) ** 2 for c in counts.values())  # 1 = one bucket
+            return 1 - hhi
+
+        divs = [d for d in (_spread(authors), _spread(types)) if d is not None]
+        if divs:
+            traits["variety"] = _clamp(sum(divs) / len(divs) * 100)
+
+    # ── Assemble the card ────────────────────────────────────────────────────────
+    trait_list = [
+        {"key": k, "score": round(traits[k]), "low": _LABELS[k][0], "high": _LABELS[k][1]}
+        for k in _ORDER
+        if k in traits
+    ]
+
+    ranked = sorted(traits.items(), key=lambda kv: abs(kv[1] - 50), reverse=True)
+
+    archetype: str | None = None
+    if ranked and abs(ranked[0][1] - 50) >= _EXTREME_MIN:
+        n_axis, n_val = ranked[0]
+        noun = _NOUN[n_axis][1 if n_val >= 50 else 0]
+        if len(ranked) >= 2 and abs(ranked[1][1] - 50) >= _EXTREME_MIN:
+            m_axis, m_val = ranked[1]
+            archetype = f"{_MOD[m_axis][1 if m_val >= 50 else 0]} {noun}"
+        else:
+            archetype = noun
+    elif trait_list:
+        archetype = "The Generalist"
+
+    if archetype == "The Generalist":
+        summary = "A bit of everything, at your own pace."
+    else:
+        tags = [
+            _PHRASE[axis][1 if val >= 50 else 0]
+            for axis, val in ranked[:3]
+            if abs(val - 50) >= 8
+        ]
+        summary = (" · ".join(tags)[:1].upper() + " · ".join(tags)[1:] + ".") if tags else None
+
+    return {
+        "ready": bool(trait_list),
+        "archetype": archetype,
+        "summary": summary,
+        "traits": trait_list,
+        "window_days": 365,
+    }

--- a/frontend/src/components/home/FocusMode.tsx
+++ b/frontend/src/components/home/FocusMode.tsx
@@ -1,0 +1,456 @@
+import { useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Play, RefreshCw, BookOpen } from 'lucide-react'
+import { api } from '@/lib/api'
+import { cn } from '@/lib/utils'
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface FocusBook {
+  book_id: number
+  title: string
+  author: string | null
+  series: string | null
+  series_index: number | null
+  description: string | null
+  has_cover: boolean
+  progress: number
+  device: string | null
+  synced: boolean
+  last_sync: string | null
+}
+interface FocusUpcoming {
+  book_id: number
+  title: string
+  series_index: number | null
+  has_cover: boolean
+  description: string | null
+}
+interface FocusData {
+  ready: boolean
+  book: FocusBook | null
+  upcoming: FocusUpcoming[]
+  ahead_count: number
+  reading: { book_id: number; title: string; author: string | null; has_cover: boolean; progress: number }[]
+}
+
+/** One cover in the rotary — the current book plus each upcoming volume. */
+interface RotaryItem {
+  book_id: number
+  series_index: number | null
+  description: string | null
+  isCurrent: boolean
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return ''
+  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)} min ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)} hours ago`
+  if (diff < 172800) return 'yesterday'
+  return `${Math.floor(diff / 86400)} days ago`
+}
+
+function deviceLabel(device: string | null): string {
+  if (!device) return 'Synced'
+  const d = device.toLowerCase()
+  if (d === 'web') return 'Read on the web'
+  if (d.includes('kindle')) return 'Synced from Kindle'
+  if (d.includes('kobo')) return 'Synced from Kobo'
+  if (d.includes('koreader')) return 'Synced from KOReader'
+  return `Synced from ${device}`
+}
+
+const cover = (id: number) => `/api/books/${id}/cover`
+const fmtVol = (n: number | null) => (n == null ? '' : String(n))
+
+// Stage geometry — a fixed, overflow-clipped box so receding covers can never
+// bleed into the meta column; the far ones clip cleanly at the stage edge.
+const STAGE_W = 540
+const STAGE_H = 460
+const CARD_W = 214
+const CARD_H = CARD_W * 1.5
+const CARD_LEFT = 18
+// A lone cover (standalone book or last volume in a series) is centered + larger,
+// since the fan is the whole composition and there isn't one.
+const SOLO_W = 300
+const SOLO_H = SOLO_W * 1.5
+
+/** Compute the 3D transform for a cover given its distance from the selected one. */
+function slot(offset: number) {
+  if (offset === 0) {
+    return { x: 0, z: 0, rot: 0, scale: 1, brightness: 1, opacity: 1, zIndex: 100 }
+  }
+  if (offset > 0) {
+    // Upcoming volumes fan back to the right.
+    return {
+      x: 96 + offset * 60,
+      z: -70 * offset,
+      rot: -42,
+      scale: Math.max(0.5, 0.74 - (offset - 1) * 0.05),
+      brightness: Math.max(0.4, 0.92 - (offset - 1) * 0.13),
+      opacity: offset <= 5 ? 1 : 0,
+      zIndex: 100 - offset,
+    }
+  }
+  // Already-passed volumes slide off to the left and fade out.
+  return {
+    x: -60 + offset * 36,
+    z: -70 * -offset,
+    rot: 42,
+    scale: 0.7,
+    brightness: 0.5,
+    opacity: 0,
+    zIndex: 100 + offset,
+  }
+}
+
+// ── Rotary display ─────────────────────────────────────────────────────────────
+
+function Rotary({
+  items,
+  selected,
+  onSelect,
+  onOpenHero,
+  mounted,
+}: {
+  items: RotaryItem[]
+  selected: number
+  onSelect: (i: number) => void
+  onOpenHero: () => void
+  mounted: boolean
+}) {
+  const wrapRef = useRef<HTMLDivElement>(null)
+  const [scale, setScale] = useState(1)
+  const [hovered, setHovered] = useState<number | null>(null)
+
+  // Scale the fixed-size stage down to fit narrow screens (mobile), never up.
+  useEffect(() => {
+    const el = wrapRef.current
+    if (!el) return
+    const update = () => setScale(Math.min(1, el.clientWidth / STAGE_W))
+    update()
+    const ro = new ResizeObserver(update)
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [])
+
+  const solo = items.length === 1
+
+  return (
+    <div ref={wrapRef} className="w-full mx-auto lg:mx-0" style={{ maxWidth: STAGE_W, height: STAGE_H * scale }}>
+      <div
+        // Clip ONLY the right edge (where the fan recedes toward the text); leave the
+        // other three sides open so the hero's bloom shadow isn't sliced into a hard line.
+        style={{
+          position: 'relative',
+          width: STAGE_W,
+          height: STAGE_H,
+          transform: `scale(${scale})`,
+          transformOrigin: 'top left',
+          perspective: 1800,
+          perspectiveOrigin: '48% 50%',
+          clipPath: solo ? 'none' : 'inset(-80px 0px -80px -80px)',
+        }}
+      >
+        {solo ? (
+          /* Lone cover — centered + larger, opens the series/book detail. */
+          <button
+            type="button"
+            onClick={onOpenHero}
+            className="absolute top-1/2 left-1/2 rounded-xl overflow-hidden cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            style={{
+              width: SOLO_W,
+              marginTop: -SOLO_H / 2,
+              marginLeft: -SOLO_W / 2,
+              transform: mounted ? 'scale(1)' : 'scale(.96)',
+              opacity: mounted ? 1 : 0,
+              boxShadow: 'var(--cover-bloom-hero)',
+              transition: 'transform 500ms cubic-bezier(.22,1,.36,1), opacity 450ms ease',
+            }}
+          >
+            <img src={cover(items[0].book_id)} alt="" className="block w-full aspect-[2/3] object-cover" draggable={false} />
+          </button>
+        ) : (
+          <div className="absolute top-1/2 left-0" style={{ transform: 'translateY(-50%)', transformStyle: 'preserve-3d' }}>
+            {items.map((it, i) => {
+              const offset = i - selected
+              const s = slot(offset)
+              const isHero = offset === 0
+              const isHover = hovered === i && !isHero && s.opacity > 0
+              // Entrance: covers start stacked at the hero spot, then fan out on mount.
+              const tx = mounted ? s.x : 0
+              const tz = mounted ? s.z + (isHover ? 40 : 0) : 0
+              const rot = mounted ? (isHover ? s.rot + 8 : s.rot) : -16
+              const sc = (mounted ? s.scale : isHero ? 1 : 0.94) * (isHover ? 1.05 : 1)
+              const op = mounted ? s.opacity : isHero ? 1 : 0
+              const bright = mounted ? (isHover ? Math.min(1, s.brightness + 0.3) : s.brightness) : 1
+              return (
+                <button
+                  key={it.book_id}
+                  type="button"
+                  onClick={() => (isHero ? onOpenHero() : onSelect(i))}
+                  onMouseEnter={() => setHovered(i)}
+                  onMouseLeave={() => setHovered((h) => (h === i ? null : h))}
+                  title={it.series_index != null ? `Volume ${fmtVol(it.series_index)}` : undefined}
+                  className="absolute top-1/2 rounded-xl overflow-hidden cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                  style={{
+                    left: CARD_LEFT,
+                    width: CARD_W,
+                    marginTop: -CARD_H / 2,
+                    transform: `translate3d(${tx}px, 0, ${tz}px) rotateY(${rot}deg) scale(${sc})`,
+                    transformStyle: 'preserve-3d',
+                    transformOrigin: 'center center',
+                    zIndex: isHover ? 90 : s.zIndex,
+                    filter: `brightness(${bright})`,
+                    opacity: op,
+                    pointerEvents: op === 0 ? 'none' : 'auto',
+                    // Soft all-edge bloom; theme-aware (see --cover-bloom-* in index.css):
+                    // soft black on light, neutral light on dark where black is invisible.
+                    boxShadow: isHero ? 'var(--cover-bloom-hero)' : 'var(--cover-bloom-fan)',
+                    transition:
+                      'transform 600ms cubic-bezier(.22,1,.36,1), filter 500ms ease, opacity 450ms ease',
+                    transitionDelay: mounted ? `${Math.max(0, offset) * 55}ms` : '0ms',
+                  }}
+                >
+                  <img src={cover(it.book_id)} alt="" className="block w-full aspect-[2/3] object-cover" draggable={false} />
+                  {!isHero && it.series_index != null && (
+                    <span className="absolute top-1.5 left-1.5 w-6 h-6 rounded-full bg-black/55 backdrop-blur-sm text-white text-[11px] font-bold grid place-items-center border border-white/20">
+                      {fmtVol(it.series_index)}
+                    </span>
+                  )}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+export function FocusMode() {
+  const navigate = useNavigate()
+  const [data, setData] = useState<FocusData | null>(null)
+  const [selected, setSelected] = useState(0)
+  const [mounted, setMounted] = useState(false)
+  // null = let the backend auto-pick the latest-synced book; a number focuses a
+  // specific in-progress book (the "Also reading" switcher).
+  const [focusId, setFocusId] = useState<number | null>(null)
+
+  // (Re)load whenever the focused book changes; replay the entrance each time.
+  useEffect(() => {
+    setMounted(false)
+    setSelected(0)
+    const q = focusId != null ? `?book_id=${focusId}` : ''
+    api.get<FocusData>(`/home/focus${q}`)
+      .then(setData)
+      .catch(() => setData({ ready: false, book: null, upcoming: [], ahead_count: 0, reading: [] }))
+  }, [focusId])
+
+  // Kick the entrance animation one frame after data lands.
+  useEffect(() => {
+    if (data?.ready) {
+      const t = setTimeout(() => setMounted(true), 60)
+      return () => clearTimeout(t)
+    }
+  }, [data])
+
+  const switchTo = (id: number) => {
+    if (id !== data?.book?.book_id) setFocusId(id)
+  }
+
+  if (!data) {
+    return <div className="flex items-center justify-center py-40 text-muted-foreground text-sm">Loading…</div>
+  }
+
+  if (!data.ready || !data.book) {
+    return (
+      <div className="flex flex-col items-center justify-center py-40 gap-4 text-center">
+        <div className="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center">
+          <BookOpen className="w-8 h-8 text-primary/40" />
+        </div>
+        <div>
+          <p className="text-base font-medium text-foreground">Nothing in progress</p>
+          <p className="text-sm text-muted-foreground mt-1">Start a book and Focus mode will pick up where you left off</p>
+        </div>
+      </div>
+    )
+  }
+
+  const b = data.book
+  const items: RotaryItem[] = [
+    { book_id: b.book_id, series_index: b.series_index, description: b.description, isCurrent: true },
+    ...data.upcoming.map((u) => ({ book_id: u.book_id, series_index: u.series_index, description: u.description, isCurrent: false })),
+  ]
+  const sel = items[selected] ?? items[0]
+  const onCurrent = sel.isCurrent
+
+  // The hero cover / series title opens the series detail page (or the book detail
+  // page for a standalone title with no series).
+  const openHero = () => {
+    if (b.series) navigate(`/?tab=series&series_detail=${encodeURIComponent(b.series)}`)
+    else navigate(`/books/${b.book_id}`)
+  }
+
+  return (
+    <div className="flex flex-col min-h-[calc(100vh-160px)]">
+      {/* Hero composition — vertically centered so the empty space is balanced */}
+      <div className="flex-1 flex items-center w-full">
+      <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-center lg:gap-14 w-full max-w-[1080px] mx-auto">
+      {/* Display — animated rotary */}
+      <div className="w-full lg:w-auto lg:shrink-0">
+        <Rotary items={items} selected={selected} onSelect={setSelected} onOpenHero={openHero} mounted={mounted} />
+      </div>
+
+      {/* Meta — reflects the selected volume */}
+      <div className="relative z-10 flex-1 min-w-0 max-w-[520px]">
+        <div className="flex items-center gap-2 text-[12px] font-bold tracking-[0.12em] uppercase text-muted-foreground">
+          {onCurrent ? 'Continue reading' : 'Up next'}
+          {b.series && (
+            <button type="button" onClick={openHero} className="text-primary hover:underline">
+              · {b.series}
+            </button>
+          )}
+        </div>
+
+        <h1 className="font-display text-3xl sm:text-4xl font-bold leading-[1.05] tracking-tight mt-3 text-foreground">
+          <button type="button" onClick={openHero} className="text-left hover:underline decoration-2 underline-offset-4">
+            {b.series ?? b.title}
+          </button>
+        </h1>
+
+        {b.series && sel.series_index != null && (
+          <div className="mt-2.5 text-[15px] font-semibold text-foreground">
+            Volume <span className="text-primary">{fmtVol(sel.series_index)}</span>
+            {onCurrent && data.ahead_count > 0 && (
+              <span className="text-muted-foreground font-medium"> · {data.ahead_count} ahead in this series</span>
+            )}
+          </div>
+        )}
+        {b.author && <div className="mt-1 text-[15px] text-muted-foreground">{b.author}</div>}
+
+        {/* Description swaps with the selected volume. */}
+        <p key={sel.book_id} className="mt-5 text-[15px] leading-relaxed text-muted-foreground line-clamp-4 min-h-[6rem] animate-[fadeIn_350ms_ease]">
+          {sel.description || 'No description yet for this volume.'}
+        </p>
+
+        {/* Progress — only the in-progress current book has it. A book that's
+            "reading" but at 0% reads better as "Just started" than an empty bar. */}
+        {onCurrent ? (
+          b.progress > 0 ? (
+            <div className="mt-6">
+              <div className="flex items-baseline justify-between mb-2">
+                <span className="text-[13px] text-muted-foreground">Progress</span>
+                <span className="text-base font-bold tabular-nums text-foreground">{Math.round(b.progress)}%</span>
+              </div>
+              <div className="h-[7px] rounded-full bg-muted overflow-hidden">
+                <div className="h-full rounded-full bg-primary transition-all duration-500" style={{ width: `${b.progress}%` }} />
+              </div>
+            </div>
+          ) : (
+            <div className="mt-6 text-[13px] font-medium text-muted-foreground">Just started</div>
+          )
+        ) : (
+          <div className="mt-6 text-[13px] text-muted-foreground">Not started yet</div>
+        )}
+
+        {/* Sync chip — the standout beat, current book only. */}
+        {onCurrent && b.last_sync && (
+          <div className="mt-5 inline-flex items-center gap-2 rounded-xl bg-primary/12 border border-primary/25 px-3.5 py-2.5 text-[14px] font-semibold text-foreground">
+            <RefreshCw className="w-[15px] h-[15px] text-primary" />
+            {deviceLabel(b.device)}
+            <span className="text-muted-foreground font-medium">· {relativeTime(b.last_sync)}</span>
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="mt-6 flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => navigate(`/reader/${sel.book_id}`)}
+            className="inline-flex items-center gap-2 rounded-xl bg-primary text-primary-foreground px-6 py-3.5 text-[16px] font-bold hover:bg-primary/90 transition-colors"
+          >
+            <Play className="w-[17px] h-[17px] fill-current" />
+            {onCurrent ? 'Resume reading' : 'Start reading'}
+          </button>
+          {onCurrent && items.length > 1 ? (
+            <button
+              type="button"
+              onClick={() => setSelected(1)}
+              className="text-[14px] font-semibold text-muted-foreground hover:text-foreground transition-colors"
+            >
+              Next: Vol {fmtVol(items[1].series_index)} →
+            </button>
+          ) : !onCurrent ? (
+            <button
+              type="button"
+              onClick={() => setSelected(0)}
+              className="text-[14px] font-semibold text-muted-foreground hover:text-foreground transition-colors"
+            >
+              ← Back to current
+            </button>
+          ) : null}
+        </div>
+      </div>
+      </div>
+      </div>{/* /hero composition */}
+
+      {/* Currently reading — a STATIC filmstrip of all in-progress books; the
+          active one is highlighted in place, so switching never reshuffles it. */}
+      {data.reading.length > 1 && (
+        <div className="w-full max-w-[1080px] mx-auto pt-8 mt-2 border-t border-border/60">
+          <div className="text-[12px] font-bold tracking-[0.12em] uppercase text-muted-foreground mb-3">
+            Currently reading
+          </div>
+          {/* px/py padding gives the active ring room — overflow-x-auto would
+              otherwise clip the ring at the container's edges. */}
+          <div className="flex gap-3 overflow-x-auto px-1 py-2 -mx-1">
+            {data.reading.map((r) => {
+              const active = r.book_id === b.book_id
+              return (
+                <button
+                  key={r.book_id}
+                  type="button"
+                  onClick={() => !active && switchTo(r.book_id)}
+                  title={r.title}
+                  className="group shrink-0 w-[64px] text-left"
+                  aria-current={active}
+                >
+                  <div
+                    className={cn(
+                      'relative w-[64px] aspect-[2/3] rounded-lg overflow-hidden bg-muted transition',
+                      active
+                        ? 'ring-2 ring-primary'
+                        : 'ring-1 ring-border opacity-70 group-hover:opacity-100 group-hover:ring-primary/60 cursor-pointer'
+                    )}
+                  >
+                    <img src={cover(r.book_id)} alt="" className="w-full h-full object-cover" draggable={false} />
+                    {r.progress > 0 && (
+                      <div className="absolute inset-x-0 bottom-0 h-[3px] bg-black/35">
+                        <div className="h-full bg-primary" style={{ width: `${r.progress}%` }} />
+                      </div>
+                    )}
+                  </div>
+                  <div
+                    className={cn(
+                      'mt-1.5 text-[11px] truncate transition-colors',
+                      active ? 'text-foreground font-semibold' : 'text-muted-foreground group-hover:text-foreground'
+                    )}
+                  >
+                    {r.title}
+                  </div>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/stats/GoalWidget.tsx
+++ b/frontend/src/components/stats/GoalWidget.tsx
@@ -311,7 +311,7 @@ export function HomeGoalRings() {
   if (goals.length === 0) return null
 
   return (
-    <div className="grid w-full grid-cols-2 gap-y-3 rounded-xl border border-border bg-card px-5 py-4 sm:flex sm:w-fit">
+    <div className="grid w-full grid-cols-2 gap-y-3 px-4 py-4 sm:flex">
       {goals.map((goal, i) => (
         <button
           key={goal.id}

--- a/frontend/src/components/stats/ReadingDNACard.tsx
+++ b/frontend/src/components/stats/ReadingDNACard.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Sparkles, Moon, Sunrise, Zap, BookMarked, Compass, ChevronDown, ChevronUp, type LucideIcon } from 'lucide-react'
+import type { ReadingDNA, ReadingDNATrait } from './shared'
+
+const COLLAPSE_KEY = 'tome_dna_collapsed'
+
+/** A pole-to-pole spectrum bar with the reader's position marked. */
+function TraitBar({ trait }: { trait: ReadingDNATrait }) {
+  const s = Math.max(0, Math.min(100, trait.score))
+  const high = s >= 50
+  return (
+    <div>
+      <div className="flex items-center justify-between text-[11px] mb-1.5">
+        <span className={high ? 'text-muted-foreground' : 'text-foreground font-semibold'}>{trait.low}</span>
+        <span className={high ? 'text-foreground font-semibold' : 'text-muted-foreground'}>{trait.high}</span>
+      </div>
+      <div className="relative h-1.5 rounded-full bg-muted">
+        <span className="absolute top-[-2px] bottom-[-2px] w-px bg-border left-1/2" />
+        <span
+          className="absolute top-0 bottom-0 rounded-full bg-primary/45"
+          style={{ left: `${Math.min(s, 50)}%`, width: `${Math.abs(s - 50)}%` }}
+        />
+        <span
+          className="absolute top-1/2 w-3 h-3 rounded-full bg-primary border-2 border-card shadow-[0_0_0_1px_var(--border)] -translate-x-1/2 -translate-y-1/2"
+          style={{ left: `${s}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
+/** Pick a glyph that echoes the reader's most-defining trait. */
+function archetypeIcon(archetype: string | null): LucideIcon {
+  const a = (archetype || '').toLowerCase()
+  if (a.includes('night')) return Moon
+  if (a.includes('dawn') || a.includes('early')) return Sunrise
+  if (a.includes('devourer') || a.includes('voracious')) return Zap
+  if (a.includes('wanderer') || a.includes('roving')) return Compass
+  if (a.includes('devotee') || a.includes('loyal') || a.includes('specialist')) return BookMarked
+  return Sparkles
+}
+
+export function ReadingDNACard({ dna }: { dna: ReadingDNA }) {
+  const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSE_KEY) === '1')
+
+  if (!dna.ready || dna.traits.length === 0) return null
+
+  const toggle = () => {
+    setCollapsed((c) => {
+      const next = !c
+      localStorage.setItem(COLLAPSE_KEY, next ? '1' : '0')
+      return next
+    })
+  }
+
+  const ArcheIcon = archetypeIcon(dna.archetype)
+
+  return (
+    <section className="p-4">
+      <button
+        type="button"
+        onClick={toggle}
+        className="flex w-full items-center justify-between gap-2"
+        aria-expanded={!collapsed}
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold min-w-0">
+          <Sparkles className="w-[15px] h-[15px] text-primary/75 shrink-0" />
+          <span className="shrink-0">Reading DNA</span>
+          {collapsed && dna.archetype && (
+            <span className="text-[13px] text-muted-foreground truncate">
+              · <span className="text-foreground font-semibold">{dna.archetype}</span>
+            </span>
+          )}
+        </span>
+        {collapsed
+          ? <ChevronDown className="w-4 h-4 text-muted-foreground shrink-0" />
+          : <ChevronUp className="w-4 h-4 text-muted-foreground shrink-0" />}
+      </button>
+
+      {!collapsed && (
+        <div className="mt-4">
+          {dna.archetype && (
+            <div className="flex items-center gap-3">
+              <span className="w-11 h-11 rounded-xl bg-primary text-primary-foreground flex items-center justify-center shrink-0">
+                <ArcheIcon className="w-[23px] h-[23px]" />
+              </span>
+              <span className="font-display text-[17px] leading-[1.12] text-foreground">{dna.archetype}</span>
+            </div>
+          )}
+
+          <div className="mt-5 flex flex-col gap-3.5">
+            {dna.traits.map((t) => <TraitBar key={t.key} trait={t} />)}
+          </div>
+
+          {dna.summary && (
+            <p className="mt-4 pt-3 border-t border-border text-[11px] text-muted-foreground text-center leading-relaxed">
+              {dna.summary}
+            </p>
+          )}
+
+          <Link
+            to="/stats"
+            className="mt-3 block text-[11px] text-muted-foreground hover:text-foreground transition-colors text-center"
+          >
+            Full breakdown →
+          </Link>
+        </div>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -79,6 +79,22 @@ export interface StatsResponse {
   rereads: {
     books: { book_id: number; title: string; author: string | null; has_cover: boolean; reread_pages: number; total_pages: number; pct: number }[]
   }
+  reading_dna?: ReadingDNA
+}
+
+export interface ReadingDNATrait {
+  key: string
+  score: number   // 0 = low pole, 100 = high pole
+  low: string
+  high: string
+}
+
+export interface ReadingDNA {
+  ready: boolean
+  archetype: string | null
+  summary: string | null
+  traits: ReadingDNATrait[]
+  window_days: number
 }
 
 export interface CompletionEstimate {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -174,6 +174,23 @@
   to   { opacity: 1; transform: none; }
 }
 
+/* Focus-mode rotary: panel text cross-fades as you rotate to another volume */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to   { opacity: 1; transform: none; }
+}
+
+/* Focus-mode cover bloom — a soft black halo on light themes, a neutral light
+   halo on dark (a black shadow is invisible against a near-black background). */
+:root {
+  --cover-bloom-hero: 0 6px 52px 10px rgba(0,0,0,.13), 0 2px 16px rgba(0,0,0,.07);
+  --cover-bloom-fan: 0 6px 38px 6px rgba(0,0,0,.11);
+}
+.dark {
+  --cover-bloom-hero: 0 6px 52px 10px rgba(255,255,255,.09), 0 2px 18px rgba(255,255,255,.05);
+  --cover-bloom-fan: 0 6px 40px 6px rgba(255,255,255,.06);
+}
+
 /* Cover-size slider (library toolbar) — the filled-track background is set
    inline from React since it depends on the current value */
 .cover-slider {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,7 +5,7 @@ import {
   LayoutGrid, List,
   ChevronUp, ChevronDown, SlidersHorizontal, Loader2,
   Library as LibraryIcon, CheckSquare, XSquare, Download, Pencil, Menu,
-  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star, Quote,
+  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star, Quote, Moon,
 } from 'lucide-react'
 import { TomeMark } from '@/components/TomeMark'
 import { useAuth, isMember, isAdmin } from '@/contexts/AuthContext'
@@ -24,6 +24,9 @@ import { BookAnimation } from '@/components/BookAnimation'
 import { SyncStatusBadge } from '@/components/SyncStatusBadge'
 import { NotificationBell } from '@/components/NotificationBell'
 import { HomeGoalRings } from '@/components/stats/GoalWidget'
+import { ReadingDNACard } from '@/components/stats/ReadingDNACard'
+import type { ReadingDNA } from '@/components/stats/shared'
+import { FocusMode } from '@/components/home/FocusMode'
 import { api } from '@/lib/api'
 import type { Book, Library, SavedFilter, ReadingStatus, Arc, SeriesMeta, SeriesStatus } from '@/lib/books'
 import { formatBytes } from '@/lib/books'
@@ -713,6 +716,15 @@ export function DashboardPage() {
   const [refreshing, setRefreshing] = useState(false)
   const [continueReading, setContinueReading] = useState<Book[]>([])
   const [homeStats, setHomeStats] = useState<HomeStats | null>(null)
+  const [readingDna, setReadingDna] = useState<ReadingDNA | null>(null)
+  // Home view mode: 'focus' = single-book Focus mode, 'dashboard' = the full grid.
+  const [homeMode, setHomeMode] = useState<'focus' | 'dashboard'>(
+    () => (localStorage.getItem('tome_home_mode') as 'focus' | 'dashboard') || 'dashboard'
+  )
+  const setHomeModePersisted = (m: 'focus' | 'dashboard') => {
+    localStorage.setItem('tome_home_mode', m)
+    setHomeMode(m)
+  }
   const [recentlyFinished, setRecentlyFinished] = useState<Book[]>([])
   const [recentlyAdded, setRecentlyAdded] = useState<Book[]>([])
   const [activityLog, setActivityLog] = useState<ActivityEntry[]>([])
@@ -919,6 +931,7 @@ export function DashboardPage() {
     api.get<ActivityEntry[]>('/home/activity').then(setActivityLog).catch(() => {})
     api.get<ForgottenBook[]>('/home/forgotten-books').then(setForgottenBooks).catch(() => {})
     api.get<HighlightSpotlight>('/annotations/spotlight').then(setSpotlight).catch(() => {})
+    api.get<ReadingDNA>(`/home/reading-dna?tz_offset=${tzOffset}`).then(setReadingDna).catch(() => {})
     api.get<SeriesItem[]>('/books/series').then(setSeriesList).catch(() => {})
   }, [])
 
@@ -975,6 +988,29 @@ export function DashboardPage() {
     { value: formatReadingTime(homeStats.reading_seconds_30d), label: 'Read · 30d', icon: <Clock className="w-5 h-5" /> },
     { value: String(homeStats.pages_turned_30d), label: 'Pages · 30d', icon: <BookOpenCheck className="w-5 h-5" /> },
   ] : []
+
+  // Compact Focus / Dashboard switch — placed inline next to the KPI band in
+  // Dashboard mode, top-right on its own in Focus mode.
+  const modeToggle = (
+    <div className="inline-flex rounded-lg border border-border bg-card p-0.5 shrink-0">
+      {([
+        { id: 'focus', label: 'Focus', icon: <Moon className="w-3.5 h-3.5" /> },
+        { id: 'dashboard', label: 'Dashboard', icon: <LayoutGrid className="w-3.5 h-3.5" /> },
+      ] as const).map((m) => (
+        <button
+          key={m.id}
+          onClick={() => setHomeModePersisted(m.id)}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium transition-colors',
+            homeMode === m.id ? 'bg-primary/15 text-foreground' : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          {m.icon}
+          {m.label}
+        </button>
+      ))}
+    </div>
+  )
 
   return (
     <div className="h-screen bg-background flex flex-col overflow-hidden">
@@ -1080,32 +1116,48 @@ export function DashboardPage() {
 
           {tab === 'home' ? (
             /* ── Home tab ────────────────────────────────────────────────── */
-            <div className="flex flex-col gap-8">
+            <div className="flex flex-col gap-7">
 
-              {/* ── Quick stats + goals — matching hairline-divided panels ── */}
-              <div className="flex flex-wrap items-stretch gap-3 empty:hidden">
-                {homeStats && (
-                  <div className="rounded-xl border border-border bg-card px-5 py-4 grid grid-cols-2 gap-y-3 sm:flex w-full sm:w-fit">
-                    {homeStatItems.map((s, i) => (
-                      <div
-                        key={s.label}
-                        className={cn(
-                          'sm:px-5',
-                          i === 0 && 'sm:pl-0',
-                          i > 0 && 'sm:border-l sm:border-border/60'
-                        )}
-                      >
-                        <p className="text-xs text-muted-foreground/70">{s.label}</p>
-                        <p className="flex items-center gap-2 text-xl font-semibold tabular-nums text-foreground leading-tight">
-                          <span className="text-primary/60">{s.icon}</span>
-                          {s.value}
-                        </p>
-                      </div>
-                    ))}
-                  </div>
-                )}
-                <HomeGoalRings />
+              {homeMode === 'focus' ? (
+              <>
+              {/* Focus mode: toggle alone, top-right */}
+              <div className="flex justify-end -mb-1">{modeToggle}</div>
+                <FocusMode />
+              </>
+              ) : (
+              <>
+
+              {/* ── Quick stats + mode toggle on one row ──────────────────── */}
+              <div className="flex items-center justify-between gap-3 flex-wrap">
+                <div className="flex flex-wrap items-stretch gap-3 empty:hidden">
+                  {homeStats && (
+                    <div className="rounded-xl border border-border bg-card px-5 py-4 grid grid-cols-2 gap-y-3 sm:flex w-full sm:w-fit">
+                      {homeStatItems.map((s, i) => (
+                        <div
+                          key={s.label}
+                          className={cn(
+                            'sm:px-5',
+                            i === 0 && 'sm:pl-0',
+                            i > 0 && 'sm:border-l sm:border-border/60'
+                          )}
+                        >
+                          <p className="text-xs text-muted-foreground/70">{s.label}</p>
+                          <p className="flex items-center gap-2 text-xl font-semibold tabular-nums text-foreground leading-tight">
+                            <span className="text-primary/60">{s.icon}</span>
+                            {s.value}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+                <div className="ml-auto">{modeToggle}</div>
               </div>
+
+              {/* ── Two-column body: content + rail ───────────────────────── */}
+              <div className="flex flex-col gap-8 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-7 lg:items-start">
+              {/* ── Main column (one connected panel, hairline-divided) ────── */}
+              <div className="rounded-2xl border border-border bg-card divide-y divide-border min-w-0 overflow-hidden">
 
               {/* ── Forgotten Books ───────────────────────────────────────── */}
               {(() => {
@@ -1117,7 +1169,7 @@ export function DashboardPage() {
                   setForgottenDismissedSig(forgottenSig)
                 }
                 return (
-                  <section className="rounded-lg border border-border bg-muted/30 px-3 py-2.5">
+                  <section className="px-5 py-4">
                     <header className="flex items-center justify-between mb-2">
                       <h2 className="text-base text-foreground">Pick up where you left off</h2>
                       <button
@@ -1154,32 +1206,8 @@ export function DashboardPage() {
                 )
               })()}
 
-              {/* ── Highlight spotlight (on this day) ──────────────────────── */}
-              {spotlight?.highlight?.highlighted_text && (
-                <section className="rounded-lg border border-border bg-muted/30 px-4 py-3.5">
-                  <header className="flex items-center justify-between mb-2.5">
-                    <h2 className="flex items-center gap-1.5 text-base text-foreground">
-                      <Quote className="w-4 h-4 text-primary/60" />
-                      {spotlight.on_this_day ? 'On this day you highlighted' : 'From your highlights'}
-                    </h2>
-                    <a href="/highlights" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-                      All highlights
-                    </a>
-                  </header>
-                  <a href={`/books/${spotlight.highlight.book_id}`} className="block group">
-                    <p className="text-sm text-foreground leading-relaxed border-l-2 border-primary/40 pl-3 italic line-clamp-4">
-                      {spotlight.highlight.highlighted_text}
-                    </p>
-                    <p className="mt-2 pl-3 text-xs text-muted-foreground group-hover:text-primary transition-colors">
-                      — {spotlight.highlight.book_title}
-                      {spotlight.highlight.book_author ? `, ${spotlight.highlight.book_author}` : ''}
-                    </p>
-                  </a>
-                </section>
-              )}
-
               {/* ── Continue Reading ──────────────────────────────────────── */}
-              <div className="flex flex-col gap-3">
+              <section className="flex flex-col gap-3 px-5 py-5">
                 <h2 className="text-base font-semibold text-foreground">Continue Reading</h2>
                 {continueReading.length === 0 ? (
                   <div className="flex flex-col items-center justify-center py-24 gap-4 text-center">
@@ -1195,67 +1223,75 @@ export function DashboardPage() {
                     </button>
                   </div>
                 ) : (
-                  <div key={view} className={gridClass} style={gridStyle}>
+                  /* Horizontal band (not a grid): one scrollable row keeps Home's
+                     left column on a consistent banded rhythm that aligns with the
+                     rail, instead of a tall wall of covers. */
+                  <div className="flex gap-4 overflow-x-auto pb-2 -mx-1 px-1">
                     {continueReading.map((book, i) => {
                       const status = readingStatuses[book.id]
                       return (
-                        <BookCard
-                          key={`${cardView}-${book.id}`}
-                          book={book}
-                          view={cardView}
-                          index={i}
-                          selected={false}
-                          onTagClick={tag => setSearchParams(prev => { const p = new URLSearchParams(prev); p.set('tab', 'books'); p.set('tag', tag); p.delete('saved_filter'); return p })}
-                          onSeriesClick={series => setSearchParams(prev => { const p = new URLSearchParams(prev); p.set('tab', 'books'); p.set('series', series); p.delete('saved_filter'); return p })}
-                          onAuthorClick={author => setSearchParams(prev => { const p = new URLSearchParams(prev); p.set('tab', 'books'); p.set('author', author); p.delete('saved_filter'); return p })}
-                          readingStatus={status?.status}
-                          progressPct={status?.progress_pct}
-                          rating={status?.rating}
-                        />
+                        <div key={book.id} className="shrink-0 w-32">
+                          <BookCard
+                            book={book}
+                            view="small"
+                            index={i}
+                            selected={false}
+                            readingStatus={status?.status}
+                            progressPct={status?.progress_pct}
+                            rating={status?.rating}
+                          />
+                        </div>
                       )
                     })}
                   </div>
                 )}
-              </div>
+              </section>
 
               {/* ── Series Progress ───────────────────────────────────────── */}
               {(() => {
-                const seriesBooks = continueReading.filter(b => b.series && b.series_index != null)
-                if (seriesBooks.length === 0) return null
+                // One card per series (a series can have several in-progress volumes),
+                // ranked by how far through it you are. Progress = completed volumes /
+                // total, so it never reads "Book 1171 of 17" off a chapter index.
+                const bySeries = new Map<string, { book: typeof continueReading[number]; read: number; total: number | null; pct: number }>()
+                for (const book of continueReading) {
+                  if (!book.series || book.series_index == null || bySeries.has(book.series)) continue
+                  const sd = seriesList.find(s => s.name === book.series)
+                  const total = sd?.book_count ?? null
+                  const read = sd?.read_count ?? 0
+                  bySeries.set(book.series, { book, read, total, pct: total ? Math.min(100, (read / total) * 100) : 0 })
+                }
+                // Only series with genuine momentum: at least one completed volume
+                // and not yet finished. Just-started (0%) series live in Continue
+                // Reading; finished ones don't belong here. Most-progressed first.
+                const rows = [...bySeries.values()]
+                  .filter(r => r.read > 0 && (r.total == null || r.read < r.total))
+                  .sort((a, b) => b.pct - a.pct)
+                  .slice(0, 6)
+                if (rows.length === 0) return null
                 return (
-                  <div className="flex flex-col gap-3">
+                  <div className="flex flex-col gap-3 px-5 py-5">
                     <h2 className="text-base font-semibold text-foreground">Series Progress</h2>
-                    <div className="flex flex-col gap-2">
-                      {seriesBooks.map(book => {
-                        const seriesData = seriesList.find(s => s.name === book.series)
-                        const total = seriesData?.book_count ?? null
-                        const current = book.series_index!
-                        // Progress reflects *completed* (read) volumes, not the index of the
-                        // book you're currently reading — otherwise starting the last book
-                        // would show the series as 100% before you've finished it.
-                        const readCount = seriesData?.read_count ?? 0
-                        const pct = total ? Math.min(100, (readCount / total) * 100) : null
-                        return (
-                          <div key={book.id} className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-muted/50 border border-border">
-                            <div className="min-w-0 flex-1">
-                              <div className="flex items-center justify-between gap-2 mb-1.5">
-                                <span className="text-xs font-medium text-foreground truncate">{book.series}</span>
-                                <span className="text-xs text-muted-foreground shrink-0">
-                                  {total ? `Book ${current} of ${total}` : `Book ${current}`}
-                                </span>
-                              </div>
-                              {pct !== null && (
-                                <div className="h-1.5 rounded-full bg-muted overflow-hidden">
-                                  <div
-                                    className="h-full rounded-full bg-primary transition-all"
-                                    style={{ width: `${pct}%` }}
-                                  />
-                                </div>
-                              )}
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+                      {rows.map(({ book, read, total, pct }) => (
+                        <a
+                          key={book.series}
+                          href={`/?tab=books&series=${encodeURIComponent(book.series!)}`}
+                          className="group flex items-center gap-3 px-3 py-2.5 rounded-xl bg-muted/40 hover:bg-muted/60 transition-colors"
+                        >
+                          <div className="relative w-9 aspect-[2/3] rounded shrink-0 overflow-hidden bg-muted">
+                            <CoverImage src={book.cover_path ? `/api/books/${book.id}/cover` : null} alt={book.series!} iconClassName="w-4 h-4" />
+                          </div>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center justify-between gap-2 mb-1.5">
+                              <span className="text-xs font-medium text-foreground truncate group-hover:text-primary transition-colors">{book.series}</span>
+                              <span className="text-[11px] text-muted-foreground shrink-0 tabular-nums">{total ? `${read}/${total}` : `${read}`}</span>
+                            </div>
+                            <div className="h-1.5 rounded-full bg-muted overflow-hidden">
+                              <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${pct}%` }} />
                             </div>
                           </div>
-                        )
-                      })}
+                        </a>
+                      ))}
                     </div>
                   </div>
                 )
@@ -1263,7 +1299,7 @@ export function DashboardPage() {
 
               {/* ── Recently Finished ─────────────────────────────────────── */}
               {recentlyFinished.length > 0 && (
-                <div className="flex flex-col gap-3">
+                <section className="flex flex-col gap-3 px-5 py-5">
                   <h2 className="text-base font-semibold text-foreground">Recently Finished</h2>
                   <div className="flex gap-3 overflow-x-auto pb-1 -mx-1 px-1">
                     {recentlyFinished.map(book => (
@@ -1279,12 +1315,12 @@ export function DashboardPage() {
                       </div>
                     ))}
                   </div>
-                </div>
+                </section>
               )}
 
               {/* ── Recently Added ────────────────────────────────────────── */}
               {recentlyAdded.length > 0 && (
-                <div className="flex flex-col gap-3">
+                <section className="flex flex-col gap-3 px-5 py-5">
                   <h2 className="text-base font-semibold text-foreground">Recently Added</h2>
                   <div className="flex gap-3 overflow-x-auto pb-1 -mx-1 px-1">
                     {recentlyAdded.map(book => (
@@ -1301,12 +1337,12 @@ export function DashboardPage() {
                       </div>
                     ))}
                   </div>
-                </div>
+                </section>
               )}
 
               {/* ── Reading Log ───────────────────────────────────────────── */}
               {activityLog.length > 0 && (
-                <div className="flex flex-col gap-3">
+                <div className="flex flex-col gap-3 px-5 py-5">
                   <h2 className="text-base font-semibold text-foreground">Reading Log</h2>
                   <div className="flex flex-col gap-1">
                     {activityLog.map((entry, i) => (
@@ -1329,6 +1365,39 @@ export function DashboardPage() {
                 </div>
               )}
 
+              </div>{/* ── /Main column ── */}
+
+              {/* ── Right rail (one connected panel, hairline-divided) ─────── */}
+              <aside className="rounded-2xl border border-border bg-card divide-y divide-border overflow-hidden">
+                {readingDna && <ReadingDNACard dna={readingDna} />}
+                <HomeGoalRings />
+                {spotlight?.highlight?.highlighted_text && (
+                  <section className="p-4">
+                    <header className="flex items-center justify-between mb-2.5">
+                      <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
+                        <Quote className="w-4 h-4 text-primary/60" />
+                        {spotlight.on_this_day ? 'On this day' : 'From your highlights'}
+                      </h2>
+                      <a href="/highlights" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+                        All →
+                      </a>
+                    </header>
+                    <a href={`/books/${spotlight.highlight.book_id}`} className="block group">
+                      <p className="text-sm text-foreground leading-relaxed border-l-2 border-primary/40 pl-3 italic line-clamp-4">
+                        {spotlight.highlight.highlighted_text}
+                      </p>
+                      <p className="mt-2 pl-3 text-xs text-muted-foreground group-hover:text-primary transition-colors">
+                        — {spotlight.highlight.book_title}
+                        {spotlight.highlight.book_author ? `, ${spotlight.highlight.book_author}` : ''}
+                      </p>
+                    </a>
+                  </section>
+                )}
+              </aside>
+
+              </div>{/* ── /Two-column body ── */}
+              </>
+              )}
             </div>
           ) : tab === 'series' ? (
             /* ── Series grid ─────────────────────────────────────────────── */

--- a/tests/test_reading_dna.py
+++ b/tests/test_reading_dna.py
@@ -1,0 +1,71 @@
+"""Tests for the Reading DNA service (backend/services/reading_dna.py)."""
+from datetime import datetime, timedelta
+
+from sqlalchemy.orm import Session
+
+from backend.models.tome_sync import ReadingSession
+from backend.models.user_book_status import UserBookStatus
+from backend.services.reading_dna import compute_reading_dna
+
+
+def _finish(db: Session, user_id: int, book, *, when: datetime, word_count: int,
+            night: bool, duration: int = 1800) -> None:
+    """Mark a book read and log a session at a night/morning hour."""
+    book.word_count = word_count
+    db.add(UserBookStatus(user_id=user_id, book_id=book.id, status="read", updated_at=when))
+    hour = 23 if night else 8
+    started = when.replace(hour=hour, minute=0, second=0, microsecond=0)
+    db.add(ReadingSession(
+        user_id=user_id, book_id=book.id,
+        started_at=started, ended_at=started + timedelta(seconds=duration),
+        duration_seconds=duration, pages_turned=30,
+    ))
+    db.flush()
+
+
+def test_dna_empty_when_no_data(db: Session, admin_user):
+    user, _ = admin_user
+    dna = compute_reading_dna(db, user, 0)
+    assert dna["ready"] is False
+    assert dna["archetype"] is None
+    assert dna["traits"] == []
+
+
+def test_dna_night_owl_epic_specialist(db: Session, admin_user, make_book):
+    user, _ = admin_user
+    base = datetime.utcnow() - timedelta(days=10)
+    # Four long books, same author, read late at night.
+    for i in range(4):
+        b = make_book(title=f"Epic {i}", author="One Author")
+        _finish(db, user.id, b, when=base + timedelta(days=i), word_count=190_000, night=True)
+
+    dna = compute_reading_dna(db, user, 0)
+    assert dna["ready"] is True
+    traits = {t["key"]: t for t in dna["traits"]}
+
+    # Long books → length leans high; late nights → time leans high.
+    assert traits["length"]["score"] > 50
+    assert traits["time"]["score"] > 50
+    # One author across all reads → focused (low variety).
+    assert traits["variety"]["score"] < 50
+    # Pole labels are carried for the UI.
+    assert traits["length"]["low"] == "Short reads" and traits["length"]["high"] == "Long epics"
+
+    # Archetype assembled from the two most-extreme traits, never contradictory.
+    assert dna["archetype"]
+    assert dna["summary"]
+
+
+def test_dna_short_morning_reader_diverges(db: Session, admin_user, make_book):
+    user, _ = admin_user
+    base = datetime.utcnow() - timedelta(days=10)
+    for i in range(4):
+        b = make_book(title=f"Novella {i}", author=f"Author {i}")
+        _finish(db, user.id, b, when=base + timedelta(days=i), word_count=40_000, night=False)
+
+    dna = compute_reading_dna(db, user, 0)
+    traits = {t["key"]: t for t in dna["traits"]}
+    # Short books → length low; mornings → time low; many authors → variety high.
+    assert traits["length"]["score"] < 50
+    assert traits["time"]["score"] < 50
+    assert traits["variety"]["score"] > 50


### PR DESCRIPTION
## Summary

Two Home-page features that ship together (they share `DashboardPage`):

### Focus mode
A minimalist Home view that spotlights the book you're most likely to pick up next — your most-recently-synced in-progress title — as a large hero cover with the upcoming volumes of its series fanned behind it in an animated 3D coverflow.

- Hero + metadata: series, "Volume X · N ahead", description, progress (0% reads "Just started"), last-sync device chip, **Resume reading**.
- **Currently reading** strip below to switch the spotlight to any other in-progress book; stays static, only the active highlight moves.
- Whole volumes only for the "N ahead" count (fractional side-stories excluded).
- Single/standalone books render as one centered, larger cover.
- Cover and series-name click through to the series detail page.
- Hover lifts a fanned cover; the stage scales to fit narrow/mobile viewports.
- Header toggle flips between **Focus** and the full **Dashboard**; choice persists in `localStorage`.

Backend: `GET /home/focus` returns the hero, its upcoming series volumes, and the full in-progress set — all gated through `book_visibility_filter`. Accepts `?book_id=` to pin a specific hero (used by the strip).

### Reading DNA
A reading-personality card — an archetype (e.g. "Night-Owl Epic Specialist") distilled from a recent trailing window of habits (when you read, session length, library breadth) — rendered on both the Home dashboard and the Stats page.

Backend: `GET /home/reading-dna` + folded into the `/stats` payload via the new `reading_dna` service.

## Testing
- `tests/test_reading_dna.py` — 3 passed
- Frontend `npm run build` — clean typecheck
- Verified live on the dev instance: Focus + Dashboard toggle, hero switching, mobile scaling, series navigation, standalone-centered layout.

## Notes
- CHANGELOG `[Unreleased]` updated for both features.