### PR TITLE
fix(stats): pagination-robust page-stat math + honest estimate confidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **A font change no longer scrambles a book's page stats.** KOReader re-paginates
+  when the font or margins change, and Tome sometimes mixed page numbers from
+  different paginations: a book finished at 250 pages then reopened once at a
+  1571-page pagination could show **"250 of 1571 pages · 16%"** despite being
+  fully read, the Completion Estimates tile could report a nearly-finished book
+  as barely started, and the **Re-reads** tile counted "page 10" under two
+  different paginations as a revisit of the same page. Page coverage and reading
+  position are now computed in fraction-of-book space (per row, against that
+  row's own page count) and expressed against the *latest* pagination. Two more
+  estimate fixes ride along: pages-per-day no longer drops the first active day
+  from the denominator (which doubled a two-day reader's pace and halved the
+  estimate), and the confidence label now comes from the signal that actually
+  drove the estimate instead of whichever source happened to have more data.
 - **Late-night reading no longer splits across two days — anywhere.** Tome has
   always counted a session started at, say, 1:30 am toward the previous evening's
   reading day for **streaks** (a local day with a 4-hour rollover), but newer

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -921,7 +921,9 @@ def get_stats(
             _PageStat.page.label("page"),
         )
         .filter(_PageStat.user_id == current_user.id)
-        .group_by(_PageStat.book_id, _PageStat.page)
+        # Page N is only "the same page" within one pagination — after a font
+        # change, page 10 is different content, not a revisit.
+        .group_by(_PageStat.book_id, _PageStat.total_pages, _PageStat.page)
         .having(func.count(func.distinct(_day)) > 1)
         .subquery()
     )
