### PR TITLE
fix(home): tidy the Home header on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **A tidier Home header on phones.** On narrow screens the stats strip now spans
+  the full width with the figures spaced apart instead of crowding together, and the
+  **Focus / Dashboard** switch sits below it as a full-width toggle rather than
+  floating in a half-empty row. The desktop layout is unchanged.
 - **Reading progress for device-read books is no longer understated.** A book you
   were, say, 35% through could show as 11% — both in its **progress** figure and in
   the **Completion Estimates** tile (which then wildly overestimated the time left).

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -992,7 +992,7 @@ export function DashboardPage() {
   // Compact Focus / Dashboard switch — placed inline next to the KPI band in
   // Dashboard mode, top-right on its own in Focus mode.
   const modeToggle = (
-    <div className="inline-flex rounded-lg border border-border bg-card p-0.5 shrink-0">
+    <div className="flex w-full sm:inline-flex sm:w-auto rounded-lg border border-border bg-card p-0.5 sm:shrink-0">
       {([
         { id: 'focus', label: 'Focus', icon: <Moon className="w-3.5 h-3.5" /> },
         { id: 'dashboard', label: 'Dashboard', icon: <LayoutGrid className="w-3.5 h-3.5" /> },
@@ -1001,7 +1001,7 @@ export function DashboardPage() {
           key={m.id}
           onClick={() => setHomeModePersisted(m.id)}
           className={cn(
-            'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium transition-colors',
+            'flex-1 justify-center sm:flex-none sm:justify-start inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium transition-colors',
             homeMode === m.id ? 'bg-primary/15 text-foreground' : 'text-muted-foreground hover:text-foreground'
           )}
         >
@@ -1128,10 +1128,10 @@ export function DashboardPage() {
               <>
 
               {/* ── Quick stats + mode toggle on one row ──────────────────── */}
-              <div className="flex items-center justify-between gap-3 flex-wrap">
-                <div className="flex flex-wrap items-stretch gap-3 empty:hidden">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:flex-wrap">
+                <div className="flex flex-wrap items-stretch gap-3 empty:hidden w-full sm:w-auto">
                   {homeStats && (
-                    <div className="rounded-xl border border-border bg-card px-5 py-4 grid grid-cols-2 gap-y-3 sm:flex w-full sm:w-fit">
+                    <div className="rounded-xl border border-border bg-card px-5 py-4 grid grid-cols-2 gap-x-4 gap-y-3 sm:gap-x-0 sm:flex w-full sm:w-fit">
                       {homeStatItems.map((s, i) => (
                         <div
                           key={s.label}
@@ -1151,7 +1151,7 @@ export function DashboardPage() {
                     </div>
                   )}
                 </div>
-                <div className="ml-auto">{modeToggle}</div>
+                <div className="w-full sm:w-auto sm:ml-auto">{modeToggle}</div>
               </div>
 
               {/* ── Two-column body: content + rail ───────────────────────── */}


### PR DESCRIPTION
Small, mobile-only polish to the Home **Dashboard** header. Desktop layout is untouched.

### Problem (mobile)
- The stats strip’s `w-full` was inert — its flex parent shrank to content, so the card sat ~60% wide with a dead gap top-right.
- The **Focus / Dashboard** toggle wrapped onto its own line, floating right with empty space beside it.
- Stat columns had no horizontal gap, so long values like `35h 37m` collided with the next column.

### Fix
All changes are mobile-gated with `sm:` resets in `DashboardPage.tsx`:
- Stats card spans full width on mobile, with `gap-x-4` between figures (reset to `sm:gap-x-0` so the desktop divider spacing is unchanged).
- Header stacks on mobile (`flex-col`); the toggle becomes a full-width 50/50 segmented control beneath the stats.
- Desktop (`sm:`+) is identical: card content-width left, toggle right, same row.

### Verification
- Rendered against a local instance at 430px (mobile) and 1440px (desktop): mobile before/after improved, desktop confirmed unchanged.
- `tsc -b` clean.