### PR TITLE
fix(tomesync): memory-bounded reading-history backfill (build 26)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **The KOReader reading-history import no longer risks out-of-memory on big
+  histories.** The plugin used to load every page-stat row since the last sync
+  into memory at once — tens of thousands of rows on a device with years of
+  reading — and resend the full book list with every upload chunk. It now reads
+  and uploads in small windows (verified against a real 34,000-row device
+  database), sends each chunk only the books it references, and an interrupted
+  run still resumes exactly where it left off. Plugin build 26; update from
+  TomeSync's "Check for updates" as usual.
 - **The series-page action buttons line up again when you follow a series.** The
   "Next: Vol N" caption under the Following button used to push the button out of
   line with Resume / Mark all read / Manage; it now hangs below without shifting

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 25
-TOMESYNC_PLUGIN_SEMVER = "1.7.0"
+TOMESYNC_PLUGIN_BUILD = 26
+TOMESYNC_PLUGIN_SEMVER = "1.7.1"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1791,61 +1791,107 @@ function TomeSync:_syncReadingStats(manual)
     end
 
     local SQ3 = require("lua-ljsqlite3/init")
-    local opened, conn = pcall(SQ3.open, path, "ro")
-    if not opened or not conn then tell("Could not open statistics database."); return end
 
-    local books, rows = {{}}, {{}}
-    local read_ok = pcall(function()
-        -- ljsqlite3 returns INTEGER columns as int64 cdata, which rapidjson can't
-        -- encode — tonumber() every numeric field. (TEXT comes back as Lua strings.)
-        local bstmt = conn:prepare("SELECT id, md5, title, authors, pages, total_read_pages FROM book")
-        for r in bstmt:rows() do
-            books[#books + 1] = {{ ko_id = tonumber(r[1]), md5 = r[2] or "", title = r[3] or "",
-                                   authors = r[4], pages = tonumber(r[5]), total_read_pages = tonumber(r[6]) }}
-        end
-        bstmt:close()
-        local pstmt = conn:prepare(
-            "SELECT id_book, page, start_time, duration, total_pages FROM page_stat_data "
-            .. "WHERE start_time >= " .. since .. " ORDER BY start_time")
-        for r in pstmt:rows() do
-            rows[#rows + 1] = {{ ko_id = tonumber(r[1]), page = tonumber(r[2]), start_time = tonumber(r[3]),
-                                duration = tonumber(r[4]), total_pages = tonumber(r[5]) }}
-        end
-        pstmt:close()
-    end)
-    pcall(function() conn:close() end)
-    if not read_ok then tell("Could not read statistics database."); return end
-    if #rows == 0 then tell("Reading history already up to date."); return end
+    -- One cheap metadata pass: the book table is one row per book, and COUNT(*)
+    -- sizes the progress message. Page rows are windowed below — memory stays
+    -- flat no matter how many years of history the device holds (a real Kindle
+    -- DB measures tens of thousands of page_stat_data rows; the old slurp-all
+    -- approach materialised every one of them as a Lua table at once).
+    local books_by_id, total = {{}}, 0
+    do
+        local opened, conn = pcall(SQ3.open, path, "ro")
+        if not opened or not conn then tell("Could not open statistics database."); return end
+        local read_ok = pcall(function()
+            -- ljsqlite3 returns INTEGER columns as int64 cdata, which rapidjson can't
+            -- encode — tonumber() every numeric field. (TEXT comes back as Lua strings.)
+            local bstmt = conn:prepare("SELECT id, md5, title, authors, pages, total_read_pages FROM book")
+            for r in bstmt:rows() do
+                books_by_id[tonumber(r[1])] = {{ ko_id = tonumber(r[1]), md5 = r[2] or "", title = r[3] or "",
+                                                 authors = r[4], pages = tonumber(r[5]), total_read_pages = tonumber(r[6]) }}
+            end
+            bstmt:close()
+            local cstmt = conn:prepare("SELECT COUNT(*) FROM page_stat_data WHERE start_time >= " .. since)
+            for r in cstmt:rows() do total = tonumber(r[1]) or 0 end
+            cstmt:close()
+        end)
+        pcall(function() conn:close() end)
+        if not read_ok then tell("Could not read statistics database."); return end
+    end
+    if total == 0 then tell("Reading history already up to date."); return end
 
     self._stats_syncing = true
     local dev   = deviceName()
-    local CHUNK = 2000
-    local total = #rows
+    local CHUNK = 500
     local sent  = 0
