### PR TITLE
feat(reader): create highlights on the web — adopted natively by KOReader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Create highlights in the web reader — they appear on your KOReader.** Select
+  text while reading on the web, pick a colour, and optionally attach a note;
+  the highlight paints immediately and syncs to your devices. Since the web
+  reader and KOReader address text differently, a new highlight carries a
+  provisional identity until your device next syncs the book: the plugin locates
+  the passage natively and "adopts" it as a first-class KOReader highlight
+  (build 25 / 1.7.0). You can also **edit notes and delete** any highlight from
+  the tap-card — including ones made on the device — and the change wins on
+  every device at its next sync. A passage the device can't locate stays
+  web-only rather than landing on the wrong words.
 - **Your KOReader highlights now show up inside the web reader.** Open a book on
   the web and the passages you highlighted on your device are painted right in
   the text, in their KOReader colours; tap one to see the full passage, its note

--- a/backend/api/annotations.py
+++ b/backend/api/annotations.py
@@ -2,25 +2,33 @@
 
 `GET /api/annotations` returns the current user's KOReader-synced highlights
 across *all* visible books (the per-book view lives at
-`GET /api/books/{id}/annotations`). KOReader owns annotations and pushes them via
-the TomeSync plugin; the one write the web offers is `DELETE /api/annotations/{id}`,
-which drops the row and leaves a tombstone so the deletion propagates back to the
-device (and stale devices can't resurrect it) — mirroring the plugin's own deletes.
+`GET /api/books/{id}/annotations`). The web's writes:
+
+- `POST /api/annotations` — create a highlight from the web reader. It gets a
+  provisional `web:<uuid>` anchor plus the selection's CFI; a KOReader device
+  later "adopts" it (locates the text, re-anchors it natively) via the sync
+  endpoint, which retires the provisional row.
+- `PUT /api/annotations/{id}` — edit note/colour; bumps the LWW mtime so the
+  change propagates to devices like any device-side edit.
+- `DELETE /api/annotations/{id}` — drops the row and leaves a tombstone so the
+  deletion propagates back to devices (and stale devices can't resurrect it).
 
 Registered before `/api/books/{id}` is irrelevant here (distinct prefix), but the
 router is mounted at /api like the rest.
 """
 from __future__ import annotations
 
+import uuid
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel
 from sqlalchemy import or_, func
 from sqlalchemy.orm import Session
 
 from backend.core.database import get_db
 from backend.core.security import get_current_user
-from backend.core.permissions import book_visibility_filter
+from backend.core.permissions import book_visibility_filter, user_can_see_book
 from backend.models.book import Book
 from backend.models.tome_sync import Annotation, AnnotationTombstone
 from backend.models.user import User
@@ -105,6 +113,123 @@ def list_annotations(
     items = [_to_item(a, b) for (a, b) in page]
 
     return {"total": total, "books": len(book_ids), "items": items}
+
+
+class AnnotationCreate(BaseModel):
+    book_id: int
+    highlighted_text: str
+    cfi: Optional[str] = None
+    note: Optional[str] = None
+    chapter: Optional[str] = None
+    color: Optional[str] = None
+    datetime: Optional[str] = None   # client wall-clock "YYYY-MM-DD HH:MM:SS"
+
+
+class AnnotationEdit(BaseModel):
+    note: Optional[str] = None
+    color: Optional[str] = None
+
+
+def _annotation_out(a: Annotation) -> dict:
+    return {
+        "id": a.id,
+        "book_id": a.book_id,
+        "anchor": a.anchor,
+        "cfi": a.cfi,
+        "highlighted_text": a.highlighted_text,
+        "note": a.note,
+        "chapter": a.chapter,
+        "color": a.color,
+        "datetime": a.koreader_datetime,
+        "datetime_updated": a.koreader_datetime_updated,
+    }
+
+
+@router.post("/annotations", status_code=status.HTTP_201_CREATED)
+def create_annotation(
+    payload: AnnotationCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Create a highlight from the web reader.
+
+    Stored under a provisional ``web:<uuid>`` anchor with the selection's CFI
+    (so the web can re-paint it directly). A KOReader device adopts it on its
+    next sync: it locates the text, creates a native annotation with a real
+    xPointer, and the sync endpoint retires this provisional row. Until then it
+    lives on the web (and in the Highlights views) like any other highlight.
+    """
+    book = db.get(Book, payload.book_id)
+    if not book or book.status != "active":
+        raise HTTPException(status_code=404, detail="Book not found")
+    if not user_can_see_book(db, current_user, book):
+        raise HTTPException(status_code=404, detail="Book not found")
+    text_ = (payload.highlighted_text or "").strip()
+    if not text_:
+        raise HTTPException(status_code=422, detail="highlighted_text must not be empty")
+    if len(text_) > 20_000:
+        raise HTTPException(status_code=422, detail="highlighted_text too long")
+
+    now = (payload.datetime or "").strip()[:19] or func_now_str()
+    row = Annotation(
+        user_id=current_user.id,
+        book_id=payload.book_id,
+        anchor=f"web:{uuid.uuid4()}",
+        cfi=payload.cfi,
+        highlighted_text=text_,
+        note=(payload.note or None),
+        chapter=(payload.chapter or None),
+        color=(payload.color or None),
+        koreader_datetime=now,
+        koreader_datetime_updated=now,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _annotation_out(row)
+
+
+@router.put("/annotations/{annotation_id}")
+def edit_annotation(
+    annotation_id: int,
+    payload: AnnotationEdit,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Edit a highlight's note/colour from the web.
+
+    Applies to web-created AND device-synced highlights: the LWW mtime is
+    bumped past the row's current one, so the edit wins on every device at its
+    next sync — exactly like an edit made on another device.
+    """
+    row = (
+        db.query(Annotation)
+        .filter(Annotation.id == annotation_id, Annotation.user_id == current_user.id)
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="Highlight not found")
+
+    raw = payload.model_dump(exclude_unset=True)
+    if "note" in raw:
+        row.note = payload.note or None
+    if "color" in raw:
+        row.color = payload.color or None
+
+    # The edit must be STRICTLY newer than the current mtime to win LWW on
+    # devices; guard against a server clock at/behind the device's wall-clock.
+    new_mtime = func_now_str()
+    if new_mtime <= (row.effective_mtime or ""):
+        from datetime import datetime as _dt, timedelta as _td
+        try:
+            base = _dt.strptime(row.effective_mtime, "%Y-%m-%d %H:%M:%S")
+            new_mtime = (base + _td(seconds=1)).strftime("%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            pass
+    row.koreader_datetime_updated = new_mtime
+    db.commit()
+    db.refresh(row)
+    return _annotation_out(row)
 
 
 @router.delete("/annotations/{annotation_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1062,6 +1062,7 @@ def get_book_annotations(
         {
             "id": a.id,
             "anchor": a.anchor,
+            "cfi": a.cfi,   # set for web-created highlights — paints without a text search
             "highlighted_text": a.highlighted_text,
             "note": a.note,
             "chapter": a.chapter,

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -2226,7 +2226,11 @@ function TomeSync:_applyServerState(alive, tombstones)
             local smtime = s.datetime_updated or s.datetime or ""
             if not L then
                 -- New highlight from another device: reconstruct so it renders.
-                local ok = pcall(function()
+                -- Rolling (crengine) docs can only draw real xPointers ("/body…");
+                -- anything else (PDF datetime fallbacks, corrupt data) would
+                -- hard-crash drawSavedHighlight → getPosFromXPointer on repaint.
+                local drawable = (not self.ui.rolling) or s.anchor:sub(1, 5) == "/body"
+                local ok = drawable and pcall(function()
                     ann:addItem({{
                         page = s.anchor, pos0 = s.anchor, pos1 = s.anchor_end or s.anchor,
                         text = s.highlighted_text, note = s.note, chapter = s.chapter,
@@ -2234,7 +2238,7 @@ function TomeSync:_applyServerState(alive, tombstones)
                         datetime = s.datetime, datetime_updated = s.datetime_updated,
                     }})
                 end)
-                changed = changed or ok
+                changed = changed or (ok == true)
             elseif smtime > L.mtime then
                 -- Newer edit from elsewhere wins (note/color/text).
                 L.item.text  = s.highlighted_text

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 24
-TOMESYNC_PLUGIN_SEMVER = "1.6.2"
+TOMESYNC_PLUGIN_BUILD = 25
+TOMESYNC_PLUGIN_SEMVER = "1.7.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -455,6 +455,12 @@ class AnnotationItem(PydanticBaseModel):
     color: Optional[str] = None
     datetime: Optional[str] = None           # KOReader creation time
     datetime_updated: Optional[str] = None   # KOReader modification time (LWW key)
+    # Set when this upsert is a device ADOPTING a web-created annotation: the
+    # provisional "web:<uuid>" anchor this item replaces. The server drops the
+    # provisional row (no tombstone — it's an identity move, not a delete).
+    # Anchors are deterministic per book copy, so two devices adopting the same
+    # web annotation produce the same real anchor and dedupe on upsert.
+    adopted_from: Optional[str] = None
 
     @property
     def mtime(self) -> str:
@@ -576,6 +582,15 @@ def sync_annotations(
             )
             db.add(row); alive[item.anchor] = row
             created += 1
+        # Adoption: the device located a web-created annotation in the book and
+        # re-anchored it natively — retire the provisional row. Runs regardless
+        # of the upsert outcome (another device may have adopted first; the
+        # canonical row then already exists and only the cleanup matters).
+        if item.adopted_from and item.adopted_from.startswith("web:"):
+            provisional = alive.get(item.adopted_from)
+            if provisional is not None:
+                db.delete(provisional)
+                alive.pop(item.adopted_from, None)
 
     for d in body.deletes:
         if not d.anchor:
@@ -1516,6 +1531,9 @@ function TomeSync:init()
     self.inbox_enabled  = false
     self.inbox_count    = 0
     self.inbox_items    = {{}}
+    -- Web-adoption ledger: real_anchor -> provisional "web:" anchor, persisted so a
+    -- failed push retries next sync (baseline alone would swallow the adoption).
+    self.adopt_pending = G_reader_settings:readSetting("tomesync_adopt_pending") or {{}}
     -- Per-book annotation sync baseline: book_id -> {{ anchor -> mtime }} as of last
     -- sync. Lets a diff tell "I deleted this" from "this is new from another device".
     self.annot_baseline = G_reader_settings:readSetting("tomesync_annot_baseline") or {{}}
@@ -2155,6 +2173,12 @@ local function annotAnchor(a)
     return (type(a.pos0) == "string" and a.pos0) or a.datetime
 end
 
+local function isWebAnchor(anchor)
+    -- Provisional anchor of a highlight created in Tome's web reader; carries no
+    -- usable position. This device "adopts" it by locating the text natively.
+    return type(anchor) == "string" and anchor:sub(1, 4) == "web:"
+end
+
 function TomeSync:_annotItem(a)
     local anchor = annotAnchor(a)
     if not anchor then return nil end
@@ -2192,8 +2216,12 @@ function TomeSync:_applyServerState(alive, tombstones)
     local changed = false
     local localmap = self:_localAnnotationMap() or {{}}
 
+    local pending_web = {{}}
     for _, s in ipairs(alive or {{}}) do
-        if s.anchor then
+        if isWebAnchor(s.anchor) then
+            -- Not a real position — never addItem it; adopt it below instead.
+            table.insert(pending_web, s)
+        elseif s.anchor then
             local L = localmap[s.anchor]
             local smtime = s.datetime_updated or s.datetime or ""
             if not L then
@@ -2230,10 +2258,74 @@ function TomeSync:_applyServerState(alive, tombstones)
         end
     end
 
+    if #pending_web > 0 then
+        local adopted = self:_adoptWebAnnotations(pending_web)
+        changed = changed or (adopted > 0)
+    end
+
     if changed then
         pcall(function() self.ui:handleEvent(Event:new("AnnotationsModified", {{ nb_highlights_added = 0 }})) end)
         pcall(function() UIManager:setDirty(self.ui.dialog, "full") end)
     end
+end
+
+function TomeSync:_adoptWebAnnotations(pending)
+    -- Highlights created in Tome's web reader arrive with a provisional "web:"
+    -- anchor and no position. Locate each one's text with crengine and create a
+    -- NATIVE annotation (real xPointers); the next push carries adopted_from so
+    -- the server retires the provisional row. Anchors are deterministic per book
+    -- copy, so two devices adopting the same highlight converge on one anchor.
+    -- EPUB (rolling) only — PDF positions aren't xPointer strings.
+    local ann = self.ui and self.ui.annotation
+    if not ann or not self.ui.rolling or not self.ui.document then return 0 end
+    local adopted = 0
+    -- Text-level dedupe: a passage already highlighted locally (e.g. adopted on a
+    -- previous pull whose push failed) must not be adopted twice.
+    local seen_text = {{}}
+    for _, a in ipairs(ann.annotations or {{}}) do
+        if a.text then seen_text[a.text] = true end
+    end
+    for _, s in ipairs(pending) do
+        local text = s.highlighted_text
+        if type(text) == "string" and text ~= "" and not seen_text[text] then
+            local ok, results = pcall(function()
+                -- (pattern, case_insensitive, nb_context_words, max_hits, regex)
+                return self.ui.document:findAllText(text, false, 2, 5, false)
+            end)
+            local hit = (ok and type(results) == "table") and results[1] or nil
+            if ok and type(results) == "table" and #results > 1 and s.chapter then
+                -- Same text in several places: prefer the chapter the web named.
+                for _, r in ipairs(results) do
+                    local okc, title = pcall(function()
+                        local page = self.ui.document:getPageFromXPointer(r.start)
+                        return self.ui.toc:getTocTitleByPage(page)
+                    end)
+                    if okc and title == s.chapter then hit = r; break end
+                end
+            end
+            if hit and type(hit.start) == "string" and type(hit["end"]) == "string" then
+                local okAdd = pcall(function()
+                    ann:addItem({{
+                        page = hit.start, pos0 = hit.start, pos1 = hit["end"],
+                        text = text, note = s.note, chapter = s.chapter,
+                        color = s.color, drawer = "lighten",
+                        datetime = s.datetime, datetime_updated = s.datetime_updated,
+                    }})
+                end)
+                if okAdd then
+                    seen_text[text] = true
+                    self.adopt_pending[hit.start] = s.anchor
+                    adopted = adopted + 1
+                end
+            end
+            -- Unlocatable text (e.g. selection spanning a page-break element):
+            -- leave the provisional alone — it stays web-only, never wrong.
+        end
+    end
+    if adopted > 0 then
+        G_reader_settings:saveSetting("tomesync_adopt_pending", self.adopt_pending)
+    end
+    return adopted
 end
 
 function TomeSync:_syncAnnotations()
@@ -2263,6 +2355,29 @@ function TomeSync:_syncAnnotations()
     if not resp then return nil end   -- offline/failed: keep baseline so we retry
 
     self:_applyServerState(resp.annotations, resp.tombstones)
+
+    -- Push freshly-adopted web annotations right away (adopted_from tells the
+    -- server to retire the provisional). On failure adopt_pending persists, so
+    -- the next sync retries — the baseline alone would swallow the adoption.
+    local adopts = {{}}
+    local after1 = self:_localAnnotationMap() or {{}}
+    for anchor, prov in pairs(self.adopt_pending) do
+        local L = after1[anchor]
+        if L then
+            local it = self:_annotItem(L.item)
+            if it then it.adopted_from = prov; table.insert(adopts, it) end
+        else
+            self.adopt_pending[anchor] = nil   -- adopted copy gone locally; drop
+        end
+    end
+    if #adopts > 0 then
+        local resp2 = apiRequest("POST", "/tome-sync/annotations/" .. self.book_id .. "/sync",
+                                 {{ upserts = adopts, deletes = {{}} }})
+        if resp2 then
+            for _, it in ipairs(adopts) do self.adopt_pending[it.anchor] = nil end
+        end
+    end
+    G_reader_settings:saveSetting("tomesync_adopt_pending", self.adopt_pending)
 
     -- Rebuild the baseline from the post-merge local state.
     local newbase = {{}}

--- a/backend/main.py
+++ b/backend/main.py
@@ -168,6 +168,12 @@ async def lifespan(app: FastAPI):
             "ON ko_page_stats (user_id, book_id, page)"
         ))
         conn.commit()
+        # Web-created annotations carry an EPUB CFI so the web reader can
+        # re-paint them without a text search (annotations table pre-exists).
+        an_cols = {r[1] for r in conn.execute(text("PRAGMA table_info(annotations)")).fetchall()}
+        if an_cols and "cfi" not in an_cols:
+            conn.execute(text("ALTER TABLE annotations ADD COLUMN cfi TEXT"))
+            conn.commit()
     ReadingGoal.__table__.create(bind=engine, checkfirst=True)
     init_fts(engine)
     backfill_fts(engine)

--- a/backend/models/tome_sync.py
+++ b/backend/models/tome_sync.py
@@ -113,6 +113,10 @@ class Annotation(Base):
     highlighted_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     note: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     color: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)
+    # EPUB CFI of the selection — set only for annotations created in the web
+    # reader (anchor "web:<uuid>"), so the web can re-paint them without a text
+    # search. Devices never see this; they adopt by locating the text.
+    cfi: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     # KOReader's own creation timestamp for the highlight (display ordering);
     # distinct from created_at, which is when Tome first stored it.
     koreader_datetime: Mapped[Optional[str]] = mapped_column(String(32), nullable=True)

--- a/frontend/src/lib/readerAnnotations.ts
+++ b/frontend/src/lib/readerAnnotations.ts
@@ -21,12 +21,16 @@
 export interface ReaderAnnotation {
   id: number
   anchor: string
+  // Set for web-created highlights (anchor "web:…") — paints directly, no search.
+  cfi?: string | null
   highlighted_text: string | null
   note: string | null
   chapter: string | null
   color: string | null
   datetime: string | null
 }
+
+export const isWebAnnotation = (a: ReaderAnnotation) => a.anchor.startsWith('web:')
 
 /** KOReader highlight colours → translucent fills that work on all reader themes. */
 const KO_FILL: Record<string, string> = {
@@ -113,11 +117,47 @@ export class AnnotationPainter {
   /** Feed the annotation set and map the TOC; unblocks section scanning. */
   async start(annotations: ReaderAnnotation[]) {
     this.annotations = annotations.filter(a => a.highlighted_text)
+    // Web-created highlights carry their own CFI — register + paint directly.
+    for (const a of this.annotations) {
+      if (a.cfi) this.register(a, a.cfi)
+    }
     try {
       await this.buildSectionLabels()
     } finally {
       this.markReady()
     }
+  }
+
+  /** Paint a highlight just created in this session (already has its CFI). */
+  addLocal(a: ReaderAnnotation) {
+    if (!a.cfi) return
+    this.annotations.push(a)
+    this.register(a, a.cfi)
+  }
+
+  /** Remove a highlight's overlay + tracking (after a server-side delete). */
+  removeById(id: number) {
+    const cfi = this.cfiById.get(id)
+    this.annotations = this.annotations.filter(a => a.id !== id)
+    if (!cfi) return
+    this.cfiById.delete(id)
+    this.byCfi.delete(cfi)
+    void this.view.addAnnotation({ value: cfi }, true)
+  }
+
+  /** Reflect an edited note/colour on the tracked annotation object. */
+  updateLocal(a: ReaderAnnotation) {
+    const cfi = this.cfiById.get(a.id)
+    if (cfi) this.byCfi.set(cfi, a)
+    this.annotations = this.annotations.map(x => (x.id === a.id ? a : x))
+    // Repaint so a colour change shows immediately.
+    if (cfi) void this.view.addAnnotation({ value: cfi, color: a.color })
+  }
+
+  private register(a: ReaderAnnotation, cfi: string) {
+    this.cfiById.set(a.id, cfi)
+    this.byCfi.set(cfi, a)
+    void this.view.addAnnotation({ value: cfi, color: a.color })
   }
 
   /** Map TOC entries to section indexes so chapter names can gate the search. */
@@ -154,7 +194,7 @@ export class AnnotationPainter {
     const sectionLabel = this.sectionLabels.get(index)
 
     for (const a of this.annotations) {
-      if (this.cfiById.has(a.id)) continue
+      if (this.cfiById.has(a.id) || a.cfi) continue
       const chapter = a.chapter ? normalize(a.chapter) : null
       // If the annotation names a chapter we know from the TOC, only search
       // sections under that label; unknown/absent chapters search everywhere.

--- a/frontend/src/pages/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage.tsx
@@ -4,14 +4,14 @@ import {
   ArrowLeft, BookOpen, Settings, Rows4,
   ChevronLeft, ChevronRight, Minus, Plus, X,
   Loader2, AlignJustify, RotateCcw, GalleryHorizontalEnd, Columns2, Square,
-  StretchHorizontal, StretchVertical, StickyNote,
+  StretchHorizontal, StretchVertical, StickyNote, Trash2,
 } from 'lucide-react'
 import * as pdfjsLib from 'pdfjs-dist'
 import pdfWorkerUrl from 'pdfjs-dist/build/pdf.worker.min.mjs?url'
 import { api } from '@/lib/api'
 import type { Book, BookFile } from '@/lib/books'
 import { cn } from '@/lib/utils'
-import { AnnotationPainter, fillForColor, type ReaderAnnotation } from '@/lib/readerAnnotations'
+import { AnnotationPainter, fillForColor, isWebAnnotation, type ReaderAnnotation } from '@/lib/readerAnnotations'
 
 // pdf.js renders pages off the main thread; point it at the bundled worker.
 pdfjsLib.GlobalWorkerOptions.workerSrc = pdfWorkerUrl
@@ -35,9 +35,20 @@ interface FoliateViewElement extends HTMLElement {
   open(file: File): Promise<void>
   goTo(target: string | number): Promise<void>
   goToFraction(fraction: number): Promise<void>
+  getCFI(index: number, range: Range): string
   prev(): void
   next(): void
 }
+
+// KOReader wall-clock format — annotations compare timestamps as strings.
+function koNow(): string {
+  const d = new Date()
+  const p = (n: number) => String(n).padStart(2, '0')
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`
+}
+
+// Colour choices for web-created highlights (KOReader's common palette).
+const HIGHLIGHT_COLORS = ['yellow', 'green', 'blue', 'purple', 'red'] as const
 
 // ── Theme / font definitions ──────────────────────────────────────────────────
 
@@ -708,6 +719,14 @@ export default function ReaderPage() {
   // KOReader highlights painted into the EPUB view; tapping one opens the card.
   const painterRef = useRef<AnnotationPainter | null>(null)
   const [activeHighlight, setActiveHighlight] = useState<ReaderAnnotation | null>(null)
+  // Text selection inside the EPUB → colour toolbar → POST → painted highlight.
+  // The range is snapshotted eagerly: clicking the toolbar (outside the iframe)
+  // can collapse the live selection before we read it.
+  const selectionRef = useRef<{ doc: Document; index: number; range: Range; text: string } | null>(null)
+  const selDocsRef = useRef<WeakSet<Document>>(new WeakSet())
+  const [selText, setSelText] = useState<string | null>(null)
+  const [noteDraft, setNoteDraft] = useState<string | null>(null)  // null = not editing
+  const [savingAnnotation, setSavingAnnotation] = useState(false)
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const initialCfi = useRef<string | null>(null)
   const readyToSave = useRef(false)
@@ -977,6 +996,22 @@ export default function ReaderPage() {
         const detail = (e as CustomEvent).detail as { doc?: Document; index?: number } | undefined
         if (detail?.doc && detail.index != null) {
           painter.onSectionLoad(detail.doc, detail.index).catch(() => {})
+          // Track text selection per section document (attach once per doc).
+          const doc = detail.doc
+          const index = detail.index
+          if (!selDocsRef.current.has(doc)) {
+            selDocsRef.current.add(doc)
+            doc.addEventListener('selectionchange', () => {
+              const sel = doc.getSelection()
+              const text = sel && !sel.isCollapsed ? sel.toString() : ''
+              if (sel && text.trim().length > 1) {
+                selectionRef.current = { doc, index, range: sel.getRangeAt(0).cloneRange(), text }
+                setSelText(text)
+              } else {
+                setSelText(prev => (prev != null ? null : prev))
+              }
+            })
+          }
         }
       })
 
@@ -1072,6 +1107,55 @@ export default function ReaderPage() {
 
   function epubPrev() { viewRef.current?.prev() }
   function epubNext() { viewRef.current?.next() }
+
+  // ── Web-created highlights (create / note / delete) ────────────────────────
+
+  const createHighlight = useCallback(async (color: string) => {
+    const s = selectionRef.current
+    const view = viewRef.current
+    if (!s || !view || savingAnnotation) return
+    setSavingAnnotation(true)
+    try {
+      const cfi = view.getCFI(s.index, s.range)
+      const created = await api.post<ReaderAnnotation>('/annotations', {
+        book_id: Number(bookId),
+        highlighted_text: s.text,
+        cfi,
+        color,
+        chapter: chapterLabel || null,
+        datetime: koNow(),
+      })
+      painterRef.current?.addLocal(created)
+      s.doc.getSelection()?.removeAllRanges()
+      selectionRef.current = null
+      setSelText(null)
+      setNoteDraft(null)
+      setActiveHighlight(created)
+    } catch { /* keep the selection so the user can retry */ }
+    finally { setSavingAnnotation(false) }
+  }, [bookId, chapterLabel, savingAnnotation])
+
+  const saveNote = useCallback(async () => {
+    if (!activeHighlight || noteDraft == null) return
+    try {
+      const updated = await api.put<ReaderAnnotation>(
+        `/annotations/${activeHighlight.id}`, { note: noteDraft.trim() || null })
+      const merged = { ...activeHighlight, ...updated }
+      painterRef.current?.updateLocal(merged)
+      setActiveHighlight(merged)
+      setNoteDraft(null)
+    } catch { /* stay in edit mode */ }
+  }, [activeHighlight, noteDraft])
+
+  const deleteHighlight = useCallback(async () => {
+    if (!activeHighlight) return
+    try {
+      await api.delete(`/annotations/${activeHighlight.id}`)
+      painterRef.current?.removeById(activeHighlight.id)
+      setActiveHighlight(null)
+      setNoteDraft(null)
+    } catch { /* leave the card open */ }
+  }, [activeHighlight])
 
   useEffect(() => {
     if (isComic || isPdf) return
@@ -1715,10 +1799,37 @@ export default function ReaderPage() {
           <div className="absolute inset-y-0 left-0 w-1/5 cursor-pointer z-10" onClick={epubPrev} />
           <div className="absolute inset-y-0 right-0 w-1/5 cursor-pointer z-10" onClick={epubNext} />
 
-          {/* Tapped-highlight card — KOReader highlights painted in the text */}
+          {/* Selection toolbar — pick a colour to create a highlight */}
+          {selText && !activeHighlight && (
+            <div
+              className="absolute bottom-6 left-1/2 -translate-x-1/2 z-30 flex items-center gap-2.5 rounded-xl border shadow-2xl px-4 py-2.5"
+              style={{
+                background: themeColors.bg,
+                color: themeColors.text,
+                borderColor: isDarkTheme ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)',
+              }}
+            >
+              <span className="text-xs font-medium mr-1" style={{ opacity: 0.55 }}>Highlight</span>
+              {HIGHLIGHT_COLORS.map(c => (
+                <button
+                  key={c}
+                  onClick={() => createHighlight(c)}
+                  disabled={savingAnnotation}
+                  aria-label={`Highlight in ${c}`}
+                  className="w-6 h-6 rounded-full transition-transform hover:scale-110 disabled:opacity-50"
+                  style={{
+                    background: fillForColor(c).replace(/[\d.]+\)$/, '0.9)'),
+                    border: '1px solid rgba(128,128,128,0.35)',
+                  }}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Tapped-highlight card — synced + web-created highlights */}
           {activeHighlight && (
             <>
-              <div className="absolute inset-0 z-20" onClick={() => setActiveHighlight(null)} />
+              <div className="absolute inset-0 z-20" onClick={() => { setActiveHighlight(null); setNoteDraft(null) }} />
               <div
                 className="absolute bottom-6 left-1/2 -translate-x-1/2 z-30 w-[min(34rem,calc(100%-2rem))] rounded-xl border shadow-2xl p-4"
                 style={{
@@ -1738,7 +1849,7 @@ export default function ReaderPage() {
                       <span className="shrink-0">· {activeHighlight.datetime.slice(0, 10)}</span>
                     )}
                   </div>
-                  <button onClick={() => setActiveHighlight(null)} style={{ opacity: 0.5 }} aria-label="Close">
+                  <button onClick={() => { setActiveHighlight(null); setNoteDraft(null) }} style={{ opacity: 0.5 }} aria-label="Close">
                     <X className="w-4 h-4" />
                   </button>
                 </div>
@@ -1750,13 +1861,55 @@ export default function ReaderPage() {
                     {activeHighlight.highlighted_text}
                   </p>
                 )}
-                {activeHighlight.note && (
+                {noteDraft != null ? (
+                  <div className="mt-2.5">
+                    <textarea
+                      value={noteDraft}
+                      onChange={e => setNoteDraft(e.target.value)}
+                      rows={3}
+                      autoFocus
+                      placeholder="Add a note…"
+                      className="w-full rounded-lg border bg-transparent p-2 text-sm focus:outline-none"
+                      style={{ borderColor: isDarkTheme ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.15)', color: themeColors.text }}
+                    />
+                    <div className="mt-1.5 flex gap-3 text-xs font-medium">
+                      <button onClick={saveNote} className="hover:underline">Save</button>
+                      <button onClick={() => setNoteDraft(null)} style={{ opacity: 0.6 }} className="hover:underline">Cancel</button>
+                    </div>
+                  </div>
+                ) : activeHighlight.note ? (
                   <p className="mt-2.5 flex items-start gap-1.5 text-sm" style={{ opacity: 0.75 }}>
                     <StickyNote className="w-3.5 h-3.5 mt-0.5 shrink-0" />
                     <span className="leading-relaxed">{activeHighlight.note}</span>
                   </p>
-                )}
-                <p className="mt-2.5 text-[11px]" style={{ opacity: 0.4 }}>Synced from KOReader</p>
+                ) : null}
+                <div className="mt-2.5 flex items-center justify-between">
+                  <p className="text-[11px]" style={{ opacity: 0.4 }}>
+                    {isWebAnnotation(activeHighlight)
+                      ? 'Made on the web — syncs to KOReader'
+                      : 'Synced from KOReader'}
+                  </p>
+                  {noteDraft == null && (
+                    <div className="flex items-center gap-3 text-xs">
+                      <button
+                        onClick={() => setNoteDraft(activeHighlight.note ?? '')}
+                        className="flex items-center gap-1 hover:underline"
+                        style={{ opacity: 0.7 }}
+                      >
+                        <StickyNote className="w-3.5 h-3.5" />
+                        {activeHighlight.note ? 'Edit note' : 'Add note'}
+                      </button>
+                      <button
+                        onClick={deleteHighlight}
+                        className="flex items-center gap-1 hover:underline"
+                        style={{ opacity: 0.7 }}
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                        Delete
+                      </button>
+                    </div>
+                  )}
+                </div>
               </div>
             </>
           )}

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -155,5 +155,9 @@ def test_build_bumped_for_rebake():
     # 1.6.2 / build 24 files each download under its own book type (issue #88):
     # the No Series bucket mixes types, so a single batch type misfiled standalone
     # books (e.g. RoyalRoad titles landing in light_novel).
-    assert TOMESYNC_PLUGIN_BUILD >= 24
-    assert TOMESYNC_PLUGIN_SEMVER == "1.6.2"
+    # 1.7.0 / build 25 adopts web-created highlights: annotations made in Tome's
+    # web reader arrive under a provisional "web:" anchor; the plugin locates the
+    # text natively, creates a first-class KOReader highlight, and the sync push
+    # (adopted_from) retires the provisional server-side.
+    assert TOMESYNC_PLUGIN_BUILD >= 25
+    assert TOMESYNC_PLUGIN_SEMVER == "1.7.0"

--- a/tests/test_web_annotations.py
+++ b/tests/test_web_annotations.py
@@ -1,0 +1,139 @@
+"""Web-created annotations + device adoption.
+
+A highlight made in the web reader is stored under a provisional "web:<uuid>"
+anchor with the selection's CFI. Devices never render the provisional anchor —
+they locate the text natively and "adopt" it: the sync upsert carries
+``adopted_from`` and the server retires the provisional row. Anchors are
+deterministic per book copy, so concurrent adoption by two devices converges
+on one canonical row.
+"""
+from backend.models.tome_sync import ApiKey, Annotation, AnnotationTombstone
+
+
+def _api_key_for(db, user_id: int) -> str:
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(user_id=user_id, key_hash=ApiKey.hash_key(plaintext),
+                  key_prefix=plaintext[:11], label="test"))
+    db.flush()
+    return plaintext
+
+
+def _sync(client, hdr, book_id, upserts=(), deletes=()):
+    return client.post(f"/api/tome-sync/annotations/{book_id}/sync", headers=hdr,
+                       json={"upserts": list(upserts), "deletes": list(deletes)})
+
+
+def _create_web(client, book_id, **over):
+    body = {
+        "book_id": book_id,
+        "highlighted_text": "The cheapest server is the one you turned off.",
+        "cfi": "epubcfi(/6/18!/4/2/2,/1:0,/1:46)",
+        "color": "yellow",
+        "chapter": "1. What Is FinOps?",
+        "datetime": "2026-07-02 10:00:00",
+        **over,
+    }
+    return client.post("/api/annotations", json=body)
+
+
+XP = "/body/DocFragment[9]/p[4]/text().0"
+XP_END = "/body/DocFragment[9]/p[4]/text().46"
+
+
+def test_create_web_annotation(client, db, admin_user, make_book):
+    book = make_book()
+    r = _create_web(client, book.id, note="from the web")
+    assert r.status_code == 201, r.text
+    a = r.json()
+    assert a["anchor"].startswith("web:")
+    assert a["cfi"].startswith("epubcfi(")
+    assert a["datetime_updated"] == "2026-07-02 10:00:00"
+
+    # Web per-book GET carries the cfi; the plugin GET lists it as alive.
+    user, _ = admin_user
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    web = client.get(f"/api/books/{book.id}/annotations").json()
+    assert web[0]["cfi"] == a["cfi"]
+    plug = client.get(f"/api/tome-sync/annotations/{book.id}", headers=hdr).json()
+    assert [x["anchor"] for x in plug["annotations"]] == [a["anchor"]]
+
+
+def test_adoption_retires_provisional(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book()
+    prov = _create_web(client, book.id).json()["anchor"]
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+
+    # Device locates the text and re-anchors it natively.
+    r = _sync(client, hdr, book.id, upserts=[{
+        "anchor": XP, "anchor_end": XP_END,
+        "highlighted_text": "The cheapest server is the one you turned off.",
+        "color": "yellow", "chapter": "1. What Is FinOps?",
+        "datetime": "2026-07-02 10:00:00", "datetime_updated": "2026-07-02 10:00:00",
+        "adopted_from": prov,
+    }])
+    assert r.status_code == 200, r.text
+    anchors = [x["anchor"] for x in r.json()["annotations"]]
+    assert anchors == [XP]                     # canonical present, provisional gone
+    assert r.json()["tombstones"] == []        # identity move, not a delete
+    assert db.query(Annotation).filter_by(book_id=book.id).count() == 1
+
+
+def test_double_adoption_is_idempotent(client, db, admin_user, make_book):
+    """Second device adopts after the first: same deterministic anchor → dedupe;
+    the missing provisional is a no-op."""
+    user, _ = admin_user
+    book = make_book()
+    prov = _create_web(client, book.id).json()["anchor"]
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    item = {
+        "anchor": XP, "anchor_end": XP_END,
+        "highlighted_text": "The cheapest server is the one you turned off.",
+        "color": "yellow", "datetime": "2026-07-02 10:00:00",
+        "datetime_updated": "2026-07-02 10:00:00", "adopted_from": prov,
+    }
+    _sync(client, hdr, book.id, upserts=[item])
+    r = _sync(client, hdr, book.id, upserts=[item])   # device B, same computation
+    assert r.status_code == 200
+    assert [x["anchor"] for x in r.json()["annotations"]] == [XP]
+    assert db.query(Annotation).filter_by(book_id=book.id).count() == 1
+
+
+def test_web_delete_before_adoption(client, db, admin_user, make_book):
+    """Deleting the web highlight before any device adopts it tombstones the
+    provisional; the device sees no alive web anchor and adopts nothing."""
+    user, _ = admin_user
+    book = make_book()
+    created = _create_web(client, book.id).json()
+    assert client.delete(f"/api/annotations/{created['id']}").status_code == 204
+
+    hdr = {"Authorization": f"Bearer {_api_key_for(db, user.id)}"}
+    g = client.get(f"/api/tome-sync/annotations/{book.id}", headers=hdr).json()
+    assert g["annotations"] == []
+    assert [t["anchor"] for t in g["tombstones"]] == [created["anchor"]]
+    # A straggling adoption for the now-deleted provisional creates the canonical
+    # copy (the device DID make a local highlight) — acceptable; no crash.
+    r = _sync(client, hdr, book.id, upserts=[{
+        "anchor": XP, "highlighted_text": "x", "datetime": "2026-07-02 11:00:00",
+        "adopted_from": created["anchor"],
+    }])
+    assert r.status_code == 200
+
+
+def test_edit_note_bumps_mtime_strictly(client, db, admin_user, make_book):
+    """A web edit must win LWW on devices even when the server clock is at or
+    behind the row's mtime (created here with a far-future device timestamp)."""
+    book = make_book()
+    created = _create_web(client, book.id, datetime="2099-01-01 00:00:00").json()
+    r = client.put(f"/api/annotations/{created['id']}", json={"note": "edited on web"})
+    assert r.status_code == 200, r.text
+    out = r.json()
+    assert out["note"] == "edited on web"
+    assert out["datetime_updated"] > "2099-01-01 00:00:00"
+
+
+def test_create_validation(client, db, admin_user, make_book):
+    book = make_book()
+    assert _create_web(client, book.id, highlighted_text="  ").status_code == 422
+    r = client.post("/api/annotations", json={"book_id": 999999, "highlighted_text": "x"})
+    assert r.status_code == 404


### PR DESCRIPTION
> **Stacked on #97** (`feat/web-reader-annotations`). Merge #97 first; this retargets automatically.

Stage 2 (A2): select text in the web reader → pick a colour → optional note → the highlight paints immediately **and lands on your KOReader as a first-class native highlight**.

## The adoption protocol

The web and KOReader address text incompatibly (CFI vs crengine xPointers), so instead of translating anchors, devices **adopt**:

1. `POST /api/annotations` stores the highlight under a provisional `web:<uuid>` anchor + the selection's CFI (web repaints directly from it; Highlights views show it like any other).
2. The plugin (**build 25 / 1.7.0**) never renders provisional anchors. On sync it locates the text via crengine `findAllText` (multiple hits disambiguated by the chapter the web recorded), creates a **native** annotation with real xPointers, and pushes it with `adopted_from`.
3. The server upserts the canonical row and retires the provisional — an identity move, no tombstone.

Safety properties:
- **Concurrent adoption converges**: anchors are deterministic per book copy, so two devices produce the same xPointer → dedupe by anchor; the second `adopted_from` is a no-op (covered by test).
- **Failed pushes self-heal**: a persisted `adopt_pending` ledger retries next sync (the baseline alone would swallow the adoption).
- **Unlocatable text degrades**: the highlight stays web-only — never painted onto the wrong words. Same rule as stage 1.
- Deleting the web highlight before adoption tombstones the provisional; devices adopt nothing.

## Also in here

- `PUT /api/annotations/{id}` — edit note/colour from the web for **any** highlight (web- or device-born). The LWW mtime is bumped strictly past the row's current one (clock-skew guarded), so the edit wins on every device at its next sync.
- Reader card gains **Add/Edit note** and **Delete**; the selection toolbar offers KOReader's five common colours; web-born highlights read "Made on the web — syncs to KOReader".
- `annotations.cfi` column (startup `ALTER TABLE` for existing DBs).

## Verified

- 6 new tests (`tests/test_web_annotations.py`): create/serialize, adoption retiring the provisional, double-adoption idempotence, delete-before-adoption, strict LWW bump on web edits, validation. Full suite: **688 passed**.
- Rendered plugin Lua passes a `luajit` syntax check.
- Full web loop driven live in the browser: select → toolbar → painted green highlight → note saved via card (screenshots in thread).

## Remaining gate before merge

The **two-emulator adoption round-trip** (web-created highlight appearing as a native KOReader highlight, then re-syncing cleanly) — next session, via the koreader-dev bridge.