### PR TITLE
feat(reader): paint KOReader highlights inside the web reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Your KOReader highlights now show up inside the web reader.** Open a book on
+  the web and the passages you highlighted on your device are painted right in
+  the text, in their KOReader colours; tap one to see the full passage, its note
+  and when you made it. Under the hood each highlight is re-anchored by its own
+  text (device anchors don't translate to the web reader's engine), so a
+  highlight whose passage can't be located — say it spans a page-break element —
+  simply doesn't paint rather than pointing at the wrong words. Highlights load
+  lazily per chapter, so big collections don't slow the reader down.
 - **Focus mode on the Home page.** A new minimalist Home view that surfaces the one
   book you're most likely to pick up next — your most-recently-synced in-progress
   title — as a large cover with the upcoming volumes of its series fanned behind it

--- a/frontend/src/lib/readerAnnotations.ts
+++ b/frontend/src/lib/readerAnnotations.ts
@@ -1,0 +1,198 @@
+/**
+ * Paints KOReader highlights inside the foliate web reader.
+ *
+ * Tome stores annotations with KOReader xPointer anchors, which mean nothing to
+ * foliate (it addresses by EPUB CFI, over a differently-normalised DOM). Rather
+ * than translating anchors, each highlight is re-anchored by its own text: when
+ * a section loads we search its document for `highlighted_text` (using
+ * foliate's own search matcher), turn the matched Range into a CFI, and draw it
+ * through foliate's overlayer. Resolution is lazy and per-section — a highlight
+ * in an unopened chapter costs nothing until that chapter renders, and one
+ * whose text can't be found (e.g. spanning a paragraph break, which the
+ * text-node haystack can't match across) simply doesn't paint — sync data is
+ * never touched.
+ *
+ * Disambiguation: when the annotation's chapter matches a TOC label, only
+ * sections under that label are searched; otherwise the first textual match in
+ * any section wins. Multiple occurrences inside one section take the first —
+ * KOReader anchors don't carry an occurrence index we could honour.
+ */
+
+export interface ReaderAnnotation {
+  id: number
+  anchor: string
+  highlighted_text: string | null
+  note: string | null
+  chapter: string | null
+  color: string | null
+  datetime: string | null
+}
+
+/** KOReader highlight colours → translucent fills that work on all reader themes. */
+const KO_FILL: Record<string, string> = {
+  red: 'rgba(239,68,68,0.35)',
+  orange: 'rgba(249,115,22,0.35)',
+  yellow: 'rgba(234,179,8,0.35)',
+  green: 'rgba(34,197,94,0.32)',
+  olive: 'rgba(132,153,55,0.35)',
+  cyan: 'rgba(6,182,212,0.32)',
+  blue: 'rgba(59,130,246,0.32)',
+  purple: 'rgba(168,85,247,0.32)',
+  gray: 'rgba(148,163,184,0.38)',
+  grey: 'rgba(148,163,184,0.38)',
+}
+export const fillForColor = (color: string | null): string =>
+  KO_FILL[(color ?? '').toLowerCase()] ?? 'rgba(234,179,8,0.35)'
+
+const normalize = (s: string) => s.replace(/\s+/g, ' ').trim().toLowerCase()
+
+// foliate modules live in /public as plain ESM (loaded natively by the reader,
+// not bundled). A Vite-transformed dynamic import 500s on public files (?import
+// middleware), so this must be a NATIVE import the bundler can't see — same
+// mechanism view.js itself uses for its relative imports.
+// eslint-disable-next-line @typescript-eslint/no-implied-eval
+const nativeImport = new Function('url', 'return import(url)') as (url: string) => Promise<unknown>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const foliate = (name: string): Promise<any> => nativeImport(`/foliate/${name}.js`)
+
+// Minimal view surface this module needs (the element is untyped upstream).
+interface AnnotationView extends HTMLElement {
+  book?: { toc?: { label: string; href: string; subitems?: unknown[] }[] } | null
+  getCFI(index: number, range: Range): string
+  resolveNavigation(target: string): Promise<{ index: number }> | { index: number }
+  addAnnotation(annotation: { value: string; color?: string | null }, remove?: boolean): Promise<unknown>
+}
+
+type Matcher = (doc: Document, query: string) => Iterable<{ range: Range }>
+
+export class AnnotationPainter {
+  private view: AnnotationView
+  private annotations: ReaderAnnotation[] = []
+  private cfiById = new Map<number, string>()
+  private byCfi = new Map<string, ReaderAnnotation>()
+  private scannedSections = new Set<number>()
+  private sectionLabels = new Map<number, string>()  // section index -> normalized TOC label
+  private tocLabels = new Set<string>()              // all normalized labels
+  private matcher: Matcher | null = null
+  private onShow: (a: ReaderAnnotation) => void
+  // Section loads can fire before the annotation fetch / TOC mapping finish —
+  // scanning waits on this so the first chapter isn't scanned against an empty set.
+  private ready: Promise<void>
+  private markReady!: () => void
+
+  constructor(view: AnnotationView, onShow: (a: ReaderAnnotation) => void) {
+    this.view = view
+    this.onShow = onShow
+    this.ready = new Promise(res => { this.markReady = res })
+
+    view.addEventListener('draw-annotation', (e: Event) => {
+      const { draw, annotation } = (e as CustomEvent).detail as {
+        draw: (fn: unknown, opts?: unknown) => void
+        annotation: { value: string; color?: string | null }
+      }
+      const a = this.byCfi.get(annotation.value)
+      foliate('overlayer').then(({ Overlayer }) => {
+        draw(Overlayer.highlight, { color: fillForColor(a?.color ?? annotation.color ?? null) })
+      })
+    })
+
+    view.addEventListener('show-annotation', (e: Event) => {
+      const { value } = (e as CustomEvent).detail as { value: string }
+      const a = this.byCfi.get(value)
+      if (a) this.onShow(a)
+    })
+
+    // Overlays are per-section and rebuilt when a section (re)loads — repaint
+    // everything already resolved for it (mirrors foliate's own search results).
+    view.addEventListener('create-overlay', (e: Event) => {
+      const { index } = (e as CustomEvent).detail as { index: number }
+      this.paintResolved(index)
+    })
+  }
+
+  /** Feed the annotation set and map the TOC; unblocks section scanning. */
+  async start(annotations: ReaderAnnotation[]) {
+    this.annotations = annotations.filter(a => a.highlighted_text)
+    try {
+      await this.buildSectionLabels()
+    } finally {
+      this.markReady()
+    }
+  }
+
+  /** Map TOC entries to section indexes so chapter names can gate the search. */
+  private async buildSectionLabels() {
+    const toc = this.view.book?.toc ?? []
+    const walk = async (items: { label: string; href: string; subitems?: unknown[] }[]) => {
+      for (const item of items) {
+        try {
+          const resolved = await this.view.resolveNavigation(item.href)
+          const label = normalize(item.label ?? '')
+          if (label && !this.sectionLabels.has(resolved.index)) {
+            this.sectionLabels.set(resolved.index, label)
+          }
+          if (label) this.tocLabels.add(label)
+        } catch { /* unresolvable TOC entry — skip */ }
+        if (item.subitems?.length) {
+          await walk(item.subitems as { label: string; href: string; subitems?: unknown[] }[])
+        }
+      }
+    }
+    await walk(toc)
+  }
+
+  /** Called on foliate's `load` event: resolve + paint this section's highlights. */
+  async onSectionLoad(doc: Document, index: number) {
+    if (this.scannedSections.has(index)) {
+      this.paintResolved(index)
+      return
+    }
+    await this.ready
+    if (this.scannedSections.has(index)) return  // raced with a concurrent load
+    this.scannedSections.add(index)
+    const matcher = await this.getMatcher()
+    const sectionLabel = this.sectionLabels.get(index)
+
+    for (const a of this.annotations) {
+      if (this.cfiById.has(a.id)) continue
+      const chapter = a.chapter ? normalize(a.chapter) : null
+      // If the annotation names a chapter we know from the TOC, only search
+      // sections under that label; unknown/absent chapters search everywhere.
+      if (chapter && this.tocLabels.has(chapter) && chapter !== sectionLabel) continue
+
+      const text = a.highlighted_text!.replace(/\s+/g, ' ').trim()
+      if (text.length < 2) continue
+      try {
+        const match = matcher(doc, text)[Symbol.iterator]().next()
+        if (match.done || !match.value) continue
+        const cfi = this.view.getCFI(index, match.value.range)
+        this.cfiById.set(a.id, cfi)
+        this.byCfi.set(cfi, a)
+        this.view.addAnnotation({ value: cfi, color: a.color })
+      } catch { /* malformed range — leave unresolved */ }
+    }
+  }
+
+  private paintResolved(index: number) {
+    for (const [cfi] of this.byCfi) {
+      // addAnnotation resolves the CFI itself and no-ops for other sections.
+      void this.view.addAnnotation({ value: cfi, color: this.byCfi.get(cfi)?.color })
+    }
+    void index
+  }
+
+  private async getMatcher(): Promise<Matcher> {
+    if (this.matcher) return this.matcher
+    const [{ searchMatcher }, { textWalker }] = await Promise.all([
+      foliate('search'),
+      foliate('text-walker'),
+    ])
+    this.matcher = searchMatcher(textWalker, {
+      defaultLocale: 'en',
+      matchCase: false,
+      matchDiacritics: true,
+      matchWholeWords: false,
+    }) as Matcher
+    return this.matcher
+  }
+}