+    -- Keyset cursor, strictly after (start_time, rowid). Starting at
+    -- (watermark, -1) keeps the old ">= watermark" boundary refetch: rows that
+    -- share the watermark second are re-sent and no-op server-side (the import
+    -- is INSERT OR IGNORE on the identity key). An interrupted run resumes
+    -- from the server watermark on the next launch, exactly as before.
+    local cur_start, cur_rowid = since, -1
+
+    local function readWindow()
+        local opened, conn = pcall(SQ3.open, path, "ro")
+        if not opened or not conn then return nil end
+        local rows = {{}}
+        local ok = pcall(function()
+            local stmt = conn:prepare(string.format(
+                "SELECT rowid, id_book, page, start_time, duration, total_pages FROM page_stat_data "
+                .. "WHERE start_time > %d OR (start_time = %d AND rowid > %d) "
+                .. "ORDER BY start_time, rowid LIMIT %d", cur_start, cur_start, cur_rowid, CHUNK))
+            for r in stmt:rows() do
+                rows[#rows + 1] = {{ rowid = tonumber(r[1]), ko_id = tonumber(r[2]), page = tonumber(r[3]),
+                                     start_time = tonumber(r[4]), duration = tonumber(r[5]), total_pages = tonumber(r[6]) }}
+            end
+            stmt:close()
+        end)
+        pcall(function() conn:close() end)
+        if not ok then return nil end
+        return rows
+    end
+
     local function finish(msg, force)
         self._stats_syncing = false
         if manual or force then UIManager:show(InfoMessage:new{{ text = msg, timeout = 3 }}) end
     end
     local sendNext
     sendNext = function()
-        if sent >= total then
-            finish(string.format("Reading history synced (%d records).", total))
-            return
-        end
         if not NetworkMgr:isConnected() then
             finish("Reading-history sync paused (offline). Resumes later.")
             return
         end
-        local chunk = {{}}
-        local stop = math.min(sent + CHUNK, total)
-        for i = sent + 1, stop do chunk[#chunk + 1] = rows[i] end
+        local rows = readWindow()
+        if rows == nil then
+            finish("Could not read statistics database.")
+            return
+        end
+        if #rows == 0 then
+            finish(string.format("Reading history synced (%d records).", sent))
+            return
+        end
+        -- Send only the books this window references, not the whole table
+        -- with every chunk. Rows whose book row has vanished are still sent
+        -- (server skips them, same as before) but never block the cursor.
+        local chunk_books, seen = {{}}, {{}}
+        local payload = {{}}
+        for i = 1, #rows do
+            local r = rows[i]
+            if books_by_id[r.ko_id] and not seen[r.ko_id] then
+                seen[r.ko_id] = true
+                chunk_books[#chunk_books + 1] = books_by_id[r.ko_id]
+            end
+            payload[#payload + 1] = {{ ko_id = r.ko_id, page = r.page, start_time = r.start_time,
+                                       duration = r.duration, total_pages = r.total_pages }}
+        end
         local resp = apiRequest("POST", "/tome-sync/stats/import",
-            {{ device = dev, books = books, page_stats = chunk }})
+            {{ device = dev, books = chunk_books, page_stats = payload }})
         if type(resp) ~= "table" then
             finish("Reading-history sync interrupted. Resumes next launch.")
             return
         end
