### PR TITLE
fix(tomesync): never reconstruct foreign annotations on paging documents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Annotations from another device can no longer break a book opened as a PDF
+  or comic.** The cross-device highlight merge only knew how to rebuild
+  annotations in the EPUB engine's format; on a PDF/CBZ it would still plant
+  incoming ones as broken highlights — positions stored as text where the
+  renderer expects page numbers and rectangles. The plugin (build 26) now
+  reconstructs an annotation only when the receiving book can actually draw it;
+  everything else stays safely in Tome instead of corrupting the book's
+  annotation list.
 - **The series-page action buttons line up again when you follow a series.** The
   "Next: Vol N" caption under the Following button used to push the button out of
   line with Resume / Mark all read / Manage; it now hangs below without shifting

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 25
+TOMESYNC_PLUGIN_BUILD = 26
 TOMESYNC_PLUGIN_SEMVER = "1.7.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
@@ -2229,7 +2229,10 @@ function TomeSync:_applyServerState(alive, tombstones)
                 -- Rolling (crengine) docs can only draw real xPointers ("/body…");
                 -- anything else (PDF datetime fallbacks, corrupt data) would
                 -- hard-crash drawSavedHighlight → getPosFromXPointer on repaint.
-                local drawable = (not self.ui.rolling) or s.anchor:sub(1, 5) == "/body"
+                -- Paging (PDF/CBZ) docs can't reconstruct foreign annotations at
+                -- all — they need a numeric page and rect tables, which anchors
+                -- don't carry — so there they stay server-side only.
+                local drawable = self.ui.rolling and s.anchor:sub(1, 5) == "/body"
                 local ok = drawable and pcall(function()
                     ann:addItem({{
                         page = s.anchor, pos0 = s.anchor, pos1 = s.anchor_end or s.anchor,


### PR DESCRIPTION
## What

Closes the paging half of the cross-device annotation reconstruction bug. The build-25 guard only covered rolling (crengine) documents — it required a `/body…` xPointer before rebuilding an incoming annotation. On paging documents (PDF/CBZ) the guard passed everything, so a cross-device merge still planted items whose `page`/`pos0`/`pos1` are strings where mupdf-format annotations need a numeric page and rect tables — corrupting the book's annotation list and crashing the receiving reader the same way the rolling path used to.

## How

Paging documents now reconstruct nothing:

```lua
local drawable = self.ui.rolling and s.anchor:sub(1, 5) == "/body"
```

Anchors carry no usable page or rectangles for a paging renderer (paging highlights sync under a datetime identity, and rolling xPointers don't translate), so foreign annotations stay server-side only. Skipped items never enter the local map or the baseline, so they are neither resurrected nor spuriously deleted — identical to the existing rolling-skip semantics.

Plugin build 25 → 26; changelog entry under Unreleased.

## Verification

- 79 TomeSync/annotation tests pass
- Rendered `main_impl.lua` passes a luajit syntax check with the new guard in place