### PR TITLE
feat(metadata): cross-source merge, unified ranking, honest rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ All notable changes to Tome are documented here. Format loosely follows
   series blurb, genres, staff and cover, and its series-level description,
   author and genres back-fill volume-level hits from the other sources that
   are missing them.
+- **Scribe: `/scribe audit editions`.** A new audit check finds books whose
+  stored ISBN belongs to the wrong edition of their series (a light novel
+  carrying the manga's ISBN — damage older auto-apply versions could cause,
+  which then poisons every later fetch) and proposes the correct edition's
+  ISBN, publisher, year and description for approval.
 - **Repeat searches are served from a short-lived cache.** Identical source
   queries within 15 minutes (re-opening the fetch dialog, bulk-fetching a
   series whose volumes share a series-level lookup) no longer re-hit the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,22 @@ All notable changes to Tome are documented here. Format loosely follows
   merge into (and poison) the English candidate, light novels no longer match
   the manga adaptation of the same series (search is edition-aware now), and a
   stored ISBN that points at the wrong edition — damage the old auto-apply
-  itself caused — no longer monopolises the results.
+  itself caused — no longer monopolises the results. Edition awareness also
+  understands custom book types now ("Webtoons", "graphic_novel", …), not just
+  the seeded four.
+- **AniList as a manga metadata source.** The existing sources are prose-first
+  and often know nothing about a manga volume beyond its title. Books with a
+  sequential-art type (manga, comics, webtoons, custom equivalents) now also
+  query AniList (no API key needed): it appears as its own candidate with the
+  series blurb, genres, staff and cover, and its series-level description,
+  author and genres back-fill volume-level hits from the other sources that
+  are missing them.
+- **Repeat searches are served from a short-lived cache.** Identical source
+  queries within 15 minutes (re-opening the fetch dialog, bulk-fetching a
+  series whose volumes share a series-level lookup) no longer re-hit the
+  external APIs — less rate-limiting, faster results. Concurrent duplicates
+  (a bulk fetch firing the same lookup for every volume at once) share a
+  single outbound request instead of racing past each other.
 - **No more flicker of the Follow UI on instances without release detection.**
   The Follow button, Following section and Upcoming-releases card rendered
   optimistically and hid after the server said the feature is off — a visible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,20 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Metadata fetching got a deep overhaul.** The same book returned by two
+  sources used to eat two of the five result slots — each copy *partial*
+  (Hardcover knows series but not language; Google the reverse). Duplicates are
+  now merged across sources into one complete candidate, results are ranked by
+  the same relevance score everywhere (the right volume of a series now beats
+  the wrong volume from a "better" source), and every path — the fetch dialog,
+  bulk review, bulk apply, Bindery, auto-import — agrees on what the best match
+  is. Rate limits are handled honestly: sources are retried once with a pause,
+  and when one is still throttled the dialog says so instead of pretending the
+  book doesn't exist. Three more sharp edges filed down: auto-import no longer
+  renames a book on a low-confidence match (it fills blanks instead), applying
+  fetched metadata no longer wipes your hand-added tags, and bulk fetching
+  paces itself instead of firing a hundred parallel searches that tripped the
+  very rate limits above.
 - **Deleting a highlight from the web now sticks, even for a highlight you just
   made.** The deletion marker was stamped with the server's clock, but compared
   against the device's local wall-clock — so with a UTC server and a device in a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,20 @@ All notable changes to Tome are documented here. Format loosely follows
   renames a book on a low-confidence match (it fills blanks instead), applying
   fetched metadata no longer wipes your hand-added tags, and bulk fetching
   paces itself instead of firing a hundred parallel searches that tripped the
-  very rate limits above.
+  very rate limits above. A cross-check against realistic library shapes (manga
+  volumes, light novels with series-only titles, wrong-edition ISBNs, foreign
+  editions) caught four more: Hardcover's **series and publisher were never
+  actually filled in production** (an id-type mismatch made that lookup a
+  silent no-op since it shipped — fixed), foreign-language editions no longer
+  merge into (and poison) the English candidate, light novels no longer match
+  the manga adaptation of the same series (search is edition-aware now), and a
+  stored ISBN that points at the wrong edition — damage the old auto-apply
+  itself caused — no longer monopolises the results.
+- **No more flicker of the Follow UI on instances without release detection.**
+  The Follow button, Following section and Upcoming-releases card rendered
+  optimistically and hid after the server said the feature is off — a visible
+  flash on every page view. They now stay hidden until the check resolves, and
+  a disabled verdict is remembered for the session.
 - **Deleting a highlight from the web now sticks, even for a highlight you just
   made.** The deletion marker was stamped with the server's clock, but compared
   against the device's local wall-clock — so with a UTC server and a device in a

