### PR TITLE
fix(series): keep the action row aligned when the Follow caption shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **The series-page action buttons line up again when you follow a series.** The
+  "Next: Vol N" caption under the Following button used to push the button out of
+  line with Resume / Mark all read / Manage; it now hangs below without shifting
+  anything.
 - **Metadata fetching got a deep overhaul.** The same book returned by two
   sources used to eat two of the five result slots — each copy *partial*
   (Hardcover knows series but not language; Google the reverse). Duplicates are

--- a/frontend/src/components/SeriesFollowButton.tsx
+++ b/frontend/src/components/SeriesFollowButton.tsx
@@ -49,7 +49,7 @@ export function SeriesFollowButton({ seriesName }: { seriesName: string }) {
   const upcoming = date != null && date >= new Date().toISOString().slice(0, 10)
 
   return (
-    <div className="flex flex-col gap-1">
+    <div className="relative">
       <button
         onClick={toggle}
         disabled={busy}
@@ -67,7 +67,7 @@ export function SeriesFollowButton({ seriesName }: { seriesName: string }) {
         {follow ? 'Following' : 'Follow'}
       </button>
       {follow && vol != null && date && (
-        <p className="text-[10px] text-muted-foreground text-center">
+        <p className="absolute top-full left-1/2 -translate-x-1/2 mt-1 whitespace-nowrap text-[10px] text-muted-foreground text-center">
           {upcoming ? 'Next' : 'Latest'}: Vol {Number.isInteger(vol) ? vol : vol.toFixed(1)} · {formatDate(date)}
         </p>
       )}


### PR DESCRIPTION
The "Next: Vol N · date" caption under the Following button was in normal flow, so its wrapper grew taller than the sibling buttons and pushed Following out of baseline with Resume / Mark all read / Manage. The caption is now absolutely positioned below the button — row stays aligned, hint still hangs underneath.

Frontend-only, one component. Spotted while reviewing the docs screenshots; the refreshed series-detail shot in #105 already shows the fixed alignment.