### PR TITLE
fix(stats): one canonical reading day (local + 4h rollover) everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Late-night reading no longer splits across two days — anywhere.** Tome has
+  always counted a session started at, say, 1:30 am toward the previous evening's
+  reading day for **streaks** (a local day with a 4-hour rollover), but newer
+  features quietly bucketed by plain calendar days instead. The consequences: the
+  activity heatmap could show a gap on a day the streak counted (the long-standing
+  heatmap/streak drift), a continuous evening read crossing midnight could mark a
+  book as a **re-read** and double its **reading-log** day count, the per-book
+  **momentum** ("last 7 days vs prior") could disagree with the dashboard, and the
+  Reading DNA **rhythm** trait split night reads into two active days. Every
+  day-based view — daily chart, heatmap, re-reads, completion estimates, per-book
+  timelines, reading intensity, momentum, Reading DNA — now shares the streak's
+  single reading-day rule. The one deliberate exception is the hour-of-weekday
+  heatmap, where 1 am should still display as 1 am.
 - **Standalone books download to the correct book-type folder in KOReader.** A book
   with no series — say a RoyalRoad title — could be filed under the wrong type's
   folder (e.g. `light_novel`) when downloaded through the plugin, while books in a

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1078,6 +1078,7 @@ def get_book_annotations(
 @router.get("/{book_id}/reading-stats")
 def get_book_reading_stats(
     book_id: int,
+    tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -1098,14 +1099,14 @@ def get_book_reading_stats(
     if not user_can_see_book(db, current_user, book):
         raise HTTPException(status_code=404, detail="Book not found")
 
-    own = compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id)
+    own = compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset)
     aggregate = (
         compute_book_aggregate_stats(db, book_id=book_id)
         if _is_admin(current_user)
         else None
     )
     # Per-page intensity from imported KOReader page-stats (None if web-only reading)
-    intensity = compute_book_page_intensity(db, user_id=current_user.id, book_id=book_id)
+    intensity = compute_book_page_intensity(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset)
 
     return {"own": own, "aggregate": aggregate, "intensity": intensity}
 
@@ -1121,6 +1122,7 @@ class ManualSessionIn(PydanticBaseModel):
 def add_manual_reading_session(
     book_id: int,
     payload: ManualSessionIn,
+    tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -1209,7 +1211,7 @@ def add_manual_reading_session(
             ))
 
     db.commit()
-    return {"own": compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id)}
+    return {"own": compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset)}
 
 
 # ── Single book ───────────────────────────────────────────────────────────────

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, HTTPException
-from sqlalchemy import func, case, Integer
+from sqlalchemy import func, case
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -20,6 +20,7 @@ from backend.models.user_book_status import UserBookStatus
 from backend.models.user_series_rating import UserSeriesRating
 from backend.models.library import BookType
 from backend.services.streaks import reconciled_user_streaks
+from backend.services.reading_day import ROLLOVER_HOURS, date_modifier, effective_today, epoch_day
 from backend.services import reconciled_reading as rr
 
 router = APIRouter(tags=["stats"])
