### PR TITLE
fix(tomesync): file standalone downloads under their own book type (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,14 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Standalone books download to the correct book-type folder in KOReader.** A book
+  with no series — say a RoyalRoad title — could be filed under the wrong type's
+  folder (e.g. `light_novel`) when downloaded through the plugin, while books in a
+  series went to the right place. The plugin filed an entire batch under a single
+  type, which is fine for a real series but wrong for the "No Series" bucket, where
+  standalone books of different types are mixed together. Each book now carries its
+  own type and is filed accordingly, in both the built-in layout and custom download
+  templates. Requires plugin build 24 (1.6.2), delivered via the usual in-app update.
 - **Reading progress for device-read books is no longer understated.** A book you
   were, say, 35% through could show as 11% — both in its **progress** figure and in
   the **Completion Estimates** tile (which then wildly overestimated the time left).

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -41,8 +41,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 23
-TOMESYNC_PLUGIN_SEMVER = "1.6.1"
+TOMESYNC_PLUGIN_BUILD = 24
+TOMESYNC_PLUGIN_SEMVER = "1.6.2"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -757,7 +757,11 @@ def get_series_books(
         .all()
     )
 
-    # Use the first book's type as the series type
+    # Series-level type, kept for backwards compatibility with older plugin
+    # builds. It's representative for a real series (all volumes share a type)
+    # but NOT for the "__unserialized__" bucket, which aggregates standalone
+    # books of mixed types — so each book also carries its own `book_type`
+    # below, which newer plugins prefer when filing downloads.
     book_type_slug = books[0].book_type.slug if books and books[0].book_type else "book"
 
     return {
@@ -769,6 +773,7 @@ def get_series_books(
                 "title": b.title,
                 "series_index": b.series_index,
                 "author": b.author,
+                "book_type": b.book_type.slug if b.book_type else None,
                 "files": [
                     {"id": f.id, "format": f.format, "file_size": f.file_size}
                     for f in b.files
@@ -2355,16 +2360,19 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
     -- Built-in layout: organize by book-type subfolder. A real series shares
     -- one folder; the No Series bucket files each book under its author
     -- (resolved per book below). Dirs are created lazily so a template run
-    -- doesn't leave empty default folders behind.
-    local type_dir, series_dir
-    local function ensureDefaultDirs()
-        if type_dir then return end
-        type_dir = base_dir .. "/" .. (book_type or "book")
+    -- doesn't leave empty default folders behind. The type is resolved PER BOOK
+    -- (book.book_type), not from the batch: the No Series bucket mixes types, so
+    -- a single batch type would misfile standalone books (issue #88). The batch
+    -- `book_type` is only a fallback for older servers that omit the per-book field.
+    local function ensureDefaultDirs(effective_type)
+        local type_dir = base_dir .. "/" .. effective_type
         lfs.mkdir(type_dir)
+        local series_dir
         if not is_no_series then
             series_dir = type_dir .. "/" .. util.getSafeFilename(series_name)
             lfs.mkdir(series_dir)
         end
+        return type_dir, series_dir
     end
 
     -- Build reverse lookup: book_id → local path (to skip already-downloaded books)
@@ -2376,6 +2384,10 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
     -- Pre-compute the download queue so progress counts only real work.
     local queue = {{}}
     local skipped = 0
+    -- Representative "saved to" folder for the summary popup. With per-book
+    -- types the No Series bucket can span several folders, so this is just the
+    -- first real destination — a sensible "look here" pointer, not the only one.
+    local save_location
     for _, book in ipairs(books) do
         if min_index and type(book.series_index) == "number" and book.series_index <= min_index then
             skipped = skipped + 1
@@ -2387,10 +2399,16 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
                 table.insert(queue, {{book = book, file = nil, dest = nil}})
             else
                 local ext = file.format or "epub"
+                -- Per-book type (server >= build 24); fall back to the batch
+                -- type for older servers. This is what fixes mixed-type No
+                -- Series downloads landing in the wrong folder (issue #88).
+                local effective_type = (type(book.book_type) == "string"
+                                        and book.book_type ~= "" and book.book_type)
+                                        or book_type or "book"
                 local dest
                 if template ~= "" then
                     local rel = renderDownloadPath(template, {{
-                        book_type = book_type or "book",
+                        book_type = effective_type,
                         series    = (not is_no_series) and series_name or "",
                         volume    = type(book.series_index) == "number"
                                     and book.series_index or nil,
@@ -2405,7 +2423,7 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
                 if not dest then
                     -- Built-in layout (also the fallback when a template
                     -- renders to nothing usable for this book).
-                    ensureDefaultDirs()
+                    local type_dir, series_dir = ensureDefaultDirs(effective_type)
                     local display_title
                     if type(book.series_index) == "number" then
                         local vol = book.series_index
@@ -2431,6 +2449,7 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
                 if lfs.attributes(dest) then
                     skipped = skipped + 1
                 else
+                    save_location = save_location or dest:match("^(.*)/[^/]+$")
                     table.insert(queue, {{book = book, file = file, dest = dest}})
                 end
             end
@@ -2489,7 +2508,7 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
         UIManager:show(InfoMessage:new{{
             text = string.format(
                 "%s\\n\\nDownloaded: %d\\nSkipped: %d\\nFailed: %d\\n\\nSaved to: %s",
-                batch_label, downloaded, skipped, failed, series_dir or type_dir
+                batch_label, downloaded, skipped, failed, save_location or base_dir
             ),
             timeout = 8,
         }})

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -152,5 +152,8 @@ def test_build_bumped_for_rebake():
     # history) so stats backfill reading from before TomeSync (time & pages only).
     # 1.6.1 / build 23 makes the sync back-off time-based (+ clears on
     # NetworkConnected) so it self-heals instead of latching offline after sleep.
-    assert TOMESYNC_PLUGIN_BUILD >= 23
-    assert TOMESYNC_PLUGIN_SEMVER == "1.6.1"
+    # 1.6.2 / build 24 files each download under its own book type (issue #88):
+    # the No Series bucket mixes types, so a single batch type misfiled standalone
+    # books (e.g. RoyalRoad titles landing in light_novel).
+    assert TOMESYNC_PLUGIN_BUILD >= 24
+    assert TOMESYNC_PLUGIN_SEMVER == "1.6.2"

--- a/tests/test_tomesync_series_booktype.py
+++ b/tests/test_tomesync_series_booktype.py
@@ -1,0 +1,92 @@
+"""Regression test for issue #88.
+
+The plugin's series browser used a single, series-level `book_type` to file
+every download in a batch. For a real series that's fine (all volumes share a
+type), but the "__unserialized__" (No Series) bucket aggregates standalone books
+of *mixed* types — so standalone RoyalRoad books were filed under whatever type
+the alphabetically-first standalone happened to be (e.g. light_novel).
+
+The fix makes `/tome-sync/series/{book_id}` emit a per-book `book_type` so the
+plugin can file each download under its own type. The series-level `book_type`
+stays for backwards compatibility with older plugin builds.
+"""
+from backend.models.library import BookType
+from backend.models.tome_sync import ApiKey
+
+
+def _api_key_for(db, user_id: int) -> str:
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(user_id=user_id, key_hash=ApiKey.hash_key(plaintext),
+                  key_prefix=plaintext[:11], label="test"))
+    db.flush()
+    return plaintext
+
+
+def _book_type(db, slug: str, label: str, sort_order: int) -> BookType:
+    bt = BookType(slug=slug, label=label, sort_order=sort_order)
+    db.add(bt)
+    db.flush()
+    return bt
+
+
+def test_unserialized_bucket_returns_per_book_type(db, client, admin_user, make_book):
+    """Mixed-type standalone books each carry their own book_type, not the
+    bucket's first book's type."""
+    user, _ = admin_user
+    ln = _book_type(db, "light_novel", "Light Novels", 1)
+    rr = _book_type(db, "royalroad", "RoyalRoad", 2)
+
+    # Alphabetical order puts the light-novel first, which is exactly the book
+    # whose type used to be stamped on the whole bucket.
+    apex = make_book(title="Apex Predator", series=None)        # light_novel
+    apex.book_type_id = ln.id
+    royal = make_book(title="Zenith Climb", series=None)        # royalroad
+    royal.book_type_id = rr.id
+    db.flush()
+
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    resp = client.get(f"/api/tome-sync/series/{royal.id}", headers=hdr)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["series_name"] == "__unserialized__"
+    by_title = {b["title"]: b for b in data["books"]}
+    # The bug: every book reported the bucket type. The fix: own types.
+    assert by_title["Zenith Climb"]["book_type"] == "royalroad"
+    assert by_title["Apex Predator"]["book_type"] == "light_novel"
+
+
+def test_real_series_reports_per_book_type_and_legacy_top_level(db, client, admin_user, make_book):
+    """A real series still exposes the legacy series-level `book_type` (for old
+    plugins) and now also a matching per-book `book_type`."""
+    user, _ = admin_user
+    manga = _book_type(db, "manga", "Manga", 1)
+
+    v1 = make_book(title="One Piece, Vol. 1", series="One Piece", series_index=1)
+    v1.book_type_id = manga.id
+    v2 = make_book(title="One Piece, Vol. 2", series="One Piece", series_index=2)
+    v2.book_type_id = manga.id
+    db.flush()
+
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    resp = client.get(f"/api/tome-sync/series/{v1.id}", headers=hdr)
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["series_name"] == "One Piece"
+    assert data["book_type"] == "manga"  # legacy series-level field preserved
+    assert all(b["book_type"] == "manga" for b in data["books"])
+
+
+def test_book_without_type_reports_null(db, client, admin_user, make_book):
+    """A standalone book with no assigned type reports book_type: null (the
+    plugin falls back to its batch type / 'book')."""
+    user, _ = admin_user
+    typeless = make_book(title="Orphan Title", series=None)
+    db.flush()
+
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    resp = client.get(f"/api/tome-sync/series/{typeless.id}", headers=hdr)
+    assert resp.status_code == 200
+    book = next(b for b in resp.json()["books"] if b["title"] == "Orphan Title")
+    assert book["book_type"] is None


### PR DESCRIPTION
Fixes #88.

## Symptom
A standalone book (e.g. a RoyalRoad or manga title with no series) downloaded through the KOReader plugin landed in the **wrong** book-type folder (the reporter saw RoyalRoad titles in `light_novel`). Books **in a series** filed correctly. Sort order, plugin reinstall, and trying other devices made no difference.

## Root cause
`book_type` was treated as a **series-level** attribute. The plugin filed an entire download batch under one type:
- For a real series that is fine — every volume shares a type.
- For the `__unserialized__` ("No Series") bucket it is wrong — that bucket aggregates standalone books of **mixed** types, and the batch type was taken from the *first* book (`tome_sync.py`, `books[0].book_type`). So every standalone was filed under that one type.

## Fix
- **Server** (`/tome-sync/series/{id}`): emit a per-book `book_type` on each book. The series-level `book_type` stays for backwards compatibility with older plugin builds.
- **Plugin**: resolve the type **per book** (`book.book_type` or the batch type as fallback) for both the built-in layout and custom download templates. The summary `Saved to:` line now points at the first real destination instead of a single batch folder.
- Plugin build **23 → 24** (1.6.2); ships via the in-app self-update.

## Testing
- **Server**: `tests/test_tomesync_series_booktype.py` — mixed-type bucket returns per-book types, real series still exposes the legacy field, typeless book reports null. Fails without the fix. Full TomeSync suite green.
- **Plugin (real emulator round-trip, reproduce → fix → confirm)**: from the same No Series bucket —
  - build 23: standalone manga `Dandadan 148` → `book/` (bug reproduced)
  - build 24: same book → `manga/`, while a `book`-type title still routes to `book/` (per-book, not a blanket default)

## Rollout note
The fix reaches a device only once it takes **plugin build 24** via the in-app updater; until then affected devices keep misfiling.