### PR TITLE
fix(highlights): web-delete tombstone survives device clocks ahead of the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Deleting a highlight from the web now sticks, even for a highlight you just
+  made.** The deletion marker was stamped with the server's clock, but compared
+  against the device's local wall-clock — so with a UTC server and a device in a
+  later timezone, deleting a recent highlight produced a marker that looked *older*
+  than the highlight itself, and the device quietly kept (and could re-upload) it.
+  The marker is now stamped no earlier than the highlight's own timestamp, so the
+  deleted copy always loses the tie while a deliberate re-highlight still wins.
+  Also, the "N from M books" counter on the Highlights page no longer under-counts
+  books after deleting when more highlights are still unloaded.
 - **Standalone books download to the correct book-type folder in KOReader.** A book
   with no series — say a RoyalRoad title — could be filed under the wrong type's
   folder (e.g. `light_novel`) when downloaded through the plugin, while books in a

--- a/backend/api/annotations.py
+++ b/backend/api/annotations.py
@@ -116,7 +116,7 @@ def delete_annotation(
     """Delete one of the current user's highlights (e.g. an accidental one).
 
     Mirrors the TomeSync delete path: we remove the `Annotation` row *and* write an
-    `AnnotationTombstone` stamped with the current wall-clock time. On its next sync
+    `AnnotationTombstone` stamped no earlier than the highlight's own mtime. On its next sync
     the device sees the tombstone, finds its local copy older, and drops it too — so
     the deletion sticks instead of being re-uploaded. A later, genuinely-newer re-add
     of the same passage (strictly newer mtime) still wins and clears the tombstone,
@@ -132,7 +132,13 @@ def delete_annotation(
 
     book_id = annotation.book_id
     anchor = annotation.anchor
-    now = func_now_str()
+    # LWW key: at least the highlight's own device-local mtime, not just the server
+    # clock. The server may sit hours behind the device's wall-clock (UTC container vs
+    # local-time device), and both tombstone checks (server upsert and plugin apply)
+    # drop copies with mtime <= tombstone — so maxing with effective_mtime guarantees
+    # the delete holds against the exact copy that was deleted, while a genuinely
+    # newer re-add (strictly greater mtime) still wins and clears the tombstone.
+    now = max(func_now_str(), annotation.effective_mtime)
 
     db.delete(annotation)
 

--- a/frontend/src/pages/HighlightsPage.tsx
+++ b/frontend/src/pages/HighlightsPage.tsx
@@ -270,11 +270,24 @@ export function HighlightsPage() {
   async function deleteHighlight(h: Highlight) {
     // Was this the last loaded highlight for its book? If so the book drops off too.
     const lastOfBook = !items.some(x => x.book_id === h.book_id && x.id !== h.id)
+    // With unloaded pages the book may still have highlights beyond what we see,
+    // so a local decrement would under-count — refetch the counts instead.
+    const fullyLoaded = items.length >= total
     try {
       await api.delete(`/annotations/${h.id}`)
       setItems(prev => prev.filter(x => x.id !== h.id))
       setTotal(t => Math.max(0, t - 1))
-      if (lastOfBook) setBooks(b => Math.max(0, b - 1))
+      if (lastOfBook) {
+        if (fullyLoaded) {
+          setBooks(b => Math.max(0, b - 1))
+        } else {
+          const p = buildParams(0)
+          p.set('limit', '1')
+          api.get<HighlightsResponse>(`/annotations?${p.toString()}`)
+            .then(d => { setBooks(d.books); setTotal(d.total) })
+            .catch(() => {})
+        }
+      }
       toast.success('Highlight deleted')
     } catch (e) {
       toast.error((e as Error).message ?? 'Failed to delete highlight')

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -203,6 +203,33 @@ def test_web_delete_propagates_and_holds_against_stale_device(client, db, admin_
     assert r.json()["annotations"] == []
 
 
+def test_web_delete_holds_when_device_clock_ahead_of_server(client, db, admin_user, make_book):
+    """A device wall-clock ahead of the server (UTC container + local-time device)
+    must not resurrect a web-deleted highlight: the tombstone is stamped no earlier
+    than the highlight's own mtime, so the exact deleted copy always loses the LWW
+    race — while a strictly newer re-add still wins."""
+    user, _ = admin_user
+    book = make_book()
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    future = "2099-01-01 00:00:00"  # device-local mtime far ahead of server now
+    _sync(client, hdr, book.id, upserts=[_hl(A1, "fresh", dtu=future)])
+    aid = client.get(f"/api/books/{book.id}/annotations").json()[0]["id"]
+    assert client.delete(f"/api/annotations/{aid}").status_code == 204
+
+    tomb = db.query(AnnotationTombstone).filter(AnnotationTombstone.book_id == book.id).one()
+    assert tomb.client_deleted_at >= future
+
+    # The exact deleted copy re-uploaded by the device -> still dropped.
+    r = _sync(client, hdr, book.id, upserts=[_hl(A1, "fresh", dtu=future)])
+    assert r.json()["applied"]["skipped"] == 1
+    assert r.json()["annotations"] == []
+
+    # A genuinely newer re-add (deliberate re-highlight) wins and clears the tombstone.
+    r = _sync(client, hdr, book.id, upserts=[_hl(A1, "on purpose", dtu="2099-01-01 00:00:01")])
+    assert r.json()["applied"]["created"] == 1
+    assert r.json()["tombstones"] == []
+
+
 def test_web_delete_scoped_to_owner(client, db, admin_user, make_book):
     """You can only delete your own highlights; another user's id (or a missing one) 404s."""
     user, _ = admin_user


### PR DESCRIPTION
## Problem

The web highlight-delete (#77) stamps its tombstone with the **server container's** wall clock — UTC in a stock Docker deployment — but the tombstone is compared as a plain string against **device-local** mtimes on both last-write-wins sites:

- server upsert skip: `item.mtime <= tomb.client_deleted_at`
- plugin apply: `L.mtime <= t.deleted_at`

With a UTC server and a device in a later timezone (e.g. CEST), deleting a highlight made within the last ~2 hours produces a tombstone that looks *older* than the highlight itself. The device keeps its copy, and any later edit re-uploads it with a newer mtime — clearing the tombstone and resurrecting the deleted highlight server-side. That's the headline use case ("delete the accidental highlight you just made") failing systematically.

## Fix

Stamp `client_deleted_at = max(server now, annotation.effective_mtime)`. Both compare sites resolve ties in the tombstone's favour, so the exact deleted copy always loses the race — while a strictly newer, deliberate re-highlight still wins and clears the tombstone, unchanged.

Also fixes the Highlights page **"N from M books" counter under-counting** after a delete: when more pages are still unloaded, the book may have highlights beyond the loaded set, so the page now refetches the authoritative counts (limit=1) instead of guessing with a local decrement.

## Testing

- New regression test `test_web_delete_holds_when_device_clock_ahead_of_server`: highlight with a device mtime ahead of server now → delete → tombstone ≥ mtime, re-add of the exact copy is skipped, strictly newer re-add wins. Fails on the previous code without any clock mocking.
- `tests/test_annotations.py` + `tests/test_annotations_aggregate.py`: 22 passed.
- `npm run build` (tsc -b) clean.