-        sent = stop
+        local last = rows[#rows]
+        cur_start, cur_rowid = last.start_time, last.rowid
+        sent = sent + #rows
         -- Yield to the UI between chunks (the device stays responsive).
         UIManager:scheduleIn(0.05, sendNext)
     end

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -159,5 +159,9 @@ def test_build_bumped_for_rebake():
     # web reader arrive under a provisional "web:" anchor; the plugin locates the
     # text natively, creates a first-class KOReader highlight, and the sync push
     # (adopted_from) retires the provisional server-side.
-    assert TOMESYNC_PLUGIN_BUILD >= 25
-    assert TOMESYNC_PLUGIN_SEMVER == "1.7.0"
+    # 1.7.1 / build 26 makes the reading-history backfill memory-bounded:
+    # keyset-windowed reads over (start_time, rowid) instead of loading every
+    # page-stat row since the watermark at once, and each upload chunk carries
+    # only the books it references. Verified against a 34k-row device DB.
+    assert TOMESYNC_PLUGIN_BUILD >= 26
+    assert TOMESYNC_PLUGIN_SEMVER == "1.7.1"

--- a/tests/test_tomesync_stats_window.py
+++ b/tests/test_tomesync_stats_window.py
@@ -1,0 +1,95 @@
+"""The plugin's reading-history backfill must stay memory-bounded.
+
+The original implementation materialised every ``page_stat_data`` row since the
+watermark into one Lua table (tens of thousands of rows on a real device) and
+resent the full ``books`` array with every chunk. These tests pin the windowed
+replacement: keyset pagination over (start_time, rowid), short-lived read-only
+connections per window, and per-chunk book subsetting. The server import is
+idempotent (INSERT OR IGNORE on the identity key), which is what makes the
+watermark-boundary refetch safe — that contract is asserted here too.
+"""
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+from backend.api.tome_sync import TOMESYNC_PLUGIN_BUILD, _main_impl_lua
+
+
+@pytest.fixture(scope="module")
+def impl() -> str:
+    return _main_impl_lua("http://localhost:8080", "tk_test", "tester")
+
+
+def test_backfill_reads_in_keyset_windows(impl):
+    """Page rows are fetched LIMIT-windowed with a (start_time, rowid) cursor —
+    never all at once."""
+    assert "start_time > %d OR (start_time = %d AND rowid > %d)" in impl
+    assert "ORDER BY start_time, rowid LIMIT" in impl
+    # the old slurp query must be gone
+    assert '.. "WHERE start_time >= " .. since .. " ORDER BY start_time")' not in impl
+
+
+def test_backfill_counts_instead_of_materialising(impl):
+    """The progress total comes from COUNT(*), not from the length of an
+    all-rows table."""
+    assert "SELECT COUNT(*) FROM page_stat_data WHERE start_time >= " in impl
+
+
+def test_backfill_sends_only_referenced_books(impl):
+    """Each chunk carries only the book rows its ko_ids reference."""
+    assert "chunk_books" in impl
+    assert "books_by_id[r.ko_id]" in impl
+    # the old full-table resend shipped the same `books` variable every chunk
+    assert "device = dev, books = books," not in impl
+
+
+def test_backfill_cursor_advances_only_on_server_ack(impl):
+    """The keyset cursor moves only after a successful import response, so an
+    interrupted run resumes from the server watermark."""
+    i_resp = impl.index('local resp = apiRequest("POST", "/tome-sync/stats/import"')
+    i_guard = impl.index('if type(resp) ~= "table" then', i_resp)
+    i_advance = impl.index("cur_start, cur_rowid = last.start_time, last.rowid")
+    assert i_resp < i_guard < i_advance
+
+
+def test_server_import_is_idempotent_for_boundary_refetch(db, admin_user, make_book):
+    """Rows re-sent across the watermark boundary must be no-ops — the plugin
+    relies on this to start each run at (watermark, rowid -1)."""
+    from backend.services.ko_stats_import import import_batch
+
+    admin_user, _token = admin_user
+    make_book(title="Window Test Book", author="A. Author")
+
+    books = [{"ko_id": 1, "md5": "f" * 32, "title": "Window Test Book",
+              "authors": "A. Author", "pages": 100, "total_read_pages": 10}]
+    rows = [{"ko_id": 1, "page": p, "start_time": 1_700_000_000 + p, "duration": 30,
+             "total_pages": 100} for p in range(1, 6)]
+
+    first = import_batch(db, admin_user, device="testdev", books=books, page_stats=rows)
+    assert first["page_rows_imported"] == 5
+
+    # same rows again — the boundary-second refetch case
+    second = import_batch(db, admin_user, device="testdev", books=books, page_stats=rows)
+    assert second["page_rows_imported"] == 0
+    assert second["page_rows_skipped"] == 5
+    assert second["watermark"] == first["watermark"]
+
+
+def test_plugin_build_bumped():
+    assert TOMESYNC_PLUGIN_BUILD >= 26
+
+
+def test_impl_still_compiles_under_luajit(impl):
+    checker = shutil.which("luajit") or shutil.which("luac5.1")
+    if not checker:
+        pytest.skip("no LuaJIT/luac5.1 available to syntax-check")
+    with tempfile.NamedTemporaryFile("w", suffix=".lua", delete=False) as f:
+        f.write(impl)
+        path = f.name
+    if "luajit" in checker:
+        res = subprocess.run([checker, "-bl", path], capture_output=True, text=True)
+    else:
+        res = subprocess.run([checker, "-p", path], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr[:2000]


### PR DESCRIPTION
Part 1 of the TomeSync-foundations arc (BookOrbit plugin teardown follow-up).

The plugin's reading-history backfill loaded **every** `page_stat_data` row since the watermark into one Lua table — 34,581 rows on a real device DB — and resent the full `books` array with every chunk. Years of history on a 256MB Kindle is a genuine OOM risk.

**Now:**
- Keyset-windowed reads: 500 rows per short-lived read-only connection, cursored strictly after `(start_time, rowid)` — exact pagination, no same-second boundary loss.
- Initial cursor `(watermark, -1)` preserves the old `>= watermark` refetch; boundary duplicates no-op server-side (existing `INSERT OR IGNORE` identity key). **No server changes.**
- Each chunk carries only the book rows it references.
- Cursor advances only on server ack — interrupted runs resume from the server watermark as before.

**Verification:** emulator round-trip against an ephemeral server seeded with the prod library export + the real 34k-row Kindle `statistics.sqlite3`: 34,553 rows imported in seconds (82 matched / 4 review / 7 unmatched books; the 28 skipped rows belong to sideloads absent from the library — unchanged semantics), and a rerun imports zero twice. 7 new tests pin the windowing, per-chunk book subsetting, ack-gated cursor, server idempotency, and luajit-compile the generated impl. Full suite green (714).

Plugin build 26 / 1.7.1 — reaches devices via the in-app self-update.