--- a/frontend/src/pages/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage.tsx
@@ -4,13 +4,14 @@ import {
   ArrowLeft, BookOpen, Settings, Rows4,
   ChevronLeft, ChevronRight, Minus, Plus, X,
   Loader2, AlignJustify, RotateCcw, GalleryHorizontalEnd, Columns2, Square,
-  StretchHorizontal, StretchVertical,
+  StretchHorizontal, StretchVertical, StickyNote,
 } from 'lucide-react'
 import * as pdfjsLib from 'pdfjs-dist'
 import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
 import { api } from '@/lib/api'
 import type { Book, BookFile } from '@/lib/books'
 import { cn } from '@/lib/utils'
+import { AnnotationPainter, fillForColor, type ReaderAnnotation } from '@/lib/readerAnnotations'
 
 // pdf.js renders pages off the main thread; point it at the bundled worker.
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl
@@ -704,6 +705,9 @@ export default function ReaderPage() {
   // ── EPUB refs ────────────────────────────────────────────────────────────────
   const containerRef = useRef<HTMLDivElement>(null)
   const viewRef = useRef<FoliateViewElement | null>(null)
+  // KOReader highlights painted into the EPUB view; tapping one opens the card.
+  const painterRef = useRef<AnnotationPainter | null>(null)
+  const [activeHighlight, setActiveHighlight] = useState<ReaderAnnotation | null>(null)
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const initialCfi = useRef<string | null>(null)
   const readyToSave = useRef(false)
@@ -953,10 +957,26 @@ export default function ReaderPage() {
       container.appendChild(view)
       viewRef.current = view
 
-      view.addEventListener('load', () => {
+      // KOReader highlights, re-anchored by text and painted via the overlayer.
+      // The fetch runs in parallel with the EPUB download; painter.start() gates
+      // section scanning until both the set and the TOC map are ready.
+      const painter = new AnnotationPainter(
+        view as unknown as ConstructorParameters<typeof AnnotationPainter>[0],
+        a => setActiveHighlight(a),
+      )
+      painterRef.current = painter
+      const annotationsPromise = api
+        .get<ReaderAnnotation[]>(`/books/${bookId}/annotations`)
+        .catch(() => [] as ReaderAnnotation[])
+
+      view.addEventListener('load', (e: Event) => {
         applyStylesRef.current()
         if (view.book?.toc) {
           setToc(flattenToc(view.book.toc))
+        }
+        const detail = (e as CustomEvent).detail as { doc?: Document; index?: number } | undefined
+        if (detail?.doc && detail.index != null) {
+          painter.onSectionLoad(detail.doc, detail.index).catch(() => {})
         }
       })
 
@@ -988,6 +1008,10 @@ export default function ReaderPage() {
       }
 
       if (cancelled) return
+
+      annotationsPromise.then(list => {
+        if (!cancelled) painter.start(list).catch(() => {})
+      })
 
       try {
         const cfi = initialCfi.current
@@ -1690,6 +1714,52 @@ export default function ReaderPage() {
           {/* Click zones for prev/next */}
           <div className="absolute inset-y-0 left-0 w-1/5 cursor-pointer z-10" onClick={epubPrev} />
           <div className="absolute inset-y-0 right-0 w-1/5 cursor-pointer z-10" onClick={epubNext} />
+
+          {/* Tapped-highlight card — KOReader highlights painted in the text */}
+          {activeHighlight && (
+            <>
+              <div className="absolute inset-0 z-20" onClick={() => setActiveHighlight(null)} />
+              <div
+                className="absolute bottom-6 left-1/2 -translate-x-1/2 z-30 w-[min(34rem,calc(100%-2rem))] rounded-xl border shadow-2xl p-4"
+                style={{
+                  background: themeColors.bg,
+                  color: themeColors.text,
+                  borderColor: isDarkTheme ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)',
+                }}
+              >
+                <div className="flex items-start justify-between gap-3 mb-2">
+                  <div className="flex items-center gap-2 min-w-0 text-xs" style={{ opacity: 0.6 }}>
+                    <span
+                      className="w-2.5 h-2.5 rounded-full shrink-0"
+                      style={{ background: fillForColor(activeHighlight.color).replace(/[\d.]+\)$/, '1)') }}
+                    />
+                    {activeHighlight.chapter && <span className="truncate">{activeHighlight.chapter}</span>}
+                    {activeHighlight.datetime && (
+                      <span className="shrink-0">· {activeHighlight.datetime.slice(0, 10)}</span>
+                    )}
+                  </div>
+                  <button onClick={() => setActiveHighlight(null)} style={{ opacity: 0.5 }} aria-label="Close">
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+                {activeHighlight.highlighted_text && (
+                  <p
+                    className="text-sm leading-relaxed max-h-40 overflow-y-auto border-l-2 pl-2.5"
+                    style={{ borderColor: fillForColor(activeHighlight.color).replace(/[\d.]+\)$/, '0.9)') }}
+                  >
+                    {activeHighlight.highlighted_text}
+                  </p>
+                )}
+                {activeHighlight.note && (
+                  <p className="mt-2.5 flex items-start gap-1.5 text-sm" style={{ opacity: 0.75 }}>
+                    <StickyNote className="w-3.5 h-3.5 mt-0.5 shrink-0" />
+                    <span className="leading-relaxed">{activeHighlight.note}</span>
+                  </p>
+                )}
+                <p className="mt-2.5 text-[11px]" style={{ opacity: 0.4 }}>Synced from KOReader</p>
+              </div>
+            </>
+          )}
         </div>
 
         {/* Settings panel */}


### PR DESCRIPTION
Stage 1 (A1) of web-side annotations — read-only rendering. Stage 2 (creating highlights on the web + device adoption) will stack on this.

## What it does

- Highlights synced from KOReader render inside the foliate web reader, in their KOReader colours.
- Tapping a highlight opens a card with the passage, note, chapter, date and a "Synced from KOReader" caption; tap outside or ✕ to dismiss.
- Resolution is lazy per section — a chapter's highlights are located only when that chapter renders, so large collections cost nothing up front.

## How it anchors

Tome stores KOReader xPointers (crengine DOM addresses); foliate speaks EPUB CFI over a differently-normalised DOM. Rather than emulating crengine, each highlight is **re-anchored by its own text** via foliate's `searchMatcher`: first match wins, gated to the annotation's chapter when it matches a TOC label. A passage that can't be located (e.g. spanning a page-break element, or text that differs from the served EPUB) simply doesn't paint — never a wrong-words highlight, and sync data is untouched.

Implementation notes:
- New `frontend/src/lib/readerAnnotations.ts` (`AnnotationPainter`) — all logic isolated from ReaderPage, which only wires events and renders the card.
- Overlays draw through foliate's own overlayer (`draw-annotation` event), so they survive section re-renders and theme switches.
- foliate modules in `/public` are loaded via a native dynamic import — Vite's `?import` transform 500s on public-dir files.

## Verified

- Live end-to-end on the dev instance: planted a real-text annotation, cold-loaded the reader, navigated to the chapter — highlight painted (wrapping a line break) and the tap-card opened. Test row removed afterwards.
- Heads-up for local testing: the **seeded dev annotations are invented quotes that exist in no book**, so they correctly stay unpainted; real KOReader-synced highlights (prod) resolve. `npm run build` clean.