--- a/backend/api/bindery.py
+++ b/backend/api/bindery.py
@@ -261,7 +261,12 @@ async def bindery_preview(
     # Strip internal private keys from file_metadata before returning
     file_metadata = {k: v for k, v in meta.items() if not k.startswith("_")}
 
-    return {"file_metadata": file_metadata, "candidates": candidates, "query_used": fetch_result.query_used}
+    return {
+        "file_metadata": file_metadata,
+        "candidates": candidates,
+        "query_used": fetch_result.query_used,
+        "sources": fetch_result.sources,
+    }
 
 
 @router.post("/accept")

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1249,86 +1249,16 @@ class BulkCandidateResult(PydanticBaseModel):
     best_match_index: Optional[int] = None  # index into candidates, None = no confident match
 
 
-def _extract_vol_number(title: str) -> int | None:
-    """Extract volume number from a title string. Handles 'v001', 'Vol. 1', 'Vol 1', 'Volume 1'."""
-    m = re.search(r'\bv(?:ol(?:ume)?\.?\s*)(\d+)\b', title, re.IGNORECASE)
-    if m:
-        return int(m.group(1))
-    # Also match bare "vNNN" (manga filename convention)
-    m = re.search(r'\bv(\d{2,4})\b', title, re.IGNORECASE)
-    if m:
-        return int(m.group(1))
-    return None
-
-
 def _score_candidate(candidate, book: Book) -> int:
-    from backend.services.metadata_fetch import _clean_title
-    score = 0
-    if candidate.description:
-        score += 2
-    if candidate.cover_url:
-        score += 1
-    if candidate.isbn and book.isbn and candidate.isbn == book.isbn:
-        score += 4
-    if candidate.year and book.year and candidate.year == book.year:
-        score += 1
-
-    # Compare against cleaned title (strips filename noise like "(Digital) (1r0n)")
-    clean_book_title = _clean_title(book.title).lower() if book.title else ""
-    if candidate.title and clean_book_title:
-        ratio = difflib.SequenceMatcher(
-            None, candidate.title.lower(), clean_book_title,
-        ).ratio()
-        if ratio > 0.85:
-            score += 3
-        elif ratio > 0.6:
-            score += 1
-    if candidate.author and book.author:
-        ratio = difflib.SequenceMatcher(
-            None, candidate.author.lower(), book.author.lower()
-        ).ratio()
-        if ratio > 0.7:
-            score += 2
-
-    # Volume number matching — critical for series like manga where all titles
-    # start with the same series name. Extract the volume from the book's raw
-    # title (e.g. "My Series v004") and check if the candidate matches.
-    book_vol = _extract_vol_number(book.title) if book.title else None
-    if book_vol is not None:
-        # Check candidate's series_index first (most reliable)
-        cand_vol = None
-        if candidate.series_index is not None:
-            cand_vol = int(candidate.series_index) if candidate.series_index == int(candidate.series_index) else None
-        # Fall back to extracting from candidate title
-        if cand_vol is None:
-            cand_vol = _extract_vol_number(candidate.title) if candidate.title else None
-        if cand_vol == book_vol:
-            score += 8  # strong signal — right volume
-        else:
-            score -= 4  # wrong volume is worse than no match
-
-    # Prefer English-language results (or results matching the book's language)
-    book_lang = (book.language or "en").lower()[:2]
-    cand_lang = (candidate.language or "en").lower()[:2]
-    if cand_lang == book_lang:
-        score += 2
-    elif cand_lang != "en":
-        score -= 3  # penalise non-English when book language unknown
-
-    # Penalise omnibus editions and spin-offs — they share volume numbers with
-    # the main series but are different books
-    if candidate.title:
-        ct = candidate.title.lower()
-        if "omnibus" in ct:
-            score -= 3
-        if "ace's story" in ct or "film:" in ct or "color walk" in ct:
-            score -= 5
-
-    # Source priority: Hardcover has best quality metadata for manga/LN/books
-    if candidate.source == "hardcover":
-        score += 6
-
-    return score
+    """Relevance of a candidate for this book — the single scoring brain now
+    lives in backend/services/metadata_rank.py (same weights); this is the
+    Book-model adapter."""
+    from backend.services.metadata_rank import ScoreContext, score_candidate
+    return score_candidate(candidate, ScoreContext(
+        title=book.title, author=book.author, isbn=book.isbn,
+        year=book.year, language=book.language,
+        series=book.series, series_index=book.series_index,
+    ))
 
 
 @router.post("/bulk-fetch-candidates", response_model=list[BulkCandidateResult])
@@ -1350,15 +1280,22 @@ async def bulk_fetch_candidates(
 
     import asyncio as _asyncio
 
+    # Bounded fan-out: 100 unbounded parallel fetches (3+ HTTP calls each) used
+    # to trip the very source rate limits that then read as "no results".
+    sem = _asyncio.Semaphore(4)
+
     async def fetch_for_book(book: Book):
         try:
-            result = await fetch_candidates(
-                title=book.title,
-                author=book.author,
-                isbn=book.isbn,
-                series=book.series,
-                series_index=book.series_index,
-            )
+            async with sem:
+                result = await fetch_candidates(
+                    title=book.title,
+                    author=book.author,
+                    isbn=book.isbn,
+                    series=book.series,
+                    series_index=book.series_index,
+                    year=book.year,
+                    language=book.language,
+                )
             candidates = result.candidates
         except Exception as e:
             logger.warning("bulk_fetch_candidates failed for book %d: %s", book.id, e)
@@ -2432,14 +2369,19 @@ def ingest_book(
 
 # ── Fetch metadata candidates ─────────────────────────────────────────────────
 
-@router.get("/{book_id}/fetch-metadata", response_model=list[MetadataCandidateOut])
+@router.get("/{book_id}/fetch-metadata")
 async def fetch_metadata(
     book_id: int,
     q: Optional[str] = Query(None, description="Override search query"),
     db: Session = Depends(get_db),
     _: User = Depends(get_current_user),
 ):
-    """Search external sources and return up to 5 metadata candidates for review."""
+    """Search external sources; return ranked candidates + per-source status.
+
+    Candidates are cross-source merged and relevance-ranked (index 0 = best).
+    ``sources`` tells the UI when an empty list means "rate limited", not
+    "this book doesn't exist anywhere".
+    """
     book = db.query(Book).filter(Book.id == book_id).first()
     if not book:
         raise HTTPException(status_code=404, detail="Book not found")
@@ -2451,8 +2393,14 @@ async def fetch_metadata(
         series=book.series,
         series_index=book.series_index,
         query_override=q,
+        year=book.year,
+        language=book.language,
     )
-    return result.candidates
+    return {
+        "candidates": [MetadataCandidateOut.model_validate(c.__dict__) for c in result.candidates],
+        "query_used": result.query_used,
+        "sources": result.sources,
+    }
 
 
 # ── Apply selected metadata ───────────────────────────────────────────────────
@@ -2478,12 +2426,19 @@ async def apply_metadata(
         if val is not None:
             setattr(book, f, val)
 
-    # Replace tags if provided
+    # Replace FETCHED tags if provided — but never wipe hand-curated ones
+    # (source="user"); applying a candidate used to delete the user's own tags.
     if body.tags is not None:
-        db.query(BookTag).filter(BookTag.book_id == book_id).delete()
+        kept = (
+            db.query(BookTag)
+            .filter(BookTag.book_id == book_id, BookTag.source == "user")
+            .all()
+        )
+        kept_lower = {t.tag.lower() for t in kept}
+        db.query(BookTag).filter(BookTag.book_id == book_id, BookTag.source != "user").delete()
         for tag in body.tags:
             tag = tag.strip()
-            if tag:
+            if tag and tag.lower() not in kept_lower:
                 db.add(BookTag(book_id=book_id, tag=tag, source="metadata_fetch"))
 
     # Download and replace cover if requested

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1258,6 +1258,7 @@ def _score_candidate(candidate, book: Book) -> int:
         title=book.title, author=book.author, isbn=book.isbn,
         year=book.year, language=book.language,
         series=book.series, series_index=book.series_index,
+        media_hint=book.book_type.slug if book.book_type else None,
     ))
 
 
@@ -1295,6 +1296,7 @@ async def bulk_fetch_candidates(
                     series_index=book.series_index,
                     year=book.year,
                     language=book.language,
+                    media_hint=book.book_type.slug if book.book_type else None,
                 )
             candidates = result.candidates
         except Exception as e:
@@ -2395,6 +2397,7 @@ async def fetch_metadata(
         query_override=q,
         year=book.year,
         language=book.language,
+        media_hint=book.book_type.slug if book.book_type else None,
     )
     return {
         "candidates": [MetadataCandidateOut.model_validate(c.__dict__) for c in result.candidates],

--- a/backend/main.py
+++ b/backend/main.py
@@ -440,12 +440,32 @@ async def _run_auto_import() -> None:
     # ------------------------------------------------------------------
 
     def _apply_metadata(book_id: int, best, content_hash: str) -> None:
+        from backend.services.metadata_rank import ScoreContext, score_candidate
+
         with SessionLocal() as db:
             book = db.get(Book, book_id)
             if not book:
                 return
-            book.title = best.title or book.title
-            book.author = best.author or book.author
+            # Title/author overwrite is confidence-gated: filenames make junky
+            # titles so a good match SHOULD replace them, but a wrong first hit
+            # used to silently rename the book. Below the bar, fill-if-empty.
+            confidence = score_candidate(best, ScoreContext(
+                title=book.title, author=book.author, isbn=book.isbn,
+                year=book.year, language=book.language,
+                series=book.series, series_index=book.series_index,
+            ))
+            if confidence >= 6:
+                book.title = best.title or book.title
+                book.author = best.author or book.author
+            else:
+                if best.title and not book.title:
+                    book.title = best.title
+                if best.author and not book.author:
+                    book.author = best.author
+                logger.info(
+                    "Auto-import: low-confidence match (score %d) for book #%d — "
+                    "keeping extracted title/author", confidence, book_id,
+                )
             if best.description and not book.description:
                 book.description = best.description
             if best.publisher and not book.publisher:

--- a/backend/main.py
+++ b/backend/main.py
@@ -453,6 +453,7 @@ async def _run_auto_import() -> None:
                 title=book.title, author=book.author, isbn=book.isbn,
                 year=book.year, language=book.language,
                 series=book.series, series_index=book.series_index,
+                media_hint=book.book_type.slug if book.book_type else None,
             ))
             if confidence >= 6:
                 book.title = best.title or book.title

--- a/backend/services/metadata_fetch.py
+++ b/backend/services/metadata_fetch.py
@@ -45,6 +45,41 @@ class MetadataCandidate:
 class FetchResult:
     candidates: list[MetadataCandidate]
     query_used: str  # the query sent to Hardcover (for display / manual re-search)
+    # Per-source outcome: ok | empty | rate_limited | timeout | error | disabled.
+    # Surfaced to the UI so a rate-limited fetch can't masquerade as "no results".
+    sources: dict = field(default_factory=dict)
+
+
+class RateLimited(Exception):
+    """A source told us to back off (429 / exhausted quota)."""
+
+
+async def _call_with_retry(name: str, factory) -> tuple[list[MetadataCandidate], str]:
+    """Run one source with a single retry on rate-limit/timeout.
+
+    ``factory`` builds a fresh coroutine per attempt. Returns (candidates,
+    status); failures degrade to an empty list with an honest status instead of
+    silently pretending the book doesn't exist.
+    """
+    for attempt in (1, 2):
+        try:
+            res = await factory()
+            return res, ("ok" if res else "empty")
+        except RateLimited:
+            if attempt == 1:
+                await asyncio.sleep(1.5)
+                continue
+            logger.warning("%s still rate-limited after retry", name)
+            return [], "rate_limited"
+        except httpx.TimeoutException:
+            if attempt == 1:
+                continue
+            logger.warning("%s timed out twice", name)
+            return [], "timeout"
+        except Exception as exc:
+            logger.warning("%s metadata fetch failed: %s", name, exc)
+            return [], "error"
+    return [], "error"
 
 
 async def fetch_candidates(
@@ -54,12 +89,21 @@ async def fetch_candidates(
     series: str | None = None,
     series_index: float | None = None,
     query_override: str | None = None,
+    year: int | None = None,
+    language: str | None = None,
 ) -> FetchResult:
-    """Return up to _MAX_RESULTS candidates, querying Hardcover, Google Books, and OpenLibrary in parallel.
+    """Query Hardcover, Google Books and OpenLibrary in parallel; return up to
+    _MAX_RESULTS candidates, cross-source merged and relevance-ranked.
 
-    Hardcover results come first — they have significantly better coverage for
-    light novels, manga, web novels, and self-published LitRPG.
+    Duplicates across sources are collapsed into ONE candidate whose missing
+    fields are filled from the others (Hardcover has series but no language;
+    Google has language but no series — merged, you get both). The result is
+    sorted by the same score the bulk-review UI uses, so ``candidates[0]`` is
+    the best match on every consumer path, not "whatever Hardcover said first".
+    ``year``/``language`` are optional ranking context.
     """
+    from backend.services.metadata_rank import ScoreContext, merge_candidates, rank_candidates
+
     # When the user has typed a manual query, ignore the stored ISBN entirely —
     # treat it like Plex "Fix Match": search only by what was typed.
     effective_isbn = None if query_override else isbn
@@ -67,43 +111,48 @@ async def fetch_candidates(
     hc_query = _build_hardcover_query(title, author, effective_isbn, series, series_index, query_override)
 
     async with httpx.AsyncClient(timeout=10) as client:
-        hc_results, gb_results, ol_results = await asyncio.gather(
-            _hardcover(client, title, author, effective_isbn, series, series_index, query_override),
-            _google_books(client, query, effective_isbn),
-            _open_library(client, query, effective_isbn),
-            return_exceptions=True,
+        async def _hc_disabled() -> tuple[list[MetadataCandidate], str]:
+            return [], "disabled"
+
+        hc_call = (
+            _call_with_retry("hardcover", lambda: _hardcover(
+                client, title, author, effective_isbn, series, series_index, query_override))
+            if settings.hardcover_token else _hc_disabled()
+        )
+        (hc, hc_status), (gb, gb_status), (ol, ol_status) = await asyncio.gather(
+            hc_call,
+            _call_with_retry("google_books", lambda: _google_books(client, query, effective_isbn)),
+            _call_with_retry("open_library", lambda: _open_library(client, query, effective_isbn)),
         )
 
-        # Fallback for Google/OL: if both returned nothing and we used a title-based query,
-        # retry with a series-aware query (helps when the per-book title is obscure).
+        # Series-aware fallback: when the per-book title is obscure, retry empty
+        # sources with a "{series} Vol N" query — including Hardcover, which the
+        # old fallback skipped entirely.
         if (
             not query_override and not isbn
             and series and series_index is not None
             and not _title_is_series_variant(title, series)
-            and not _any_results(gb_results, ol_results)
         ):
             fallback_query = _build_series_query(series, series_index, author)
-            gb_results, ol_results = await asyncio.gather(
-                _google_books(client, fallback_query, None),
-                _open_library(client, fallback_query, None),
-                return_exceptions=True,
-            )
+            if not gb and not ol:
+                (gb, gb_status), (ol, ol_status) = await asyncio.gather(
+                    _call_with_retry("google_books", lambda: _google_books(client, fallback_query, None)),
+                    _call_with_retry("open_library", lambda: _open_library(client, fallback_query, None)),
+                )
+            if not hc and hc_status not in ("disabled", "rate_limited"):
+                hc, hc_status = await _call_with_retry("hardcover", lambda: _hardcover(
+                    client, title, author, None, series, series_index, fallback_query))
 
-    candidates: list[MetadataCandidate] = []
-    seen: set[str] = set()  # deduplicate by ISBN
-
-    # Hardcover first (best quality), then Google, then OL
-    for result_set in (hc_results, gb_results, ol_results):
-        if isinstance(result_set, Exception):
-            logger.warning("Metadata fetch failed: %s", result_set)
-            continue
-        for c in result_set:
-            key = c.isbn or f"{c.source}:{c.source_id}"
-            if key not in seen:
-                seen.add(key)
-                candidates.append(c)
-
-    return FetchResult(candidates=candidates[:_MAX_RESULTS], query_used=hc_query)
+    merged = merge_candidates([*hc, *gb, *ol])
+    ranked = rank_candidates(merged, ScoreContext(
+        title=title, author=author, isbn=effective_isbn,
+        year=year, language=language, series=series, series_index=series_index,
+    ))
+    return FetchResult(
+        candidates=ranked[:_MAX_RESULTS],
+        query_used=hc_query,
+        sources={"hardcover": hc_status, "google_books": gb_status, "open_library": ol_status},
+    )
 
 
 # ── Hardcover ─────────────────────────────────────────────────────────────────
@@ -161,20 +210,17 @@ async def _hardcover(
     """
 
     headers = {"authorization": token}
-    try:
-        resp = await client.post(
-            HARDCOVER_URL,
-            json={"query": graphql_query, "variables": {"q": query_str, "perPage": _MAX_RESULTS}},
-            headers=headers,
-        )
-        if resp.status_code == 429:
-            logger.warning("Hardcover rate limited")
-            return []
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception as exc:
-        logger.warning("Hardcover request failed: %s", exc)
-        return []
+    # Failures propagate — _call_with_retry classifies them (retry on 429/timeout)
+    # so the UI can distinguish "rate limited" from "book doesn't exist".
+    resp = await client.post(
+        HARDCOVER_URL,
+        json={"query": graphql_query, "variables": {"q": query_str, "perPage": _MAX_RESULTS}},
+        headers=headers,
+    )
+    if resp.status_code == 429:
+        raise RateLimited("hardcover")
+    resp.raise_for_status()
+    data = resp.json()
 
     search = data.get("data", {}).get("search", {})
     hits = search.get("results", {}).get("hits", [])
@@ -421,13 +467,6 @@ async def _fetch_hardcover_details(
         logger.warning("Failed to fetch Hardcover details", exc_info=True)
 
 
-def _any_results(*result_sets: object) -> bool:
-    for rs in result_sets:
-        if isinstance(rs, list) and rs:
-            return True
-    return False
-
-
 def _build_series_query(series: str, series_index: float, author: str | None) -> str:
     clean = _clean_series_name(series)
     vol = int(series_index) if series_index == int(series_index) else series_index
@@ -564,27 +603,23 @@ async def _google_books(
     }
     if settings.google_books_key:
         params["key"] = settings.google_books_key
-    try:
-        resp = await client.get(GOOGLE_BOOKS_URL, params=params)
-        if resp.status_code in (400, 429):
-            # 400 is how Google reports an exhausted key quota ("Quota Exceeded");
-            # 429 is the anonymous shared-pool limit. Either way there's nothing
-            # more to fetch — log loudly when a key is configured so the operator
-            # knows it's *their* project quota that's drained, not a code bug.
-            if settings.google_books_key:
-                logger.warning(
-                    "Google Books quota exhausted for the configured API key "
-                    "(HTTP %s)", resp.status_code,
-                )
-            else:
-                logger.warning("Google Books rate limited (HTTP %s) — no API key "
-                               "configured; set TOME_GOOGLE_BOOKS_KEY", resp.status_code)
-            return []
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception as exc:
-        logger.warning("Google Books request failed: %s", exc)
-        return []
+    resp = await client.get(GOOGLE_BOOKS_URL, params=params)
+    if resp.status_code in (400, 429):
+        # 400 is how Google reports an exhausted key quota ("Quota Exceeded");
+        # 429 is the anonymous shared-pool limit. Log loudly when a key is
+        # configured so the operator knows it's *their* project quota that's
+        # drained, not a code bug — then let the retry/status machinery run.
+        if settings.google_books_key:
+            logger.warning(
+                "Google Books quota exhausted for the configured API key "
+                "(HTTP %s)", resp.status_code,
+            )
+        else:
+            logger.warning("Google Books rate limited (HTTP %s) — no API key "
+                           "configured; set TOME_GOOGLE_BOOKS_KEY", resp.status_code)
+        raise RateLimited("google_books")
+    resp.raise_for_status()
+    data = resp.json()
 
     candidates = []
     for item in data.get("items", []):
@@ -655,13 +690,12 @@ async def _open_library(
         plain = re.sub(r'\b(intitle|inauthor|isbn):', '', query).strip()
         params["q"] = plain
 
-    try:
-        resp = await client.get(OPEN_LIBRARY_SEARCH, params=params)
-        resp.raise_for_status()
-        data = resp.json()
-    except Exception as exc:
-        logger.warning("Open Library request failed: %s", exc)
-        return []
+    # Failures propagate to _call_with_retry for classification/retry.
+    resp = await client.get(OPEN_LIBRARY_SEARCH, params=params)
+    if resp.status_code == 429:
+        raise RateLimited("open_library")
+    resp.raise_for_status()
+    data = resp.json()
 
     docs = data.get("docs", [])
     candidates = [_parse_ol(doc) for doc in docs]

--- a/backend/services/metadata_fetch.py
+++ b/backend/services/metadata_fetch.py
@@ -4,8 +4,10 @@ Sources: Hardcover (primary), Google Books, Open Library — all queried in para
 Returns a list of MetadataCandidate objects for the user to review.
 """
 import asyncio
+import copy
 import logging
 import re
+import time
 from dataclasses import dataclass, field
 
 import httpx
@@ -19,6 +21,7 @@ OPEN_LIBRARY_SEARCH = "https://openlibrary.org/search.json"
 OPEN_LIBRARY_WORK = "https://openlibrary.org{key}.json"
 OPEN_LIBRARY_COVER = "https://covers.openlibrary.org/b/id/{cover_id}-L.jpg"
 HARDCOVER_URL = "https://api.hardcover.app/v1/graphql"
+ANILIST_URL = "https://graphql.anilist.co"
 
 _MAX_RESULTS = 5
 
@@ -54,13 +57,42 @@ class RateLimited(Exception):
     """A source told us to back off (429 / exhausted quota)."""
 
 
-async def _call_with_retry(name: str, factory) -> tuple[list[MetadataCandidate], str]:
-    """Run one source with a single retry on rate-limit/timeout.
+# Short-lived per-source result cache. Re-opening the fetch dialog, retrying
+# after a rate limit, or bulk-fetching a series (whose volumes share the
+# series-level AniList lookup) should not re-hit the external APIs. Keyed by
+# (source, query); successful results only — failures always retry live.
+# Single-process in-memory, same assumption as the bake job.
+_CACHE_TTL = 900.0   # 15 minutes
+_CACHE_MAX = 512
+_source_cache: dict[tuple, tuple[float, list[MetadataCandidate]]] = {}
 
-    ``factory`` builds a fresh coroutine per attempt. Returns (candidates,
-    status); failures degrade to an empty list with an honest status instead of
-    silently pretending the book doesn't exist.
-    """
+
+def _cache_get(key: tuple) -> list[MetadataCandidate] | None:
+    hit = _source_cache.get(key)
+    if not hit or hit[0] < time.monotonic():
+        _source_cache.pop(key, None)
+        return None
+    # Deep copy both ways — merge_candidates MUTATES candidates (field fill).
+    return copy.deepcopy(hit[1])
+
+
+def _cache_put(key: tuple, candidates: list[MetadataCandidate]) -> None:
+    if len(_source_cache) >= _CACHE_MAX:
+        for k in sorted(_source_cache, key=lambda k: _source_cache[k][0])[: _CACHE_MAX // 4]:
+            _source_cache.pop(k, None)
+    _source_cache[key] = (time.monotonic() + _CACHE_TTL, copy.deepcopy(candidates))
+
+
+# In-flight request dedup: bulk-fetching a series fires the SAME series-level
+# query for every volume concurrently — the TTL cache alone can't help because
+# none of them has finished yet. Followers await the leader's future instead
+# of going out themselves.
+_inflight: dict[tuple, "asyncio.Future"] = {}
+
+
+async def _attempt_source(name: str, factory) -> tuple[list[MetadataCandidate], str]:
+    """One source, one retry on rate-limit/timeout; never raises (except
+    cancellation) — failures degrade to ([], honest_status)."""
     for attempt in (1, 2):
         try:
             res = await factory()
@@ -76,10 +108,52 @@ async def _call_with_retry(name: str, factory) -> tuple[list[MetadataCandidate],
                 continue
             logger.warning("%s timed out twice", name)
             return [], "timeout"
+        except asyncio.CancelledError:
+            raise
         except Exception as exc:
             logger.warning("%s metadata fetch failed: %s", name, exc)
             return [], "error"
     return [], "error"
+
+
+async def _call_with_retry(name: str, factory, cache_key=None) -> tuple[list[MetadataCandidate], str]:
+    """Run one source with retry, short-TTL caching and in-flight dedup.
+
+    ``factory`` builds a fresh coroutine per attempt. Returns (candidates,
+    status). ``cache_key`` (usually the query string) enables the cache —
+    empty-but-successful results are cached too, so a book no source knows
+    isn't re-searched every time — and makes concurrent identical calls share
+    one outbound request.
+    """
+    key = (name, cache_key) if cache_key is not None else None
+    if key is not None:
+        cached = _cache_get(key)
+        if cached is not None:
+            return cached, ("ok" if cached else "empty")
+        pending = _inflight.get(key)
+        if pending is not None:
+            res, status = await pending
+            return copy.deepcopy(res), status
+
+    fut: asyncio.Future | None = None
+    if key is not None:
+        fut = asyncio.get_running_loop().create_future()
+        _inflight[key] = fut
+    try:
+        res, status = await _attempt_source(name, factory)
+        if key is not None and status in ("ok", "empty"):
+            _cache_put(key, res)
+        if fut is not None:
+            fut.set_result((copy.deepcopy(res), status))
+        return res, status
+    except BaseException:
+        # cancellation — release followers with an honest error, don't wedge them
+        if fut is not None and not fut.done():
+            fut.set_result(([], "error"))
+        raise
+    finally:
+        if key is not None:
+            _inflight.pop(key, None)
 
 
 async def fetch_candidates(
@@ -103,7 +177,7 @@ async def fetch_candidates(
     the best match on every consumer path, not "whatever Hardcover said first".
     ``year``/``language`` are optional ranking context.
     """
-    from backend.services.metadata_rank import ScoreContext, merge_candidates, rank_candidates
+    from backend.services.metadata_rank import ScoreContext, merge_candidates, rank_candidates, classify_media_hint
 
     # When the user has typed a manual query, ignore the stored ISBN entirely —
     # treat it like Plex "Fix Match": search only by what was typed.
@@ -111,19 +185,36 @@ async def fetch_candidates(
     query = _build_query(title, author, effective_isbn, series, series_index, query_override)
     hc_query = _build_hardcover_query(title, author, effective_isbn, series, series_index, query_override, media_hint)
 
+    hint_cls = classify_media_hint(media_hint)
+
     async with httpx.AsyncClient(timeout=10) as client:
         async def _hc_disabled() -> tuple[list[MetadataCandidate], str]:
             return [], "disabled"
 
+        async def _al_skipped() -> tuple[list[MetadataCandidate], str]:
+            return [], "skipped"
+
         hc_call = (
             _call_with_retry("hardcover", lambda: _hardcover(
-                client, title, author, effective_isbn, series, series_index, query_override, media_hint))
+                client, title, author, effective_isbn, series, series_index, query_override, media_hint),
+                cache_key=hc_query)
             if settings.hardcover_token else _hc_disabled()
         )
-        (hc, hc_status), (gb, gb_status), (ol, ol_status) = await asyncio.gather(
+        # AniList is manga-specialised (no key needed) — only worth a call for
+        # sequential-art book types. It knows series, staff, genres and covers
+        # far better than the prose-first sources, but at SERIES level.
+        al_query = query_override or series or title
+        al_call = (
+            _call_with_retry("anilist", lambda: _anilist(client, al_query), cache_key=al_query)
+            if hint_cls == "art" else _al_skipped()
+        )
+        (hc, hc_status), (gb, gb_status), (ol, ol_status), (al, al_status) = await asyncio.gather(
             hc_call,
-            _call_with_retry("google_books", lambda: _google_books(client, query, effective_isbn)),
-            _call_with_retry("open_library", lambda: _open_library(client, query, effective_isbn)),
+            _call_with_retry("google_books", lambda: _google_books(client, query, effective_isbn),
+                             cache_key=(query, effective_isbn)),
+            _call_with_retry("open_library", lambda: _open_library(client, query, effective_isbn),
+                             cache_key=(query, effective_isbn)),
+            al_call,
         )
 
         # Series-aware fallback: when the per-book title is obscure, retry empty
@@ -137,12 +228,15 @@ async def fetch_candidates(
             fallback_query = _build_series_query(series, series_index, author)
             if not gb and not ol:
                 (gb, gb_status), (ol, ol_status) = await asyncio.gather(
-                    _call_with_retry("google_books", lambda: _google_books(client, fallback_query, None)),
-                    _call_with_retry("open_library", lambda: _open_library(client, fallback_query, None)),
+                    _call_with_retry("google_books", lambda: _google_books(client, fallback_query, None),
+                                     cache_key=(fallback_query, None)),
+                    _call_with_retry("open_library", lambda: _open_library(client, fallback_query, None),
+                                     cache_key=(fallback_query, None)),
                 )
             if not hc and hc_status not in ("disabled", "rate_limited"):
                 hc, hc_status = await _call_with_retry("hardcover", lambda: _hardcover(
-                    client, title, author, None, series, series_index, fallback_query))
+                    client, title, author, None, series, series_index, fallback_query),
+                    cache_key=fallback_query)
 
         # Suspect-ISBN fallback: a stored ISBN belonging to the WRONG edition
         # (the manga's ISBN on a light novel — old auto-apply versions caused
@@ -150,12 +244,12 @@ async def fetch_candidates(
         # search never returned. If every Hardcover hit violates the media
         # hint, re-query by title/series with the edition bias and prepend.
         def _violates_hint(c: MetadataCandidate) -> bool:
-            if not media_hint or not c.title:
+            if not hint_cls or not c.title:
                 return False
             ct = c.title.lower()
-            if media_hint == "light_novel":
+            if hint_cls in ("prose", "light_novel"):
                 return "(manga)" in ct
-            if media_hint in ("manga", "comic", "comics"):
+            if hint_cls == "art":
                 return "(light novel)" in ct
             return False
 
@@ -164,21 +258,131 @@ async def fetch_candidates(
             and hc and all(_violates_hint(c) for c in hc)
         ):
             hc2, _st = await _call_with_retry("hardcover", lambda: _hardcover(
-                client, title, author, None, series, series_index, None, media_hint))
+                client, title, author, None, series, series_index, None, media_hint),
+                cache_key=_build_hardcover_query(title, author, None, series, series_index, None, media_hint))
             if hc2:
                 hc = [*hc2, *hc]
 
-    merged = merge_candidates([*hc, *gb, *ol])
+    merged = merge_candidates([*hc, *gb, *ol, *al])
+    if al:
+        _fill_from_anilist(merged, al)
     ranked = rank_candidates(merged, ScoreContext(
         title=title, author=author, isbn=effective_isbn,
         year=year, language=language, series=series, series_index=series_index,
         media_hint=media_hint,
     ))
+    sources = {"hardcover": hc_status, "google_books": gb_status, "open_library": ol_status}
+    if al_status != "skipped":
+        sources["anilist"] = al_status
     return FetchResult(
         candidates=ranked[:_MAX_RESULTS],
         query_used=hc_query,
-        sources={"hardcover": hc_status, "google_books": gb_status, "open_library": ol_status},
+        sources=sources,
     )
+
+
+# ── AniList (manga) ───────────────────────────────────────────────────────────
+
+_ANILIST_QUERY = """
+query ($search: String) {
+  Page(perPage: 3) {
+    media(search: $search, type: MANGA) {
+      id
+      title { english romaji }
+      description(asHtml: false)
+      coverImage { extraLarge large }
+      startDate { year }
+      genres
+      countryOfOrigin
+      staff(perPage: 6) { edges { role node { name { full } } } }
+    }
+  }
+}
+"""
+
+
+def _strip_anilist_markup(text: str | None) -> str | None:
+    """AniList descriptions carry light HTML (<br>, <i>) and source credits."""
+    if not text:
+        return None
+    text = re.sub(r"<br\s*/?>", "\n", text)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = re.sub(r"\(Source:[^)]*\)\s*$", "", text.strip()).strip()
+    return text or None
+
+
+async def _anilist(client: httpx.AsyncClient, search: str) -> list[MetadataCandidate]:
+    """Search AniList for manga SERIES metadata (no API key required).
+
+    AniList models series, not volumes — the candidate carries series-level
+    description/staff/genres/cover. It both appears as its own candidate and
+    back-fills missing fields on volume-level hits via ``_fill_from_anilist``.
+    """
+    resp = await client.post(ANILIST_URL, json={
+        "query": _ANILIST_QUERY, "variables": {"search": search},
+    })
+    if resp.status_code == 429:
+        raise RateLimited("anilist 429")
+    resp.raise_for_status()
+    media = (resp.json().get("data") or {}).get("Page", {}).get("media") or []
+
+    out: list[MetadataCandidate] = []
+    for m in media:
+        titles = m.get("title") or {}
+        name = titles.get("english") or titles.get("romaji")
+        if not name:
+            continue
+        author = None
+        for edge in (m.get("staff") or {}).get("edges") or []:
+            role = (edge.get("role") or "").lower()
+            if "story" in role or "original creator" in role:
+                author = ((edge.get("node") or {}).get("name") or {}).get("full")
+                break
+        cover = (m.get("coverImage") or {})
+        out.append(MetadataCandidate(
+            source="anilist",
+            source_id=str(m.get("id")),
+            title=name,
+            author=author,
+            description=_strip_anilist_markup(m.get("description")),
+            cover_url=cover.get("extraLarge") or cover.get("large"),
+            year=(m.get("startDate") or {}).get("year"),
+            tags=list(m.get("genres") or []),
+            series=name,
+        ))
+    return out
+
+
+def _norm_series(name: str | None) -> str:
+    n = re.sub(r"[^\w\s]", "", (name or "").lower())
+    return re.sub(r"\s+", " ", n).strip()
+
+
+def _fill_from_anilist(candidates: list[MetadataCandidate], al: list[MetadataCandidate]) -> None:
+    """Back-fill missing description/author/tags on volume-level candidates from
+    the matching AniList series. Manga volumes are the books most often missing
+    a description in the prose-first sources; the series blurb beats nothing.
+    Covers are NOT filled — AniList's is the series (vol 1) art.
+    """
+    by_series = {_norm_series(a.title): a for a in al}
+    for c in candidates:
+        if c.source == "anilist":
+            continue
+        key = _norm_series(c.series)
+        a = by_series.get(key)
+        if a is None and c.title:
+            # no series on the candidate — try "title starts with series name"
+            nt = _norm_series(c.title)
+            a = next((v for k, v in by_series.items() if k and nt.startswith(k)), None)
+        if a is None:
+            continue
+        if not c.description and a.description:
+            c.description = a.description
+        if not c.author and a.author:
+            c.author = a.author
+        if a.tags:
+            existing = {t.lower() for t in c.tags}
+            c.tags.extend(t for t in a.tags if t.lower() not in existing)
 
 
 # ── Hardcover ─────────────────────────────────────────────────────────────────
@@ -205,7 +409,8 @@ def _build_hardcover_query(
         # "... Vol. N (light novel)" and manga ones "(Manga)". For a
         # series-variant query ("Slime 13") Typesense often surfaces ONLY the
         # wrong edition — ranking can't fix what search never returned.
-        if media_hint == "light_novel":
+        from backend.services.metadata_rank import classify_media_hint
+        if classify_media_hint(media_hint) == "light_novel":
             return f"{clean} {vol} light novel"
         return f"{clean} {vol}"
     vol_match = re.search(r'\bv(\d{2,4})\b', title, re.IGNORECASE)

--- a/backend/services/metadata_fetch.py
+++ b/backend/services/metadata_fetch.py
@@ -91,6 +91,7 @@ async def fetch_candidates(
     query_override: str | None = None,
     year: int | None = None,
     language: str | None = None,
+    media_hint: str | None = None,
 ) -> FetchResult:
     """Query Hardcover, Google Books and OpenLibrary in parallel; return up to
     _MAX_RESULTS candidates, cross-source merged and relevance-ranked.
@@ -108,7 +109,7 @@ async def fetch_candidates(
     # treat it like Plex "Fix Match": search only by what was typed.
     effective_isbn = None if query_override else isbn
     query = _build_query(title, author, effective_isbn, series, series_index, query_override)
-    hc_query = _build_hardcover_query(title, author, effective_isbn, series, series_index, query_override)
+    hc_query = _build_hardcover_query(title, author, effective_isbn, series, series_index, query_override, media_hint)
 
     async with httpx.AsyncClient(timeout=10) as client:
         async def _hc_disabled() -> tuple[list[MetadataCandidate], str]:
@@ -116,7 +117,7 @@ async def fetch_candidates(
 
         hc_call = (
             _call_with_retry("hardcover", lambda: _hardcover(
-                client, title, author, effective_isbn, series, series_index, query_override))
+                client, title, author, effective_isbn, series, series_index, query_override, media_hint))
             if settings.hardcover_token else _hc_disabled()
         )
         (hc, hc_status), (gb, gb_status), (ol, ol_status) = await asyncio.gather(
@@ -143,10 +144,35 @@ async def fetch_candidates(
                 hc, hc_status = await _call_with_retry("hardcover", lambda: _hardcover(
                     client, title, author, None, series, series_index, fallback_query))
 
+        # Suspect-ISBN fallback: a stored ISBN belonging to the WRONG edition
+        # (the manga's ISBN on a light novel — old auto-apply versions caused
+        # exactly this) monopolises retrieval, and ranking can't demote what
+        # search never returned. If every Hardcover hit violates the media
+        # hint, re-query by title/series with the edition bias and prepend.
+        def _violates_hint(c: MetadataCandidate) -> bool:
+            if not media_hint or not c.title:
+                return False
+            ct = c.title.lower()
+            if media_hint == "light_novel":
+                return "(manga)" in ct
+            if media_hint in ("manga", "comic", "comics"):
+                return "(light novel)" in ct
+            return False
+
+        if (
+            not query_override and effective_isbn and media_hint
+            and hc and all(_violates_hint(c) for c in hc)
+        ):
+            hc2, _st = await _call_with_retry("hardcover", lambda: _hardcover(
+                client, title, author, None, series, series_index, None, media_hint))
+            if hc2:
+                hc = [*hc2, *hc]
+
     merged = merge_candidates([*hc, *gb, *ol])
     ranked = rank_candidates(merged, ScoreContext(
         title=title, author=author, isbn=effective_isbn,
         year=year, language=language, series=series, series_index=series_index,
+        media_hint=media_hint,
     ))
     return FetchResult(
         candidates=ranked[:_MAX_RESULTS],
@@ -164,6 +190,7 @@ def _build_hardcover_query(
     series: str | None,
     series_index: float | None,
     query_override: str | None = None,
+    media_hint: str | None = None,
 ) -> str:
     """Build the query string sent to Hardcover's Typesense search."""
     if query_override:
@@ -174,6 +201,12 @@ def _build_hardcover_query(
     if series and series_index is not None and _title_is_series_variant(title, series):
         clean = _clean_series_name(series)
         vol = int(series_index) if series_index == int(series_index) else series_index
+        # Retrieval-side edition bias: Hardcover titles LN editions
+        # "... Vol. N (light novel)" and manga ones "(Manga)". For a
+        # series-variant query ("Slime 13") Typesense often surfaces ONLY the
+        # wrong edition — ranking can't fix what search never returned.
+        if media_hint == "light_novel":
+            return f"{clean} {vol} light novel"
         return f"{clean} {vol}"
     vol_match = re.search(r'\bv(\d{2,4})\b', title, re.IGNORECASE)
     if vol_match:
@@ -192,13 +225,14 @@ async def _hardcover(
     series: str | None,
     series_index: float | None,
     query_override: str | None = None,
+    media_hint: str | None = None,
 ) -> list[MetadataCandidate]:
     """Fetch candidates from Hardcover.app GraphQL API."""
     token = settings.hardcover_token
     if not token:
         return []
 
-    query_str = _build_hardcover_query(title, author, isbn, series, series_index, query_override)
+    query_str = _build_hardcover_query(title, author, isbn, series, series_index, query_override, media_hint)
 
     graphql_query = """
     query SearchBook($q: String!, $perPage: Int!) {
@@ -405,9 +439,15 @@ async def _fetch_hardcover_details(
     hc_ids: list[str],
     headers: dict,
 ) -> None:
-    """Fetch publisher and series info from Hardcover for each candidate, in-place."""
+    """Fetch publisher and series info from Hardcover for each candidate, in-place.
+
+    The search response's ``ids`` array holds INTS while document ids parse as
+    STRINGS — compare as strings, or nothing ever matches (this exact mismatch
+    made the details call a silent no-op in production: Hardcover series and
+    publisher were never filled).
+    """
     id_to_candidate = {c.source_id: c for c in candidates}
-    int_ids = [int(i) for i in hc_ids if i in id_to_candidate]
+    int_ids = [int(i) for i in hc_ids if str(i) in id_to_candidate]
     if not int_ids:
         return
 
@@ -604,9 +644,10 @@ async def _google_books(
     if settings.google_books_key:
         params["key"] = settings.google_books_key
     resp = await client.get(GOOGLE_BOOKS_URL, params=params)
-    if resp.status_code in (400, 429):
+    if resp.status_code in (400, 403, 429):
         # 400 is how Google reports an exhausted key quota ("Quota Exceeded");
-        # 429 is the anonymous shared-pool limit. Log loudly when a key is
+        # 429 is the anonymous shared-pool limit; 403 shows up for "usage
+        # limits" bursts on the anonymous pool. Log loudly when a key is
         # configured so the operator knows it's *their* project quota that's
         # drained, not a code bug — then let the retry/status machinery run.
         if settings.google_books_key:

--- a/backend/services/metadata_rank.py
+++ b/backend/services/metadata_rank.py
@@ -1,0 +1,175 @@
+"""Cross-source candidate merging + relevance ranking for metadata fetching.
+
+Two jobs, both previously scattered or missing:
+
+- ``merge_candidates``: the same book returned by two sources used to occupy two
+  of the five result slots, each *partially* filled (Hardcover knows series but
+  not language; Google knows language but not series). Duplicates are detected
+  by ISBN or by fuzzy title+author, and merged field-by-field into one complete
+  candidate.
+- ``score_candidate`` / ``rank_candidates``: one scoring brain for every
+  consumer. Before this, only the bulk-review endpoint scored candidates —
+  single fetch, bulk auto-apply, Bindery and auto-import all blindly trusted
+  whatever the highest-priority source returned first.
+"""
+from __future__ import annotations
+
+import difflib
+import re
+from dataclasses import dataclass
+
+_SOURCE_PRIORITY = {"hardcover": 0, "google_books": 1, "open_library": 2}
+
+
+def extract_vol_number(title: str) -> int | None:
+    """Volume number from a title: 'v001', 'Vol. 1', 'Vol 1', 'Volume 1'."""
+    m = re.search(r"\bv(?:ol(?:ume)?\.?\s*)(\d+)\b", title, re.IGNORECASE)
+    if m:
+        return int(m.group(1))
+    m = re.search(r"\bv(\d{2,4})\b", title, re.IGNORECASE)  # bare manga "vNNN"
+    if m:
+        return int(m.group(1))
+    return None
+
+
+@dataclass
+class ScoreContext:
+    """What we know about the book being matched (all optional but title)."""
+    title: str | None = None
+    author: str | None = None
+    isbn: str | None = None
+    year: int | None = None
+    language: str | None = None
+    series: str | None = None
+    series_index: float | None = None
+
+
+def score_candidate(candidate, ctx: ScoreContext) -> int:
+    """Relevance of one candidate against the book context. Higher is better.
+
+    Ported verbatim from the old books.py `_score_candidate` (same weights, so
+    bulk-review behaviour is unchanged) with the Book model swapped for a plain
+    context — the fetch service can't import models.
+    """
+    from backend.services.metadata_fetch import _clean_title
+
+    score = 0
+    if candidate.description:
+        score += 2
+    if candidate.cover_url:
+        score += 1
+    if candidate.isbn and ctx.isbn and candidate.isbn == ctx.isbn:
+        score += 4
+    if candidate.year and ctx.year and candidate.year == ctx.year:
+        score += 1
+
+    clean_book_title = _clean_title(ctx.title).lower() if ctx.title else ""
+    if candidate.title and clean_book_title:
+        ratio = difflib.SequenceMatcher(None, candidate.title.lower(), clean_book_title).ratio()
+        if ratio > 0.85:
+            score += 3
+        elif ratio > 0.6:
+            score += 1
+    if candidate.author and ctx.author:
+        ratio = difflib.SequenceMatcher(None, candidate.author.lower(), ctx.author.lower()).ratio()
+        if ratio > 0.7:
+            score += 2
+
+    # Volume matching — critical for series where every title shares the name.
+    book_vol = extract_vol_number(ctx.title) if ctx.title else None
+    if book_vol is None and ctx.series_index is not None and float(ctx.series_index).is_integer():
+        book_vol = int(ctx.series_index)
+    if book_vol is not None:
+        cand_vol = None
+        if candidate.series_index is not None:
+            cand_vol = int(candidate.series_index) if candidate.series_index == int(candidate.series_index) else None
+        if cand_vol is None:
+            cand_vol = extract_vol_number(candidate.title) if candidate.title else None
+        if cand_vol == book_vol:
+            score += 8
+        else:
+            score -= 4
+
+    book_lang = (ctx.language or "en").lower()[:2]
+    cand_lang = (candidate.language or "en").lower()[:2]
+    if cand_lang == book_lang:
+        score += 2
+    elif cand_lang != "en":
+        score -= 3
+
+    if candidate.title:
+        ct = candidate.title.lower()
+        if "omnibus" in ct:
+            score -= 3
+        if "ace's story" in ct or "film:" in ct or "color walk" in ct:
+            score -= 5
+
+    if candidate.source == "hardcover":
+        score += 6
+
+    return score
+
+
+_MERGE_FIELDS = (
+    "author", "description", "cover_url", "publisher", "year",
+    "page_count", "isbn", "language", "series", "series_index",
+)
+
+
+def _fuzzy_key(candidate) -> tuple[str, str]:
+    """Cross-source identity when ISBN is missing: normalized title + author surname."""
+    t = re.sub(r"[^\w\s]", "", (candidate.title or "").lower())
+    t = re.sub(r"\s+", " ", t).strip()
+    a = (candidate.author or "").lower().split(",")[0].strip()
+    surname = a.split()[-1] if a else ""
+    return (t, surname)
+
+
+def merge_candidates(candidates: list) -> list:
+    """Collapse the same book seen by several sources into one candidate.
+
+    Identity: shared ISBN, or fuzzy (normalized title, author surname). The
+    highest-priority source's candidate is the base; missing fields are filled
+    from the duplicates and tags are unioned — so the merged result is more
+    complete than any single source's answer. Input order (source priority) is
+    preserved for the survivors.
+    """
+    merged: list = []
+    by_isbn: dict[str, int] = {}
+    by_fuzzy: dict[tuple[str, str], int] = {}
+
+    for c in candidates:
+        idx = None
+        if c.isbn and c.isbn in by_isbn:
+            idx = by_isbn[c.isbn]
+        else:
+            fk = _fuzzy_key(c)
+            if fk[0] and fk in by_fuzzy:
+                idx = by_fuzzy[fk]
+
+        if idx is None:
+            merged.append(c)
+            idx = len(merged) - 1
+        else:
+            base = merged[idx]
+            for f in _MERGE_FIELDS:
+                if getattr(base, f) in (None, "") and getattr(c, f) not in (None, ""):
+                    setattr(base, f, getattr(c, f))
+            existing = {t.lower() for t in base.tags}
+            base.tags.extend(t for t in c.tags if t.lower() not in existing)
+
+        c2 = merged[idx]
+        if c2.isbn:
+            by_isbn[c2.isbn] = idx
+        fk = _fuzzy_key(c2)
+        if fk[0]:
+            by_fuzzy[fk] = idx
+    return merged
+
+
+def rank_candidates(candidates: list, ctx: ScoreContext) -> list:
+    """Sort by relevance, ties broken by source priority (stable)."""
+    return sorted(
+        candidates,
+        key=lambda c: (-score_candidate(c, ctx), _SOURCE_PRIORITY.get(c.source, 9)),
+    )

--- a/backend/services/metadata_rank.py
+++ b/backend/services/metadata_rank.py
@@ -18,7 +18,31 @@ import difflib
 import re
 from dataclasses import dataclass
 
-_SOURCE_PRIORITY = {"hardcover": 0, "google_books": 1, "open_library": 2}
+_SOURCE_PRIORITY = {"hardcover": 0, "google_books": 1, "open_library": 2, "anilist": 3}
+
+_ART_WORDS = ("manga", "manhwa", "manhua", "webtoon", "comic", "graphic")
+_PROSE_WORDS = ("novel", "book")
+
+
+def classify_media_hint(hint: str | None) -> str | None:
+    """Coarse edition class from a BookType slug — custom slugs included.
+
+    Slugs are user-defined ("Webtoons", "graphic_novel", "LightNovels"), so
+    exact matching only covers the seeded four. Normalize and substring-match
+    instead. Returns "art" (sequential art), "light_novel" (a prose subclass —
+    the only one that gets the retrieval-side query bias), "prose", or None.
+    Art words win: "graphic_novel" is art despite containing "novel".
+    """
+    if not hint:
+        return None
+    h = re.sub(r"[^a-z]", "", hint.lower())
+    if any(w in h for w in _ART_WORDS):
+        return "art"
+    if h == "ln" or ("light" in h and "novel" in h):
+        return "light_novel"
+    if any(w in h for w in _PROSE_WORDS):
+        return "prose"
+    return None
 
 
 def extract_vol_number(title: str) -> int | None:
@@ -109,13 +133,14 @@ def score_candidate(candidate, ctx: ScoreContext) -> int:
 
     # Wrong edition type of the right series: a light novel must not match the
     # manga adaptation (Hardcover titles them "… (Manga), Vol. N") and vice versa.
-    if ctx.media_hint and candidate.title:
+    hint_cls = classify_media_hint(ctx.media_hint)
+    if hint_cls and candidate.title:
         ct = candidate.title.lower()
         cand_manga = "(manga)" in ct
         cand_ln = "(light novel)" in ct or "light novel" in ct
-        if ctx.media_hint in ("light_novel", "novel", "book") and cand_manga:
+        if hint_cls in ("prose", "light_novel") and cand_manga:
             score -= 5
-        elif ctx.media_hint in ("manga", "comic", "comics") and cand_ln:
+        elif hint_cls == "art" and cand_ln:
             score -= 5
 
     if candidate.source == "hardcover":

--- a/backend/services/metadata_rank.py
+++ b/backend/services/metadata_rank.py
@@ -42,6 +42,9 @@ class ScoreContext:
     language: str | None = None
     series: str | None = None
     series_index: float | None = None
+    # BookType slug ("manga", "light_novel", …) — lets ranking reject the wrong
+    # EDITION of the right series (the manga adaptation of a light novel).
+    media_hint: str | None = None
 
 
 def score_candidate(candidate, ctx: ScoreContext) -> int:
@@ -104,6 +107,17 @@ def score_candidate(candidate, ctx: ScoreContext) -> int:
         if "ace's story" in ct or "film:" in ct or "color walk" in ct:
             score -= 5
 
+    # Wrong edition type of the right series: a light novel must not match the
+    # manga adaptation (Hardcover titles them "… (Manga), Vol. N") and vice versa.
+    if ctx.media_hint and candidate.title:
+        ct = candidate.title.lower()
+        cand_manga = "(manga)" in ct
+        cand_ln = "(light novel)" in ct or "light novel" in ct
+        if ctx.media_hint in ("light_novel", "novel", "book") and cand_manga:
+            score -= 5
+        elif ctx.media_hint in ("manga", "comic", "comics") and cand_ln:
+            score -= 5
+
     if candidate.source == "hardcover":
         score += 6
 
@@ -138,13 +152,21 @@ def merge_candidates(candidates: list) -> list:
     by_isbn: dict[str, int] = {}
     by_fuzzy: dict[tuple[str, str], int] = {}
 
+    def _langs_compatible(a, b) -> bool:
+        # A fuzzy title+author match across DIFFERENT languages is a different
+        # EDITION (e.g. the Italian Fellowship of the Ring) — merging it would
+        # poison the base candidate's language/ISBN. Unknown matches anything.
+        la = (a.language or "").lower()[:2]
+        lb = (b.language or "").lower()[:2]
+        return not la or not lb or la == lb
+
     for c in candidates:
         idx = None
         if c.isbn and c.isbn in by_isbn:
             idx = by_isbn[c.isbn]
         else:
             fk = _fuzzy_key(c)
-            if fk[0] and fk in by_fuzzy:
+            if fk[0] and fk in by_fuzzy and _langs_compatible(merged[by_fuzzy[fk]], c):
                 idx = by_fuzzy[fk]
 
         if idx is None:

--- a/frontend/src/components/MetadataFetchModal.tsx
+++ b/frontend/src/components/MetadataFetchModal.tsx
@@ -49,6 +49,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
   const [applying, setApplying] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [candidates, setCandidates] = useState<MetadataCandidate[]>([])
+  const [sourceNotice, setSourceNotice] = useState<string | null>(null)
   const [selected, setSelected] = useState<MetadataCandidate | null>(null)
   const [fields, setFields] = useState<FieldRow[]>([])
   const [query, setQuery] = useState('')
@@ -71,6 +72,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
     setApplying(false)
     setError(null)
     setCandidates([])
+    setSourceNotice(null)
     setSelected(null)
     setFields([])
     setQuery('')
@@ -80,17 +82,30 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
     setLoading(true)
     setError(null)
     setCandidates([])
+    setSourceNotice(null)
     try {
       const qs = q.trim() ? `?q=${encodeURIComponent(q)}` : ''
       const r = await fetch(`${API}/api/books/${book.id}/fetch-metadata${qs}`, {
         headers: authHeader(),
       })
       if (!r.ok) throw new Error(await r.text())
-      const data: MetadataCandidate[] = await r.json()
-      if (data.length === 0) {
-        setError('No results found. Try a different search query.')
+      const data: { candidates: MetadataCandidate[]; sources?: Record<string, string> } = await r.json()
+
+      // Be honest about degraded sources — "no results" used to swallow 429s.
+      const labels: Record<string, string> = {
+        hardcover: 'Hardcover', google_books: 'Google Books', open_library: 'Open Library',
+      }
+      const degraded = Object.entries(data.sources ?? {})
+        .filter(([, s]) => s === 'rate_limited' || s === 'timeout' || s === 'error')
+        .map(([k, s]) => `${labels[k] ?? k} ${s === 'rate_limited' ? 'is rate-limited — try again in a minute' : s === 'timeout' ? 'timed out' : 'errored'}`)
+      if (degraded.length) setSourceNotice(degraded.join(' · '))
+
+      if (data.candidates.length === 0) {
+        setError(degraded.length
+          ? 'No results — but some sources were unavailable (see below); retrying may help.'
+          : 'No results found. Try a different search query.')
       } else {
-        setCandidates(data)
+        setCandidates(data.candidates)
       }
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : 'Search failed')
@@ -217,12 +232,16 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                 </div>
               )}
 
+              {!loading && sourceNotice && (
+                <p className="text-xs text-amber-600 dark:text-amber-400 mb-2">{sourceNotice}</p>
+              )}
+
               {!loading && candidates.length > 0 && (
                 <div className="space-y-2">
                   <p className="text-xs text-muted-foreground">
                     {candidates.length} result{candidates.length !== 1 ? 's' : ''} — pick one to review
                   </p>
-                  {candidates.map(c => (
+                  {candidates.map((c, i) => (
                     <button
                       key={`${c.source}-${c.source_id}`}
                       className="w-full text-left rounded-lg border border-border bg-card p-3 hover:bg-accent transition-colors flex gap-3"
@@ -238,8 +257,15 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                       <div className="min-w-0 flex-1">
                         <div className="flex items-start justify-between gap-2">
                           <p className="font-medium line-clamp-2">{c.title}</p>
-                          <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded border border-border text-muted-foreground bg-muted">
-                            {c.source === 'hardcover' ? 'Hardcover' : c.source === 'google_books' ? 'Google' : 'OpenLib'}
+                          <span className="flex items-center gap-1 shrink-0">
+                            {i === 0 && (
+                              <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/15 text-primary font-medium">
+                                Best match
+                              </span>
+                            )}
+                            <span className="text-[10px] px-1.5 py-0.5 rounded border border-border text-muted-foreground bg-muted">
+                              {c.source === 'hardcover' ? 'Hardcover' : c.source === 'google_books' ? 'Google' : 'OpenLib'}
+                            </span>
                           </span>
                         </div>
                         {c.author && <p className="text-sm text-muted-foreground mt-0.5">{c.author}</p>}

--- a/frontend/src/components/MetadataFetchModal.tsx
+++ b/frontend/src/components/MetadataFetchModal.tsx
@@ -93,7 +93,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
 
       // Be honest about degraded sources — "no results" used to swallow 429s.
       const labels: Record<string, string> = {
-        hardcover: 'Hardcover', google_books: 'Google Books', open_library: 'Open Library',
+        hardcover: 'Hardcover', google_books: 'Google Books', open_library: 'Open Library', anilist: 'AniList',
       }
       const degraded = Object.entries(data.sources ?? {})
         .filter(([, s]) => s === 'rate_limited' || s === 'timeout' || s === 'error')
@@ -264,7 +264,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                               </span>
                             )}
                             <span className="text-[10px] px-1.5 py-0.5 rounded border border-border text-muted-foreground bg-muted">
-                              {c.source === 'hardcover' ? 'Hardcover' : c.source === 'google_books' ? 'Google' : 'OpenLib'}
+                              {c.source === 'hardcover' ? 'Hardcover' : c.source === 'google_books' ? 'Google' : c.source === 'anilist' ? 'AniList' : 'OpenLib'}
                             </span>
                           </span>
                         </div>
@@ -321,7 +321,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                   <span>
                     Incoming
                     <span className="ml-1.5 text-[10px] px-1.5 py-0.5 rounded border border-border bg-background normal-case tracking-normal">
-                      {selected.source === 'hardcover' ? 'Hardcover' : selected.source === 'google_books' ? 'Google Books' : 'Open Library'}
+                      {selected.source === 'hardcover' ? 'Hardcover' : selected.source === 'google_books' ? 'Google Books' : selected.source === 'anilist' ? 'AniList' : 'Open Library'}
                     </span>
                   </span>
                 </div>

--- a/frontend/src/components/MetadataManager.tsx
+++ b/frontend/src/components/MetadataManager.tsx
@@ -483,7 +483,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
                       <div className="flex items-start justify-between gap-1">
                         <p className="text-xs font-medium line-clamp-1">{c.title}</p>
                         <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded border border-border text-muted-foreground bg-muted">
-                          {c.source === 'hardcover' ? 'HC' : c.source === 'google_books' ? 'GB' : 'OL'}
+                          {c.source === 'hardcover' ? 'HC' : c.source === 'google_books' ? 'GB' : c.source === 'anilist' ? 'AL' : 'OL'}
                         </span>
                       </div>
                       {c.author && <p className="text-[11px] text-muted-foreground">{c.author}</p>}

--- a/frontend/src/components/MetadataManager.tsx
+++ b/frontend/src/components/MetadataManager.tsx
@@ -220,9 +220,10 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
     setFields([])
     try {
       const qs = q?.trim() ? `?q=${encodeURIComponent(q)}` : ''
-      const data = await fetch(`${API}/api/books/${id}/fetch-metadata${qs}`, {
+      const resp = await fetch(`${API}/api/books/${id}/fetch-metadata${qs}`, {
         headers: authHeader(),
-      }).then(r => r.json()) as MetadataCandidate[]
+      }).then(r => r.json()) as { candidates: MetadataCandidate[] }
+      const data = resp.candidates ?? []
       setCandidates(data)
       if (data.length > 0 && book) {
         setSelectedCandidate(data[0])

--- a/frontend/src/components/SeriesFollowButton.tsx
+++ b/frontend/src/components/SeriesFollowButton.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { BellPlus, BellRing, Loader2 } from 'lucide-react'
 import { api } from '@/lib/api'
+import { getFollows, invalidateFollows, type FollowOut } from '@/lib/follows'
 import { useToast } from '@/contexts/ToastContext'
 import { cn, formatDate } from '@/lib/utils'
 
@@ -11,35 +12,21 @@ import { cn, formatDate } from '@/lib/utils'
  * release date under the button — labelled "Next" when the date is upcoming.
  */
 
-interface FollowOut {
-  id: number
-  name: string
-  latest_known_index: number | null
-  latest_known_title: string | null
-  latest_release_date: string | null
-}
-
 export function SeriesFollowButton({ seriesName }: { seriesName: string }) {
   const { toast } = useToast()
-  const [enabled, setEnabled] = useState(true)
-  const [loaded, setLoaded] = useState(false)
-  const [follow, setFollow] = useState<FollowOut | null>(null)
+  // undefined = follows not resolved yet (render NOTHING — an optimistic
+  // button flickered on instances where release detection is disabled).
+  const [rows, setRows] = useState<FollowOut[] | null | undefined>(undefined)
   const [busy, setBusy] = useState(false)
 
-  const load = useCallback(() => {
-    api.get<FollowOut[]>('/wishlist/follows')
-      .then(rows => {
-        setFollow(rows.find(f => f.name.toLowerCase() === seriesName.toLowerCase()) ?? null)
-        setLoaded(true)
-      })
-      .catch(() => setEnabled(false))
-  }, [seriesName])
+  const load = useCallback(() => { getFollows().then(setRows) }, [seriesName])
   useEffect(load, [load])
 
-  if (!enabled || seriesName === '__unserialized__') return null
+  if (rows == null || seriesName === '__unserialized__') return null
+  const follow = rows.find(f => f.name.toLowerCase() === seriesName.toLowerCase()) ?? null
 
   const toggle = async () => {
-    if (busy || !loaded) return
+    if (busy) return
     setBusy(true)
     try {
       if (follow) {
@@ -48,7 +35,8 @@ export function SeriesFollowButton({ seriesName }: { seriesName: string }) {
         await api.post('/wishlist/follow', { name: seriesName })
         toast.success(`Following "${seriesName}" — you'll hear when a new volume is out`)
       }
-      load()
+      invalidateFollows()
+      getFollows().then(setRows)
     } catch (e) {
       toast.error((e as Error).message ?? 'Could not resolve this series on Hardcover')
     } finally {
@@ -64,7 +52,7 @@ export function SeriesFollowButton({ seriesName }: { seriesName: string }) {
     <div className="flex flex-col gap-1">
       <button
         onClick={toggle}
-        disabled={busy || !loaded}
+        disabled={busy}
         className={cn(
           'flex items-center gap-2 px-3 py-2 rounded-lg border text-sm font-medium transition-all disabled:opacity-50',
           follow

--- a/frontend/src/components/UpcomingReleases.tsx
+++ b/frontend/src/components/UpcomingReleases.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { CalendarClock } from 'lucide-react'
-import { api } from '@/lib/api'
+import { getFollows, type FollowOut } from '@/lib/follows'
 import { formatDate } from '@/lib/utils'
 
 /**
@@ -10,28 +10,20 @@ import { formatDate } from '@/lib/utils'
  * users, most of the time, it simply isn't there.
  */
 
-interface FollowOut {
-  id: number
-  name: string
-  cover_url: string | null
-  latest_known_index: number | null
-  latest_known_title: string | null
-  latest_release_date: string | null
-}
-
 export function UpcomingReleases() {
   const [rows, setRows] = useState<FollowOut[]>([])
 
   useEffect(() => {
     const today = new Date().toISOString().slice(0, 10)
-    api.get<FollowOut[]>('/wishlist/follows')
-      .then(all => setRows(
+    getFollows().then(all => {
+      if (!all) return   // detection off (cached; no repeat 403s)
+      setRows(
         all
           .filter(f => f.latest_release_date != null && f.latest_release_date >= today)
           .sort((a, b) => (a.latest_release_date! < b.latest_release_date! ? -1 : 1))
           .slice(0, 5),
-      ))
-      .catch(() => {})   // 403 = detection off; card stays absent
+      )
+    })
   }, [])
 
   if (rows.length === 0) return null

--- a/frontend/src/lib/follows.ts
+++ b/frontend/src/lib/follows.ts
@@ -1,0 +1,51 @@
+import { api } from '@/lib/api'
+
+/**
+ * Shared, session-cached access to the user's followed series.
+ *
+ * Release detection is opt-in (TOME_RELEASE_DETECTION); when it's off the
+ * follows endpoint 403s. Every consumer (Wishlist Following section, the
+ * series-page Follow button, the Home Upcoming-releases card) must render
+ * NOTHING until this resolves — rendering optimistically caused a visible
+ * flicker on instances with the feature disabled. A disabled verdict is cached
+ * for the session so later navigations neither flicker nor re-fire the 403.
+ */
+
+export interface FollowOut {
+  id: number
+  name: string
+  author: string | null
+  cover_url: string | null
+  source_id?: string | null
+  latest_known_index: number | null
+  latest_known_title: string | null
+  latest_release_date: string | null
+  owned_max_index: number | null
+  last_checked_at?: string | null
+}
+
+// undefined = not fetched yet · null = feature disabled · array = follows
+let cached: FollowOut[] | null | undefined
+let inflight: Promise<FollowOut[] | null> | null = null
+
+/** Follows list, or null when release detection is disabled. */
+export function getFollows(force = false): Promise<FollowOut[] | null> {
+  if (cached === null) return Promise.resolve(null)         // disabled — final for the session
+  if (!force && cached !== undefined) return Promise.resolve(cached)
+  if (!force && inflight) return inflight
+  inflight = api.get<FollowOut[]>('/wishlist/follows')
+    .then(rows => { cached = rows; return rows as FollowOut[] | null })
+    .catch((e: Error) => {
+      // Our own endpoint's 403 detail mentions "disabled"; anything else
+      // (network blip) is transient — don't latch the feature off for it.
+      if (/disabled/i.test(e.message ?? '')) cached = null
+      return cached ?? null
+    })
+    .finally(() => { inflight = null })
+  return inflight
+}
+
+/** Call after follow/unfollow so the next getFollows refetches. */
+export function invalidateFollows() {
+  if (cached !== null) cached = undefined
+}

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -9,6 +9,7 @@ import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
 import { listWishes, deleteWish, type WishOut } from '@/lib/wishlist'
 import { api } from '@/lib/api'
+import { getFollows, invalidateFollows, type FollowOut } from '@/lib/follows'
 import { WishlistModal } from '@/components/WishlistModal'
 import { SeriesCoverageStrip } from '@/components/SeriesCoverageStrip'
 import { docsLink, DOCS } from '@/lib/docs'
@@ -45,16 +46,6 @@ function ageLabel(iso: string): string {
 // ── Following (release detection) ─────────────────────────────────────────────
 // Renders nothing when TOME_RELEASE_DETECTION is off (the follows endpoint 403s).
 
-interface FollowOut {
-  id: number
-  name: string
-  author: string | null
-  cover_url: string | null
-  latest_known_index: number | null
-  owned_max_index: number | null
-  last_checked_at: string | null
-}
-
 interface SeriesHit {
   source_id: string
   name: string
@@ -66,18 +57,15 @@ interface SeriesHit {
 const fmtVol = (n: number | null) => (n == null ? null : (Number.isInteger(n) ? String(n) : String(n)))
 
 function FollowingSection() {
-  const [enabled, setEnabled] = useState(true)
-  const [follows, setFollows] = useState<FollowOut[]>([])
+  // undefined = not resolved yet: render NOTHING (optimistic render flickered
+  // on instances with release detection disabled); null = disabled.
+  const [follows, setFollows] = useState<FollowOut[] | null | undefined>(undefined)
   const [q, setQ] = useState('')
   const [results, setResults] = useState<SeriesHit[]>([])
   const [searching, setSearching] = useState(false)
   const [busy, setBusy] = useState(false)
 
-  const load = () => {
-    api.get<FollowOut[]>('/wishlist/follows')
-      .then(setFollows)
-      .catch(() => setEnabled(false))
-  }
+  const load = () => { getFollows().then(setFollows) }
   useEffect(load, [])
 
   useEffect(() => {
@@ -101,16 +89,17 @@ function FollowingSection() {
         name: r.name, source_id: r.source_id, author: r.author, cover_url: r.cover_url,
       })
       setQ(''); setResults([])
+      invalidateFollows()
       load()
     } catch { /* dup or offline — list stays as-is */ }
     finally { setBusy(false) }
   }
 
   const unfollow = async (id: number) => {
-    try { await api.delete(`/wishlist/${id}`); load() } catch { /* keep row */ }
+    try { await api.delete(`/wishlist/${id}`); invalidateFollows(); load() } catch { /* keep row */ }
   }
 
-  if (!enabled) return null
+  if (follows == null) return null
 
   return (
     <div>

--- a/skills/scribe/SKILL.md
+++ b/skills/scribe/SKILL.md
@@ -974,10 +974,12 @@ ones, and apply fixes with user approval.
 
 - `/scribe audit` — all books (null/missing fields + series drift)
 - `/scribe audit years [scope]` — publication-year drift check (see "Year-drift audit" subsection below)
+- `/scribe audit editions [scope]` — wrong-edition ISBN check for manga/light-novel libraries (see "Edition audit" subsection below)
 - "audit metadata" / "find books with missing metadata"
 - "audit the manga library" / "audit books in Light Novels"
 - "audit books by X"
 - "audit years", "check publication years", "verify years for tarzan"
+- "audit editions", "check for wrong-edition ISBNs", "is any light novel carrying a manga ISBN"
 
 Narrow scope is parsed with the same natural-language interpretation as
 Update mode Step U1.
@@ -1113,6 +1115,71 @@ first-pub years are usually correct in OL even if pre-modern.
 **Never** auto-apply year corrections without surfacing them.  Even perfect
 confidence requires explicit user approval — same rule as series title
 drift.
+
+---
+
+### Edition audit (trigger: `/scribe audit editions [scope]`)
+
+**Motivation:** older Tome versions auto-applied the top metadata candidate
+blindly, which could write the WRONG edition's identity onto a book — the
+manga adaptation's ISBN (and sometimes publisher/description) on a light
+novel, or vice versa.  A wrong stored ISBN then *monopolises* every later
+fetch (ISBN queries dominate retrieval), so the damage self-perpetuates
+until the ISBN itself is corrected.  This check found and fixed 5 such books
+on a real 560-book library (4 Slime LNs + 1 Black Summoner LN carrying manga
+ISBNs).
+
+**Scope:** books that have an ISBN **and** a book type classifying as
+sequential-art (manga/comics/webtoon-like slugs) or light-novel/prose.
+Resolve `book_type_id → slug` via `GET /api/book-types`.  Books without an
+ISBN or with untyped/other types are skipped.
+
+**Detection is fetch-based** (like year drift): for each book in scope call
+`GET /api/books/<id>/fetch-metadata` in batches of 4 (external sources are
+rate-limited; if the response carries `sources` with `"hardcover":
+"rate_limited"`, pause 60 s and retry that book — do not classify a
+rate-limited response).  Handle both response shapes: newer servers return
+`{"candidates": [...], "sources": {...}}`, older ones a bare list.
+
+Classify by finding the candidate whose `isbn` equals the stored ISBN:
+
+| Observation | Status |
+|-------------|--------|
+| Stored-ISBN candidate title contains `(Manga)` but the book type is light-novel/prose | **wrong_edition** |
+| Stored-ISBN candidate title contains `(Light Novel)` but the book type is sequential-art | **wrong_edition** |
+| Stored-ISBN candidate matches the book's edition class | match |
+| No candidate carries the stored ISBN | no_signal |
+| Stored-ISBN candidate has no edition label in its title | unlabelled (fine — most single-edition series are unlabelled) |
+
+**Correction:** the same fetch response usually already contains the right
+edition (newer servers bias retrieval toward the book's edition when the
+stored ISBN looks suspect).  Pick the top candidate that (a) does NOT
+violate the edition class and (b) matches the volume (`series_index`
+equal).  Propose a patch of `isbn` (always) plus `publisher`, `year` and
+`description` from that candidate — the old auto-apply usually poisoned
+those too.  Do NOT touch title, series or cover (covers were typically
+corrected by hand long ago; check before clobbering).
+
+State file: `~/.cache/tome-scribe/.scribe-audit-editions-<profile>-<timestamp>.json`,
+same conventions as the year audit (persist per fetch, resumable, delete on
+clean completion).
+
+Present findings compactly and require explicit approval, same options as
+the year audit (`accept all` / `skip #N` / `show #N` / `cancel`):
+
+```
+333 books scanned · 5 wrong edition · 60 match · 251 unlabelled · 17 no signal
+
+Wrong-edition ISBNs:
+  #id=54  "That Time I Got Reincarnated as a Slime" (light_novel, vol 13)
+          stored 9781646510078 → "…(Manga), Vol. 13" [Kodansha Comics]
+          fix    9781975314460 → "…(Light Novel), Vol. 13" [Yen On]
+  ...
+```
+
+On apply, `POST /api/books/{id}/apply-metadata` with only the proposed
+fields.  Re-verify by re-fetching once and confirming the stored-ISBN
+candidate now matches the edition class.
 
 ---
 

--- a/tests/test_metadata_fetch_orchestration.py
+++ b/tests/test_metadata_fetch_orchestration.py
@@ -10,7 +10,7 @@ import respx
 
 from backend.core.config import settings
 from backend.services import metadata_fetch as mf
-from backend.services.metadata_rank import ScoreContext, merge_candidates, rank_candidates
+from backend.services.metadata_rank import ScoreContext, merge_candidates, rank_candidates, score_candidate
 
 pytestmark = pytest.mark.anyio
 
@@ -54,6 +54,7 @@ def _empty_ol():
 def _token(monkeypatch):
     monkeypatch.setattr(settings, "hardcover_token", "hc_test")
     monkeypatch.setattr(settings, "google_books_key", None)
+    mf._source_cache.clear()   # module-level TTL cache persists across tests
     # Details second-call for hardcover returns nothing extra.
     yield
 
@@ -157,3 +158,126 @@ def test_rank_right_volume_beats_source_priority():
     ctx = ScoreContext(title="My Series v004", author="A. Author")
     ranked = rank_candidates([wrong, right], ctx)
     assert ranked[0] is right
+
+
+def test_classify_media_hint_covers_custom_slugs():
+    """Edition awareness must work for user-created BookTypes, not just the
+    seeded four — slugs are normalized and substring-classified."""
+    from backend.services.metadata_rank import classify_media_hint
+
+    assert classify_media_hint("light_novel") == "light_novel"
+    assert classify_media_hint("LightNovels") == "light_novel"
+    assert classify_media_hint("ln") == "light_novel"
+    assert classify_media_hint("book") == "prose"
+    assert classify_media_hint("novel") == "prose"
+    for art in ("manga", "comic", "webtoon", "Manhwa", "manhua", "graphic_novel"):
+        assert classify_media_hint(art) == "art", art
+    assert classify_media_hint(None) is None
+    assert classify_media_hint("magazine") is None
+
+
+def test_media_hint_penalty_applies_to_custom_slug():
+    """A custom 'webtoon' type must penalise light-novel editions same as manga."""
+    ln = mf.MetadataCandidate(source="hardcover", source_id="1",
+                              title="Solo Leveling, Vol. 1 (light novel)")
+    ctx_art = ScoreContext(title="Solo Leveling, Vol. 1", media_hint="webtoon")
+    ctx_none = ScoreContext(title="Solo Leveling, Vol. 1")
+    assert score_candidate(ln, ctx_art) == score_candidate(ln, ctx_none) - 5
+
+
+AL = mf.ANILIST_URL
+
+
+def _al_payload():
+    return {"data": {"Page": {"media": [{
+        "id": 30002,
+        "title": {"english": "Berserk", "romaji": "Berserk"},
+        "description": "His name is Guts.<br><br>(Source: Dark Horse)",
+        "coverImage": {"extraLarge": "https://img/al.jpg"},
+        "startDate": {"year": 1989},
+        "genres": ["Action", "Fantasy"],
+        "countryOfOrigin": "JP",
+        "staff": {"edges": [
+            {"role": "Story & Art", "node": {"name": {"full": "Kentarou Miura"}}},
+        ]},
+    }]}}}
+
+
+@respx.mock
+async def test_anilist_queried_for_art_types_and_fills_missing_description():
+    """A manga fetch adds the AniList series candidate AND back-fills a missing
+    description on the volume-level Hardcover hit from the series blurb."""
+    hc = _hc_payload("Berserk, Vol. 1")
+    doc = hc["data"]["search"]["results"]["hits"][0]["document"]
+    doc["description"] = None
+    doc["author_names"] = ["Kentaro Miura"]   # keeps the desc-less doc _is_useful
+    respx.post(HC).mock(return_value=httpx.Response(200, json=hc))
+    respx.get(GB).mock(return_value=httpx.Response(200, json=_empty_gb()))
+    respx.get(OL).mock(return_value=httpx.Response(200, json=_empty_ol()))
+    respx.post(AL).mock(return_value=httpx.Response(200, json=_al_payload()))
+
+    result = await mf.fetch_candidates("Berserk, Vol. 1", series="Berserk",
+                                       series_index=1, media_hint="manga")
+    assert result.sources["anilist"] == "ok"
+    al = [c for c in result.candidates if c.source == "anilist"]
+    assert al and al[0].author == "Kentarou Miura"
+    assert al[0].description == "His name is Guts."      # markup + credit stripped
+    assert al[0].tags == ["Action", "Fantasy"]
+    hc_cand = next(c for c in result.candidates if c.source == "hardcover")
+    assert hc_cand.description == "His name is Guts."    # filled from the series
+
+
+@respx.mock
+async def test_anilist_skipped_for_prose_types():
+    """Light novels and plain books never hit AniList — no wasted call, and the
+    sources dict doesn't mention it."""
+    respx.post(HC).mock(return_value=httpx.Response(200, json=_hc_payload("Some Novel")))
+    respx.get(GB).mock(return_value=httpx.Response(200, json=_empty_gb()))
+    respx.get(OL).mock(return_value=httpx.Response(200, json=_empty_ol()))
+    al_route = respx.post(AL).mock(return_value=httpx.Response(200, json=_al_payload()))
+
+    result = await mf.fetch_candidates("Some Novel", media_hint="light_novel")
+    assert not al_route.called
+    assert "anilist" not in result.sources
+
+
+@respx.mock
+async def test_repeat_fetch_served_from_cache():
+    """An identical fetch within the TTL re-uses cached source results instead
+    of re-hitting the external APIs."""
+    hc_route = respx.post(HC).mock(return_value=httpx.Response(200, json=_hc_payload("Some Novel", isbn="9781111111111")))
+    gb_route = respx.get(GB).mock(return_value=httpx.Response(200, json=_empty_gb()))
+    respx.get(OL).mock(return_value=httpx.Response(200, json=_empty_ol()))
+
+    r1 = await mf.fetch_candidates("Some Novel", author="Eric Ugland")
+    hc_calls, gb_calls = hc_route.call_count, gb_route.call_count
+    r2 = await mf.fetch_candidates("Some Novel", author="Eric Ugland")
+    assert hc_route.call_count == hc_calls          # no new outbound calls
+    assert gb_route.call_count == gb_calls
+    assert [c.title for c in r2.candidates] == [c.title for c in r1.candidates]
+    assert r2.sources["hardcover"] == "ok"
+
+
+@respx.mock
+async def test_concurrent_series_volumes_share_one_anilist_call():
+    """Bulk-fetching volumes of one series concurrently must not fan the same
+    series-level AniList query out N times — followers await the leader."""
+    import asyncio
+
+    def _hc_vol(req):
+        return httpx.Response(200, json=_hc_payload("Berserk"))
+
+    respx.post(HC).mock(side_effect=_hc_vol)
+    respx.get(GB).mock(return_value=httpx.Response(200, json=_empty_gb()))
+    respx.get(OL).mock(return_value=httpx.Response(200, json=_empty_ol()))
+    al_route = respx.post(AL).mock(return_value=httpx.Response(200, json=_al_payload()))
+
+    results = await asyncio.gather(*[
+        mf.fetch_candidates(f"Berserk, Vol. {i}", series="Berserk",
+                            series_index=i, media_hint="manga")
+        for i in (1, 2, 3, 4)
+    ])
+    assert al_route.call_count == 1
+    for r in results:
+        assert r.sources["anilist"] == "ok"
+        assert any(c.source == "anilist" for c in r.candidates)

--- a/tests/test_metadata_fetch_orchestration.py
+++ b/tests/test_metadata_fetch_orchestration.py
@@ -1,0 +1,159 @@
+"""fetch_candidates orchestration: cross-source merge, ranking, retry, status.
+
+These behaviours — the ones most implicated in metadata pains — were entirely
+unpinned before: the same book from two sources ate two result slots, 429s
+read as "no results", and only the bulk path ranked anything.
+"""
+import httpx
+import pytest
+import respx
+
+from backend.core.config import settings
+from backend.services import metadata_fetch as mf
+from backend.services.metadata_rank import ScoreContext, merge_candidates, rank_candidates
+
+pytestmark = pytest.mark.anyio
+
+GB = "https://www.googleapis.com/books/v1/volumes"
+OL = "https://openlibrary.org/search.json"
+HC = mf.HARDCOVER_URL
+
+
+def _hc_payload(title, isbn=None, series=None):
+    doc = {
+        "id": 42, "title": title, "description": "A hardcover description.",
+        "release_year": 2021, "pages": 300, "image": {"url": "https://img/hc.jpg"},
+        "genres": ["Fantasy"], "isbns": [isbn] if isbn else [],
+        "contributions": [{"author": {"name": "Eric Ugland"}}],
+    }
+    return {"data": {"search": {"ids": ["42"], "results": {"hits": [{"document": doc}]}}}}
+
+
+def _gb_payload(title, isbn=None, language="en"):
+    ident = [{"type": "ISBN_13", "identifier": isbn}] if isbn else []
+    return {"items": [{
+        "id": "gb1",
+        "volumeInfo": {
+            "title": title, "authors": ["Eric Ugland"], "language": language,
+            "publisher": "Ugland House", "publishedDate": "2021-05-01",
+            "industryIdentifiers": ident, "categories": ["Fiction"],
+            "imageLinks": {"thumbnail": "http://img/gb.jpg"},
+        },
+    }]}
+
+
+def _empty_gb():
+    return {"items": []}
+
+
+def _empty_ol():
+    return {"docs": []}
+
+
+@pytest.fixture(autouse=True)
+def _token(monkeypatch):
+    monkeypatch.setattr(settings, "hardcover_token", "hc_test")
+    monkeypatch.setattr(settings, "google_books_key", None)
+    # Details second-call for hardcover returns nothing extra.
+    yield
+
+
+def _mock_hc_details(router):
+    # _fetch_hardcover_details posts to the same URL; return empty books list.
+    return router
+
+
+@respx.mock
+async def test_cross_source_merge_fills_missing_fields():
+    """Hardcover (series, no language) + Google (language, same ISBN) → ONE
+    candidate carrying both."""
+    hc_calls = respx.post(HC).mock(side_effect=[
+        httpx.Response(200, json=_hc_payload("The Good Guys Vol 4", isbn="9781234567890")),
+        httpx.Response(200, json={"data": {"books": [{"id": 42, "editions": [], "book_series": [
+            {"series": {"name": "The Good Guys"}, "position": 4}]}]}}),
+    ])
+    respx.get(GB).mock(return_value=httpx.Response(200, json=_gb_payload("The Good Guys Vol 4", isbn="9781234567890")))
+    respx.get(OL).mock(return_value=httpx.Response(200, json=_empty_ol()))
+
+    result = await mf.fetch_candidates("The Good Guys Vol 4", author="Eric Ugland")
+    assert hc_calls.called
+    assert len(result.candidates) == 1          # merged, not two slots
+    c = result.candidates[0]
+    assert c.source == "hardcover"              # base = higher-priority source
+    assert c.series == "The Good Guys"          # from Hardcover details
+    assert c.language == "en"                   # filled from Google
+    assert c.publisher                          # from either source
+    assert set(t.lower() for t in c.tags) >= {"fantasy", "fiction"}
+    assert result.sources == {"hardcover": "ok", "google_books": "ok", "open_library": "empty"}
+
+
+@respx.mock
+async def test_rate_limit_is_reported_not_swallowed(monkeypatch):
+    """429 twice → status rate_limited; other sources still deliver."""
+    async def _no_sleep(_): return None
+    monkeypatch.setattr(mf.asyncio, "sleep", _no_sleep)
+
+    respx.post(HC).mock(return_value=httpx.Response(429))
+    respx.get(GB).mock(return_value=httpx.Response(200, json=_gb_payload("Some Book")))
+    respx.get(OL).mock(return_value=httpx.Response(200, json=_empty_ol()))
+
+    result = await mf.fetch_candidates("Some Book")
+    assert result.sources["hardcover"] == "rate_limited"
+    assert result.sources["google_books"] == "ok"
+    assert len(result.candidates) == 1
+
+
+@respx.mock
+async def test_rate_limit_retry_succeeds(monkeypatch):
+    """First call 429, retry 200 → candidates arrive, status ok."""
+    async def _no_sleep(_): return None
+    monkeypatch.setattr(mf.asyncio, "sleep", _no_sleep)
+
+    respx.post(HC).mock(side_effect=[
+        httpx.Response(429),
+        httpx.Response(200, json=_hc_payload("Retry Book")),
+        httpx.Response(200, json={"data": {"books": []}}),
+    ])
+    respx.get(GB).mock(return_value=httpx.Response(200, json=_empty_gb()))
+    respx.get(OL).mock(return_value=httpx.Response(200, json=_empty_ol()))
+
+    result = await mf.fetch_candidates("Retry Book")
+    assert result.sources["hardcover"] == "ok"
+    assert result.candidates and result.candidates[0].title == "Retry Book"
+
+
+@respx.mock
+async def test_hardcover_disabled_without_token(monkeypatch):
+    monkeypatch.setattr(settings, "hardcover_token", None)
+    respx.get(GB).mock(return_value=httpx.Response(200, json=_empty_gb()))
+    respx.get(OL).mock(return_value=httpx.Response(200, json=_empty_ol()))
+
+    result = await mf.fetch_candidates("Anything")
+    assert result.sources["hardcover"] == "disabled"
+    assert result.candidates == []
+
+
+def test_merge_candidates_fuzzy_without_isbn():
+    """Same title+author from two sources, neither with ISBN → merged."""
+    a = mf.MetadataCandidate(source="google_books", source_id="g", title="Dungeon Crawler Carl",
+                             author="Matt Dinniman", language="en")
+    b = mf.MetadataCandidate(source="open_library", source_id="o", title="Dungeon Crawler Carl!",
+                             author="Matt Dinniman", description="LitRPG.", tags=["LitRPG"])
+    # note: punctuation differences are normalized away by the fuzzy key
+    merged = merge_candidates([a, b])
+    assert len(merged) == 1
+    assert merged[0].source == "google_books"
+    assert merged[0].description == "LitRPG."      # filled from OL
+    assert merged[0].language == "en"
+
+
+def test_rank_right_volume_beats_source_priority():
+    """A Google hit for the RIGHT volume outranks a Hardcover hit for the wrong
+    one — the old candidates[0] behaviour always surfaced Hardcover."""
+    wrong = mf.MetadataCandidate(source="hardcover", source_id="h", title="My Series Vol 2",
+                                 author="A. Author", description="d", cover_url="c")
+    right = mf.MetadataCandidate(source="google_books", source_id="g", title="My Series Vol 4",
+                                 author="A. Author", description="d", cover_url="c")
+    ctx = ScoreContext(title="My Series v004", author="A. Author")
+    ranked = rank_candidates([wrong, right], ctx)
+    assert ranked[0] is right


### PR DESCRIPTION
Deep pass over metadata fetching — the "works, but not without pains" areas were structural. Five roots, all addressed:

## 1. Cross-source merge (the big quality win)
Candidates were deduped only by exact ISBN, so the same book from 2–3 sources filled the 5-slot list with *partial* copies — Hardcover never returns language, Google never returns series. New `backend/services/metadata_rank.py` merges duplicates (shared ISBN or fuzzy title+author-surname) **field-by-field** into one complete candidate, tags unioned. Verified live: Re:ZERO Vol 13 now returns one merged English candidate (language filled from Google into the Hardcover base) + the genuinely-distinct Japanese edition — instead of three overlapping partials.

## 2. One "best match" brain
Only bulk-review scored candidates; single fetch, bulk apply, Bindery and auto-import all took `candidates[0]` = whatever Hardcover said first. The scorer (same weights) moved into the service and `fetch_candidates` **ranks its output** — `candidates[0]` is now the best match on every path, and the right volume of a series outranks the wrong volume from a higher-priority source (pinned by test).

## 3. Honest rate limits
Hardcover 429s and Google quota errors returned `[]`, which the UI showed as "No results found". Sources now raise `RateLimited`; a single retry-with-pause runs per source; `FetchResult.sources` carries per-source status which the fetch dialog surfaces ("Google Books is rate-limited — try again in a minute"). The series-aware fallback now includes Hardcover, which it previously skipped entirely.

## 4. Auto-import stops renaming books on bad matches
Title/author overwrite is confidence-gated (score ≥ 6); below the bar it fills blanks only and logs why.

## 5. Bulk fetch stops DDoSing the sources
Up to 100 unbounded parallel fetches (3+ HTTP calls each) used to trip the very limits in §3 — now a 4-wide semaphore.

**Also:** applying fetched metadata preserves hand-added tags (`source="user"`) instead of wiping everything; the modal shows a "Best match" badge on the top candidate; `fetch-metadata` returns `{candidates, query_used, sources}` (MetadataManager updated for the new shape); ranking context includes year/language.

## Tests
6 new orchestration tests with respx-mocked sources — merge, fuzzy dedup, rank-over-source-priority, retry-success, rate-limited status, disabled-token. This area had **zero** coverage before. Existing query-builder tests untouched and green. Full suite: **699 passed**, build clean.