@@ -933,11 +935,16 @@ def get_stats(
     reread_books: list[dict] = []
     if reread_counts:
         rr_ids = list(reread_counts.keys())
-        rr_totals = dict(
-            db.query(_PageStat.book_id, func.max(_PageStat.total_pages))
-            .filter(_PageStat.user_id == current_user.id, _PageStat.book_id.in_(rr_ids))
+        # Latest pagination per book (SQLite bare-column rule with a single
+        # max() aggregate) — not max(total_pages), which mixes paginations.
+        rr_totals = {
+            r[0]: int(r[1] or 0)
+            for r in db.query(_PageStat.book_id, _PageStat.total_pages,
+                              func.max(_PageStat.start_time))
+            .filter(_PageStat.user_id == current_user.id, _PageStat.book_id.in_(rr_ids),
+                    _PageStat.total_pages > 0)
             .group_by(_PageStat.book_id).all()
-        )
+        }
         rr_meta = {
             b.id: b for b in db.query(Book).filter(
                 Book.id.in_(rr_ids), Book.status == "active",
@@ -1070,29 +1077,41 @@ def get_completion_estimates(
         # count so device-only books (no live sessions) still get an estimate.
         ps = (
             db.query(
-                func.count(func.distinct(PageStat.page)),
-                func.max(PageStat.total_pages),
                 func.count(func.distinct(case((PageStat.start_time >= window_epoch, PageStat.page)))),
                 func.count(func.distinct(case((PageStat.start_time >= window_epoch,
                                                epoch_day(PageStat.start_time, tz_offset))))),
-                func.max(PageStat.page),
+                # Furthest position as a per-row page/total fraction — a page
+                # number only means anything against its own row's pagination.
+                func.max(PageStat.page * 1.0 / PageStat.total_pages),
             )
             .filter(PageStat.user_id == current_user.id, PageStat.book_id == row.id)
             .one()
         )
-        ps_pages, ps_total, ps_pages_30, ps_days_30, ps_max_page = (
-            int(ps[0] or 0), int(ps[1] or 0), int(ps[2] or 0), int(ps[3] or 0), int(ps[4] or 0))
-        ps_days_30 = max(ps_days_30 - (1 if ps_pages_30 else 0), 0)  # gained over the gaps, not the first day
+        ps_pages_30, ps_days_30 = int(ps[0] or 0), int(ps[1] or 0)
+        ps_frac = min(float(ps[2] or 0.0), 1.0)
+        # Latest pagination for the remaining-pages arithmetic: total_pages from
+        # the max(start_time) row (SQLite bare-column rule, single aggregate) —
+        # max(total_pages) would let a long-gone pagination inflate it.
+        latest = (
+            db.query(PageStat.total_pages, func.max(PageStat.start_time))
+            .filter(PageStat.user_id == current_user.id, PageStat.book_id == row.id,
+                    PageStat.total_pages > 0)
+            .one()
+        )
+        ps_total = int(latest[0] or 0)
         # Progress = how far through: the best of the synced position (set above)
-        # and the furthest page reached. Page-stats are coverage, so use the
-        # furthest page, not the distinct-page count. max() covers a synced
+        # and the furthest position reached. Page-stats are coverage, so use the
+        # furthest position, not the distinct-page count. max() covers a synced
         # position ahead of the dwell history *and* a stale position behind it.
-        page_pct = round(ps_max_page / ps_total * 100, 1) if (ps_total > 0 and ps_max_page > 0) else 0.0
+        page_pct = round(ps_frac * 100, 1)
         progress = min(max(progress, page_pct), 100.0)
 
         estimated_days: Optional[int] = None
         if session_count == 0 and ps_total > 0 and ps_pages_30 > 0 and ps_days_30 >= 1 and progress < 100:
             # Device-only: pages read per active-day → days to read the rest.
+            # All active days count — subtracting the first day (as the session
+            # path does for progress *deltas*) doubles the pace of a 2-day
+            # reader, because absolute page counts aren't gained "over gaps".
             pages_per_day = ps_pages_30 / ps_days_30
             # Remaining measured from your position, not from uncovered pages.
             remaining_pages = max(round((1 - progress / 100.0) * ps_total), 0)
@@ -1110,9 +1129,11 @@ def get_completion_estimates(
             remaining = 100.0 - progress
             estimated_days = max(1, round(remaining / progress_per_day))
 
-        # Confidence from whichever signal drove the estimate (live sessions or
-        # page-stat reading-days for device-only books).
-        evidence = max(session_count, ps_days_30)
+        # Confidence from the signal that actually drove the estimate: live
+        # sessions when present (the session path never looks at page-stat
+        # pace), else page-stat reading-days. max() of the two let unrelated
+        # evidence inflate confidence in the other path's estimate.
+        evidence = session_count if session_count > 0 else ps_days_30
         if evidence >= 5:
             confidence = "high"
         elif evidence >= 2:

--- a/backend/main.py
+++ b/backend/main.py
@@ -152,6 +152,13 @@ async def lifespan(app: FastAPI):
         if rg_cols and "book_type_id" not in rg_cols:
             conn.execute(text("DROP TABLE reading_goals"))
             conn.commit()
+        # Composite index for the re-reads group-by over (user, book, page) —
+        # create_all only builds indexes for brand-new tables.
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_ko_page_stats_user_book_page "
+            "ON ko_page_stats (user_id, book_id, page)"
+        ))
+        conn.commit()
     ReadingGoal.__table__.create(bind=engine, checkfirst=True)
     init_fts(engine)
     backfill_fts(engine)

--- a/backend/models/ko_stats.py
+++ b/backend/models/ko_stats.py
@@ -19,6 +19,7 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -43,6 +44,9 @@ class PageStat(Base):
             "user_id", "book_id", "page", "start_time", "device",
             name="uq_ko_page_stat_identity",
         ),
+        # The re-reads block group-bys (user, book, page) over the full history;
+        # existing DBs get this via the startup CREATE INDEX IF NOT EXISTS.
+        Index("ix_ko_page_stats_user_book_page", "user_id", "book_id", "page"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/backend/services/reading_stats.py
+++ b/backend/services/reading_stats.py
@@ -19,6 +19,34 @@ from backend.models.user_book_status import UserBookStatus
 from backend.services.reading_day import date_modifier, effective_today, epoch_day, epoch_day_int
 
 
+def _covered_fraction(page_rows) -> float:
+    """Fraction of the book covered by dwelled pages, pagination-robust.
+
+    Each (page, total_pages) row covers the fraction interval
+    [(page-1)/total, page/total); the union's length is the coverage. Mixing
+    absolute page numbers across paginations either under- or over-counts —
+    250 pages of a fully-read 250-page pagination cover the whole book even if
+    the latest pagination says 1571 pages.
+    """
+    ivs = sorted(
+        ((p - 1) / tp, p / tp)
+        for p, tp in page_rows
+        if tp and tp > 0 and p and p > 0
+    )
+    covered = 0.0
+    cur_s = cur_e = None
+    for s, e in ivs:
+        if cur_e is None or s > cur_e + 1e-9:
+            if cur_e is not None:
+                covered += cur_e - cur_s
+            cur_s, cur_e = s, e
+        else:
+            cur_e = max(cur_e, e)
+    if cur_e is not None:
+        covered += cur_e - cur_s
+    return min(covered, 1.0)
+
+
 # ── Per-book, per-user ────────────────────────────────────────────────────────
 
 def compute_book_reading_stats(
@@ -115,23 +143,45 @@ def compute_book_reading_stats(
     ps = (
         db.query(
             func.coalesce(func.sum(PageStat.duration_seconds), 0),
-            func.count(func.distinct(PageStat.page)),
             func.min(PageStat.start_time),
             func.max(PageStat.start_time),
-            func.max(PageStat.total_pages),
-            func.max(PageStat.page),
+            # Furthest *position* as a per-row fraction: a page number only means
+            # anything against its own row's pagination (font changes re-paginate),
+            # so max(page)/max(total_pages) across paginations understates badly.
+            func.max(PageStat.page * 1.0 / PageStat.total_pages),
         )
         .filter(PageStat.user_id == user_id, PageStat.book_id == book_id)
         .one()
     )
     ps_seconds = int(ps[0] or 0)
     ps_total_pages = 0
-    ps_max_page = 0
+    ps_position = 0.0
     if ps_seconds > 0:
         total_seconds = ps_seconds
-        pages_turned = int(ps[1] or 0)          # distinct pages genuinely read
-        ps_total_pages = int(ps[4] or 0)
-        ps_max_page = int(ps[5] or 0)           # furthest page reached (position fallback)
+        ps_position = min(float(ps[3] or 0.0), 1.0)   # furthest fraction reached
+        # Latest pagination — total_pages from the max(start_time) row (SQLite's
+        # bare-column rule applies: exactly one aggregate). max(total_pages)
+        # would let a long-gone pagination inflate the denominator forever.
+        latest = (
+            db.query(PageStat.total_pages, func.max(PageStat.start_time))
+            .filter(PageStat.user_id == user_id, PageStat.book_id == book_id,
+                    PageStat.total_pages > 0)
+            .one()
+        )
+        ps_total_pages = int(latest[0] or 0)
+        # Pages read = covered fraction × latest pagination, so coverage from
+        # different paginations doesn't mix absolute page numbers ("250 of 1571").
+        page_rows = (
+            db.query(PageStat.page, PageStat.total_pages)
+            .filter(PageStat.user_id == user_id, PageStat.book_id == book_id,
+                    PageStat.total_pages > 0)
+            .distinct()
+            .all()
+        )
+        if ps_total_pages > 0:
+            pages_turned = round(_covered_fraction(page_rows) * ps_total_pages)
+        else:
+            pages_turned = len({p for p, _tp in page_rows})
         # Daily buckets from page-stats, by reading day (local + 4h rollover).
         day_rows = (
             db.query(
@@ -150,10 +200,10 @@ def compute_book_reading_stats(
         ]
         sessions = len(session_timeline)        # one "session" per reading day
         avg_session_seconds = round(total_seconds / sessions) if sessions else 0
+        if ps[1]:
+            first_read = datetime.fromtimestamp(int(ps[1]), timezone.utc).isoformat()
         if ps[2]:
-            first_read = datetime.fromtimestamp(int(ps[2]), timezone.utc).isoformat()
-        if ps[3]:
-            last_read = datetime.fromtimestamp(int(ps[3]), timezone.utc).isoformat()
+            last_read = datetime.fromtimestamp(int(ps[2]), timezone.utc).isoformat()
         total_minutes = total_seconds / 60.0
         if total_minutes > 0 and pages_turned > 0:
             pace_pages_per_min = round(pages_turned / total_minutes, 2)
@@ -258,12 +308,13 @@ def compute_book_reading_stats(
 
     # ── Progress = how far through the book ──────────────────────────────────
     # Best available evidence of position: the synced reading position OR the
-    # furthest page reached. Page-stats are *coverage*, so use the furthest page,
-    # never the distinct-page count (which trails position when pages are
-    # skimmed). max() handles both directions: a synced position ahead of the
-    # dwell history (you skimmed/jumped), and a stale-low position behind pages
-    # you've since read. A finished book is always 100%.
-    page_progress = (ps_max_page / ps_total_pages) if (ps_total_pages and ps_max_page) else 0.0
+    # furthest position reached (per-row page/total_pages fraction — robust to
+    # pagination changes). Page-stats are *coverage*, so use the furthest
+    # position, never the distinct-page count (which trails position when pages
+    # are skimmed). max() handles both directions: a synced position ahead of
+    # the dwell history (you skimmed/jumped), and a stale-low position behind
+    # pages you've since read. A finished book is always 100%.
+    page_progress = ps_position
     if book_status == "read":
         progress = 1.0
     else:
@@ -342,9 +393,13 @@ def compute_book_page_intensity(
 
     curve = [0] * bins
     bin_days: dict[int, set] = defaultdict(set)
-    distinct_pages: set[int] = set()
     total_seconds = 0
+    # "Latest" pagination = the most recent row's total_pages. NOT max():
+    # reopening a finished 250-page book once at a 1571-page pagination must
+    # not turn it into "250 of 1571 pages".
     latest_total_pages = 0
+    latest_start = -1
+    page_pairs: set[tuple[int, int]] = set()
 
     for page, total_pages, dur, start_time in rows:
         if not total_pages or total_pages <= 0:
@@ -355,16 +410,18 @@ def compute_book_page_intensity(
         dur = int(dur or 0)
         curve[b] += dur
         total_seconds += dur
-        distinct_pages.add(int(page))
-        latest_total_pages = max(latest_total_pages, int(total_pages))
+        page_pairs.add((int(page), int(total_pages)))
+        if int(start_time or 0) >= latest_start:
+            latest_start = int(start_time or 0)
+            latest_total_pages = int(total_pages)
         # reading-day bucket (page revisited on a different day ⇒ a re-read)
         bin_days[b].add(epoch_day_int(int(start_time), tz_offset) if start_time else 0)
 
-    pages_read = len(distinct_pages)
-    pct_read = (
-        min(round(pages_read / latest_total_pages * 100, 1), 100.0)
-        if latest_total_pages else 0.0
-    )
+    # Coverage as a fraction-space interval union — pagination-robust — then
+    # expressed against the latest pagination for the "X of Y pages" line.
+    covered = _covered_fraction(page_pairs)
+    pages_read = round(covered * latest_total_pages) if latest_total_pages else 0
+    pct_read = min(round(covered * 100, 1), 100.0) if latest_total_pages else 0.0
     reread_bins = sum(1 for days in bin_days.values() if len(days) > 1)
 
     return {

--- a/tests/test_pagestat_pagination.py
+++ b/tests/test_pagestat_pagination.py
@@ -1,0 +1,119 @@
+"""Pagination-robust page-stat math.
+
+KOReader re-paginates whenever font/margins change, so absolute page numbers
+are only meaningful against their own row's ``total_pages``. Regressions here:
+mixing paginations shrank a finished book to "250 of 1571 pages · 16%",
+counted page N under two paginations as a re-read, halved/doubled device-only
+completion estimates, and let one source's evidence inflate the other's
+confidence.
+"""
+from datetime import datetime, timezone
+
+from backend.models.ko_stats import PageStat
+from backend.models.tome_sync import ReadingSession
+from backend.models.user_book_status import UserBookStatus
+
+DAY = 86_400
+BASE = 1_700_000_000
+NOW = int(datetime.utcnow().replace(tzinfo=timezone.utc).timestamp())
+
+
+def _page(db, user, book, page, total, ts, dur=60, device="Kindle"):
+    db.add(PageStat(user_id=user.id, book_id=book.id, page=page, total_pages=total,
+                    start_time=ts, duration_seconds=dur, device=device))
+
+
+def test_repagination_does_not_shrink_a_finished_book(client, db, admin_user, make_book):
+    """Fully read at a 250-page pagination, reopened once at 1571 pages: the
+    book page must not claim '250 of 1571 pages · 16%'."""
+    user, _ = admin_user
+    book = make_book(title="Font Change Victim")
+    for p in range(1, 251):                       # cover to cover at 250 pages
+        _page(db, user, book, p, 250, BASE + p)
+    _page(db, user, book, 400, 1571, BASE + 30 * DAY)   # one later dwell, re-paginated
+    db.flush()
+
+    r = client.get(f"/api/books/{book.id}/reading-stats?tz_offset=0").json()
+    own, intensity = r["own"], r["intensity"]
+    assert intensity["total_pages"] == 1571        # latest pagination, not max()
+    assert intensity["pct_read"] == 100.0          # coverage is fraction-space
+    assert intensity["pages_read"] == 1571
+    assert own["pages_turned"] == 1571
+    assert own["progress"] == 1.0                  # furthest per-row fraction = 250/250
+
+
+def test_estimates_progress_uses_per_row_fraction(client, db, admin_user, make_book):
+    """Position = max(page/total per row): 245/250 (98%) must win over the
+    misleading max(page)=245 vs max(total)=1571 (16%)."""
+    user, _ = admin_user
+    book = make_book(title="Almost Done")
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="reading", progress_pct=0.0))
+    for p in range(240, 246):                      # near the end at 250 pages
+        _page(db, user, book, p, 250, NOW - 2 * DAY + p)
+    _page(db, user, book, 100, 1571, NOW - DAY)    # later re-paginated dwell
+    db.flush()
+
+    rows = client.get("/api/stats/completion-estimates?tz_offset=0").json()
+    row = next(r for r in rows if r["book_id"] == book.id)
+    assert row["progress"] == 98.0
+
+
+def test_rereads_scoped_to_one_pagination(client, db, admin_user, make_book):
+    """Page 10 dwelled under two different paginations is different content,
+    not a revisit; the same pagination on two days still is."""
+    user, _ = admin_user
+    cross = make_book(title="Cross Pagination")
+    real = make_book(title="Real Reread")
+    for p in range(1, 6):
+        _page(db, user, cross, p, 250, BASE + 12 * 3600 + p)             # day 0, 250pp
+        _page(db, user, cross, p, 1571, BASE + 10 * DAY + 12 * 3600 + p)  # day 10, 1571pp
+        _page(db, user, real, p, 250, BASE + 12 * 3600 + p)
+        _page(db, user, real, p, 250, BASE + 10 * DAY + 12 * 3600 + p)   # same pagination
+    db.flush()
+
+    rr = {b["book_id"]: b for b in client.get("/api/stats?days=0&tz_offset=0").json()["rereads"]["books"]}
+    assert cross.id not in rr
+    assert real.id in rr
+    assert rr[real.id]["reread_pages"] == 5
+    assert rr[real.id]["total_pages"] == 250
+
+
+def test_device_estimate_counts_all_active_days(client, db, admin_user, make_book):
+    """20 pages over 2 active days is 10 pages/day — the first-day subtraction
+    made it 20/day and halved the estimate."""
+    user, _ = admin_user
+    book = make_book(title="Steady Reader")
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="reading", progress_pct=0.0))
+    for i, p in enumerate(range(1, 21)):
+        ts = NOW - (2 * DAY if p <= 10 else DAY)   # two reading days, 10 pages each
+        _page(db, user, book, p, 100, ts + i)
+    db.flush()
+
+    rows = client.get("/api/stats/completion-estimates?tz_offset=0").json()
+    row = next(r for r in rows if r["book_id"] == book.id)
+    assert row["progress"] == 20.0
+    # 80 pages left at 10/day → 8 days (the old first-day subtraction said 4).
+    assert row["estimated_days"] == 8
+    assert row["confidence"] == "medium"           # 2 page-stat days
+
+
+def test_confidence_follows_the_estimating_path(client, db, admin_user, make_book):
+    """A session-driven estimate with 2 sessions stays 'medium' even when the
+    book also has many page-stat reading days (which that path never uses)."""
+    user, _ = admin_user
+    book = make_book(title="Mixed Sources")
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="reading", progress_pct=0.5))
+    # 10 page-stat reading days (would be "high" under max(...) cross-talk)
+    for d in range(10):
+        _page(db, user, book, d + 1, 100, NOW - (d + 2) * DAY + 12 * 3600)
+    # 2 live sessions in the window → the session path drives the estimate
+    for d in (1, 2):
+        started = datetime.utcfromtimestamp(NOW - d * DAY)
+        db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=started,
+                              ended_at=started, duration_seconds=1200,
+                              progress_start=0.3, progress_end=0.5, device="web-reader"))
+    db.flush()
+
+    rows = client.get("/api/stats/completion-estimates?tz_offset=0").json()
+    row = next(r for r in rows if r["book_id"] == book.id)
+    assert row["confidence"] == "medium"


### PR DESCRIPTION
> **Stacked on #92** (`fix/day-bucketing-consolidation`) — it touches the same lines in `stats.py` / `reading_stats.py`. Merge #92 first; this PR then retargets to `main` automatically when the base branch is deleted.

## Problem

KOReader re-paginates whenever the font or margins change, so an absolute page number only means anything against its own row's `total_pages`. Several page-stat paths from #79 mixed paginations by taking `max(page)` and `max(total_pages)` independently:

- **Per-book stats + reading intensity**: finish a book at a 250-page pagination, reopen it once after a font change that yields 1571 pages → the book page reads **"250 of 1571 pages · 16%"** on a fully-read book, and `progress` falls back to 245/1571 instead of 245/250.
- **Completion estimates**: same progress understatement → wildly inflated time-remaining.
- **Re-reads tile**: "page 10" under two different paginations is different content, but it counted as the same page revisited.

Plus two estimate-logic bugs: the device-only path subtracted the first active day from the pages-per-day denominator (2 active days → pace doubled, estimate halved), and `confidence = max(session_count, ps_days_30)` let page-stat evidence inflate confidence in a session-driven estimate that never looked at page-stat pace.

## Fix

- New `_covered_fraction()` in `reading_stats.py`: coverage as an interval union in fraction-of-book space (each row covers `[(page-1)/total, page/total)`), expressed against the **latest** pagination (`total_pages` from the `max(start_time)` row via SQLite's bare-column rule). Used by per-book stats and intensity.
- Reading position = `max(page / total_pages)` per row, everywhere (per-book stats, estimates).
- Re-read identity = `(book, total_pages, page)`; the tile's denominator is the latest pagination.
- Estimates: all active days count in the pace denominator; confidence follows the path that produced the estimate.
- Perf (C4): composite `(user_id, book_id, page)` index on `ko_page_stats` — model-level for fresh DBs, `CREATE INDEX IF NOT EXISTS` at startup for existing ones.

## Testing

- New `tests/test_pagestat_pagination.py` (5 tests): repagination not shrinking a finished book, per-row-fraction progress in estimates, re-reads scoped to one pagination, all-active-days pace (8 days, not 4), and confidence staying `medium` on a 2-session estimate despite 10 page-stat days. All fail on the previous code.
- Full backend suite: **675 passed**.