### PR TITLE
fix(nav): one shared header — restore Upload icon, wish toast, and "/" on standalone pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **The top bar on Stats, Highlights, Wishlist and the Bindery is now the real
+  one.** It was a near-copy of the dashboard's header that had already drifted:
+  on phones its Upload button was an empty pill (the icon had been lost in the
+  copy), uploading from those pages silently dropped the "this upload satisfies
+  N wishes" notice — and on the Bindery didn't refresh the inbox — and the
+  search box neither advertised nor honoured the **/** focus shortcut the
+  dashboard has. There is now a single shared header component used everywhere,
+  so the two can't drift apart again; the wish notice, Bindery refresh and
+  **/** shortcut all work from every page.
 - **Standalone books download to the correct book-type folder in KOReader.** A book
   with no series — say a RoyalRoad title — could be filed under the wrong type's
   folder (e.g. `light_novel`) when downloaded through the plugin, while books in a

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -1,0 +1,93 @@
+import { type ReactNode, type RefObject } from 'react'
+import { Menu, Search, Upload, X } from 'lucide-react'
+import { useAuth, isMember } from '@/contexts/AuthContext'
+import { TomeMark } from '@/components/TomeMark'
+import { SyncStatusBadge } from '@/components/SyncStatusBadge'
+import { NotificationBell } from '@/components/NotificationBell'
+
+/**
+ * The one top navbar — menu button, wordmark, a search slot, and the right-side
+ * cluster (page actions, sync badge, bell, Upload). Rendered by AppShell for
+ * the standalone pages and by DashboardPage directly, so the two can't drift
+ * apart again (the AppShell copy once shipped an Upload button whose icon was
+ * missing — a blank pill on phones).
+ */
+export function AppHeader({ onMenuClick, search, actions, onUploadClick }: {
+  onMenuClick: () => void
+  search: ReactNode
+  actions?: ReactNode
+  onUploadClick?: () => void
+}) {
+  const { user } = useAuth()
+  return (
+    <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-20 shrink-0 safe-top">
+      <div className="px-4 h-14 flex items-center gap-3">
+        <button
+          className="md:hidden flex items-center justify-center w-8 h-8 text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-muted shrink-0"
+          onClick={onMenuClick}
+          aria-label="Open navigation"
+        >
+          <Menu className="w-5 h-5" />
+        </button>
+        <div className="flex items-center gap-2 mr-2 shrink-0 group cursor-default">
+          <TomeMark className="w-5 h-5 text-primary logo-bob" strokeWidth={7} />
+          <span className="font-semibold text-sm">Tome</span>
+        </div>
+        {search}
+        <div className="flex items-center gap-1.5 ml-auto">
+          {actions}
+          <SyncStatusBadge />
+          <NotificationBell />
+          {onUploadClick && isMember(user) && (
+            <button
+              onClick={onUploadClick}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card hover:bg-muted transition-all touch-feedback"
+            >
+              <Upload className="w-3.5 h-3.5" />
+              <span className="hidden sm:inline">Upload</span>
+            </button>
+          )}
+        </div>
+      </div>
+    </header>
+  )
+}
+
+/** The header's search box. With `onSubmit` it's a form (Enter submits — the
+ *  standalone pages jump to the dashboard results); without, a live filter. */
+export function HeaderSearch({ value, onChange, onClear, onSubmit, inputRef, placeholder = 'Search books… (/)' }: {
+  value: string
+  onChange: (v: string) => void
+  onClear: () => void
+  onSubmit?: (e: React.FormEvent) => void
+  inputRef?: RefObject<HTMLInputElement | null>
+  placeholder?: string
+}) {
+  const inner = (
+    <>
+      <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
+      <input
+        ref={inputRef}
+        className="w-full h-8 pl-9 pr-8 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        placeholder={placeholder}
+        value={value}
+        onChange={e => onChange(e.target.value)}
+      />
+      {value && (
+        <button
+          type="button"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+          aria-label="Clear search"
+          onClick={onClear}
+        >
+          <X className="w-3.5 h-3.5" />
+        </button>
+      )}
+    </>
+  )
+  return onSubmit ? (
+    <form onSubmit={onSubmit} className="relative flex-1 sm:max-w-md">{inner}</form>
+  ) : (
+    <div className="relative flex-1 sm:max-w-md">{inner}</div>
+  )
+}

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -68,7 +68,10 @@ export function HeaderSearch({ value, onChange, onClear, onSubmit, inputRef, pla
       <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
       <input
         ref={inputRef}
-        className="w-full h-8 pl-9 pr-8 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        aria-label="Search books"
+        // On phones the box can shrink to a sliver (page actions squeeze it) and
+        // the placeholder clips mid-letter — hide it there; the icon says enough.
+        className="w-full h-8 pl-9 pr-8 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground max-sm:placeholder:text-transparent focus:outline-none focus:ring-1 focus:ring-ring"
         placeholder={placeholder}
         value={value}
         onChange={e => onChange(e.target.value)}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -1,13 +1,11 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Menu, Search, X } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
+import { useToast } from '@/contexts/ToastContext'
 import { api } from '@/lib/api'
 import type { Library, SavedFilter } from '@/lib/books'
 import { Sidebar } from '@/components/Sidebar'
-import { TomeMark } from '@/components/TomeMark'
-import { SyncStatusBadge } from '@/components/SyncStatusBadge'
-import { NotificationBell } from '@/components/NotificationBell'
+import { AppHeader, HeaderSearch } from '@/components/AppHeader'
 import { UploadModal } from '@/components/UploadModal'
 
 /**
@@ -15,7 +13,9 @@ import { UploadModal } from '@/components/UploadModal'
  * Sidebar (docked on desktop, drawer on mobile) that the dashboard uses, so the
  * standalone pages (Stats, Highlights, Wishlist, Bindery) get the *real* nav
  * instead of a stripped-down clone. The page renders its own content as children;
- * `actions` slots page-specific controls into the navbar's right side.
+ * `actions` slots page-specific controls into the navbar's right side, and
+ * `onUploaded` lets a page refresh itself after an Upload from this navbar
+ * (e.g. the Bindery reloading its inbox).
  *
  * Home / All Books / Series in the sidebar navigate back to the dashboard; the
  * active section item (Stats/Highlights/…) highlights itself by route.
@@ -23,17 +23,21 @@ import { UploadModal } from '@/components/UploadModal'
 export function AppShell({
   children,
   actions,
+  onUploaded,
 }: {
   children: ReactNode
   actions?: ReactNode
+  onUploaded?: () => void
 }) {
   const navigate = useNavigate()
   const { user } = useAuth()
+  const { toast } = useToast()
   const [libraries, setLibraries] = useState<Library[]>([])
   const [savedFilters, setSavedFilters] = useState<SavedFilter[]>([])
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [uploadOpen, setUploadOpen] = useState(false)
   const [searchInput, setSearchInput] = useState('')
+  const searchInputRef = useRef<HTMLInputElement>(null)
 
   // Global library search from any page: Enter jumps to the dashboard's book
   // results (it never live-yanks you off the current page mid-type).
@@ -43,65 +47,49 @@ export function AppShell({
     navigate(q ? `/?tab=books&q=${encodeURIComponent(q)}` : '/?tab=books')
   }
 
+  // "/" focuses the search — same shortcut the dashboard's box advertises.
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const tag = (e.target as HTMLElement).tagName
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return
+      if (e.key === '/' && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        e.preventDefault()
+        searchInputRef.current?.focus()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
   const loadLibraries = () => { api.get<Library[]>('/libraries').then(setLibraries).catch(() => {}) }
   const loadSavedFilters = () => { api.get<SavedFilter[]>('/saved-filters').then(setSavedFilters).catch(() => {}) }
   useEffect(() => { loadLibraries(); loadSavedFilters() }, [])
 
   return (
     <div className="h-screen bg-background flex flex-col overflow-hidden">
-      <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-20 shrink-0 safe-top">
-        <div className="px-4 h-14 flex items-center gap-3">
-          <button
-            className="md:hidden flex items-center justify-center w-8 h-8 text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-muted shrink-0"
-            onClick={() => setMobileSidebarOpen(true)}
-            aria-label="Open navigation"
-          >
-            <Menu className="w-5 h-5" />
-          </button>
-          <div className="flex items-center gap-2 mr-2 shrink-0 group cursor-default">
-            <TomeMark className="w-5 h-5 text-primary logo-bob" strokeWidth={7} />
-            <span className="font-semibold text-sm">Tome</span>
-          </div>
-          <form onSubmit={submitSearch} className="relative flex-1 sm:max-w-md">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
-            <input
-              className="w-full h-8 pl-9 pr-8 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-              placeholder="Search books…"
-              value={searchInput}
-              onChange={e => setSearchInput(e.target.value)}
-            />
-            {searchInput && (
-              <button
-                type="button"
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                aria-label="Clear search"
-                onClick={() => setSearchInput('')}
-              >
-                <X className="w-3.5 h-3.5" />
-              </button>
-            )}
-          </form>
-          <div className="flex items-center gap-1.5 ml-auto">
-            {actions}
-            <SyncStatusBadge />
-            <NotificationBell />
-            {isMember(user) && (
-              <button
-                onClick={() => setUploadOpen(true)}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card hover:bg-muted transition-all touch-feedback"
-              >
-                <span className="hidden sm:inline">Upload</span>
-              </button>
-            )}
-          </div>
-        </div>
-      </header>
+      <AppHeader
+        onMenuClick={() => setMobileSidebarOpen(true)}
+        search={
+          <HeaderSearch
+            value={searchInput}
+            onChange={setSearchInput}
+            onClear={() => setSearchInput('')}
+            onSubmit={submitSearch}
+            inputRef={searchInputRef}
+          />
+        }
+        actions={actions}
+        onUploadClick={isMember(user) ? () => setUploadOpen(true) : undefined}
+      />
 
       <UploadModal
         isOpen={uploadOpen}
         onClose={() => setUploadOpen(false)}
-        onDone={() => {}}
-        onWishMatches={() => {}}
+        onDone={() => onUploaded?.()}
+        onWishMatches={(wishIds) => {
+          const n = wishIds.length
+          toast.info(`This upload satisfies ${n} wish${n !== 1 ? 'es' : ''} — review in Admin > Wishlist`)
+        }}
       />
 
       <div className="flex flex-1 overflow-hidden">

--- a/frontend/src/pages/BinderyPage.tsx
+++ b/frontend/src/pages/BinderyPage.tsx
@@ -1107,6 +1107,7 @@ export function BinderyPage() {
 
     return (
       <AppShell
+        onUploaded={fetchAll}
         actions={
           <button
             onClick={fetchAll}
@@ -1499,7 +1500,7 @@ export function BinderyPage() {
   const currentForm = currentItem ? formData[currentItem.path] : null
 
   return (
-    <AppShell>
+    <AppShell onUploaded={fetchAll}>
     <div className={cn('flex flex-col h-full transition-opacity duration-150', viewTransition ? 'opacity-0' : 'opacity-100')}>
       {/* Header */}
       <div className="sticky top-0 z-10 bg-background border-b border-border px-6 pt-5 pb-3">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, type ReactNode } from 'react'
 import { useSearchParams, useNavigate } from 'react-router-dom'
 import {
-  BookOpen, Upload, Search, X, Home, ChevronRight,
+  BookOpen, X, Home, ChevronRight,
   LayoutGrid, List,
   ChevronUp, ChevronDown, SlidersHorizontal, Loader2,
-  Library as LibraryIcon, CheckSquare, XSquare, Download, Pencil, Menu,
+  Library as LibraryIcon, CheckSquare, XSquare, Download, Pencil,
   Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star, Quote, Moon,
 } from 'lucide-react'
