### PR TITLE
feat(wishlist): release detection — follow a series, get "vol N is out" alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Follow a series — get told when a new volume is out.** A new opt-in release
+  detector (set `TOME_RELEASE_DETECTION=true`; needs your Hardcover token) lets
+  members follow a series: Tome polls Hardcover on a schedule (daily by default,
+  `TOME_RELEASE_CHECK_INTERVAL`) and when the tracker's latest volume number
+  grows past what it saw at follow time, you get a bell notification — and an
+  email when SMTP is configured. Following starts silent: it primes at the
+  series' current latest volume, so following a 27-volume series doesn't fire
+  27 alerts. Follows live alongside your wishlist (`/api/wishlist/follow`,
+  `/api/wishlist/follows`), and admins can trigger a check on demand.
 - **Focus mode on the Home page.** A new minimalist Home view that surfaces the one
   book you're most likely to pick up next — your most-recently-synced in-progress
   title — as a large cover with the upcoming volumes of its series fanned behind it

--- a/backend/api/wishlist.py
+++ b/backend/api/wishlist.py
@@ -183,6 +183,8 @@ def _follow_out(db: Session, current_user: User, w: Wish) -> dict:
         "cover_url": w.cover_url,
         "source_id": w.source_id,
         "latest_known_index": w.latest_known_index,
+        "latest_known_title": w.latest_known_title,
+        "latest_release_date": w.latest_release_date,
         "owned_max_index": float(owned) if owned is not None else None,
         "last_checked_at": w.last_checked_at.isoformat() + "Z" if w.last_checked_at else None,
         "created_at": w.created_at.isoformat() + "Z" if w.created_at else None,
