### PR TITLE
fix(home): Focus mode polish + Reading DNA tile on Stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ All notable changes to Tome are documented here. Format loosely follows
   **Currently reading** strip to switch the spotlight to any other in-progress book.
   Clicking the cover or series name jumps to the series. Toggle between **Focus** and
   the full **Dashboard** from the Home header; your choice is remembered.
-- **Your Reading DNA.** The Home dashboard and Stats page now show a reading-personality
-  card — an archetype (e.g. "Night-Owl Epic Specialist") distilled from a few traits
-  like when you read, how long your sessions run, and how widely you range across the
-  library — computed over a recent trailing window.
+- **Your Reading DNA.** The Home dashboard shows a reading-personality card — an
+  archetype (e.g. "Night-Owl Epic Specialist") distilled from a few traits like
+  when you read, how long your sessions run, and how widely you range across the
+  library. On Reading Stats it's also available as a **Reading DNA** tile — add it
+  from **Add tile** under Habits; the Home card's "Full breakdown" link points there.
 - **A richer reading log on every book.** A book's Reading Stats now show more of
   its story: a **progress line** traced over the activity bars so you can see how
   far you got on each reading day, a **momentum** indicator comparing the last week
@@ -29,6 +30,22 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Focus mode rough edges, rounded off.** A book without a cover showed the
+  browser's broken-image glyph in the hero, the fan and the Currently-reading
+  strip — it now gets the same tidy placeholder as everywhere else. Rapidly
+  switching between strip books could leave the hero stuck on the wrong book (a
+  slower earlier response landing last); switches are now cancelled cleanly. With
+  more than 12 books in progress the extras were silently unreachable — the strip
+  now ends in a **"+N more"** chip into the filtered library. Sync times read
+  naturally ("1 hour ago", and past a month the actual date instead of "412 days
+  ago"), the empty state gained a **Browse library** button, Series Progress rows
+  no longer reload the whole app, and a brand-new user no longer sees an empty
+  bordered box beside the dashboard. The Reading DNA figures are also no longer
+  computed for views that never show them (and on phones, only fetched when the
+  Home dashboard actually renders).
+- **Sharper axis labels and richer tooltips on stats charts** *(shipped in v1.7.x
+  polish, previously missing from this log)*: KPI tile labels no longer truncate
+  mid-word, and the daily chart's tooltips include pages alongside minutes.
 - **The top bar on Stats, Highlights, Wishlist and the Bindery is now the real
   one.** It was a near-copy of the dashboard's header that had already drifted:
   on phones its Upload button was an empty pill (the icon had been lost in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,11 @@ All notable changes to Tome are documented here. Format loosely follows
   no longer reload the whole app, and a brand-new user no longer sees an empty
   bordered box beside the dashboard. The Reading DNA figures are also no longer
   computed for views that never show them (and on phones, only fetched when the
-  Home dashboard actually renders).
+  Home dashboard actually renders). Two touch-ups from a polish pass: the small
+  kicker line no longer repeats the series name that the big title right below
+  it already shows, and on phones the hero stacks from the top instead of
+  floating mid-screen with dead space above the covers. The Reading DNA trait
+  markers also stay inside their bars at the extremes instead of half-clipping.
 - **Sharper axis labels and richer tooltips on stats charts** *(shipped in v1.7.x
   polish, previously missing from this log)*: KPI tile labels no longer truncate
   mid-word, and the daily chart's tooltips include pages alongside minutes.

--- a/backend/api/home.py
+++ b/backend/api/home.py
@@ -18,7 +18,13 @@ router = APIRouter(prefix="/home", tags=["home"])
 
 
 def _norm_pct(raw: float | None) -> float:
-    """Normalise a progress value (KOReader 0–1 or legacy 0–100) to 0–100."""
+    """Normalise a progress value (KOReader 0–1 or legacy 0–100) to 0–100.
+
+    Everything written since the web reader/TomeSync convention is a 0–1
+    fraction, so <= 1.0 means "fraction". A legacy 0–100 row that happened to
+    sit below 1% is misread as 80–100% — unavoidable ambiguity, accepted as
+    vanishingly rare.
+    """
     if not raw:
         return 0.0
     return round(raw * 100, 1) if raw <= 1.0 else round(raw, 1)
@@ -135,6 +141,9 @@ def get_focus(
 
     return {
         "ready": True,
+        # Books 13+ can't be focused from the strip — the frontend shows a
+        # "+N more" link into the filtered library instead of hiding them.
+        "reading_total": len(ordered),
         "book": {
             "book_id": hero.id,
             "title": hero.title,

--- a/backend/services/reading_dna.py
+++ b/backend/services/reading_dna.py
@@ -196,10 +196,11 @@ def compute_reading_dna(db: Session, user: User, tz_offset: int) -> dict:
         ]
         summary = (" · ".join(tags)[:1].upper() + " · ".join(tags)[1:] + ".") if tags else None
 
+    # No window_days field: nothing consumed it, and no single window is honest —
+    # time uses 365d, rhythm 120d, and length/pace/variety are all-time.
     return {
         "ready": bool(trait_list),
         "archetype": archetype,
         "summary": summary,
         "traits": trait_list,
-        "window_days": 365,
     }

--- a/frontend/src/components/home/FocusMode.tsx
+++ b/frontend/src/components/home/FocusMode.tsx
@@ -328,9 +328,10 @@ export function FocusMode() {
   }
 
   return (
-    <div className="flex flex-col min-h-[calc(100vh-160px)]">
-      {/* Hero composition — vertically centered so the empty space is balanced */}
-      <div className="flex-1 flex items-center w-full">
+    // Vertical centering balances the desktop hero; on phones it left a
+    // screen-third of dead space above the fan — stack from the top there.
+    <div className="flex flex-col lg:min-h-[calc(100vh-160px)]">
+      <div className="flex-1 flex items-start lg:items-center w-full">
       <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-center lg:gap-14 w-full max-w-[1080px] mx-auto">
       {/* Display — animated rotary */}
       <div className="w-full lg:w-auto lg:shrink-0">
@@ -339,13 +340,10 @@ export function FocusMode() {
 
       {/* Meta — reflects the selected volume */}
       <div className="relative z-10 flex-1 min-w-0 max-w-[520px]">
+        {/* No series name here — the h1 right below IS the series (same link);
+            repeating it 40px apart just duplicated the title. */}
         <div className="flex items-center gap-2 text-[12px] font-bold tracking-[0.12em] uppercase text-muted-foreground">
           {onCurrent ? 'Continue reading' : 'Up next'}
-          {b.series && (
-            <button type="button" onClick={openHero} className="text-primary hover:underline">
-              · {b.series}
-            </button>
-          )}
         </div>
 
         <h1 className="font-display text-3xl sm:text-4xl font-bold leading-[1.05] tracking-tight mt-3 text-foreground">

--- a/frontend/src/components/home/FocusMode.tsx
+++ b/frontend/src/components/home/FocusMode.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { Play, RefreshCw, BookOpen } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { CoverImage } from '@/components/CoverImage'
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -32,6 +33,7 @@ interface FocusData {
   upcoming: FocusUpcoming[]
   ahead_count: number
   reading: { book_id: number; title: string; author: string | null; has_cover: boolean; progress: number }[]
+  reading_total?: number
 }
 
 /** One cover in the rotary — the current book plus each upcoming volume. */
@@ -46,11 +48,17 @@ interface RotaryItem {
 
 function relativeTime(iso: string | null): string {
   if (!iso) return ''
-  const diff = Math.floor((Date.now() - new Date(iso).getTime()) / 1000)
+  const then = new Date(iso)
+  const diff = Math.floor((Date.now() - then.getTime()) / 1000)
   if (diff < 60) return 'just now'
   if (diff < 3600) return `${Math.floor(diff / 60)} min ago`
+  if (diff < 7200) return '1 hour ago'
   if (diff < 86400) return `${Math.floor(diff / 3600)} hours ago`
   if (diff < 172800) return 'yesterday'
+  // Past a month, "412 days ago" reads worse than the date itself.
+  if (diff >= 30 * 86400) {
+    return `on ${then.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`
+  }
   return `${Math.floor(diff / 86400)} days ago`
 }
 
@@ -172,7 +180,10 @@ function Rotary({
               transition: 'transform 500ms cubic-bezier(.22,1,.36,1), opacity 450ms ease',
             }}
           >
-            <img src={cover(items[0].book_id)} alt="" className="block w-full aspect-[2/3] object-cover" draggable={false} />
+            {/* CoverImage: a coverless book shows the placeholder, not a broken-image glyph */}
+            <div className="relative w-full aspect-[2/3]">
+              <CoverImage src={cover(items[0].book_id)} alt="" iconClassName="w-12 h-12" />
+            </div>
           </button>
         ) : (
           <div className="absolute top-1/2 left-0" style={{ transform: 'translateY(-50%)', transformStyle: 'preserve-3d' }}>
@@ -216,7 +227,9 @@ function Rotary({
                     transitionDelay: mounted ? `${Math.max(0, offset) * 55}ms` : '0ms',
                   }}
                 >
-                  <img src={cover(it.book_id)} alt="" className="block w-full aspect-[2/3] object-cover" draggable={false} />
+                  <div className="relative w-full aspect-[2/3]">
+                    <CoverImage src={cover(it.book_id)} alt="" iconClassName="w-10 h-10" />
+                  </div>
                   {!isHero && it.series_index != null && (
                     <span className="absolute top-1.5 left-1.5 w-6 h-6 rounded-full bg-black/55 backdrop-blur-sm text-white text-[11px] font-bold grid place-items-center border border-white/20">
                       {fmtVol(it.series_index)}
@@ -244,13 +257,22 @@ export function FocusMode() {
   const [focusId, setFocusId] = useState<number | null>(null)
 
   // (Re)load whenever the focused book changes; replay the entrance each time.
+  // Aborted on re-fire: without it, clicking strip book A then quickly book B
+  // could let A's slower response land last — hero showing A while focusId is B,
+  // and re-clicking A a no-op (switchTo guards on the displayed book id).
   useEffect(() => {
     setMounted(false)
     setSelected(0)
+    const ctrl = new AbortController()
     const q = focusId != null ? `?book_id=${focusId}` : ''
-    api.get<FocusData>(`/home/focus${q}`)
+    api.get<FocusData>(`/home/focus${q}`, ctrl.signal)
       .then(setData)
-      .catch(() => setData({ ready: false, book: null, upcoming: [], ahead_count: 0, reading: [] }))
+      .catch((e) => {
+        if ((e as Error).name !== 'AbortError') {
+          setData({ ready: false, book: null, upcoming: [], ahead_count: 0, reading: [] })
+        }
+      })
+    return () => ctrl.abort()
   }, [focusId])
 
   // Kick the entrance animation one frame after data lands.
@@ -279,6 +301,13 @@ export function FocusMode() {
           <p className="text-base font-medium text-foreground">Nothing in progress</p>
           <p className="text-sm text-muted-foreground mt-1">Start a book and Focus mode will pick up where you left off</p>
         </div>
+        <button
+          type="button"
+          onClick={() => navigate('/?tab=books')}
+          className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
+        >
+          Browse library
+        </button>
       </div>
     )
   }
@@ -430,7 +459,7 @@ export function FocusMode() {
                         : 'ring-1 ring-border opacity-70 group-hover:opacity-100 group-hover:ring-primary/60 cursor-pointer'
                     )}
                   >
-                    <img src={cover(r.book_id)} alt="" className="w-full h-full object-cover" draggable={false} />
+                    <CoverImage src={cover(r.book_id)} alt="" iconClassName="w-5 h-5" />
                     {r.progress > 0 && (
                       <div className="absolute inset-x-0 bottom-0 h-[3px] bg-black/35">
                         <div className="h-full bg-primary" style={{ width: `${r.progress}%` }} />
@@ -448,6 +477,19 @@ export function FocusMode() {
                 </button>
               )
             })}
+            {(data.reading_total ?? data.reading.length) > data.reading.length && (
+              <button
+                type="button"
+                onClick={() => navigate('/?tab=books&reading_status=reading')}
+                className="shrink-0 w-[64px] self-stretch"
+                title="See all in-progress books"
+              >
+                <div className="w-[64px] aspect-[2/3] rounded-lg ring-1 ring-border bg-muted/60 grid place-items-center text-xs font-semibold text-muted-foreground hover:text-foreground hover:ring-primary/60 transition">
+                  +{(data.reading_total ?? 0) - data.reading.length}
+                </div>
+                <div className="mt-1.5 text-[11px] text-muted-foreground text-left truncate">more</div>
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/frontend/src/components/stats/ReadingDNACard.tsx
+++ b/frontend/src/components/stats/ReadingDNACard.tsx
@@ -41,6 +41,45 @@ function archetypeIcon(archetype: string | null): LucideIcon {
   return Sparkles
 }
 
+/** The card's content — archetype, trait spectra, one-line summary — shared by
+ *  the Home rail card and the Stats page's "Reading DNA" tile. `showLink`
+ *  appends the "Full breakdown →" link (Home only; the Stats tile IS the
+ *  breakdown). */
+export function ReadingDNABody({ dna, showLink = false }: { dna: ReadingDNA; showLink?: boolean }) {
+  const ArcheIcon = archetypeIcon(dna.archetype)
+  return (
+    <div>
+      {dna.archetype && (
+        <div className="flex items-center gap-3">
+          <span className="w-11 h-11 rounded-xl bg-primary text-primary-foreground flex items-center justify-center shrink-0">
+            <ArcheIcon className="w-[23px] h-[23px]" />
+          </span>
+          <span className="font-display text-[17px] leading-[1.12] text-foreground">{dna.archetype}</span>
+        </div>
+      )}
+
+      <div className="mt-5 flex flex-col gap-3.5">
+        {dna.traits.map((t) => <TraitBar key={t.key} trait={t} />)}
+      </div>
+
+      {dna.summary && (
+        <p className="mt-4 pt-3 border-t border-border text-[11px] text-muted-foreground text-center leading-relaxed">
+          {dna.summary}
+        </p>
+      )}
+
+      {showLink && (
+        <Link
+          to="/stats"
+          className="mt-3 block text-[11px] text-muted-foreground hover:text-foreground transition-colors text-center"
+        >
+          Full breakdown →
+        </Link>
+      )}
+    </div>
+  )
+}
+
 export function ReadingDNACard({ dna }: { dna: ReadingDNA }) {
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem(COLLAPSE_KEY) === '1')
 
@@ -53,8 +92,6 @@ export function ReadingDNACard({ dna }: { dna: ReadingDNA }) {
       return next
     })
   }
-
-  const ArcheIcon = archetypeIcon(dna.archetype)
 
   return (
     <section className="p-4">
@@ -80,31 +117,7 @@ export function ReadingDNACard({ dna }: { dna: ReadingDNA }) {
 
       {!collapsed && (
         <div className="mt-4">
-          {dna.archetype && (
-            <div className="flex items-center gap-3">
-              <span className="w-11 h-11 rounded-xl bg-primary text-primary-foreground flex items-center justify-center shrink-0">
-                <ArcheIcon className="w-[23px] h-[23px]" />
-              </span>
-              <span className="font-display text-[17px] leading-[1.12] text-foreground">{dna.archetype}</span>
-            </div>
-          )}
-
-          <div className="mt-5 flex flex-col gap-3.5">
-            {dna.traits.map((t) => <TraitBar key={t.key} trait={t} />)}
-          </div>
-
-          {dna.summary && (
-            <p className="mt-4 pt-3 border-t border-border text-[11px] text-muted-foreground text-center leading-relaxed">
-              {dna.summary}
-            </p>
-          )}
-
-          <Link
-            to="/stats"
-            className="mt-3 block text-[11px] text-muted-foreground hover:text-foreground transition-colors text-center"
-          >
-            Full breakdown →
-          </Link>
+          <ReadingDNABody dna={dna} showLink />
         </div>
       )}
     </section>

--- a/frontend/src/components/stats/ReadingDNACard.tsx
+++ b/frontend/src/components/stats/ReadingDNACard.tsx
@@ -23,7 +23,8 @@ function TraitBar({ trait }: { trait: ReadingDNATrait }) {
         />
         <span
           className="absolute top-1/2 w-3 h-3 rounded-full bg-primary border-2 border-card shadow-[0_0_0_1px_var(--border)] -translate-x-1/2 -translate-y-1/2"
-          style={{ left: `${s}%` }}
+          // Clamp the marker inside the track — at 0/100 the dot half-clipped.
+          style={{ left: `${Math.min(Math.max(s, 3), 97)}%` }}
         />
       </div>
     </div>

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -94,7 +94,6 @@ export interface ReadingDNA {
   archetype: string | null
   summary: string | null
   traits: ReadingDNATrait[]
-  window_days: number
 }
 
 export interface CompletionEstimate {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -929,9 +929,17 @@ export function DashboardPage() {
     api.get<ActivityEntry[]>('/home/activity').then(setActivityLog).catch(() => {})
     api.get<ForgottenBook[]>('/home/forgotten-books').then(setForgottenBooks).catch(() => {})
     api.get<HighlightSpotlight>('/annotations/spotlight').then(setSpotlight).catch(() => {})
-    api.get<ReadingDNA>(`/home/reading-dna?tz_offset=${tzOffset}`).then(setReadingDna).catch(() => {})
     api.get<SeriesItem[]>('/books/series').then(setSeriesList).catch(() => {})
   }, [])
+
+  // Reading DNA is the costliest home request — fetch it lazily, only once the
+  // dashboard Home view (the one place the card renders) is actually shown.
+  useEffect(() => {
+    if (tab !== 'home' || homeMode !== 'dashboard' || readingDna) return
+    api.get<ReadingDNA>(`/home/reading-dna?tz_offset=${new Date().getTimezoneOffset()}`)
+      .then(setReadingDna)
+      .catch(() => {})
+  }, [tab, homeMode, readingDna])
 
   // ── Filter chip helpers ───────────────────────────────────────────────────
   const activeFilterChips: { label: string; key: string }[] = [
@@ -1240,10 +1248,11 @@ export function DashboardPage() {
                     <h2 className="text-base font-semibold text-foreground">Series Progress</h2>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
                       {rows.map(({ book, read, total, pct }) => (
-                        <a
+                        <button
                           key={book.series}
-                          href={`/?tab=books&series=${encodeURIComponent(book.series!)}`}
-                          className="group flex items-center gap-3 px-3 py-2.5 rounded-xl bg-muted/40 hover:bg-muted/60 transition-colors"
+                          type="button"
+                          onClick={() => setSearchParams({ tab: 'books', series: book.series! })}
+                          className="group flex items-center gap-3 px-3 py-2.5 rounded-xl bg-muted/40 hover:bg-muted/60 transition-colors text-left"
                         >
                           <div className="relative w-9 aspect-[2/3] rounded shrink-0 overflow-hidden bg-muted">
                             <CoverImage src={book.cover_path ? `/api/books/${book.id}/cover` : null} alt={book.series!} iconClassName="w-4 h-4" />
@@ -1257,7 +1266,7 @@ export function DashboardPage() {
                               <div className="h-full rounded-full bg-primary transition-all" style={{ width: `${pct}%` }} />
                             </div>
                           </div>
-                        </a>
+                        </button>
                       ))}
                     </div>
                   </div>
@@ -1334,8 +1343,11 @@ export function DashboardPage() {
 
               </div>{/* ── /Main column ── */}
 
-              {/* ── Right rail (one connected panel, hairline-divided) ─────── */}
-              <aside className="rounded-2xl border border-border bg-card divide-y divide-border overflow-hidden">
+              {/* ── Right rail (one connected panel, hairline-divided) ───────
+                  empty:hidden — every child is conditional (no sessions / no
+                  goals / no highlights), and a brand-new user would otherwise
+                  see a bare bordered box. */}
+              <aside className="rounded-2xl border border-border bg-card divide-y divide-border overflow-hidden empty:hidden">
                 {readingDna && <ReadingDNACard dna={readingDna} />}
                 <HomeGoalRings />
                 {spotlight?.highlight?.highlighted_text && (

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -15,6 +15,7 @@ import { api } from '@/lib/api'
 import { BookAnimation } from '@/components/BookAnimation'
 import { DOCS, docsLink } from '@/lib/docs'
 import { type StatsResponse, type CompletionEstimate } from '@/components/stats/shared'
+import { ReadingDNABody } from '@/components/stats/ReadingDNACard'
 import { GoalWidgetBody } from '@/components/stats/GoalWidget'
 import { listGoals, type Goal } from '@/lib/goals'
 import {
@@ -357,6 +358,15 @@ const WIDGETS: WidgetDef[] = [
     render: ({ estimates }) => <CompletionEstimatesList estimates={estimates} />,
   },
   {
+    id: 'reading-dna',
+    title: 'Reading DNA',
+    size: { w: 4, h: 3, minW: 3, minH: 2 },
+    render: ({ stats }) =>
+      stats.reading_dna?.ready
+        ? <ReadingDNABody dna={stats.reading_dna} />
+        : <p className="text-sm text-muted-foreground">Not enough reading history yet.</p>,
+  },
+  {
     id: 'period-comparison',
     title: 'Period Comparison',
     size: { w: 6, h: 1, minW: 3, minH: 1 },
@@ -646,7 +656,7 @@ const GALLERY_GROUPS: { label: string; ids: string[] }[] = [
   },
   {
     label: 'Habits',
-    ids: ['hour-dow', 'reading-clock', 'session-timeline', 'reading-pace', 'pace-by-format', 'true-wpm', 'dow-bar', 'time-of-day', 'time-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'],
+    ids: ['hour-dow', 'reading-clock', 'reading-dna', 'session-timeline', 'reading-pace', 'pace-by-format', 'true-wpm', 'dow-bar', 'time-of-day', 'time-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'],
   },
   {
     label: 'Library',


### PR DESCRIPTION
> **Stacked on #95** (`fix/appshell-polish`) — both touch `DashboardPage.tsx`. Merge #95 first; this retargets automatically.

## Focus mode (PR #87 follow-ups)

- **Broken-image glyphs on coverless books** — hero, fan and Currently-reading strip now use `CoverImage`'s placeholder fallback (verified live: rotary geometry unchanged).
- **Switcher race** — the `focusId` fetch now aborts on re-fire; previously clicking strip book A then quickly B could leave the hero wedged on A (whose slower response landed last) with re-clicking A a no-op.
- **Invisible 12-book cap** — the backend returns `reading_total` and the strip ends in a **"+N more"** chip into `?tab=books&reading_status=reading`; books 13+ were previously unreachable.
- **Text polish** — "1 hour ago" (was "1 hours ago"), dates past a month ("on May 12" instead of "412 days ago"), a **Browse library** CTA on the empty state, and Series Progress rows navigate in-app instead of a full page reload.

## Reading DNA

- **`/stats` computed a DNA payload nothing rendered, and the Home card linked to a "full breakdown" that didn't exist.** Per the chosen direction, there's now a **Reading DNA tile** (Add tile → Habits) on the Stats dashboard, sharing the card body via a new `ReadingDNABody`; the payload and the link are both justified.
- **Lazy fetch** — the Home dashboard requests DNA only when the Home tab's dashboard view is actually shown (it used to fire on every mount, including `?tab=books` and Focus mode).
- Dropped the dead `window_days` field (no single window was honest: time 365d, rhythm 120d, the rest all-time).
- The dashboard's right rail hides itself when all three children are empty (`empty:hidden`) — new users saw a bare bordered box.

## Changelog

Also adds the missing entry for the v1.7.x stats polish (KPI label truncation + richer chart tooltips) — Rule 6 (this was finding E1).

## Testing

- Full backend suite: **664 passed**; `npm run build` (tsc -b) clean.
- Live-app verification (Playwright screenshot vs dev server): Focus hero + fan + strip render correctly after the CoverImage change.