-import { TomeMark } from '@/components/TomeMark'
+import { AppHeader, HeaderSearch } from '@/components/AppHeader'
 import { useAuth, isMember, isAdmin } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
 import { BookCard, type ViewMode } from '@/components/BookCard'
@@ -21,8 +21,6 @@ import { UploadModal } from '@/components/UploadModal'
 import { ManageSeriesModal } from '@/components/ManageSeriesModal'
 import { SendButton } from '@/components/SendButton'
 import { BookAnimation } from '@/components/BookAnimation'
-import { SyncStatusBadge } from '@/components/SyncStatusBadge'
-import { NotificationBell } from '@/components/NotificationBell'
 import { HomeGoalRings } from '@/components/stats/GoalWidget'
 import { ReadingDNACard } from '@/components/stats/ReadingDNACard'
 import type { ReadingDNA } from '@/components/stats/shared'
@@ -1014,50 +1012,19 @@ export function DashboardPage() {
 
   return (
     <div className="h-screen bg-background flex flex-col overflow-hidden">
-      {/* ── Navbar ──────────────────────────────────────────────────────── */}
-      <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-20 shrink-0 safe-top">
-        <div className="px-4 h-14 flex items-center gap-3">
-          <button
-            className="md:hidden flex items-center justify-center w-8 h-8 text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-muted shrink-0"
-            onClick={() => setMobileSidebarOpen(true)}
-            aria-label="Open navigation"
-          >
-            <Menu className="w-5 h-5" />
-          </button>
-          <div className="flex items-center gap-2 mr-2 shrink-0 group cursor-default">
-            <TomeMark className="w-5 h-5 text-primary logo-bob" strokeWidth={7} />
-            <span className="font-semibold text-sm">Tome</span>
-          </div>
-          <div className="relative flex-1 sm:max-w-md">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
-            <input
-              ref={searchInputRef}
-              className="w-full h-8 pl-9 pr-8 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-              placeholder="Search books… (/)"
-              value={searchInput}
-              onChange={e => handleSearchInput(e.target.value)}
-            />
-            {searchInput && (
-              <button className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-                aria-label="Clear search"
-                onClick={() => { setSearchInput(''); setFilter('q', '') }}>
-                <X className="w-3.5 h-3.5" />
-              </button>
-            )}
-          </div>
-          <div className="flex items-center gap-1.5 ml-auto">
-            <SyncStatusBadge />
-            <NotificationBell />
-            {isMember(user) && (
-              <button onClick={() => setUploadModalOpen(true)}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card hover:bg-muted transition-all touch-feedback">
-                <Upload className="w-3.5 h-3.5" />
-                <span className="hidden sm:inline">Upload</span>
-              </button>
-            )}
-          </div>
-        </div>
-      </header>
+      {/* ── Navbar (shared with the standalone pages via AppShell) ───────── */}
+      <AppHeader
+        onMenuClick={() => setMobileSidebarOpen(true)}
+        search={
+          <HeaderSearch
+            value={searchInput}
+            onChange={handleSearchInput}
+            onClear={() => { setSearchInput(''); setFilter('q', '') }}
+            inputRef={searchInputRef}
+          />
+        }
+        onUploadClick={isMember(user) ? () => setUploadModalOpen(true) : undefined}
+      />
 
       <UploadModal
         isOpen={uploadModalOpen}


### PR DESCRIPTION
## Problem

AppShell's header (PR #78) was a ~50-line near-copy of DashboardPage's header, and it had already drifted in three user-visible ways:

- **Blank Upload button on phones** — the `<Upload />` icon was lost in the copy, and the label is hidden below `sm`, leaving an empty unlabeled pill.
- **Uploads from standalone pages lost feedback** — `onDone`/`onWishMatches` were no-ops, so the "this upload satisfies N wishes" notice never showed from Stats/Highlights/Wishlist/Bindery, and an upload from the Bindery's own header didn't refresh its inbox.
- **No `/` search shortcut** — the identical-looking search box neither advertised nor honoured the `/` focus shortcut the dashboard has.

## Fix

Extract the header into shared `AppHeader` + `HeaderSearch` components (`frontend/src/components/AppHeader.tsx`) used by **both** AppShell and DashboardPage — the clone is gone, so the two can't drift apart again. AppShell gains the wish-match toast, an `onUploaded` callback (BinderyPage passes its `fetchAll`), and the `/` shortcut with the `(/)` placeholder hint.

## Testing

- `npm run build` (tsc -b) clean.
- Verified against the live dev app (Playwright screenshots): dashboard and Highlights headers render identically on desktop (1440px) and mobile (390px), Upload icon present on both, search hint shown.