@@ -76,7 +77,10 @@ def get_stats(
     if start:
         try:
             sdate = datetime.strptime(start, "%Y-%m-%d")
-            cutoff = sdate + timedelta(minutes=tz_offset)
+            # Reading day D spans local D 04:00 → D+1 04:00 (the 4h rollover), so
+            # the UTC filter bounds shift by the rollover too — otherwise a 1am
+            # session inside the range's last day would be filtered out of it.
+            cutoff = sdate + timedelta(minutes=tz_offset, hours=ROLLOVER_HOURS)
             fill_start_local = sdate.date()
         except ValueError:
             cutoff = _date_range(days)
@@ -84,7 +88,7 @@ def get_stats(
             if end:
                 try:
                     edate = datetime.strptime(end, "%Y-%m-%d")
-                    range_end = edate + timedelta(days=1) + timedelta(minutes=tz_offset)
+                    range_end = edate + timedelta(days=1) + timedelta(minutes=tz_offset, hours=ROLLOVER_HOURS)
                     fill_end_local = edate.date()
                 except ValueError:
                     range_end = None
@@ -97,14 +101,20 @@ def get_stats(
     else:
         effective_days = 0  # all-time
 
-    # Inclusive fill window for the daily chart.
+    # Inclusive fill window for the daily chart. "Today" is the user's current
+    # reading day (4h rollover), which at 00:00–04:00 local is still yesterday.
     fill_start = fill_start_local or (cutoff or (now - timedelta(days=365))).date()
-    fill_end = fill_end_local or now.date()
+    fill_end = fill_end_local or effective_today(tz_offset)
 
     # Convert JS getTimezoneOffset (minutes, negative = east of UTC) to SQLite modifier
     # e.g. CEST = UTC+2 → JS returns -120 → we need '+2 hours'
     offset_hours = -(tz_offset // 60)
     tz_modifier = f"{offset_hours:+d} hours"
+    # Day-identity bucketing goes through the canonical reading-day modifier
+    # (local day + 4h rollover — see backend/services/reading_day.py) so daily
+    # charts, the heatmap and re-read detection agree with the streak. The plain
+    # tz_modifier stays ONLY for hour-of-day display (hour × weekday heatmap).
+    day_modifier = date_modifier(tz_offset)
 
     # Base query filtered to this user (still used by session-level tiles: pace, timeline,
     # pace-by-format — page-stats have no natural "sessions" so those stay session-sourced).
@@ -119,7 +129,7 @@ def get_stats(
     covered = rr.covered_book_ids(db, current_user.id)
 
     total_seconds, total_sessions, pages_turned = rr.totals(
-        db, current_user.id, tz_modifier, covered, cutoff, range_end
+        db, current_user.id, day_modifier, covered, cutoff, range_end
     )
 
     avg_session = int(total_seconds / total_sessions) if total_sessions > 0 else 0
@@ -142,15 +152,15 @@ def get_stats(
 
     # Daily aggregation (for selected range) — reconciled (page-stats win per book).
     daily = _fill_daily_map(
-        rr.daily_map(db, current_user.id, tz_modifier, covered, cutoff, range_end),
+        rr.daily_map(db, current_user.id, day_modifier, covered, cutoff, range_end),
         fill_start, fill_end,
     )
 
     # Heatmap daily — always last 365 days — reconciled.
     heatmap_cutoff = now - timedelta(days=365)
     heatmap_daily = _fill_daily_map(
-        rr.daily_map(db, current_user.id, tz_modifier, covered, heatmap_cutoff, None),
-        heatmap_cutoff.date(), now.date(),
+        rr.daily_map(db, current_user.id, day_modifier, covered, heatmap_cutoff, None),
+        heatmap_cutoff.date(), effective_today(tz_offset),
     )
 
     # Books finished list (for chart)
@@ -172,7 +182,7 @@ def get_stats(
 
     # Reconciled per-book reading time for the window (page-stats win per book), reused by
     # top-books, category, per-book table, and author-affinity below.
-    win_book = rr.book_seconds(db, current_user.id, tz_modifier, covered, cutoff, range_end)
+    win_book = rr.book_seconds(db, current_user.id, day_modifier, covered, cutoff, range_end)
     book_meta: dict[int, tuple] = {}
     if win_book:
         for bid, title, author, cover, label in (
@@ -303,7 +313,7 @@ def get_stats(
         duration = (range_end or now) - cutoff
         prev_start = start_date - duration
         prev_seconds = rr.totals(
-            db, current_user.id, tz_modifier, covered, prev_start, start_date
+            db, current_user.id, day_modifier, covered, prev_start, start_date
         )[0]
         pct_change: Optional[float] = 0.0
         if prev_seconds > 0:
@@ -380,7 +390,7 @@ def get_stats(
 
     # ── Monthly comparison (last 12 months) ── reconciled ──────────────────
     month_cutoff = now - timedelta(days=365)
-    _mm = rr.monthly_map(db, current_user.id, tz_modifier, covered, month_cutoff)
+    _mm = rr.monthly_map(db, current_user.id, day_modifier, covered, month_cutoff)
     month_session_map: dict[str, dict] = {
         m: {"seconds": v[0], "sessions": v[1]} for m, v in _mm.items()
     }
@@ -388,7 +398,7 @@ def get_stats(
     # Books finished per month
     month_finished_rows = (
         db.query(
-            func.strftime('%Y-%m', UserBookStatus.updated_at).label("month"),
+            func.strftime('%Y-%m', UserBookStatus.updated_at, day_modifier).label("month"),
             func.count(UserBookStatus.id).label("cnt"),
         )
         .filter(
@@ -396,7 +406,7 @@ def get_stats(
             UserBookStatus.status == "read",
             UserBookStatus.updated_at >= month_cutoff,
         )
-        .group_by(func.strftime('%Y-%m', UserBookStatus.updated_at))
+        .group_by(func.strftime('%Y-%m', UserBookStatus.updated_at, day_modifier))
         .all()
     )
     month_finished_map = {r.month: int(r.cnt) for r in month_finished_rows}
@@ -419,7 +429,7 @@ def get_stats(
 
     # ── Genre over time (last 12 months, stacked) ── reconciled ───────────
     # Reconciled per-(book, month) seconds, rolled up to book-type per month.
-    _bm = rr.book_month_seconds(db, current_user.id, tz_modifier, covered, month_cutoff)
+    _bm = rr.book_month_seconds(db, current_user.id, day_modifier, covered, month_cutoff)
     _genre_ids = {bid for (bid, _m) in _bm.keys()}
     _genre_cat: dict[int, str] = {}
     if _genre_ids:
@@ -639,7 +649,7 @@ def get_stats(
 
     # ── Ratings / taste (all-time, independent of the date window) ─────────────
     # Your taste isn't a 30-day thing, so these ignore cutoff/range entirely.
-    book_seconds_all = rr.book_seconds(db, current_user.id, tz_modifier, covered, None, None)
+    book_seconds_all = rr.book_seconds(db, current_user.id, day_modifier, covered, None, None)
     rated_rows = (
         db.query(
             Book.id, Book.title, Book.author, Book.cover_path,
@@ -720,8 +730,8 @@ def get_stats(
     }
 
     # ── Lifetime / records / TBR / language (all-time, ignore the date range) ──
-    lt_secs, lt_sessions, lt_pages = rr.totals(db, current_user.id, tz_modifier, covered, None, None)
-    all_daily = rr.daily_map(db, current_user.id, tz_modifier, covered, None, None)
+    lt_secs, lt_sessions, lt_pages = rr.totals(db, current_user.id, day_modifier, covered, None, None)
+    all_daily = rr.daily_map(db, current_user.id, day_modifier, covered, None, None)
     lifetime = {
         "seconds": lt_secs,
         "sessions": lt_sessions,
@@ -901,10 +911,10 @@ def get_stats(
     }
 
     # ── Re-reads (all-time) — books with pages revisited on a later day ─────────
-    # A page read on 2+ distinct local-days is a re-read. We rank books by how
+    # A page read on 2+ distinct reading days is a re-read. We rank books by how
     # many of their pages got revisited. Pure page-stats, no plugin work.
     from backend.models.ko_stats import PageStat as _PageStat
-    _day = func.cast(_PageStat.start_time / 86400, Integer)
+    _day = epoch_day(_PageStat.start_time, tz_offset)
     _reread_pages_sq = (
         db.query(
             _PageStat.book_id.label("book_id"),
@@ -998,6 +1008,7 @@ def get_stats(
 
 @router.get("/stats/completion-estimates")
 def get_completion_estimates(
+    tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> list:
@@ -1063,7 +1074,7 @@ def get_completion_estimates(
                 func.max(PageStat.total_pages),
                 func.count(func.distinct(case((PageStat.start_time >= window_epoch, PageStat.page)))),
                 func.count(func.distinct(case((PageStat.start_time >= window_epoch,
-                                               func.cast(PageStat.start_time / 86400, Integer))))),
+                                               epoch_day(PageStat.start_time, tz_offset))))),
                 func.max(PageStat.page),
             )
             .filter(PageStat.user_id == current_user.id, PageStat.book_id == row.id)

--- a/backend/services/reading_day.py
+++ b/backend/services/reading_day.py
@@ -1,0 +1,46 @@
+"""The canonical "reading day" — the user's local calendar day with a 4-hour rollover.
+
+A session started at 01:30 local time belongs to the previous evening's reading
+day, so a bedtime read never splits across two days. Everything that buckets
+reading activity by day — streaks, the daily chart, the activity heatmap,
+re-read detection, per-book timelines, momentum, active-day sets — MUST go
+through these helpers so the buckets can never drift apart. The one deliberate
+exception is hour-of-day display (the hour × weekday heatmap): it uses the
+plain timezone offset, because a 01:00 session should render at 1 AM, not 9 PM.
+
+``tz_offset`` follows JS ``getTimezoneOffset()``: minutes, negative east of UTC
+(CEST → -120).
+"""
+from datetime import date, datetime, timedelta
+
+from sqlalchemy import func
+
+ROLLOVER_HOURS = 4
+
+
+def effective_hours(tz_offset_minutes: int, rollover_hours: int = ROLLOVER_HOURS) -> int:
+    """Hours to add to a UTC timestamp so its date() is the reading day."""
+    tz_hours = -(tz_offset_minutes // 60)
+    return tz_hours - rollover_hours
+
+
+def date_modifier(tz_offset_minutes: int, rollover_hours: int = ROLLOVER_HOURS) -> str:
+    """SQLite modifier for DateTime columns: ``func.date(col, date_modifier(tz))``."""
+    return f"{effective_hours(tz_offset_minutes, rollover_hours):+d} hours"
+
+
+def epoch_day(column, tz_offset_minutes: int):
+    """SQLAlchemy expression: epoch-seconds column (e.g. ``PageStat.start_time``)
+    → its reading day as a 'YYYY-MM-DD' string."""
+    return func.date(column, "unixepoch", date_modifier(tz_offset_minutes))
+
+
+def epoch_day_int(epoch_seconds: int, tz_offset_minutes: int) -> int:
+    """Python-side reading-day ordinal for an epoch timestamp — for set-based
+    day grouping where only day *identity* matters, not the date string."""
+    return (epoch_seconds + effective_hours(tz_offset_minutes) * 3600) // 86400
+
+
+def effective_today(tz_offset_minutes: int, rollover_hours: int = ROLLOVER_HOURS) -> date:
+    """The user's current reading day — what walking back a streak starts from."""
+    return (datetime.utcnow() + timedelta(hours=effective_hours(tz_offset_minutes, rollover_hours))).date()

--- a/backend/services/reading_dna.py
+++ b/backend/services/reading_dna.py
@@ -24,6 +24,7 @@ from backend.models.book import Book
 from backend.models.user import User
 from backend.models.user_book_status import UserBookStatus
 from backend.services import reconciled_reading as rr
+from backend.services.reading_day import date_modifier, effective_today
 
 # Per-axis vocabulary, tone-checked. Tuple is (low-pole word, high-pole word).
 _NOUN = {
@@ -76,8 +77,11 @@ def _lerp_score(v: float, lo: float, hi: float) -> float:
 
 def compute_reading_dna(db: Session, user: User, tz_offset: int) -> dict:
     now = datetime.utcnow()
+    # Plain local offset — used ONLY for the hour-of-day trait, where 1am must
+    # read as hour 1. Day-identity buckets use the reading-day modifier below.
     offset_hours = -(tz_offset // 60)
     tzm = f"{offset_hours:+d} hours"
+    day_mod = date_modifier(tz_offset)
     covered = rr.covered_book_ids(db, user.id)
 
     traits: dict[str, float] = {}
@@ -96,9 +100,11 @@ def compute_reading_dna(db: Session, user: User, tz_offset: int) -> dict:
         traits["time"] = _lerp_score(mean_hour, 8, 24)  # 8am→early, midnight→night
 
     # ── Rhythm (sporadic ↔ consistent) — active-day density, last 120d ───────────
-    adays = rr.active_days(db, user.id, tzm, covered)
+    # Reading-day buckets (4h rollover) so a midnight session doesn't split into
+    # two active days, and the user's own "today" — not the UTC date.
+    adays = rr.active_days(db, user.id, day_mod, covered)
     if adays:
-        today = now.date()
+        today = effective_today(tz_offset)
         window = 120
         first = min(adays)
         span = min(window, (today - first).days + 1)
@@ -128,7 +134,7 @@ def compute_reading_dna(db: Session, user: User, tz_offset: int) -> dict:
 
     # Pace (savorer ↔ speed demon) — true WPM = words ÷ reconciled read-time.
     if word_counts:
-        book_secs = rr.book_seconds(db, user.id, tzm, covered, None, None)
+        book_secs = rr.book_seconds(db, user.id, day_mod, covered, None, None)
         words_sum = secs_sum = counted = 0
         for r in finished:
             if not r.word_count:

--- a/backend/services/reading_stats.py
+++ b/backend/services/reading_stats.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from backend.models.book import Book
 from backend.models.tome_sync import ReadingSession
 from backend.models.user_book_status import UserBookStatus
+from backend.services.reading_day import date_modifier, effective_today, epoch_day, epoch_day_int
 
 
 # ── Per-book, per-user ────────────────────────────────────────────────────────
@@ -25,8 +26,12 @@ def compute_book_reading_stats(
     *,
     user_id: int,
     book_id: int,
+    tz_offset: int = 0,
 ) -> dict:
     """Return reading statistics for one user on one book.
+
+    ``tz_offset`` (JS getTimezoneOffset minutes) buckets the timeline/momentum
+    by the user's reading day — local day with 4h rollover, matching streaks.
 
     Returns a dict with keys:
       total_seconds, sessions, pages_turned, avg_session_seconds,
@@ -84,15 +89,16 @@ def compute_book_reading_stats(
     # progress_pct is stored as 0-1 fraction in UserBookStatus
     progress: Optional[float] = status_row.progress_pct if status_row else None
 
-    # ── Session timeline — daily buckets ─────────────────────────────────────
+    # ── Session timeline — reading-day buckets ────────────────────────────────
+    day_mod = date_modifier(tz_offset)
     timeline_rows = (
         base.with_entities(
-            func.date(ReadingSession.started_at).label("date"),
+            func.date(ReadingSession.started_at, day_mod).label("date"),
             func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
             func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages"),
         )
-        .group_by(func.date(ReadingSession.started_at))
-        .order_by(func.date(ReadingSession.started_at))
+        .group_by(func.date(ReadingSession.started_at, day_mod))
+        .order_by(func.date(ReadingSession.started_at, day_mod))
         .all()
     )
     session_timeline = [
@@ -126,10 +132,10 @@ def compute_book_reading_stats(
         pages_turned = int(ps[1] or 0)          # distinct pages genuinely read
         ps_total_pages = int(ps[4] or 0)
         ps_max_page = int(ps[5] or 0)           # furthest page reached (position fallback)
-        # Daily buckets from page-stats (local-day = start_time // 86400, UTC).
+        # Daily buckets from page-stats, by reading day (local + 4h rollover).
         day_rows = (
             db.query(
-                func.cast(PageStat.start_time / 86400, Integer).label("day"),
+                epoch_day(PageStat.start_time, tz_offset).label("day"),
                 func.coalesce(func.sum(PageStat.duration_seconds), 0).label("seconds"),
                 func.count(func.distinct(PageStat.page)).label("pages"),
             )
@@ -139,11 +145,7 @@ def compute_book_reading_stats(
             .all()
         )
         session_timeline = [
-            {
-                "date": datetime.fromtimestamp(int(r.day) * 86400, timezone.utc).strftime("%Y-%m-%d"),
-                "seconds": int(r.seconds),
-                "pages": int(r.pages),
-            }
+            {"date": r.day, "seconds": int(r.seconds), "pages": int(r.pages)}
             for r in day_rows
         ]
         sessions = len(session_timeline)        # one "session" per reading day
@@ -170,10 +172,10 @@ def compute_book_reading_stats(
         # Web sessions: the furthest progress_end reached on each day.
         prog_rows = (
             base.with_entities(
-                func.date(ReadingSession.started_at).label("date"),
+                func.date(ReadingSession.started_at, day_mod).label("date"),
                 func.max(ReadingSession.progress_end).label("p"),
             )
-            .group_by(func.date(ReadingSession.started_at))
+            .group_by(func.date(ReadingSession.started_at, day_mod))
             .all()
         )
         for r in prog_rows:
@@ -193,7 +195,7 @@ def compute_book_reading_stats(
             db.query(
                 func.coalesce(PageStat.device, "koreader").label("device"),
                 func.coalesce(func.sum(PageStat.duration_seconds), 0).label("seconds"),
-                func.count(func.distinct(func.cast(PageStat.start_time / 86400, Integer))).label("units"),
+                func.count(func.distinct(epoch_day(PageStat.start_time, tz_offset))).label("units"),
             )
             .filter(PageStat.user_id == user_id, PageStat.book_id == book_id)
             .group_by("device")
@@ -216,7 +218,8 @@ def compute_book_reading_stats(
     ]
 
     # ── Reading momentum: last 7 days vs the 7 before ─────────────────────────
-    today = datetime.now(timezone.utc).date()
+    # "Today" is the user's current reading day, matching the timeline buckets.
+    today = effective_today(tz_offset)
     recent_seconds = prior_seconds = 0
     for row in session_timeline:
         try:
@@ -304,6 +307,7 @@ def compute_book_page_intensity(
     user_id: int,
     book_id: int,
     bins: int = 50,
+    tz_offset: int = 0,
 ) -> Optional[dict]:
     """Per-page reading intensity for one book, from imported KOReader page-stats.
 
@@ -353,8 +357,8 @@ def compute_book_page_intensity(
         total_seconds += dur
         distinct_pages.add(int(page))
         latest_total_pages = max(latest_total_pages, int(total_pages))
-        # local-day bucket (page revisited on a different day ⇒ a re-read)
-        bin_days[b].add(int(start_time) // 86400 if start_time else 0)
+        # reading-day bucket (page revisited on a different day ⇒ a re-read)
+        bin_days[b].add(epoch_day_int(int(start_time), tz_offset) if start_time else 0)
 
     pages_read = len(distinct_pages)
     pct_read = (
@@ -407,6 +411,8 @@ def compute_book_aggregate_stats(
         )
     }
     # Per-user page-stat totals (seconds, distinct reading days = "sessions").
+    # UTC days on purpose: this aggregates across ALL readers, so there is no
+    # single viewer timezone to bucket by — and only the day *count* is used.
     ps_by_user = {
         uid: (int(secs or 0), int(days or 0))
         for uid, secs, days in (

--- a/backend/services/streaks.py
+++ b/backend/services/streaks.py
@@ -1,32 +1,17 @@
 """Shared reading-streak computation.
 
-Buckets sessions by the user's local day with a 4-hour rollover, so a session
-started at 01:30 CEST still counts toward the previous day's bedtime read.
+Buckets sessions by the user's reading day (local day with a 4-hour rollover —
+see ``backend/services/reading_day.py``), so a session started at 01:30 CEST
+still counts toward the previous day's bedtime read.
 """
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from backend.models.tome_sync import ReadingSession
-
-ROLLOVER_HOURS = 4
-
-
-def _effective_hours(tz_offset_minutes: int, rollover_hours: int = ROLLOVER_HOURS) -> int:
-    # JS getTimezoneOffset: minutes, negative = east of UTC (e.g. CEST → -120)
-    tz_hours = -(tz_offset_minutes // 60)
-    return tz_hours - rollover_hours
-
-
-def date_modifier(tz_offset_minutes: int, rollover_hours: int = ROLLOVER_HOURS) -> str:
-    """SQLite date() modifier that maps a UTC timestamp to its local day with rollover."""
-    return f"{_effective_hours(tz_offset_minutes, rollover_hours):+d} hours"
-
-
-def effective_today(tz_offset_minutes: int, rollover_hours: int = ROLLOVER_HOURS) -> date:
-    """The user's current 'reading day' — what walking back a streak should start from."""
-    return (datetime.utcnow() + timedelta(hours=_effective_hours(tz_offset_minutes, rollover_hours))).date()
+# Re-exported for existing importers; the canonical home is reading_day.
+from backend.services.reading_day import ROLLOVER_HOURS, date_modifier, effective_today  # noqa: F401
 
 
 def streaks_from_dates(day_set: set[date], today: date) -> tuple[int, int]:

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -214,7 +214,7 @@ export function BookDetailPage() {
       .then(r => { if (r.linked && r.device) setKosyncDevice(r.device) })
       .catch(() => {})  // KOSync is optional — silent fail is fine
     api.get<Annotation[]>(`/books/${id}/annotations`).then(setAnnotations).catch(() => {})
-    api.get<ReadingStatsResponse>(`/books/${id}/reading-stats`).then(setReadingStats).catch(() => {})
+    api.get<ReadingStatsResponse>(`/books/${id}/reading-stats?tz_offset=${new Date().getTimezoneOffset()}`).then(setReadingStats).catch(() => {})
   }, [id])
 
   // Animate progress bar from 0 after it loads
@@ -704,7 +704,7 @@ export function BookDetailPage() {
   // imported KOReader page-stats (a book read only on the device has no sessions
   // but does have an intensity curve).
   const refreshStats = () =>
-    api.get<ReadingStatsResponse>(`/books/${id}/reading-stats`).then(setReadingStats).catch(() => {})
+    api.get<ReadingStatsResponse>(`/books/${id}/reading-stats?tz_offset=${new Date().getTimezoneOffset()}`).then(setReadingStats).catch(() => {})
   const hasReadingData = readingStats && (readingStats.own.sessions > 0 || !!readingStats.intensity)
   const statsFull = readingStats ? (
     <div className="mt-1 mb-5">
@@ -1412,7 +1412,7 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
         const p = parseFloat(pct)
         if (!Number.isNaN(p)) body.end_progress = Math.min(Math.max(p / 100, 0), 1)
       }
-      await api.post(`/books/${bookId}/sessions`, body)
+      await api.post(`/books/${bookId}/sessions?tz_offset=${new Date().getTimezoneOffset()}`, body)
       setMinutes(''); setPct(''); setLogging(false)
       onChange()
     } finally {

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1718,7 +1718,7 @@ export function StatsPage() {
   }, [days, custom])
 
   useEffect(() => {
-    api.get<CompletionEstimate[]>('/stats/completion-estimates').then(setEstimates).catch(() => {})
+    api.get<CompletionEstimate[]>(`/stats/completion-estimates?tz_offset=${new Date().getTimezoneOffset()}`).then(setEstimates).catch(() => {})
   }, [])
 
   const reloadGoals = useCallback(() => {

--- a/tests/test_reading_day.py
+++ b/tests/test_reading_day.py
@@ -1,0 +1,143 @@
+"""The canonical reading day (local day + 4h rollover) applies everywhere.
+
+Regression for the recurring "forgot the rollover" bug class: streaks always
+bucketed by ``reading_day.date_modifier`` while newer features (daily chart,
+activity heatmap, re-reads, per-book timelines, momentum, DNA rhythm) buckets
+drifted onto plain-UTC or plain-local days. One evening session crossing a
+day boundary must never split into two days — or fabricate a re-read.
+"""
+from datetime import datetime, timedelta, timezone
+
+from backend.models.ko_stats import PageStat
+from backend.models.tome_sync import ReadingSession
+from backend.services.reading_day import (
+    date_modifier,
+    effective_today,
+    epoch_day_int,
+)
+
+CEST = -120  # JS getTimezoneOffset for UTC+2
+
+
+def _epoch(y, m, d, hh, mm=0):
+    return int(datetime(y, m, d, hh, mm, tzinfo=timezone.utc).timestamp())
+
+
+def test_helpers_roll_midnight_sessions_back():
+    # 01:30 local (CEST) = 23:30 UTC the day before +2h = 01:30 → rolls to previous day
+    assert date_modifier(CEST) == "-2 hours"          # +2h tz, -4h rollover
+    assert date_modifier(0) == "-4 hours"
+    # Epoch at 01:30 local on Jun 2 (23:30 UTC Jun 1) → reading day Jun 1
+    e = _epoch(2026, 6, 1, 23, 30)
+    assert epoch_day_int(e, CEST) == epoch_day_int(_epoch(2026, 6, 1, 20), CEST)
+    # ...but 05:00 local on Jun 2 is Jun 2
+    assert epoch_day_int(_epoch(2026, 6, 2, 3), CEST) == epoch_day_int(e, CEST) + 1
+
+
+def test_rereads_ignore_a_session_crossing_utc_midnight(client, db, admin_user, make_book):
+    """A continuous 23:30–00:30 UTC evening read (UTC+2 user) is ONE reading day,
+    so its pages are not re-reads. Under UTC-day bucketing every page dwelled on
+    both sides of midnight counted as revisited."""
+    user, _ = admin_user
+    book = make_book(title="Evening Read")
+    before = _epoch(2026, 6, 1, 23, 30)
+    after = _epoch(2026, 6, 2, 0, 15)
+    for p in range(1, 6):                     # pages 1-5 before midnight...
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=p, total_pages=100,
+                        start_time=before + p, duration_seconds=60, device="Kindle"))
+    for p in range(1, 6):                     # ...and dwelled again just after
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=p, total_pages=100,
+                        start_time=after + p, duration_seconds=60, device="Kindle"))
+    db.flush()
+
+    rr = client.get(f"/api/stats?days=0&tz_offset={CEST}").json()["rereads"]["books"]
+    assert book.id not in {b["book_id"] for b in rr}
+
+    # A genuine revisit ten days later still registers.
+    later = after + 10 * 86_400
+    for p in range(1, 6):
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=p, total_pages=100,
+                        start_time=later + p, duration_seconds=60, device="Kindle"))
+    db.flush()
+    rr = client.get(f"/api/stats?days=0&tz_offset={CEST}").json()["rereads"]["books"]
+    assert book.id in {b["book_id"] for b in rr}
+
+
+def test_per_book_timeline_one_day_across_midnight(client, db, admin_user, make_book):
+    """The per-book reading log buckets a midnight-crossing device read into one
+    reading day (one 'session'), not two."""
+    user, _ = admin_user
+    book = make_book(title="Night Owl Book")
+    for i, ts in enumerate([_epoch(2026, 6, 1, 23, 30), _epoch(2026, 6, 2, 0, 15)]):
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=i + 1, total_pages=100,
+                        start_time=ts, duration_seconds=600, device="Kindle"))
+    db.flush()
+
+    own = client.get(f"/api/books/{book.id}/reading-stats?tz_offset={CEST}").json()["own"]
+    assert own["sessions"] == 1
+    assert len(own["session_timeline"]) == 1
+    assert own["session_timeline"][0]["date"] == "2026-06-01"
+    assert own["session_timeline"][0]["seconds"] == 1200
+
+
+def test_web_session_timeline_uses_reading_day(client, db, admin_user, make_book):
+    """Live web sessions bucket by the same reading day: a 01:30-local session
+    belongs to the previous evening, matching the streak."""
+    user, _ = admin_user
+    book = make_book(title="Bedtime Web Read")
+    # 23:30 UTC Jun 1 = 01:30 local Jun 2 (CEST) → reading day Jun 1
+    when = datetime(2026, 6, 1, 23, 30)
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when,
+                          ended_at=when + timedelta(minutes=30),
+                          duration_seconds=1800, pages_turned=20, device="web-reader"))
+    db.flush()
+
+    own = client.get(f"/api/books/{book.id}/reading-stats?tz_offset={CEST}").json()["own"]
+    assert [r["date"] for r in own["session_timeline"]] == ["2026-06-01"]
+
+
+def test_daily_chart_and_heatmap_agree_with_streak(client, db, admin_user, make_book):
+    """A midnight–4am-only reading day lands on the same date in the daily chart,
+    the heatmap AND the streak (the original heatmap/streak drift bug)."""
+    user, _ = admin_user
+    book = make_book(title="After Midnight")
+    # 01:00 local today (tz_offset=0) → reading day = yesterday's date... anchor
+    # instead on the effective today so the streak is deterministic: read at
+    # 01:00 local on the day after effective-today's calendar date.
+    eff_today = effective_today(0)
+    when = datetime(eff_today.year, eff_today.month, eff_today.day, 1, 0) + timedelta(days=1)
+    if when > datetime.utcnow():
+        # If 01:00 next-day hasn't happened yet in real time, use today 01:00
+        # (which rolls to yesterday) — the invariant under test is identical.
+        when -= timedelta(days=1)
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when,
+                          ended_at=when + timedelta(minutes=45),
+                          duration_seconds=2700, pages_turned=30, device="web-reader"))
+    db.flush()
+
+    data = client.get("/api/stats?days=30&tz_offset=0").json()
+    streak_day = (when - timedelta(hours=4)).date().isoformat()
+    daily_hit = [d["date"] for d in data["daily"] if d["seconds"] > 0]
+    heatmap_hit = [d["date"] for d in data["heatmap_daily"] if d["seconds"] > 0]
+    assert daily_hit == [streak_day]
+    assert heatmap_hit == [streak_day]
+    assert data["headline"]["current_streak_days"] >= 1
+
+
+def test_dna_rhythm_counts_midnight_read_as_one_active_day(db, admin_user, make_book):
+    """DNA rhythm's active-day set uses reading days: 20 midnight-crossing
+    evening reads are 20 active days, not 40."""
+    from backend.services import reconciled_reading as rr
+
+    user, _ = admin_user
+    book = make_book(title="DNA Book")
+    base = _epoch(2026, 5, 1, 23, 30)
+    for day in range(20):
+        for ts in (base + day * 86_400, base + day * 86_400 + 3_000):  # straddles midnight UTC
+            db.add(PageStat(user_id=user.id, book_id=book.id, page=1, total_pages=100,
+                            start_time=ts, duration_seconds=300, device="Kindle"))
+    db.flush()
+
+    covered = rr.covered_book_ids(db, user.id)
+    days = rr.active_days(db, user.id, date_modifier(CEST), covered)
+    assert len(days) == 20


### PR DESCRIPTION
## Problem

Streaks have always bucketed sessions by the user's **reading day** — local calendar day with a 4-hour rollover, so a 1:30 am read counts toward the previous evening. But newer features quietly re-derived their own day identity:

- **#79 page-stat paths** used raw UTC epoch days (`start_time // 86400`): re-reads, completion-estimate active days, the per-book timeline, and reading intensity. A continuous 23:30–00:30 evening read (UTC+2 user) split into two "days" — every page dwelled on both sides of midnight became a false **re-read**, and per-book day counts doubled.
- **#83 momentum** compared timeline buckets against the UTC `today`, so "last 7 days vs prior" could disagree with the dashboard around week boundaries.
- **#87 DNA rhythm** built its active-day set without the rollover and against the UTC date, splitting night reads into two active days and dropping "today" for users east of UTC.
- And the long-standing **heatmap/streak drift**: the daily chart and activity heatmap bucketed by plain local days, so a midnight–4am-only reading day showed as a heatmap gap on a day the streak counted.

## Fix

New `backend/services/reading_day.py` is the single source of truth (`date_modifier` for DateTime columns, `epoch_day` / `epoch_day_int` for epoch columns, `effective_today`); `streaks.py` re-exports from it. Every day-identity bucket now routes through it: `/stats` daily chart + heatmap + totals + monthly + re-reads, completion estimates, per-book timeline / progress line / by-source / momentum, reading intensity, and DNA rhythm. Custom stats date ranges shift their UTC filter bounds by the rollover so filter and bucket boundaries agree.

**Deliberate exceptions, documented in place:**
- the hour × weekday heatmap keeps the plain tz offset — 1 am must render as 1 am, not 9 pm;
- the all-users per-book aggregate keeps UTC days — there is no single viewer timezone, and only the day *count* is used;
- goals keep their existing calendar windows (period bounds are calendar-defined; changing goal accounting is out of scope — flagging in case you want it aligned later).

The per-book reading-stats endpoints (`GET /books/{id}/reading-stats`, `POST /books/{id}/sessions`) and `GET /stats/completion-estimates` now accept `tz_offset`, and the frontend sends it.

## Testing

- New `tests/test_reading_day.py` (6 tests): helper semantics, re-reads ignoring a midnight-crossing session (and still catching a genuine 10-days-later revisit), per-book timeline bucketing one day across midnight for both device and web reads, daily chart + heatmap + streak agreeing on a midnight–4am-only day, and DNA rhythm counting 20 midnight-straddling evening reads as 20 active days. The bucketing tests fail on the previous code.
- Full backend suite: **670 passed**.
- `npm run build` (tsc -b) clean.