### PR TITLE
fix(stats): per-source reading reconciliation + explicit finish date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,31 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Hand-logged and web-reader sessions no longer vanish on device-synced books.**
+  On a book with imported KOReader history, the "history wins" rule replaced *all*
+  other reading records — so logging 30 minutes of paper reading appeared to do
+  nothing, and web-reader time was invisible. The rule is now per source: the
+  imported history replaces only the device's own live sessions (the same reading,
+  recorded twice), while web-reader and manual sessions add on top — everywhere,
+  from the book page's reading log down to the dashboard totals and streak days.
+  A pleasant side effect: **"Where you read"** now actually shows the web/device
+  split for mixed readers, and the progress line can draw through web-reading days
+  on a device-synced book. Manual logging also got sturdier: a failed log now
+  shows an error instead of silently resetting, absurd inputs (negative pages, a
+  duration over 24h) are rejected instead of crashing, and a timezone-annotated
+  start time is converted to UTC instead of having its offset ignored.
+- **The "Finished" date is now the date you finished.** It used to be the last
+  time anything touched the status row — rating a book in March that you finished
+  in January showed "Finished: Mar", and even a device sync could nudge it. The
+  finish date is now recorded explicitly at the moment a book becomes "read"
+  (existing read books keep their best-known date), survives later ratings,
+  reviews and position syncs, and clears if you un-finish the book. Also fixed on
+  the way: a book synced straight from unread to 100% in one sitting now lands on
+  "read" immediately (it used to sit at "reading" until the next sync), the
+  admin-only "All readers" line counts consistent units (reading days) instead of
+  mixing sessions with days, a book whose progress was known but had only one
+  progress point showed that progress nowhere, and the chart "i" hints now close
+  on outside tap on iPhones.
 - **A font change no longer scrambles a book's page stats.** KOReader re-paginates
   when the font or margins change, and Tome sometimes mixed page numbers from
   different paginations: a book finished at 250 pages then reopened once at a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,10 +44,9 @@ All notable changes to Tome are documented here. Format loosely follows
   start time is converted to UTC instead of having its offset ignored. The
   Activity chart also earned a real time axis: days without reading now appear
   as gaps instead of active days being stretched edge-to-edge (two adjacent
-  bars could silently be a month apart), short histories get day-sized bars
-  rather than full-width slabs, the "Where you read" bar separates its segments
-  with a hairline seam, and the admin "All readers" line stays hidden when the
-  only reader it would describe is you.
+  bars could silently be a month apart), the "Where you read" bar separates its
+  segments with a hairline seam, and the admin "All readers" line stays hidden
+  when the only reader it would describe is you.
 - **The "Finished" date is now the date you finished.** It used to be the last
   time anything touched the status row — rating a book in March that you finished
   in January showed "Finished: Mar", and even a device sync could nudge it. The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,13 @@ All notable changes to Tome are documented here. Format loosely follows
   on a device-synced book. Manual logging also got sturdier: a failed log now
   shows an error instead of silently resetting, absurd inputs (negative pages, a
   duration over 24h) are rejected instead of crashing, and a timezone-annotated