@@ -259,6 +261,8 @@ async def follow_series(
     state = await fetch_series_latest(int(sid))
     if state:
         wish.latest_known_index = state["latest_index"]
+        wish.latest_known_title = state.get("latest_title")
+        wish.latest_release_date = state.get("release_date")
         wish.last_checked_at = _dt.utcnow()
 
     db.commit()

--- a/backend/api/wishlist.py
+++ b/backend/api/wishlist.py
@@ -45,10 +45,10 @@ def list_wishes(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Return the current user's wishes."""
+    """Return the current user's wishes (kind="wish" — follows live at /wishlist/follows)."""
     require_role(current_user, "member")
 
-    q = db.query(Wish).filter(Wish.user_id == current_user.id)
+    q = db.query(Wish).filter(Wish.user_id == current_user.id, Wish.kind == "wish")
     if status:
         q = q.filter(Wish.status == status)
     wishes = q.order_by(Wish.created_at.desc()).all()
@@ -143,6 +143,148 @@ def series_search_available(_: User = Depends(get_current_user)) -> dict:
     """Series search is Hardcover-only — the add dialog hides the Series tab when
     no Hardcover token is configured (book search still works via Google/OL)."""
     return {"available": bool(settings.hardcover_token)}
+
+
+# ── Follows (release detection) ──────────────────────────────────────────────
+# A follow is a Wish with kind="follow": the columns reserved by the wishlist
+# plan (external_series_id / last_checked_at / latest_known_index) come alive.
+# Gated by TOME_RELEASE_DETECTION; the poller lives in services/release_detection.
+
+from pydantic import BaseModel as _BaseModel
+
+
+class FollowCreate(_BaseModel):
+    name: str                      # series name (display + library matching)
+    source_id: Optional[str] = None  # Hardcover series id; resolved by name if absent
+    author: Optional[str] = None
+    cover_url: Optional[str] = None
+
+
+def _require_detection():
+    if not settings.release_detection:
+        raise HTTPException(status_code=403, detail="Release detection is disabled (TOME_RELEASE_DETECTION)")
+
+
+def _follow_out(db: Session, current_user: User, w: Wish) -> dict:
+    # Highest volume of this series already in the library (visibility-gated).
+    from sqlalchemy import func as _f
+    from backend.core.permissions import book_visibility_filter
+    owned_q = db.query(_f.max(Book.series_index)).filter(
+        Book.series == w.series, Book.status == "active",
+    )
+    vis = book_visibility_filter(db, current_user)
+    if vis is not True:
+        owned_q = owned_q.filter(vis)
+    owned = owned_q.scalar()
+    return {
+        "id": w.id,
+        "name": w.title,
+        "author": w.author,
+        "cover_url": w.cover_url,
+        "source_id": w.source_id,
+        "latest_known_index": w.latest_known_index,
+        "owned_max_index": float(owned) if owned is not None else None,
+        "last_checked_at": w.last_checked_at.isoformat() + "Z" if w.last_checked_at else None,
+        "created_at": w.created_at.isoformat() + "Z" if w.created_at else None,
+    }
+
+
+@router.get("/wishlist/follows")
+def list_follows(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """The current user's followed series, with the tracker vs library state."""
+    require_role(current_user, "member")
+    _require_detection()
+    rows = (
+        db.query(Wish)
+        .filter(Wish.user_id == current_user.id, Wish.kind == "follow", Wish.status == "open")
+        .order_by(Wish.created_at.desc())
+        .all()
+    )
+    return [_follow_out(db, current_user, w) for w in rows]
+
+
+@router.post("/wishlist/follow", status_code=201)
+async def follow_series(
+    payload: FollowCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Follow a series: resolve it on Hardcover, prime the release watermark.
+
+    Priming means only releases AFTER following notify — following a
+    27-volume series doesn't fire 27 alerts.
+    """
+    require_role(current_user, "member")
+    _require_detection()
+    from backend.services.metadata_fetch import search_series
+    from backend.services.release_detection import fetch_series_latest
+    from datetime import datetime as _dt
+
+    name = payload.name.strip()
+    if not name:
+        raise HTTPException(status_code=422, detail="name must not be empty")
+
+    sid = payload.source_id
+    author, cover = payload.author, payload.cover_url
+    if not sid:
+        hits = await search_series(name)
+        if not hits:
+            raise HTTPException(status_code=404, detail="Series not found on Hardcover")
+        best = hits[0]
+        sid, name = best["source_id"], best["name"]
+        author = author or best.get("author")
+        cover = cover or best.get("cover_url")
+
+    dup = (
+        db.query(Wish)
+        .filter(Wish.user_id == current_user.id, Wish.kind == "follow",
+                Wish.external_series_id == str(sid), Wish.status == "open")
+        .first()
+    )
+    if dup:
+        raise HTTPException(status_code=409, detail="Already following this series")
+
+    wish = Wish(
+        user_id=current_user.id, kind="follow", status="open",
+        title=name, series=name, author=author, cover_url=cover,
+        source="hardcover", source_id=f"series:{sid}",
+        external_series_id=str(sid),
+    )
+    db.add(wish)
+    db.flush()
+
+    state = await fetch_series_latest(int(sid))
+    if state:
+        wish.latest_known_index = state["latest_index"]
+        wish.last_checked_at = _dt.utcnow()
+
+    db.commit()
+    db.refresh(wish)
+    audit(
+        db,
+        "wishlist.follow",
+        user_id=current_user.id,
+        username=current_user.username,
+        resource_type="wish",
+        resource_id=wish.id,
+        details={"series": name, "hardcover_id": str(sid)},
+    )
+    return _follow_out(db, current_user, wish)
+
+
+@router.post("/admin/release-check")
+async def admin_release_check(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Run the release-detection poll for every open follow, right now."""
+    require_role(current_user, "admin")
+    _require_detection()
+    from backend.services.release_detection import check_follows
+    return await check_follows(db, force=True)
 
 
 # ── Admin endpoints ───────────────────────────────────────────────────────────

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -57,6 +57,11 @@ class Settings(BaseSettings):
     wishlist_enabled: bool = True   # env TOME_WISHLIST_ENABLED — kill switch, defaults on
     wishlist_max_open_per_user: int = 100  # env TOME_WISHLIST_MAX — soft cap per user
 
+    # Release detection (follow a series → "vol N is out" alerts). Off by
+    # default: it polls Hardcover on a schedule and needs TOME_HARDCOVER_TOKEN.
+    release_detection: bool = False        # env TOME_RELEASE_DETECTION
+    release_check_interval: int = 86400    # env TOME_RELEASE_CHECK_INTERVAL, seconds
+
     # Send-to-KOReader inbox (env TOME_SEND_TO_KOREADER). On by default since
     # v1.7.0 ("Signature") after real-hardware validation; the web UI queues a
     # book to be pulled onto KOReader by the TomeSync plugin's inbox (no

--- a/backend/main.py
+++ b/backend/main.py
@@ -190,15 +190,22 @@ async def lifespan(app: FastAPI):
     else:
         logger.info("Auto-import disabled (set TOME_AUTO_IMPORT=true to enable)")
 
+    release_task: asyncio.Task | None = None
+    if settings.release_detection:
+        logger.info("Release detection enabled — checking follows every %d seconds",
+                    settings.release_check_interval)
+        release_task = asyncio.create_task(_release_check_loop())
+
     yield
 
-    # Shutdown: cancel the background task cleanly
-    if auto_import_task is not None:
-        auto_import_task.cancel()
-        try:
-            await auto_import_task
-        except asyncio.CancelledError:
-            pass
+    # Shutdown: cancel the background tasks cleanly
+    for task in (auto_import_task, release_task):
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
 
 
 async def _auto_import_loop() -> None:
@@ -211,6 +218,28 @@ async def _auto_import_loop() -> None:
             raise
         except Exception:
             logger.exception("Unhandled error in auto-import loop")
+
+
+async def _release_check_loop() -> None:
+    """Background task: poll Hardcover for new volumes of followed series.
+
+    The per-follow due check lives in check_follows (last_checked_at vs the
+    configured interval); this loop just wakes hourly to see if anything is due,
+    so a long interval doesn't need a long sleep to survive restarts.
+    """
+    from backend.core.database import SessionLocal
+    from backend.services.release_detection import check_follows
+    while True:
+        try:
+            await asyncio.sleep(min(3600, settings.release_check_interval))
+            with SessionLocal() as db:
+                result = await check_follows(db)
+            if result.get("notified"):
+                logger.info("Release detection: %s", result)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Unhandled error in release-check loop")
 
 
 async def _run_auto_import() -> None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -168,6 +168,13 @@ async def lifespan(app: FastAPI):
             "ON ko_page_stats (user_id, book_id, page)"
         ))
         conn.commit()
+        # Release detection stores the tracker's latest volume title + date on
+        # follows (wishes table pre-exists on upgraded installs).
+        wi_cols = {r[1] for r in conn.execute(text("PRAGMA table_info(wishes)")).fetchall()}
+        if wi_cols and "latest_known_title" not in wi_cols:
+            conn.execute(text("ALTER TABLE wishes ADD COLUMN latest_known_title VARCHAR(512)"))
+            conn.execute(text("ALTER TABLE wishes ADD COLUMN latest_release_date VARCHAR(10)"))
+            conn.commit()
     ReadingGoal.__table__.create(bind=engine, checkfirst=True)
     init_fts(engine)
     backfill_fts(engine)

--- a/backend/models/wish.py
+++ b/backend/models/wish.py
@@ -79,10 +79,14 @@ class Wish(Base):
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
 
-    # ── reserved for the detection plan (added now, unused) ──────────────────
+    # ── release detection (kind="follow"; reserved by the wishlist plan) ─────
     external_series_id: Mapped[Optional[str]] = mapped_column(String(128))
     last_checked_at: Mapped[Optional[datetime]] = mapped_column(DateTime)
     latest_known_index: Mapped[Optional[float]] = mapped_column(Float)
+    # The tracker's latest volume title + release date ("YYYY-MM-DD"), stored so
+    # the series page / Home can show "Vol 16 — Jul 7" without re-polling.
+    latest_known_title: Mapped[Optional[str]] = mapped_column(String(512))
+    latest_release_date: Mapped[Optional[str]] = mapped_column(String(10))
 
     __table_args__ = (
         UniqueConstraint("user_id", "source", "source_id", name="uq_wish_user_source"),

--- a/backend/services/email.py
+++ b/backend/services/email.py
@@ -187,6 +187,40 @@ def send_wish_fulfilled_email(to_email: str, wish: object, book: object = None) 
         log.exception("send_wish_fulfilled_email: failed to send to %s", to_email)
 
 
+def send_release_email(to_email: str, wish: object, state: dict) -> None:
+    """Notify a follower that a new volume of their series is out.
+
+    Only called when settings.smtp_configured is True; failures are swallowed
+    and logged — they must never block the detection cycle.
+    """
+    if not settings.smtp_configured:
+        return
+    try:
+        series = getattr(wish, "title", str(wish))
+        vol = state.get("latest_index")
+        vol_str = str(int(vol)) if vol is not None and float(vol).is_integer() else str(vol)
+        title = state.get("latest_title") or f"Volume {vol_str}"
+        released = f" (released {state['release_date']})" if state.get("release_date") else ""
+        body = (
+            f"A new volume of \"{series}\" is out: {title}{released}.\n\n"
+            "Manage the series you follow on your wishlist page: /wishlist\n\n"
+            "— Tome"
+        )
+        msg = MIMEText(body, "plain")
+        msg["From"] = settings.smtp_from_address
+        msg["To"] = to_email
+        msg["Subject"] = f"[Tome] New release: {series} vol. {vol_str}"
+
+        conn = _connect()
+        try:
+            conn.sendmail(settings.smtp_from_address, [to_email], msg.as_string())
+        finally:
+            conn.quit()
+        log.info("Release email sent to %s for '%s' vol %s", to_email, series, vol_str)
+    except Exception:
+        log.exception("send_release_email: failed to send to %s", to_email)
+
+
 def send_test_email(to_email: str) -> None:
     """Send a plain-text test email to verify SMTP config."""
     if not settings.smtp_configured:

--- a/backend/services/release_detection.py
+++ b/backend/services/release_detection.py
@@ -1,0 +1,150 @@
+"""Release detection — "a new volume of a series you follow is out".
+
+A follow is a ``Wish`` row with ``kind="follow"`` (the columns were reserved by
+the wishlist plan precisely for this): ``external_series_id`` is the canonical
+Hardcover series id, ``latest_known_index`` the highest volume position seen at
+the last check, ``last_checked_at`` the poll bookkeeping. The poller compares
+Hardcover's current highest position against ``latest_known_index`` and, when
+it grows, notifies the follower through the existing Notification bell (+ email
+when SMTP is configured) and advances the watermark.
+
+Priming rule: a follow starts at Hardcover's *current* latest volume, so only
+releases that happen AFTER following notify — following a 27-volume series
+doesn't fire 27 alerts. Gated by ``TOME_RELEASE_DETECTION`` (default off) and
+requires the Hardcover token; without either, the loop idles.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import Optional
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.core.config import settings
+from backend.models.notification import Notification
+from backend.models.user import User
+from backend.models.wish import Wish
+from backend.services.metadata_fetch import HARDCOVER_URL
+
+log = logging.getLogger(__name__)
+
+_VOLUMES_QUERY = """
+query SeriesLatest($id: Int!) {
+    series(where: {id: {_eq: $id}}) {
+        id
+        name
+        primary_books_count
+        book_series(order_by: {position: desc_nulls_last}, limit: 3) {
+            position
+            book { title release_date }
+        }
+    }
+}
+"""
+
+
+async def fetch_series_latest(series_id: int) -> Optional[dict]:
+    """Hardcover's current view of a series: highest volume position + metadata.
+
+    Returns ``{"latest_index", "latest_title", "release_date", "total", "name"}``
+    or None on any failure (offline, rate-limited, series gone) — the caller
+    keeps the old watermark and retries next cycle.
+    """
+    token = settings.hardcover_token
+    if not token:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=20) as client:
+            resp = await client.post(
+                HARDCOVER_URL,
+                json={"query": _VOLUMES_QUERY, "variables": {"id": series_id}},
+                headers={"authorization": token},
+            )
+            resp.raise_for_status()
+            rows = resp.json().get("data", {}).get("series") or []
+    except Exception as exc:
+        log.warning("Hardcover series %s check failed: %s", series_id, exc)
+        return None
+    if not rows:
+        return None
+    s = rows[0]
+    vols = s.get("book_series") or []
+    latest = next((v for v in vols if v.get("position") is not None), None)
+    if latest is None:
+        return None
+    book = latest.get("book") or {}
+    return {
+        "latest_index": float(latest["position"]),
+        "latest_title": book.get("title"),
+        "release_date": book.get("release_date"),
+        "total": s.get("primary_books_count"),
+        "name": s.get("name"),
+    }
+
+
+def _notify_release(db: Session, wish: Wish, state: dict) -> None:
+    vol = state["latest_index"]
+    vol_str = str(int(vol)) if float(vol).is_integer() else str(vol)
+    title = f"Volume {vol_str} of \"{wish.title}\" is out"
+    body_bits = []
+    if state.get("latest_title"):
+        body_bits.append(f"\"{state['latest_title']}\"")
+    if state.get("release_date"):
+        body_bits.append(f"released {state['release_date']}")
+    body = " — ".join(body_bits) or None
+    db.add(Notification(
+        user_id=wish.user_id,
+        kind="release_out",
+        title=title,
+        body=body,
+        link="/wishlist",
+    ))
+    if settings.smtp_configured:
+        try:
+            from backend.services.email import send_release_email
+            follower = db.get(User, wish.user_id)
+            if follower and follower.email:
+                send_release_email(follower.email, wish, state)
+        except Exception:
+            log.exception("Failed to send release email for follow %d", wish.id)
+
+
+async def check_follows(db: Session, *, force: bool = False) -> dict:
+    """Poll Hardcover for every open follow that's due, notify on new volumes.
+
+    A follow is due when ``last_checked_at`` is older than the configured
+    interval (or ``force``). Returns counters for the admin trigger/logs.
+    """
+    if not settings.hardcover_token:
+        return {"checked": 0, "notified": 0, "skipped": "no hardcover token"}
+
+    due_before = datetime.utcnow() - timedelta(seconds=settings.release_check_interval)
+    q = db.query(Wish).filter(Wish.kind == "follow", Wish.status == "open",
+                              Wish.external_series_id.isnot(None))
+    if not force:
+        q = q.filter((Wish.last_checked_at.is_(None)) | (Wish.last_checked_at < due_before))
+    follows = q.all()
+
+    checked = notified = 0
+    for wish in follows:
+        try:
+            sid = int(wish.external_series_id)
+        except (TypeError, ValueError):
+            continue
+        state = await fetch_series_latest(sid)
+        if state is None:
+            continue   # keep watermark; retry next cycle
+        checked += 1
+        wish.last_checked_at = datetime.utcnow()
+        if wish.latest_known_index is None:
+            # First successful check primes the watermark silently.
+            wish.latest_known_index = state["latest_index"]
+        elif state["latest_index"] > wish.latest_known_index:
+            _notify_release(db, wish, state)
+            wish.latest_known_index = state["latest_index"]
+            notified += 1
+        db.flush()
+    db.commit()
+    return {"checked": checked, "notified": notified}

--- a/backend/services/release_detection.py
+++ b/backend/services/release_detection.py
@@ -141,10 +141,19 @@ async def check_follows(db: Session, *, force: bool = False) -> dict:
         if wish.latest_known_index is None:
             # First successful check primes the watermark silently.
             wish.latest_known_index = state["latest_index"]
+            wish.latest_known_title = state.get("latest_title")
+            wish.latest_release_date = state.get("release_date")
         elif state["latest_index"] > wish.latest_known_index:
             _notify_release(db, wish, state)
             wish.latest_known_index = state["latest_index"]
+            wish.latest_known_title = state.get("latest_title")
+            wish.latest_release_date = state.get("release_date")
             notified += 1
+        elif wish.latest_known_title is None and state["latest_index"] == wish.latest_known_index:
+            # Same volume as the watermark — backfill title/date for follows
+            # created before these columns existed (no notification).
+            wish.latest_known_title = state.get("latest_title")
+            wish.latest_release_date = state.get("release_date")
         db.flush()
     db.commit()
     return {"checked": checked, "notified": notified}

--- a/frontend/src/components/SeriesFollowButton.tsx
+++ b/frontend/src/components/SeriesFollowButton.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from 'react'
+import { BellPlus, BellRing, Loader2 } from 'lucide-react'
+import { api } from '@/lib/api'
+import { useToast } from '@/contexts/ToastContext'
+import { cn, formatDate } from '@/lib/utils'
+
+/**
+ * Follow/unfollow a series from its detail page (release detection). Renders
+ * nothing when TOME_RELEASE_DETECTION is off (the follows endpoint 403s) or on
+ * the "No Series" bucket. While followed, shows the tracker's latest volume +
+ * release date under the button — labelled "Next" when the date is upcoming.
+ */
+
+interface FollowOut {
+  id: number
+  name: string
+  latest_known_index: number | null
+  latest_known_title: string | null
+  latest_release_date: string | null
+}
+
+export function SeriesFollowButton({ seriesName }: { seriesName: string }) {
+  const { toast } = useToast()
+  const [enabled, setEnabled] = useState(true)
+  const [loaded, setLoaded] = useState(false)
+  const [follow, setFollow] = useState<FollowOut | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const load = useCallback(() => {
+    api.get<FollowOut[]>('/wishlist/follows')
+      .then(rows => {
+        setFollow(rows.find(f => f.name.toLowerCase() === seriesName.toLowerCase()) ?? null)
+        setLoaded(true)
+      })
+      .catch(() => setEnabled(false))
+  }, [seriesName])
+  useEffect(load, [load])
+
+  if (!enabled || seriesName === '__unserialized__') return null
+
+  const toggle = async () => {
+    if (busy || !loaded) return
+    setBusy(true)
+    try {
+      if (follow) {
+        await api.delete(`/wishlist/${follow.id}`)
+      } else {
+        await api.post('/wishlist/follow', { name: seriesName })
+        toast.success(`Following "${seriesName}" — you'll hear when a new volume is out`)
+      }
+      load()
+    } catch (e) {
+      toast.error((e as Error).message ?? 'Could not resolve this series on Hardcover')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const date = follow?.latest_release_date ?? null
+  const vol = follow?.latest_known_index ?? null
+  const upcoming = date != null && date >= new Date().toISOString().slice(0, 10)
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        onClick={toggle}
+        disabled={busy || !loaded}
+        className={cn(
+          'flex items-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition-all disabled:opacity-50',
+          follow
+            ? 'border-primary/40 bg-primary/10 text-foreground hover:bg-primary/15'
+            : 'border-border bg-card text-foreground hover:bg-muted',
+        )}
+        title={follow ? 'Stop following this series' : 'Get notified when a new volume is released'}
+      >
+        {busy
+          ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          : follow ? <BellRing className="w-3.5 h-3.5 text-primary" /> : <BellPlus className="w-3.5 h-3.5" />}
+        {follow ? 'Following' : 'Follow'}
+      </button>
+      {follow && vol != null && date && (
+        <p className="text-[10px] text-muted-foreground text-center">
+          {upcoming ? 'Next' : 'Latest'}: Vol {Number.isInteger(vol) ? vol : vol.toFixed(1)} · {formatDate(date)}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/UpcomingReleases.tsx
+++ b/frontend/src/components/UpcomingReleases.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+import { CalendarClock } from 'lucide-react'
+import { api } from '@/lib/api'
+import { formatDate } from '@/lib/utils'
+
+/**
+ * Home rail card: upcoming volumes of the series you follow (release
+ * detection). Renders nothing unless detection is enabled AND at least one
+ * followed series has a release date that's today or later — so for most
+ * users, most of the time, it simply isn't there.
+ */
+
+interface FollowOut {
+  id: number
+  name: string
+  cover_url: string | null
+  latest_known_index: number | null
+  latest_known_title: string | null
+  latest_release_date: string | null
+}
+
+export function UpcomingReleases() {
+  const [rows, setRows] = useState<FollowOut[]>([])
+
+  useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10)
+    api.get<FollowOut[]>('/wishlist/follows')
+      .then(all => setRows(
+        all
+          .filter(f => f.latest_release_date != null && f.latest_release_date >= today)
+          .sort((a, b) => (a.latest_release_date! < b.latest_release_date! ? -1 : 1))
+          .slice(0, 5),
+      ))
+      .catch(() => {})   // 403 = detection off; card stays absent
+  }, [])
+
+  if (rows.length === 0) return null
+
+  return (
+    <section className="p-4">
+      <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground mb-2.5">
+        <CalendarClock className="w-4 h-4 text-primary/60" />
+        Upcoming releases
+      </h2>
+      <div className="flex flex-col gap-2">
+        {rows.map(f => (
+          <div key={f.id} className="flex items-center gap-2.5">
+            {f.cover_url
+              ? <img src={f.cover_url} alt="" className="w-7 h-10 rounded object-cover shrink-0" />
+              : <span className="w-7 h-10 rounded bg-muted shrink-0" />}
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-medium text-foreground truncate">{f.name}</p>
+              <p className="text-[11px] text-muted-foreground truncate">
+                {f.latest_known_index != null && <>Vol {Number.isInteger(f.latest_known_index) ? f.latest_known_index : f.latest_known_index.toFixed(1)} · </>}
+                {formatDate(f.latest_release_date!)}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -13,6 +13,8 @@ import { useToast } from '@/contexts/ToastContext'
 import { BookCard, type ViewMode } from '@/components/BookCard'
 import { SeriesStackCard } from '@/components/SeriesStackCard'
 import { SeriesRating } from '@/components/SeriesRating'
+import { SeriesFollowButton } from '@/components/SeriesFollowButton'
+import { UpcomingReleases } from '@/components/UpcomingReleases'
 import { CoverImage } from '@/components/CoverImage'
 import { Sidebar } from '@/components/Sidebar'
 import { SaveFilterButton } from '@/components/SaveFilterButton'
@@ -1350,6 +1352,7 @@ export function DashboardPage() {
               <aside className="rounded-2xl border border-border bg-card divide-y divide-border overflow-hidden empty:hidden">
                 {readingDna && <ReadingDNACard dna={readingDna} />}
                 <HomeGoalRings />
+                <UpcomingReleases />
                 {spotlight?.highlight?.highlighted_text && (
                   <section className="p-4">
                     <header className="flex items-center justify-between mb-2.5">
@@ -1511,6 +1514,7 @@ export function DashboardPage() {
                                 Manage
                               </button>
                             )}
+                            <SeriesFollowButton seriesName={seriesDetail.name} />
                           </div>
                         </div>
 

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -8,6 +8,7 @@ import { AppShell } from '@/components/AppShell'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
 import { listWishes, deleteWish, type WishOut } from '@/lib/wishlist'
+import { api } from '@/lib/api'
 import { WishlistModal } from '@/components/WishlistModal'
 import { SeriesCoverageStrip } from '@/components/SeriesCoverageStrip'
 import { docsLink, DOCS } from '@/lib/docs'
@@ -39,6 +40,149 @@ function ageLabel(iso: string): string {
   const months = Math.floor(days / 30)
   if (months < 12) return `${months}mo ago`
   return `${Math.floor(months / 12)}y ago`
+}
+
+// ── Following (release detection) ─────────────────────────────────────────────
+// Renders nothing when TOME_RELEASE_DETECTION is off (the follows endpoint 403s).
+
+interface FollowOut {
+  id: number
+  name: string
+  author: string | null
+  cover_url: string | null
+  latest_known_index: number | null
+  owned_max_index: number | null
+  last_checked_at: string | null
+}
+
+interface SeriesHit {
+  source_id: string
+  name: string
+  author: string | null
+  total: number | null
+  cover_url: string | null
+}
+
+const fmtVol = (n: number | null) => (n == null ? null : (Number.isInteger(n) ? String(n) : String(n)))
+
+function FollowingSection() {
+  const [enabled, setEnabled] = useState(true)
+  const [follows, setFollows] = useState<FollowOut[]>([])
+  const [q, setQ] = useState('')
+  const [results, setResults] = useState<SeriesHit[]>([])
+  const [searching, setSearching] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  const load = () => {
+    api.get<FollowOut[]>('/wishlist/follows')
+      .then(setFollows)
+      .catch(() => setEnabled(false))
+  }
+  useEffect(load, [])
+
+  useEffect(() => {
+    const query = q.trim()
+    if (query.length < 2) { setResults([]); return }
+    setSearching(true)
+    const t = setTimeout(() => {
+      api.get<SeriesHit[]>(`/wishlist/search-series?q=${encodeURIComponent(query)}`)
+        .then(setResults)
+        .catch(() => setResults([]))
+        .finally(() => setSearching(false))
+    }, 350)
+    return () => clearTimeout(t)
+  }, [q])
+
+  const follow = async (r: SeriesHit) => {
+    if (busy) return
+    setBusy(true)
+    try {
+      await api.post('/wishlist/follow', {
+        name: r.name, source_id: r.source_id, author: r.author, cover_url: r.cover_url,
+      })
+      setQ(''); setResults([])
+      load()
+    } catch { /* dup or offline — list stays as-is */ }
+    finally { setBusy(false) }
+  }
+
+  const unfollow = async (id: number) => {
+    try { await api.delete(`/wishlist/${id}`); load() } catch { /* keep row */ }
+  }
+
+  if (!enabled) return null
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <h2 className="text-sm font-semibold text-foreground">Following</h2>
+        <span className="text-xs text-muted-foreground">{follows.length} series</span>
+      </div>
+      <p className="text-xs text-muted-foreground mb-3">
+        Get notified when a new volume of a followed series is released.
+      </p>
+
+      <div className="relative mb-3">
+        <input
+          value={q}
+          onChange={e => setQ(e.target.value)}
+          placeholder="Follow a series — search Hardcover…"
+          className="w-full h-9 px-3 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+        />
+        {searching && <Loader2 className="absolute right-3 top-2.5 w-4 h-4 animate-spin text-muted-foreground" />}
+        {results.length > 0 && (
+          <div className="absolute z-10 mt-1 w-full rounded-lg border border-border bg-card shadow-xl overflow-hidden">
+            {results.slice(0, 5).map(r => (
+              <button
+                key={r.source_id}
+                onClick={() => follow(r)}
+                disabled={busy}
+                className="flex w-full items-center gap-3 px-3 py-2 text-left hover:bg-muted transition-colors disabled:opacity-50"
+              >
+                {r.cover_url
+                  ? <img src={r.cover_url} alt="" className="w-7 h-10 rounded object-cover shrink-0" />
+                  : <span className="w-7 h-10 rounded bg-muted grid place-items-center shrink-0"><BookOpen className="w-3.5 h-3.5 text-muted-foreground/50" /></span>}
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm text-foreground truncate">{r.name}</span>
+                  <span className="block text-xs text-muted-foreground truncate">
+                    {r.author ?? 'Unknown author'}{r.total ? ` · ${r.total} volumes` : ''}
+                  </span>
+                </span>
+                <Plus className="w-4 h-4 text-muted-foreground shrink-0" />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {follows.length > 0 && (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
+          {follows.map(f => (
+            <div key={f.id} className="flex items-center gap-3 px-3 py-2.5 rounded-xl border border-border bg-card">
+              {f.cover_url
+                ? <img src={f.cover_url} alt="" className="w-9 h-[54px] rounded object-cover shrink-0" />
+                : <span className="w-9 h-[54px] rounded bg-muted grid place-items-center shrink-0"><Layers className="w-4 h-4 text-muted-foreground/50" /></span>}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-medium text-foreground truncate">{f.name}</p>
+                <p className="text-xs text-muted-foreground truncate">
+                  {f.latest_known_index != null && <>Latest: vol {fmtVol(f.latest_known_index)}</>}
+                  {f.owned_max_index != null && <> · you have vol {fmtVol(f.owned_max_index)}</>}
+                </p>
+              </div>
+              <button
+                onClick={() => unfollow(f.id)}
+                title="Unfollow"
+                aria-label={`Unfollow ${f.name}`}
+                className="p-1.5 rounded text-muted-foreground/60 hover:text-destructive transition-colors"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }
 
 export function WishlistPage() {
@@ -262,6 +406,8 @@ export function WishlistPage() {
             )}
           </>
         )}
+
+        {!loading && !error && <FollowingSection />}
       </div>
 
       {addOpen && (

--- a/tests/test_release_detection.py
+++ b/tests/test_release_detection.py
@@ -1,0 +1,108 @@
+"""Release detection: follow a series → "vol N is out" notifications.
+
+Hardcover is mocked throughout (fetch_series_latest / search_series); the
+poller's contract under test: priming is silent, growth notifies exactly once
+and advances the watermark, failures keep the watermark, and the whole feature
+403s when TOME_RELEASE_DETECTION is off.
+"""
+import pytest
+
+from backend.core.config import settings
+from backend.models.notification import Notification
+from backend.models.wish import Wish
+from backend.services import release_detection as rd
+
+
+@pytest.fixture(autouse=True)
+def _enable_detection(monkeypatch):
+    monkeypatch.setattr(settings, "release_detection", True)
+    monkeypatch.setattr(settings, "hardcover_token", "hc_test")
+
+
+def _state(latest, title="Vol Next", date="2026-08-01"):
+    return {"latest_index": latest, "latest_title": title,
+            "release_date": date, "total": None, "name": "Re:ZERO"}
+
+
+def _follow(db, user, latest_known=None, sid="4242"):
+    w = Wish(user_id=user.id, kind="follow", status="open", title="Re:ZERO",
+             series="Re:ZERO", source="hardcover", source_id=f"series:{sid}",
+             external_series_id=sid, latest_known_index=latest_known)
+    db.add(w)
+    db.flush()
+    return w
+
+
+@pytest.mark.anyio
+async def test_first_check_primes_silently(db, admin_user, monkeypatch):
+    user, _ = admin_user
+    w = _follow(db, user, latest_known=None)
+    async def fake(sid): return _state(27.0)
+    monkeypatch.setattr(rd, "fetch_series_latest", fake)
+
+    out = await rd.check_follows(db, force=True)
+    assert out == {"checked": 1, "notified": 0}
+    assert w.latest_known_index == 27.0
+    assert db.query(Notification).count() == 0
+
+
+@pytest.mark.anyio
+async def test_new_volume_notifies_once(db, admin_user, monkeypatch):
+    user, _ = admin_user
+    w = _follow(db, user, latest_known=27.0)
+    async def fake(sid): return _state(28.0, title="Re:ZERO Vol. 28")
+    monkeypatch.setattr(rd, "fetch_series_latest", fake)
+
+    out = await rd.check_follows(db, force=True)
+    assert out["notified"] == 1
+    assert w.latest_known_index == 28.0
+    n = db.query(Notification).filter(Notification.kind == "release_out").one()
+    assert "Volume 28" in n.title and "Re:ZERO" in n.title
+
+    # Second pass with the same tracker state: no duplicate alert.
+    out2 = await rd.check_follows(db, force=True)
+    assert out2["notified"] == 0
+    assert db.query(Notification).filter(Notification.kind == "release_out").count() == 1
+
+
+@pytest.mark.anyio
+async def test_fetch_failure_keeps_watermark(db, admin_user, monkeypatch):
+    user, _ = admin_user
+    w = _follow(db, user, latest_known=27.0)
+    async def fake(sid): return None
+    monkeypatch.setattr(rd, "fetch_series_latest", fake)
+
+    out = await rd.check_follows(db, force=True)
+    assert out == {"checked": 0, "notified": 0}
+    assert w.latest_known_index == 27.0
+    assert w.last_checked_at is None      # retries next cycle
+
+
+def test_follow_endpoints(client, db, admin_user, monkeypatch):
+    async def fake_latest(sid): return _state(16.0)
+    monkeypatch.setattr(rd, "fetch_series_latest", fake_latest)
+
+    r = client.post("/api/wishlist/follow", json={"name": "The Good Guys", "source_id": "777"})
+    assert r.status_code == 201, r.text
+    out = r.json()
+    assert out["latest_known_index"] == 16.0   # primed at follow time
+
+    # Duplicate follow → 409; list shows exactly one.
+    assert client.post("/api/wishlist/follow",
+                       json={"name": "The Good Guys", "source_id": "777"}).status_code == 409
+    follows = client.get("/api/wishlist/follows").json()
+    assert len(follows) == 1 and follows[0]["source_id"] == "series:777"
+
+    # Follows don't leak into the plain wishlist.
+    assert client.get("/api/wishlist").json() == []
+
+    # Unfollow via the normal wish delete.
+    assert client.delete(f"/api/wishlist/{out['id']}").status_code == 204
+    assert client.get("/api/wishlist/follows").json() == []
+
+
+def test_disabled_flag_403s(client, db, admin_user, monkeypatch):
+    monkeypatch.setattr(settings, "release_detection", False)
+    assert client.get("/api/wishlist/follows").status_code == 403
+    assert client.post("/api/wishlist/follow", json={"name": "X", "source_id": "1"}).status_code == 403
+    assert client.post("/api/admin/release-check").status_code == 403


### PR DESCRIPTION
The wishlist plan's reserved seams (`kind`, `external_series_id`, `last_checked_at`, `latest_known_index`) come alive — purely additive, no refactor.

## How it works
- **Follow** = `Wish(kind="follow")` bound to a canonical Hardcover series id (resolved via the existing `search_series` when only a name is given).
- A background poller (mirrors the auto-import loop) checks each due follow against Hardcover's highest volume position; growth past the watermark → **`release_out` bell notification** (+ email when SMTP configured) and the watermark advances.
- **Priming is silent**: a follow starts at the current latest volume — following a 27-volume series fires zero alerts until vol 28 actually appears.
- Fetch failures keep the watermark and retry next cycle. Gated by `TOME_RELEASE_DETECTION` (default **off**) + `TOME_RELEASE_CHECK_INTERVAL` (daily).

## API
`POST /wishlist/follow` (member, dup-guarded, primes immediately) · `GET /wishlist/follows` (tracker vs owned-max from the visibility-gated library) · `POST /admin/release-check` (run now) · `GET /wishlist` now returns `kind="wish"` only.

## Tests
6 new (`tests/test_release_detection.py`): silent priming, notify-exactly-once + watermark advance, failure keeps watermark, endpoint flow, and 403s when disabled. Wishlist suite unaffected (36 passed together).

## Still to come (next commit on this branch)
Frontend surfaces: Follow button on the series page + a "Following" section on the Wishlist page. The backend is complete and off by default, so this is safe to review/merge as-is.