-  start time is converted to UTC instead of having its offset ignored.
+  start time is converted to UTC instead of having its offset ignored. The
+  Activity chart also earned a real time axis: days without reading now appear
+  as gaps instead of active days being stretched edge-to-edge (two adjacent
+  bars could silently be a month apart), short histories get day-sized bars
+  rather than full-width slabs, the "Where you read" bar separates its segments
+  with a hairline seam, and the admin "All readers" line stays hidden when the
+  only reader it would describe is you.
 - **The "Finished" date is now the date you finished.** It used to be the last
   time anything touched the status row — rating a book in March that you finished
   in January showed "Finished: Mar", and even a device sync could nudge it. The

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1132,10 +1132,11 @@ def add_manual_reading_session(
     entry advances progress/status the same way a synced one would. Returns the
     refreshed per-book ``own`` stats so the UI can update without a second call.
     """
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone as _timezone
     import uuid as _uuid
     from backend.models.tome_sync import ReadingSession
     from backend.models.user_book_status import UserBookStatus
+    from backend.services.book_progress import apply_progress_to_status
     from backend.services.reading_stats import compute_book_reading_stats
 
     book = db.get(Book, book_id)
@@ -1146,17 +1147,24 @@ def add_manual_reading_session(
 
     if payload.duration_minutes is None or payload.duration_minutes <= 0:
         raise HTTPException(status_code=422, detail="duration_minutes must be positive")
+    if payload.duration_minutes > 24 * 60:
+        # Also guards timedelta overflow (a huge value 500'd instead of 422ing).
+        raise HTTPException(status_code=422, detail="duration_minutes must be at most 1440 (24 hours)")
     if payload.end_progress is not None and not (0.0 <= payload.end_progress <= 1.0):
         raise HTTPException(status_code=422, detail="end_progress must be between 0 and 1")
+    if payload.pages is not None and payload.pages < 0:
+        raise HTTPException(status_code=422, detail="pages must be zero or positive")
 
     duration = round(payload.duration_minutes * 60)
     if payload.started_at:
         try:
-            started = datetime.fromisoformat(
-                payload.started_at.replace("Z", "+00:00")
-            ).replace(tzinfo=None)
+            started = datetime.fromisoformat(payload.started_at.replace("Z", "+00:00"))
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid started_at")
+        if started.tzinfo is not None:
+            # Convert to UTC — everything else in the DB is UTC-naive. Stripping
+            # the offset would store "23:30+02:00" as 23:30 UTC (2h off).
+            started = started.astimezone(_timezone.utc).replace(tzinfo=None)
     else:
         started = datetime.utcnow()
 
@@ -1189,26 +1197,13 @@ def add_manual_reading_session(
         session_uuid=str(_uuid.uuid4()),
     ))
 
-    # Sticky completion: a manual session never un-finishes a "read" book.
+    # Shared sticky-completion rule: a manual session advances progress/status
+    # the same way a synced one would, and never un-finishes a "read" book.
     if payload.end_progress is not None:
-        pct = payload.end_progress
-        if status_row:
-            if status_row.status != "read":
-                if pct > (status_row.progress_pct or 0):
-                    status_row.progress_pct = pct
-                if status_row.status == "unread" and pct > 0:
-                    status_row.status = "reading"
-                if pct >= 0.99:
-                    status_row.status = "read"
-                    status_row.progress_pct = 1.0
-        else:
-            new_status = "read" if pct >= 0.99 else ("reading" if pct > 0 else "unread")
-            db.add(UserBookStatus(
-                user_id=current_user.id,
-                book_id=book_id,
-                status=new_status,
-                progress_pct=1.0 if new_status == "read" else pct,
-            ))
+        apply_progress_to_status(
+            db, user_id=current_user.id, book_id=book_id,
+            pct=payload.end_progress, status_row=status_row,
+        )
 
     db.commit()
     return {"own": compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset)}

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -28,6 +28,7 @@ from backend.models.user_book_status import UserBookStatus
 from backend.models.tome_sync import Annotation, AnnotationTombstone, ApiKey, ReadingSession, TomeSyncPosition
 from backend.models.ko_stats import StatsImport
 from backend.models.send_queue import SendQueueItem
+from backend.services.book_progress import apply_progress_to_status
 
 router = APIRouter(tags=["tome-sync"])
 logger = logging.getLogger(__name__)
@@ -231,39 +232,13 @@ def put_position(
         )
         db.add(pos)
 
-    # Keep UserBookStatus in sync.
-    # Completion is sticky: a "read" book stays read/100% regardless of what the
-    # device reports next (e.g. opening the book again from page 1).
-    # Resume position always tracks the device (last-write-wins) — that is
-    # handled above on the TomeSyncPosition row, not here.
-    status_row = (
-        db.query(UserBookStatus)
-        .filter(UserBookStatus.user_id == user.id, UserBookStatus.book_id == book_id)
-        .first()
+    # Keep UserBookStatus in sync via the shared sticky-completion rule.
+    # Position sync tracks the device last-write-wins (monotonic=False) — a
+    # re-opened book CAN report lower progress; only completion is sticky.
+    apply_progress_to_status(
+        db, user_id=user.id, book_id=book_id, pct=pct,
+        monotonic=False, cfi=body.progress or None,
     )
-    if status_row:
-        # Resume CFI tracks the device unconditionally (last-write-wins).
-        if body.progress:
-            status_row.cfi = body.progress
-        if status_row.status == "read":
-            # Sticky: leave status and progress_pct alone once finished.
-            pass
-        else:
-            status_row.progress_pct = pct
-            if status_row.status == "unread" and pct > 0:
-                status_row.status = "reading"
-            elif pct >= 0.99:
-                status_row.status = "read"
-                status_row.progress_pct = 1.0
-    else:
-        new_status = "read" if pct >= 0.99 else ("reading" if pct > 0 else "unread")
-        db.add(UserBookStatus(
-            user_id=user.id,
-            book_id=book_id,
-            status=new_status,
-            progress_pct=1.0 if new_status == "read" else pct,
-            cfi=body.progress,
-        ))
 
     db.commit()
     return {"ok": True, "timestamp": datetime.utcnow().isoformat() + "Z"}
@@ -389,37 +364,13 @@ def post_session(
     )
     db.add(session)
 
-    # Keep UserBookStatus in sync — catches up when position PUTs failed
-    # but queued sessions flush later.
-    # Completion is sticky: once a book is "read", a later session (e.g. a
-    # re-read) cannot drag it back to "reading" or lower its progress.
+    # Keep UserBookStatus in sync — catches up when position PUTs failed but
+    # queued sessions flush later. Shared sticky-completion rule; monotonic:
+    # a flushed session only ever advances progress, never lowers it.
     if body.progress_end is not None:
-        pct = body.progress_end
-        status_row = (
-            db.query(UserBookStatus)
-            .filter(UserBookStatus.user_id == user.id, UserBookStatus.book_id == body.book_id)
-            .first()
+        apply_progress_to_status(
+            db, user_id=user.id, book_id=body.book_id, pct=body.progress_end,
         )
-        if status_row:
-            if status_row.status == "read":
-                # Sticky: a later session never un-finishes a completed book.
-                pass
-            else:
-                if pct > (status_row.progress_pct or 0):
-                    status_row.progress_pct = pct
-                if status_row.status == "unread" and pct > 0:
-                    status_row.status = "reading"
-                elif pct >= 0.99:
-                    status_row.status = "read"
-                    status_row.progress_pct = 1.0
-        else:
-            new_status = "read" if pct >= 0.99 else ("reading" if pct > 0 else "unread")
-            db.add(UserBookStatus(
-                user_id=user.id,
-                book_id=body.book_id,
-                status=new_status,
-                progress_pct=1.0 if new_status == "read" else pct,
-            ))
 
     db.commit()
     db.refresh(session)

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -118,6 +118,13 @@ def set_book_status(
     # Only overwrite progress_pct/cfi when explicitly sent (not just defaulting to None)
     raw = body.model_dump(exclude_unset=True)
     if row:
+        # finished_at marks the transition into "read" (updated_at is useless as
+        # a finish date — it moves on every rating/CFI write) and clears when
+        # the user un-finishes the book.
+        if body.status == "read" and row.status != "read":
+            row.finished_at = datetime.utcnow()
+        elif body.status != "read":
+            row.finished_at = None
         row.status = body.status
         if body.status == 'unread':
             row.progress_pct = None
@@ -135,6 +142,7 @@ def set_book_status(
             status=body.status,
             progress_pct=body.progress_pct,
             cfi=body.cfi,
+            finished_at=datetime.utcnow() if body.status == "read" else None,
             updated_at=datetime.utcnow(),
         )
         db.add(row)

--- a/backend/main.py
+++ b/backend/main.py
@@ -145,6 +145,15 @@ async def lifespan(app: FastAPI):
             conn.execute(text("ALTER TABLE user_book_status ADD COLUMN review TEXT"))
             conn.execute(text("ALTER TABLE user_book_status ADD COLUMN rated_at DATETIME"))
             conn.commit()
+        # Explicit finish date — updated_at also moves on rating/review/CFI writes,
+        # so it can't be shown as "Finished". Backfill from updated_at (the best
+        # available guess) for rows already marked read.
+        if ubs_cols and "finished_at" not in ubs_cols:
+            conn.execute(text("ALTER TABLE user_book_status ADD COLUMN finished_at DATETIME"))
+            conn.execute(text(
+                "UPDATE user_book_status SET finished_at = updated_at WHERE status = 'read'"
+            ))
+            conn.commit()
         # reading_goals from the parked feat/reading-goals WIP (never shipped) lacks
         # book_type_id and carries a stale (user_id, kind) unique constraint that
         # SQLite can't alter away — recreate the table on the current schema.

--- a/backend/models/user_book_status.py
+++ b/backend/models/user_book_status.py
@@ -23,4 +23,9 @@ class UserBookStatus(Base):
     rating: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     review: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     rated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    # When the book was marked read. updated_at is NOT a finish date — it moves
+    # on every rating/review/CFI write (onupdate), so it must not be displayed
+    # as one. Stamped by apply_progress_to_status / the status endpoint on the
+    # transition into "read"; cleared when the book is un-finished.
+    finished_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)

--- a/backend/services/book_progress.py
+++ b/backend/services/book_progress.py
@@ -1,0 +1,81 @@
+"""The sticky-completion progress→status rule, shared by every write path.
+
+Used by the device position sync, the device session flush (TomeSync), and the
+manual "Log session" endpoint. Before this helper each site carried its own
+diverging copy — the tome_sync copies had an ``if/elif`` quirk where an unread
+book synced straight to 100% became "reading" instead of "read" until the next
+sync.
+
+Rules:
+- Completion is sticky: a "read" book is never un-finished by a later write
+  (re-reads don't drag it back); only the resume CFI keeps tracking.
+- ``pct >= 0.99`` finishes the book: status "read", progress pinned to 1.0,
+  ``finished_at`` stamped (once) — even coming straight from "unread".
+- Otherwise any positive progress moves an "unread" book to "reading".
+- ``monotonic=True`` (session flush, manual log) only ever advances
+  ``progress_pct``; ``monotonic=False`` (device position sync) tracks the
+  reported position last-write-wins, downward included.
+"""
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from backend.models.user_book_status import UserBookStatus
+
+
+def apply_progress_to_status(
+    db: Session,
+    *,
+    user_id: int,
+    book_id: int,
+    pct: float,
+    monotonic: bool = True,
+    cfi: Optional[str] = None,
+    status_row: Optional[UserBookStatus] = None,
+) -> UserBookStatus:
+    """Apply a progress report to the user's status row (creating it if needed).
+
+    Does not commit — the caller owns the transaction.
+    """
+    if status_row is None:
+        status_row = (
+            db.query(UserBookStatus)
+            .filter(UserBookStatus.user_id == user_id, UserBookStatus.book_id == book_id)
+            .first()
+        )
+
+    if status_row is None:
+        finished = pct >= 0.99
+        status_row = UserBookStatus(
+            user_id=user_id,
+            book_id=book_id,
+            status="read" if finished else ("reading" if pct > 0 else "unread"),
+            progress_pct=1.0 if finished else pct,
+            cfi=cfi,
+            finished_at=datetime.utcnow() if finished else None,
+        )
+        db.add(status_row)
+        return status_row
+
+    # Resume position tracks the latest report even on finished books.
+    if cfi is not None:
+        status_row.cfi = cfi
+
+    if status_row.status == "read":
+        return status_row  # sticky — status and progress stay finished
+
+    if monotonic:
+        if pct > (status_row.progress_pct or 0):
+            status_row.progress_pct = pct
+    else:
+        status_row.progress_pct = pct
+
+    if pct >= 0.99:
+        status_row.status = "read"
+        status_row.progress_pct = 1.0
+        status_row.finished_at = datetime.utcnow()
+    elif status_row.status == "unread" and pct > 0:
+        status_row.status = "reading"
+
+    return status_row

--- a/backend/services/reading_stats.py
+++ b/backend/services/reading_stats.py
@@ -135,10 +135,14 @@ def compute_book_reading_stats(
     ]
 
     # ── Reconcile with imported KOReader page-stats ──────────────────────────
-    # Page-stats win per book (same rule as the dashboard's reconciled_reading),
-    # so a book read only on the device isn't shown empty. Untouched when the
-    # book has no page-stats — ps_seconds is 0 and this whole block is skipped.
+    # Page-stats win per book for *device* reading (same rule as the dashboard's
+    # reconciled_reading), so a book read only on the device isn't shown empty.
+    # Web-reader and manual-log sessions are invisible to KOReader's history and
+    # stay ADDITIVE on top — replacing them made a hand-logged paper session on
+    # a Kindle-synced book vanish without a trace. Untouched when the book has
+    # no page-stats — ps_seconds is 0 and this whole block is skipped.
     from backend.models.ko_stats import PageStat
+    from backend.services.reconciled_reading import NON_DEVICE_SOURCES
 
     ps = (
         db.query(
@@ -157,7 +161,6 @@ def compute_book_reading_stats(
     ps_total_pages = 0
     ps_position = 0.0
     if ps_seconds > 0:
-        total_seconds = ps_seconds
         ps_position = min(float(ps[3] or 0.0), 1.0)   # furthest fraction reached
         # Latest pagination — total_pages from the max(start_time) row (SQLite's
         # bare-column rule applies: exactly one aggregate). max(total_pages)
@@ -194,16 +197,63 @@ def compute_book_reading_stats(
             .order_by("day")
             .all()
         )
+
+        # Additive sessions: web-reader + manual logs merge on top of page-stats.
+        additive = base.filter(ReadingSession.device.in_(NON_DEVICE_SOURCES))
+        add_agg = additive.with_entities(
+            func.coalesce(func.sum(ReadingSession.duration_seconds), 0),
+            func.count(ReadingSession.id),
+            func.coalesce(func.sum(ReadingSession.pages_turned), 0),
+            func.min(ReadingSession.started_at),
+            func.max(func.coalesce(ReadingSession.ended_at, ReadingSession.started_at)),
+        ).one()
+        add_secs, add_count, add_pages = int(add_agg[0] or 0), int(add_agg[1] or 0), int(add_agg[2] or 0)
+
+        total_seconds = ps_seconds + add_secs
+        pages_turned += add_pages
+
+        day_map: dict[str, list[int]] = {r.day: [int(r.seconds), int(r.pages)] for r in day_rows}
+        ps_day_count = len(day_map)
+        if add_count:
+            add_rows = (
+                additive.with_entities(
+                    func.date(ReadingSession.started_at, day_mod).label("date"),
+                    func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
+                    func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages"),
+                )
+                .group_by("date")
+                .all()
+            )
+            for r in add_rows:
+                e = day_map.setdefault(r.date, [0, 0])
+                e[0] += int(r.seconds or 0)
+                e[1] += int(r.pages or 0)
         session_timeline = [
-            {"date": r.day, "seconds": int(r.seconds), "pages": int(r.pages)}
-            for r in day_rows
+            {"date": d, "seconds": v[0], "pages": v[1]}
+            for d, v in sorted(day_map.items())
         ]
-        sessions = len(session_timeline)        # one "session" per reading day
+        # Device reading counts one "session" per reading day; additive sessions
+        # keep their real counts.
+        sessions = ps_day_count + add_count
         avg_session_seconds = round(total_seconds / sessions) if sessions else 0
-        if ps[1]:
-            first_read = datetime.fromtimestamp(int(ps[1]), timezone.utc).isoformat()
-        if ps[2]:
-            last_read = datetime.fromtimestamp(int(ps[2]), timezone.utc).isoformat()
+
+        first_dt = (
+            datetime.fromtimestamp(int(ps[1]), timezone.utc).replace(tzinfo=None)
+            if ps[1] else None
+        )
+        last_dt = (
+            datetime.fromtimestamp(int(ps[2]), timezone.utc).replace(tzinfo=None)
+            if ps[2] else None
+        )
+        if add_agg[3] is not None:
+            first_dt = min(first_dt, add_agg[3]) if first_dt else add_agg[3]
+        if add_agg[4] is not None:
+            last_dt = max(last_dt, add_agg[4]) if last_dt else add_agg[4]
+        if first_dt:
+            first_read = first_dt.isoformat() + "Z"
+        if last_dt:
+            last_read = last_dt.isoformat() + "Z"
+
         total_minutes = total_seconds / 60.0
         if total_minutes > 0 and pages_turned > 0:
             pace_pages_per_min = round(pages_turned / total_minutes, 2)
@@ -211,26 +261,25 @@ def compute_book_reading_stats(
     # ── Journey: cumulative progress per reading day (the progress line) ──────
     # Augments each session_timeline day with the furthest-progress reached, so
     # the frontend can plot a progress arc over the minutes-per-day bars.
+    # Page-stat days carry no position (dwell is *coverage* — you can be 35% in
+    # having dwelled on 11% of pages), but web/manual sessions record
+    # progress_end, so their days contribute points even on a device-synced book.
     day_progress: dict[str, float] = {}
-    if ps_seconds > 0:
-        # Covered (device) book: a per-day position can't be reconstructed from
-        # page dwell — that's *coverage*, not position (you can be 35% in having
-        # dwelled on only 11% of pages). So draw no progress line here; the
-        # headline % (synced position) and the intensity chart tell that story.
-        pass
-    else:
-        # Web sessions: the furthest progress_end reached on each day.
-        prog_rows = (
-            base.with_entities(
-                func.date(ReadingSession.started_at, day_mod).label("date"),
-                func.max(ReadingSession.progress_end).label("p"),
-            )
-            .group_by(func.date(ReadingSession.started_at, day_mod))
-            .all()
+    prog_base = (
+        base.filter(ReadingSession.device.in_(NON_DEVICE_SOURCES))
+        if ps_seconds > 0 else base
+    )
+    prog_rows = (
+        prog_base.with_entities(
+            func.date(ReadingSession.started_at, day_mod).label("date"),
+            func.max(ReadingSession.progress_end).label("p"),
         )
-        for r in prog_rows:
-            if r.p is not None:
-                day_progress[r.date] = min(float(r.p), 1.0)
+        .group_by(func.date(ReadingSession.started_at, day_mod))
+        .all()
+    )
+    for r in prog_rows:
+        if r.p is not None:
+            day_progress[r.date] = min(float(r.p), 1.0)
 
     # Forward-fill so the arc never dips on a day with reading-time-but-no-progress.
     running = 0.0
@@ -241,13 +290,24 @@ def compute_book_reading_stats(
 
     # ── Where the reading time came from (web reader vs device) ───────────────
     if ps_seconds > 0:
-        src_rows = (
+        # Page-stat devices + additive web/manual sessions, so a mixed reader
+        # actually sees the split (device-only rows used to hide the section).
+        src_rows = list(
             db.query(
                 func.coalesce(PageStat.device, "koreader").label("device"),
                 func.coalesce(func.sum(PageStat.duration_seconds), 0).label("seconds"),
                 func.count(func.distinct(epoch_day(PageStat.start_time, tz_offset))).label("units"),
             )
             .filter(PageStat.user_id == user_id, PageStat.book_id == book_id)
+            .group_by("device")
+            .all()
+        ) + list(
+            base.filter(ReadingSession.device.in_(NON_DEVICE_SOURCES))
+            .with_entities(
+                ReadingSession.device.label("device"),
+                func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
+                func.count(ReadingSession.id).label("units"),
+            )
             .group_by("device")
             .all()
         )
@@ -302,9 +362,13 @@ def compute_book_reading_stats(
         }
 
     # ── Finished date (when the book was marked read) ─────────────────────────
+    # Prefer the explicit finished_at; updated_at also moves on rating/review/
+    # CFI writes, so it only serves as a legacy fallback for pre-column rows.
     finished_at: Optional[str] = None
-    if status_row and status_row.status == "read" and status_row.updated_at:
-        finished_at = status_row.updated_at.isoformat() + "Z"
+    if status_row and status_row.status == "read":
+        ts = status_row.finished_at or status_row.updated_at
+        if ts:
+            finished_at = ts.isoformat() + "Z"
 
     # ── Progress = how far through the book ──────────────────────────────────
     # Best available evidence of position: the synced reading position OR the
@@ -448,19 +512,23 @@ def compute_book_aggregate_stats(
     KOReader page-stats win over live sessions for a given reader, so a book read
     only on the device still counts here (was previously shown as 0).
 
+    ``total_sessions`` counts *reading days* for both sources — page-stats have
+    no natural session, and mixing raw session counts with day counts made the
+    labelled sum lie for mixed-reader books.
+
     Returns a dict with keys:
       total_seconds, total_sessions, distinct_readers
     """
     from backend.models.ko_stats import PageStat
 
-    # Per-user live-session totals (seconds, session count).
+    # Per-user live-session totals (seconds, distinct reading days).
     sess_by_user = {
         uid: (int(secs or 0), int(cnt or 0))
         for uid, secs, cnt in (
             db.query(
                 ReadingSession.user_id,
                 func.coalesce(func.sum(ReadingSession.duration_seconds), 0),
-                func.count(ReadingSession.id),
+                func.count(func.distinct(func.date(ReadingSession.started_at))),
             )
             .filter(ReadingSession.book_id == book_id)
             .group_by(ReadingSession.user_id)

--- a/backend/services/reconciled_reading.py
+++ b/backend/services/reconciled_reading.py
@@ -3,9 +3,13 @@
 Both sources can describe the *same* Kindle reading (the plugin POSTs live sessions AND
 KOReader's statistics.sqlite3 records every page), so naively summing them double-counts.
 
-Rule (book-level): if a book has ANY imported `ko_page_stats`, those are authoritative for
-its reading time (idle-capped, full history) and its live `reading_sessions` are ignored;
-books with no page-stats fall back to sessions (web reader, or never read on KOReader).
+Rule (per book, per source): if a book has ANY imported `ko_page_stats`, those are
+authoritative for its *device* reading time (idle-capped, full history) and its live
+device-origin `reading_sessions` are ignored — they describe the same reading twice.
+Web-reader and manual-log sessions (`NON_DEVICE_SOURCES`) are invisible to KOReader's
+history, so they stay ADDITIVE even on covered books; replacing them silently discarded
+e.g. a hand-logged paper session on a Kindle-synced book. Books with no page-stats fall
+back to sessions entirely.
 
 Invariant: when a user has no page-stats at all, `covered_book_ids` is empty and every
 helper returns exactly what the session-only query would — so existing stats behaviour is
@@ -21,11 +25,15 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Integer, func
+from sqlalchemy import Integer, func, or_
 from sqlalchemy.orm import Session
 
 from backend.models.ko_stats import PageStat
 from backend.models.tome_sync import ReadingSession
+
+# ReadingSession.device values that can never be described by imported KOReader
+# page-stats. Everything else (device names, NULL legacy rows) is device-origin.
+NON_DEVICE_SOURCES = ("web", "web-reader", "manual")
 
 
 def _epoch(dt: Optional[datetime]) -> Optional[int]:
@@ -51,7 +59,12 @@ def _rs_filtered(db: Session, user_id: int, covered: list[int],
                  cutoff: Optional[datetime], range_end: Optional[datetime]):
     q = db.query(ReadingSession).filter(ReadingSession.user_id == user_id)
     if covered:
-        q = q.filter(ReadingSession.book_id.notin_(covered))
+        # Covered books drop only their device-origin sessions (page-stats
+        # already describe that reading); web/manual sessions stay additive.
+        q = q.filter(or_(
+            ReadingSession.book_id.notin_(covered),
+            ReadingSession.device.in_(NON_DEVICE_SOURCES),
+        ))
     if cutoff is not None:
         q = q.filter(ReadingSession.started_at >= cutoff)
     if range_end is not None:

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1223,8 +1223,8 @@ interface StatsLayoutProps {
 
 /** Activity bars (minutes per reading day) + an optional progress lane below.
  *  The progress lane is the per-book "journey" — % complete over calendar time —
- *  gated by `showProgress` so it only appears when there's no Reading-intensity
- *  chart (web/manual books); a book never stacks two look-alike area charts. */
+ *  drawn whenever the timeline carries 2+ progress points (the backend only
+ *  emits progress_pct where a position is actually known). */
 function ActivityChart({ timeline }: {
   timeline: { date: string; seconds: number; pages: number; progress_pct?: number | null }[]
 }) {
@@ -1298,7 +1298,7 @@ function ActivityChart({ timeline }: {
 
 // Friendly label for a ReadingSession.device value.
 function sourceLabel(device: string): string {
-  if (!device || device === 'web-reader') return 'Web reader'
+  if (!device || device === 'web-reader' || device === 'web') return 'Web reader'
   if (device === 'manual') return 'Manual'
   if (device === 'koreader') return 'KOReader'
   return device
@@ -1396,6 +1396,7 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
   onChange: () => void
   exportRows?: { date: string; seconds: number; pages: number; progress_pct: number | null }[]
 }) {
+  const { toast } = useToast()
   const [logging, setLogging] = useState(false)
   const [minutes, setMinutes] = useState('')
   const [pct, setPct] = useState('')
@@ -1415,6 +1416,8 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
       await api.post(`/books/${bookId}/sessions?tz_offset=${new Date().getTimezoneOffset()}`, body)
       setMinutes(''); setPct(''); setLogging(false)
       onChange()
+    } catch (e) {
+      toast.error((e as Error).message ?? 'Failed to log session')
     } finally {
       setSaving(false)
     }
@@ -1501,8 +1504,19 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
 // touch (native title tooltips don't). Reserved for the non-obvious charts.
 function InfoHint({ text }: { text: string }) {
   const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLSpanElement>(null)
+  // iOS Safari doesn't focus buttons on tap, so onBlur alone never closes the
+  // popover there — close on any tap outside instead.
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
   return (
-    <span className="relative inline-flex leading-none">
+    <span ref={rootRef} className="relative inline-flex leading-none">
       <button
         type="button"
         aria-label="What is this chart?"
@@ -1527,7 +1541,6 @@ function InfoHint({ text }: { text: string }) {
 }
 
 function MomentumChip({ momentum }: { momentum: NonNullable<BookReadingStats['momentum']> }) {
-  if (momentum.recent_seconds === 0 && momentum.prior_seconds === 0) return null
   const Icon = momentum.direction === 'up' ? TrendingUp : momentum.direction === 'down' ? TrendingDown : Minus
   const tone =
     momentum.direction === 'up' ? 'text-emerald-600 dark:text-emerald-400'
@@ -1599,11 +1612,13 @@ function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps)
           <ActivityChart timeline={own.session_timeline} />
         </div>
       )}
-      {/* Current progress — only when there's no journey line (device books).
-          Web books already show their % in the journey line's header, so this
-          avoids two "Progress" rows saying the same thing. */}
+      {/* Current progress — only when the journey line doesn't actually render
+          (it needs 2+ progress points; a single point used to suppress BOTH,
+          leaving real progress displayed nowhere). Web books with a drawn line
+          show their % in its header, so this avoids two "Progress" rows. */}
       {own.progress != null && own.progress > 0 &&
-        !own.session_timeline.some(d => d.progress_pct != null) && (
+        !(own.session_timeline.length > 1 &&
+          own.session_timeline.filter(d => d.progress_pct != null).length > 1) && (
         <div className="mt-4">
           <div className="flex items-center justify-between mb-1.5">
             <span className="text-xs text-muted-foreground/70">Progress</span>
@@ -1628,7 +1643,7 @@ function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps)
       )}
       {aggregate && (
         <p className="text-xs text-muted-foreground/60 mt-3">
-          All readers: {formatDuration(aggregate.total_seconds)} · {aggregate.total_sessions} sessions · {aggregate.distinct_readers} reader{aggregate.distinct_readers !== 1 ? 's' : ''}
+          All readers: {formatDuration(aggregate.total_seconds)} · {aggregate.total_sessions} reading day{aggregate.total_sessions !== 1 ? 's' : ''} · {aggregate.distinct_readers} reader{aggregate.distinct_readers !== 1 ? 's' : ''}
         </p>
       )}
       {/* Log a session by hand · export the log */}

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1258,10 +1258,10 @@ function ActivityChart({ timeline }: {
     .filter(Boolean) as string[])
   const lastProgress = [...days].reverse().find(d => d.progress_pct != null)?.progress_pct ?? null
   return (
-    // Short spans don't stretch edge-to-edge: cap the axis width so a 3-day
-    // book gets three day-sized bars, not three slabs. Labels + progress lane
-    // share the same width so the axis stays aligned.
-    <div className="flex flex-col" style={{ maxWidth: Math.max(n * 44, 320) }}>
+    // Always full card width — a narrower "day-sized bars" cap was tried and
+    // looked half-finished against the full-width card chrome. Big bars for a
+    // short history are fine; the gap-filled axis keeps the spacing honest.
+    <div className="flex flex-col">
       <p className="text-xs text-muted-foreground/70 mb-1.5 shrink-0">Activity</p>
       {/* Fixed-height strip: flex-1 fill only works inside a sized flex parent,
           and the hero wraps this in a plain div — flex-1 collapsed to 0px there

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1229,22 +1229,39 @@ function ActivityChart({ timeline }: {
   timeline: { date: string; seconds: number; pages: number; progress_pct?: number | null }[]
 }) {
   if (timeline.length < 2) return null
-  const max = Math.max(...timeline.map(d => d.seconds), 1)
-  const n = timeline.length
-  const first = timeline[0]
-  const last = timeline[timeline.length - 1]
+  // Real time axis: fill the calendar days between the first and last reading
+  // day with zero bars. Active-days-only bars, evenly spaced, misrepresent the
+  // span (two adjacent bars could be one day or a month apart) — and with 2–3
+  // reading days they rendered as giant full-width slabs. Capped at the last
+  // 365 days so a years-long log can't produce more bars than pixels.
+  const byDate = new Map(timeline.map(d => [d.date, d]))
+  const startD = new Date(timeline[0].date + 'T00:00:00')
+  const endD = new Date(timeline[timeline.length - 1].date + 'T00:00:00')
+  let days: typeof timeline = []
+  for (const d = new Date(startD); d <= endD; d.setDate(d.getDate() + 1)) {
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+    days.push(byDate.get(key) ?? { date: key, seconds: 0, pages: 0 })
+  }
+  if (days.length > 365) days = days.slice(-365)
+  const max = Math.max(...days.map(d => d.seconds), 1)
+  const n = days.length
+  const first = days[0]
+  const last = days[days.length - 1]
   const fmtDay = (iso: string) =>
     new Date(iso + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
   // Progress journey: % complete on each reading day, drawn as a slim lane below.
-  const hasJourney = timeline.some(d => d.progress_pct != null)
-  const lanePts = (timeline
+  const hasJourney = days.some(d => d.progress_pct != null)
+  const lanePts = (days
     .map((d, i) => (d.progress_pct != null
       ? `${((i / (n - 1)) * 100).toFixed(2)},${(100 - d.progress_pct).toFixed(2)}`
       : null))
     .filter(Boolean) as string[])
-  const lastProgress = [...timeline].reverse().find(d => d.progress_pct != null)?.progress_pct ?? null
+  const lastProgress = [...days].reverse().find(d => d.progress_pct != null)?.progress_pct ?? null
   return (
-    <div className="flex flex-col">
+    // Short spans don't stretch edge-to-edge: cap the axis width so a 3-day
+    // book gets three day-sized bars, not three slabs. Labels + progress lane
+    // share the same width so the axis stays aligned.
+    <div className="flex flex-col" style={{ maxWidth: Math.max(n * 44, 320) }}>
       <p className="text-xs text-muted-foreground/70 mb-1.5 shrink-0">Activity</p>
       {/* Fixed-height strip: flex-1 fill only works inside a sized flex parent,
           and the hero wraps this in a plain div — flex-1 collapsed to 0px there
@@ -1252,8 +1269,8 @@ function ActivityChart({ timeline }: {
       <div className="relative h-20">
         {/* faint baseline rule */}
         <div className="absolute bottom-0 left-0 right-0 h-px bg-border/40" />
-        <div className="absolute inset-0 flex items-end gap-1.5">
-          {timeline.map(d => {
+        <div className={cn('absolute inset-0 flex items-end', n > 60 ? 'gap-px' : 'gap-1.5')}>
+          {days.map(d => {
             const pct = d.seconds > 0 ? Math.max(d.seconds / max, 0.06) : 0
             const mins = Math.round(d.seconds / 60)
             const tip = `${fmtDay(d.date)}: ${mins}m${d.pages > 0 ? `, ${d.pages} pages` : ''}${d.progress_pct != null ? ` · ${d.progress_pct}% in` : ''}`
@@ -1262,7 +1279,7 @@ function ActivityChart({ timeline }: {
                 key={d.date}
                 className="flex-1 min-w-px bg-primary/60 hover:bg-primary transition-colors rounded-t-sm"
                 style={{ height: pct > 0 ? `${Math.round(pct * 100)}%` : '0%' }}
-                title={tip}
+                title={d.seconds > 0 ? tip : undefined}
               />
             )
           })}
@@ -1314,7 +1331,8 @@ function SourceSplit({ sources }: { sources: { device: string; seconds: number; 
   return (
     <div className="mt-4">
       <p className="text-xs text-muted-foreground/70 mb-1.5">Where you read</p>
-      <div className="flex h-2 rounded-full overflow-hidden bg-muted">
+      {/* gap-px: adjacent primary shades are close — a hairline seam marks the split */}
+      <div className="flex gap-px h-2 rounded-full overflow-hidden bg-muted">
         {sources.map((s, i) => (
           <div
             key={s.device}
@@ -1598,7 +1616,8 @@ function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps)
           <p className="text-sm text-muted-foreground">read</p>
         </div>
         {own.momentum && <MomentumChip momentum={own.momentum} />}
-        <div className="flex items-baseline gap-x-5 gap-y-1 flex-wrap">
+        {/* 2×2 on phones — free wrapping left "pace" orphaned on its own line */}
+        <div className="grid grid-cols-2 gap-x-5 gap-y-1 sm:flex sm:items-baseline sm:flex-wrap">
           {supporting.map(s => (
             <div key={s.label} className="flex items-baseline gap-1.5">
               <span className="text-sm font-medium tabular-nums text-foreground">{s.value}</span>
@@ -1641,7 +1660,9 @@ function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps)
           ))}
         </div>
       )}
-      {aggregate && (
+      {/* Skip when the only reader is you — the line would just repeat the hero.
+          Still shown when someone ELSE read a book you haven't touched. */}
+      {aggregate && (aggregate.distinct_readers > 1 || own.total_seconds === 0) && (
         <p className="text-xs text-muted-foreground/60 mt-3">
           All readers: {formatDuration(aggregate.total_seconds)} · {aggregate.total_sessions} reading day{aggregate.total_sessions !== 1 ? 's' : ''} · {aggregate.distinct_readers} reader{aggregate.distinct_readers !== 1 ? 's' : ''}
         </p>

--- a/tests/test_reading_log_sources.py
+++ b/tests/test_reading_log_sources.py
@@ -1,0 +1,127 @@
+"""Per-source reading reconciliation + the explicit finish date.
+
+Page-stats replace only *device-origin* sessions (they describe the same
+reading twice); web-reader and manual-log sessions are invisible to KOReader's
+history and must stay additive. Regression: logging 30 minutes of paper
+reading on a Kindle-synced book returned 201 and changed nothing visible.
+
+finished_at: updated_at moves on every rating/review/CFI write, so it is not a
+finish date. The explicit column is stamped on the transition into "read".
+"""
+from datetime import datetime, timezone
+
+from backend.models.ko_stats import PageStat
+from backend.models.tome_sync import ReadingSession
+from backend.models.user_book_status import UserBookStatus
+from backend.services.book_progress import apply_progress_to_status
+
+DAY = 86_400
+BASE = 1_700_000_000
+
+
+def _pages(db, user, book, n=5, total=100, base=BASE, dur=600):
+    for p in range(1, n + 1):
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=p, total_pages=total,
+                        start_time=base + p, duration_seconds=dur, device="Kindle"))
+
+
+def test_manual_session_visible_on_device_synced_book(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Kindle + Paper")
+    _pages(db, user, book, n=5, dur=600)          # 3000s of device reading
+    db.flush()
+
+    before = client.get(f"/api/books/{book.id}/reading-stats?tz_offset=0").json()["own"]
+    assert before["total_seconds"] == 3000
+
+    r = client.post(f"/api/books/{book.id}/sessions?tz_offset=0",
+                    json={"duration_minutes": 30})
+    assert r.status_code == 201, r.text
+    own = r.json()["own"]
+
+    assert own["total_seconds"] == 3000 + 1800     # the paper session is not swallowed
+    assert own["sessions"] == before["sessions"] + 1
+    # "Where you read" now shows the split (device + manual = 2 sources).
+    devices = {s["device"] for s in own["by_source"]}
+    assert "Kindle" in devices and "manual" in devices
+
+
+def test_web_sessions_additive_in_dashboard_totals(client, db, admin_user, make_book):
+    """A covered book's web session counts in /stats; its device session doesn't
+    (page-stats already describe that reading)."""
+    user, _ = admin_user
+    book = make_book(title="Covered Mixed")
+    _pages(db, user, book, n=5, dur=600)          # 3000s page-stats
+    when = datetime.utcfromtimestamp(BASE + 5 * DAY)
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when, ended_at=when,
+                          duration_seconds=900, device="web"))          # additive
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when, ended_at=when,
+                          duration_seconds=1200, device="Kindle"))      # double-counts → dropped
+    db.flush()
+
+    headline = client.get("/api/stats?days=0&tz_offset=0").json()["headline"]
+    assert headline["total_reading_seconds"] == 3000 + 900
+
+
+def test_finished_at_survives_rating_and_cfi_updates(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Finished In January")
+
+    client.put(f"/api/books/{book.id}/status", json={"status": "read"})
+    row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
+    finished = row.finished_at
+    assert finished is not None
+
+    # Rating later must not move the finish date (updated_at will move; that's fine).
+    client.put(f"/api/books/{book.id}/rating", json={"rating": 5})
+    db.expire_all()
+    row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
+    assert row.finished_at == finished
+
+    own = client.get(f"/api/books/{book.id}/reading-stats?tz_offset=0").json()["own"]
+    assert own["finished_at"].startswith(finished.isoformat()[:19])
+
+    # Un-finishing clears the date.
+    client.put(f"/api/books/{book.id}/status", json={"status": "reading"})
+    db.expire_all()
+    row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
+    assert row.finished_at is None
+
+
+def test_progress_helper_finishes_straight_from_unread(db, admin_user, make_book):
+    """The old tome_sync if/elif quirk: an unread book synced straight to 100%
+    stayed 'reading' until the next sync. The shared rule finishes it at once."""
+    user, _ = admin_user
+    book = make_book(title="One Sitting")
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="unread"))
+    db.flush()
+
+    row = apply_progress_to_status(db, user_id=user.id, book_id=book.id, pct=1.0)
+    assert row.status == "read"
+    assert row.progress_pct == 1.0
+    assert row.finished_at is not None
+
+
+def test_manual_session_started_at_converts_timezone(client, db, admin_user, make_book):
+    """'23:30+02:00' is 21:30 UTC — stripping the offset stored it as 23:30."""
+    user, _ = admin_user
+    book = make_book(title="TZ Aware")
+    r = client.post(f"/api/books/{book.id}/sessions?tz_offset=0", json={
+        "duration_minutes": 10,
+        "started_at": "2026-06-01T23:30:00+02:00",
+    })
+    assert r.status_code == 201, r.text
+    s = db.query(ReadingSession).filter_by(user_id=user.id, book_id=book.id).one()
+    assert s.started_at == datetime(2026, 6, 1, 21, 30)
+
+
+def test_manual_session_input_validation(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Bad Inputs")
+    # A huge duration used to overflow timedelta into an unhandled 500.
+    r = client.post(f"/api/books/{book.id}/sessions?tz_offset=0",
+                    json={"duration_minutes": 1e10})
+    assert r.status_code == 422
+    r = client.post(f"/api/books/{book.id}/sessions?tz_offset=0",
+                    json={"duration_minutes": 10, "pages": -5})
+    assert r.status_code == 422


### PR DESCRIPTION
> **Stacked on #93** (`fix/pagestat-math`), which stacks on #92. Merge order: #92 → #93 → this. Retargets automatically as base branches are deleted.

## Problems

1. **Manual/web sessions vanished on device-synced books.** The "page-stats win" rule replaced a covered book's entire reading record. The reading-log PR (#83) put "Log session" on exactly those books: the POST succeeded, the UI refreshed, nothing changed. Web-reader time was equally invisible, which is why "Where you read" could never show a split for mixed readers.
2. **"Finished" was the last touch of the status row, not the finish date.** `updated_at` moves on every rating/review/CFI write (a device sync writes CFI unconditionally), so finishing in January and rating in March showed "Finished: Mar".
3. **Sticky-completion logic existed in 3 diverging copies** — the tome_sync copies had an `if/elif` quirk where a book synced straight from unread to 100% stayed "reading" until the *next* sync.

## Fixes

- **Per-source reconciliation:** imported history replaces only device-origin live sessions; `web`/`web-reader`/`manual` sessions (`NON_DEVICE_SOURCES` in `reconciled_reading.py`) stay additive — per-book log, dashboard totals, and streak days all agree. The per-book view merges timelines, sources (D5: the split now renders), first/last read, and the progress line can draw through web-reading days on covered books.
- **`finished_at` column** on `UserBookStatus`: stamped on the transition into "read", backfilled from `updated_at` at startup for existing read rows, cleared on un-finish, survives ratings/CFI syncs.
- **Shared `apply_progress_to_status()`** (`backend/services/book_progress.py`) replaces all three copies, with `monotonic=False` for position sync (device is truth, downward included) and `monotonic=True` for session flush / manual log. Fixes the unread→100% quirk.
- **Manual-log hardening:** 422 on duration > 24 h (previously a `timedelta` overflow → 500) and negative pages; timezone-annotated `started_at` converted to UTC instead of offset-stripped (D4); failed logs show an error toast instead of silently resetting (D3).
- **Smaller ones:** admin "All readers" line uses uniform units (reading days, D10), the current-progress bar shows when the journey line can't render (D7), InfoHint closes on outside tap on iOS (D8), dead MomentumChip guard removed.

## Testing

- New `tests/test_reading_log_sources.py` (6 tests): manual session visible on a device-synced book (fails on previous code), web additive / device dropped in dashboard totals, finished_at surviving rating + clearing on un-finish, unread→100% finishing immediately, tz conversion, input validation.
- Full backend suite: **681 passed**. `npm run build` clean.