### PR TITLE
feat(tomesync): series-browser UX batch (build 29)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Re-downloading a book no longer deletes its synced highlights.** A fresh
+  copy of a book starts with an empty annotation sidecar; the sync used to read
+  that as "the user deleted every highlight" and pushed the deletions to the
+  server (verified live — one re-download tombstoned the book's highlights
+  everywhere). The sync now recognises a sidecar it hasn't seen before and
+  re-applies the server's highlights instead. Deleting highlights on the device
+  still propagates exactly as before.
 - **Highlights from another device can no longer land on the wrong words.**
   Before painting a highlight that was made elsewhere, the plugin (build 28)
   now verifies the stored position actually reproduces the highlighted text on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **The KOReader reading-history import no longer risks out-of-memory on big
+  histories.** The plugin used to load every page-stat row since the last sync
+  into memory at once — tens of thousands of rows on a device with years of
+  reading — and resend the full book list with every upload chunk. It now reads
+  and uploads in small windows (verified against a real 34,000-row device
+  database), sends each chunk only the books it references, and an interrupted
+  run still resumes exactly where it left off. Plugin build 26; update from
+  TomeSync's "Check for updates" as usual.
 - **The series-page action buttons line up again when you follow a series.** The
   "Next: Vol N" caption under the Following button used to push the button out of
   line with Resume / Mark all read / Manage; it now hangs below without shifting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,18 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Highlights from another device can no longer land on the wrong words.**
+  Before painting a highlight that was made elsewhere, the plugin (build 28)
+  now verifies the stored position actually reproduces the highlighted text on
+  this copy of the book. When it doesn't (a re-downloaded copy can shift
+  positions), the passage is found by its text and painted there — while the
+  original device's position stays untouched on the server, so the two devices
+  can't fight over it. Text that can't be located is skipped rather than
+  guessed. Notes edited on a repaired highlight still sync everywhere.
+- **Book matching no longer trusts a stale device checksum.** KOReader's
+  sidecar hash can be inherited from a different copy of a book (metadata
+  restores); the plugin now hashes the actual file when identifying it,
+  which the emulator tests caught producing wrong lookups.
 - **The KOReader reading-history import no longer risks out-of-memory on big
   histories.** The plugin used to load every page-stat row since the last sync
   into memory at once — tens of thousands of rows on a device with years of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **The KOReader series browser got a quality pass** (plugin build 29). Big
+  downloads show live progress (percent of file size) instead of sitting mute;
+  a failed list-load or download offers **Retry** instead of a dead-end popup;
+  a single fresh download asks **"Open now?"**; volumes you already have are
+  marked **"on device"** in the list; and every request now has tight network
+  timeouts, so a dead server stalls the reader for seconds, not a minute. The
+  position heartbeat also moved off the page-turn path — it fires when the
+  reader is idle, never while you're turning.
 - **KOReader files are now recognised by content, not just by name.** Tome
   records the KOReader-style hash of every file it scans and every copy it
   serves, and the plugin (build 27) sends the open file's hash when it asks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **KOReader files are now recognised by content, not just by name.** Tome
+  records the KOReader-style hash of every file it scans and every copy it
+  serves, and the plugin (build 27) sends the open file's hash when it asks
+  "which book is this?". A book you renamed or moved on the device — or
+  sideloaded from the same source — now resolves exactly, with the careful
+  filename matching kept as fallback. The reading-history import uses the same
+  hashes first, so device history matches your library deterministically
+  before any title guessing.
+- **Session counts from imported device history are real sessions now.** The
+  stats reconciliation used to approximate "one session per book per day";
+  it now splits device reading at 30-minute gaps, the same way sessions are
+  actually experienced. On a real multi-year device history that corrected a
+  one-third undercount (320 → 470 sessions); reading time and page counts are
+  unchanged, and a read across midnight counts once, on the day it began.
 - **File books into libraries straight from the Bindery.** The review form
   (and the batch "apply to all" bar) now has a Libraries picker like the one
   on the book page, so an accepted book lands in the right libraries in one

--- a/backend/api/bindery.py
+++ b/backend/api/bindery.py
@@ -28,6 +28,7 @@ from backend.core.permissions import require_role, is_admin
 from backend.models.book import Book, BookFile, BookTag
 from backend.models.user import User
 from backend.services.audit import audit
+from backend.services.ko_hash import ko_partial_md5, record_ko_hash
 from backend.services.book_types import assign_book_to_type_library
 from backend.services.filename_parser import parse_filename
 from backend.services.metadata import extract_metadata, sha256_file
@@ -355,6 +356,7 @@ def bindery_accept(
                 file_size=dest.stat().st_size,
                 content_hash=content_hash,
             ))
+            record_ko_hash(db, book.id, ko_partial_md5(dest), "raw")
 
             # Word count (EPUB only) — parsed from the accepted file on disk.
             if suffix == "epub":

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -11,6 +11,7 @@ from typing import Optional
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, UploadFile, File, Form, status
 from backend.services.safe_fetch import fetch_safe_image, UnsafeURLError
+from backend.services.ko_hash import ko_partial_md5, record_ko_hash, record_served_artifact
 from fastapi.responses import FileResponse, StreamingResponse
 from sqlalchemy.orm import Session
 
@@ -1671,6 +1672,7 @@ def download_book(
 
     from backend.services.metadata_embed import get_baked_path
     serve_path = get_baked_path(book_file.book, book_file)
+    record_served_artifact(db, book_file.book_id, book_file, serve_path)
 
     filename = f"{book_file.book.title}.{book_file.format}"
     audit(db, "books.downloaded", user_id=current_user.id, username=current_user.username,
@@ -2041,6 +2043,7 @@ def upload_book(
                 file_size=dest.stat().st_size,
                 content_hash=content_hash,
             ))
+            record_ko_hash(db, existing.id, ko_partial_md5(dest), "raw")
         else:
             tmp_path.unlink(missing_ok=True)
         db.commit()
@@ -2093,6 +2096,7 @@ def upload_book(
         file_size=dest.stat().st_size,
         content_hash=content_hash,
     ))
+    record_ko_hash(db, book.id, ko_partial_md5(dest), "raw")
 
     # Create genre tags from embedded metadata (epub dc:subject / CBZ ComicInfo)
     if meta.get("_genres"):
@@ -2313,6 +2317,7 @@ def ingest_book(
         file_size=dest.stat().st_size,
         content_hash=content_hash,
     ))
+    record_ko_hash(db, book.id, ko_partial_md5(dest), "raw")
 
     # Word count (EPUB only) — parsed from the ingested file on disk.
     if suffix == "epub":

--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -39,6 +39,7 @@ def bulk_download(
         raise HTTPException(404, "No books found")
 
     from backend.services.metadata_embed import get_baked_path
+    from backend.services.ko_hash import record_served_artifact
 
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
@@ -54,6 +55,7 @@ def bulk_download(
                 # download path (single/OPDS/TomeSync). Falls back to the raw
                 # file if baking fails. Keep the original filename in the zip.
                 serve = get_baked_path(book, f)
+                record_served_artifact(db, book.id, f, serve)
                 zf.write(str(serve), f"{folder}/{raw.name}")
 
     buf.seek(0)

--- a/backend/api/opds.py
+++ b/backend/api/opds.py
@@ -408,7 +408,9 @@ def opds_download(
         pass
 
     from backend.services.metadata_embed import get_baked_path
+    from backend.services.ko_hash import record_served_artifact
     serve_path = get_baked_path(book, book_file)
+    record_served_artifact(db, book.id, book_file, serve_path)
 
     media_type = FORMAT_MIME.get(book_file.format, "application/octet-stream")
     filename = f"{book.title}.{book_file.format}"

--- a/backend/api/send_to_device.py
+++ b/backend/api/send_to_device.py
@@ -28,6 +28,7 @@ from backend.services.email import (
     send_test_email,
 )
 from backend.services.metadata_embed import get_baked_path
+from backend.services.ko_hash import record_served_artifact
 from backend.services.organizer import koreader_style_name
 
 log = logging.getLogger(__name__)
@@ -229,6 +230,7 @@ def send_to_device(
         raise HTTPException(404, "Device not found")
 
     baked = get_baked_path(book, book_file)
+    record_served_artifact(db, book.id, book_file, baked)
     if not baked.exists():
         raise HTTPException(404, "Book file not found on disk")
 
@@ -304,6 +306,7 @@ def bulk_send_to_device(
             errors.append({"book_id": bid, "error": "No file available"})
             continue
         baked = get_baked_path(book, bf)
+        record_served_artifact(db, book.id, bf, baked)
         if not baked.exists():
             errors.append({"book_id": bid, "error": "File not found on disk"})
             continue

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -2481,6 +2481,22 @@ function TomeSync:_syncAnnotations()
     local bk = tostring(self.book_id)
     local baseline = self.annot_baseline[bk] or {{}}
 
+    -- Bind the baseline to THIS sidecar instance. A fresh sidecar (new
+    -- download of the book, or a wiped sidecar) starts without our marker:
+    -- its empty annotation list reflects a NEW FILE, not the user deleting
+    -- every highlight — diffing the old baseline against it would push
+    -- deletes and tombstone the book's highlights server-side (observed live:
+    -- re-downloading a book wiped its synced highlight). Reset the baseline
+    -- instead; the pull below re-applies the server state. True deletions
+    -- still propagate: once the marker is set, baseline diffs work as before.
+    if self.ui.doc_settings then
+        if not self.ui.doc_settings:readSetting("tomesync_annot_bound") and next(baseline) ~= nil then
+            baseline = {{}}
+            self.annot_baseline[bk] = {{}}
+        end
+        self.ui.doc_settings:saveSetting("tomesync_annot_bound", true)
+    end
+
     local upserts, deletes = {{}}, {{}}
     for anchor, L in pairs(localmap) do
         if baseline[anchor] == nil or baseline[anchor] ~= L.mtime then

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 25
-TOMESYNC_PLUGIN_SEMVER = "1.7.0"
+TOMESYNC_PLUGIN_BUILD = 26
+TOMESYNC_PLUGIN_SEMVER = "1.7.1"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1791,61 +1791,107 @@ function TomeSync:_syncReadingStats(manual)
     end
 
     local SQ3 = require("lua-ljsqlite3/init")
-    local opened, conn = pcall(SQ3.open, path, "ro")
-    if not opened or not conn then tell("Could not open statistics database."); return end
 
-    local books, rows = {{}}, {{}}
-    local read_ok = pcall(function()
-        -- ljsqlite3 returns INTEGER columns as int64 cdata, which rapidjson can't
-        -- encode — tonumber() every numeric field. (TEXT comes back as Lua strings.)
-        local bstmt = conn:prepare("SELECT id, md5, title, authors, pages, total_read_pages FROM book")
-        for r in bstmt:rows() do
-            books[#books + 1] = {{ ko_id = tonumber(r[1]), md5 = r[2] or "", title = r[3] or "",
-                                   authors = r[4], pages = tonumber(r[5]), total_read_pages = tonumber(r[6]) }}
-        end
-        bstmt:close()
-        local pstmt = conn:prepare(
-            "SELECT id_book, page, start_time, duration, total_pages FROM page_stat_data "
-            .. "WHERE start_time >= " .. since .. " ORDER BY start_time")
-        for r in pstmt:rows() do
-            rows[#rows + 1] = {{ ko_id = tonumber(r[1]), page = tonumber(r[2]), start_time = tonumber(r[3]),
-                                duration = tonumber(r[4]), total_pages = tonumber(r[5]) }}
-        end
-        pstmt:close()
-    end)
-    pcall(function() conn:close() end)
-    if not read_ok then tell("Could not read statistics database."); return end
-    if #rows == 0 then tell("Reading history already up to date."); return end
+    -- One cheap metadata pass: the book table is one row per book, and COUNT(*)
+    -- sizes the progress message. Page rows are windowed below — memory stays
+    -- flat no matter how many years of history the device holds (a real Kindle
+    -- DB measures tens of thousands of page_stat_data rows; the old slurp-all
+    -- approach materialised every one of them as a Lua table at once).
+    local books_by_id, total = {{}}, 0
+    do
+        local opened, conn = pcall(SQ3.open, path, "ro")
+        if not opened or not conn then tell("Could not open statistics database."); return end
+        local read_ok = pcall(function()
+            -- ljsqlite3 returns INTEGER columns as int64 cdata, which rapidjson can't
+            -- encode — tonumber() every numeric field. (TEXT comes back as Lua strings.)
+            local bstmt = conn:prepare("SELECT id, md5, title, authors, pages, total_read_pages FROM book")
+            for r in bstmt:rows() do
+                books_by_id[tonumber(r[1])] = {{ ko_id = tonumber(r[1]), md5 = r[2] or "", title = r[3] or "",
+                                                 authors = r[4], pages = tonumber(r[5]), total_read_pages = tonumber(r[6]) }}
+            end
+            bstmt:close()
+            local cstmt = conn:prepare("SELECT COUNT(*) FROM page_stat_data WHERE start_time >= " .. since)
+            for r in cstmt:rows() do total = tonumber(r[1]) or 0 end
+            cstmt:close()
+        end)
+        pcall(function() conn:close() end)
+        if not read_ok then tell("Could not read statistics database."); return end
+    end
+    if total == 0 then tell("Reading history already up to date."); return end
 
     self._stats_syncing = true
     local dev   = deviceName()
-    local CHUNK = 2000
-    local total = #rows
+    local CHUNK = 500
     local sent  = 0
+    -- Keyset cursor, strictly after (start_time, rowid). Starting at
+    -- (watermark, -1) keeps the old ">= watermark" boundary refetch: rows that
+    -- share the watermark second are re-sent and no-op server-side (the import
+    -- is INSERT OR IGNORE on the identity key). An interrupted run resumes
+    -- from the server watermark on the next launch, exactly as before.
+    local cur_start, cur_rowid = since, -1
+
+    local function readWindow()
+        local opened, conn = pcall(SQ3.open, path, "ro")
+        if not opened or not conn then return nil end
+        local rows = {{}}
+        local ok = pcall(function()
+            local stmt = conn:prepare(string.format(
+                "SELECT rowid, id_book, page, start_time, duration, total_pages FROM page_stat_data "
+                .. "WHERE start_time > %d OR (start_time = %d AND rowid > %d) "
+                .. "ORDER BY start_time, rowid LIMIT %d", cur_start, cur_start, cur_rowid, CHUNK))
+            for r in stmt:rows() do
+                rows[#rows + 1] = {{ rowid = tonumber(r[1]), ko_id = tonumber(r[2]), page = tonumber(r[3]),
+                                     start_time = tonumber(r[4]), duration = tonumber(r[5]), total_pages = tonumber(r[6]) }}
+            end
+            stmt:close()
+        end)
+        pcall(function() conn:close() end)
+        if not ok then return nil end
+        return rows
+    end
+
     local function finish(msg, force)
         self._stats_syncing = false
         if manual or force then UIManager:show(InfoMessage:new{{ text = msg, timeout = 3 }}) end
     end
     local sendNext
     sendNext = function()
-        if sent >= total then
-            finish(string.format("Reading history synced (%d records).", total))
-            return
-        end
         if not NetworkMgr:isConnected() then
             finish("Reading-history sync paused (offline). Resumes later.")
             return
         end
-        local chunk = {{}}
-        local stop = math.min(sent + CHUNK, total)
-        for i = sent + 1, stop do chunk[#chunk + 1] = rows[i] end
+        local rows = readWindow()
+        if rows == nil then
+            finish("Could not read statistics database.")
+            return
+        end
+        if #rows == 0 then
+            finish(string.format("Reading history synced (%d records).", sent))
+            return
+        end
+        -- Send only the books this window references, not the whole table
+        -- with every chunk. Rows whose book row has vanished are still sent
+        -- (server skips them, same as before) but never block the cursor.
+        local chunk_books, seen = {{}}, {{}}
+        local payload = {{}}
+        for i = 1, #rows do
+            local r = rows[i]
+            if books_by_id[r.ko_id] and not seen[r.ko_id] then
+                seen[r.ko_id] = true
+                chunk_books[#chunk_books + 1] = books_by_id[r.ko_id]
+            end
+            payload[#payload + 1] = {{ ko_id = r.ko_id, page = r.page, start_time = r.start_time,
+                                       duration = r.duration, total_pages = r.total_pages }}
+        end
         local resp = apiRequest("POST", "/tome-sync/stats/import",
-            {{ device = dev, books = books, page_stats = chunk }})
+            {{ device = dev, books = chunk_books, page_stats = payload }})
         if type(resp) ~= "table" then
             finish("Reading-history sync interrupted. Resumes next launch.")
             return
         end
-        sent = stop
+        local last = rows[#rows]
+        cur_start, cur_rowid = last.start_time, last.rowid
+        sent = sent + #rows
         -- Yield to the UI between chunks (the device stays responsive).
         UIManager:scheduleIn(0.05, sendNext)
     end

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -1549,9 +1549,12 @@ function TomeSync:init()
     -- Web-adoption ledger: real_anchor -> provisional "web:" anchor, persisted so a
     -- failed push retries next sync (baseline alone would swallow the adoption).
     self.adopt_pending = G_reader_settings:readSetting("tomesync_adopt_pending") or {{}}
-    -- local rendering position -> {{ anchor, anchor_end }} of the SERVER identity
-    -- for foreign highlights that had to be re-anchored on this copy (see
-    -- _applyForeign). Persisted so repairs survive restarts.
+    -- "<book_id>|<local pos0>" -> {{ anchor, anchor_end }} of the SERVER
+    -- identity for foreign highlights that had to be re-anchored on this copy
+    -- (see _applyForeign). Keys are book-scoped: xPointers are only unique
+    -- WITHIN a book, and structurally common positions (p[1]/text().0) would
+    -- otherwise collide across books and mistranslate pushes. Persisted so
+    -- repairs survive restarts.
     self.repair_map = G_reader_settings:readSetting("tomesync_repair_map") or {{}}
     -- Per-book annotation sync baseline: book_id -> {{ anchor -> mtime }} as of last
     -- sync. Lets a diff tell "I deleted this" from "this is new from another device".
@@ -2284,7 +2287,8 @@ function TomeSync:_localAnnotationMap()
             -- their SERVER identity: index them under the server anchor so
             -- edits/deletes/tombstones from other devices reach them, and our
             -- own pushes never mint a duplicate identity for the same words.
-            local alias = self.repair_map and self.repair_map[anchor]
+            local alias = self.repair_map and self.book_id
+                and self.repair_map[tostring(self.book_id) .. "|" .. anchor]
             map[(alias and alias.anchor) or anchor] = {{ item = a, mtime = annotMtime(a) }}
         end
     end
@@ -2418,7 +2422,7 @@ function TomeSync:_applyForeign(ann, s)
         if a.pos0 == p0 then return false end   -- already rendered by an earlier repair
     end
     if not add(p0, p1) then return false end
-    self.repair_map[p0] = {{ anchor = s.anchor, anchor_end = s.anchor_end }}
+    self.repair_map[tostring(self.book_id) .. "|" .. p0] = {{ anchor = s.anchor, anchor_end = s.anchor_end }}
     G_reader_settings:saveSetting("tomesync_repair_map", self.repair_map)
     logger.info("TomeSync: repaired foreign highlight to", p0)
     return true
@@ -2485,7 +2489,7 @@ function TomeSync:_syncAnnotations()
                 if it.anchor ~= anchor then
                     -- repaired item: push under its server identity, with the
                     -- ORIGIN device's positions (ours are local rendering only)
-                    local alias = self.repair_map[it.anchor]
+                    local alias = self.repair_map[bk .. "|" .. it.anchor]
                     it.anchor = anchor
                     it.anchor_end = (alias and alias.anchor_end) or it.anchor_end
                 end
@@ -2543,8 +2547,11 @@ function TomeSync:_syncAnnotations()
         if type(a.pos0) == "string" then raw[a.pos0] = true end
     end
     local pruned = false
-    for pos0 in pairs(self.repair_map) do
-        if not raw[pos0] then self.repair_map[pos0] = nil; pruned = true end
+    local prefix = bk .. "|"
+    for key in pairs(self.repair_map) do
+        if key:sub(1, #prefix) == prefix and not raw[key:sub(#prefix + 1)] then
+            self.repair_map[key] = nil; pruned = true
+        end
     end
     if pruned then G_reader_settings:saveSetting("tomesync_repair_map", self.repair_map) end
     return resp

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -1293,9 +1293,11 @@ local function apiRequest(method, path, body)
         headers["Content-Length"] = tostring(#req_body)
     end
 
-    -- Tight per-request timeouts (block, total) via socketutil — bounded even
-    -- on a dead route, and no mutation of the global http.TIMEOUT.
-    socketutil:set_timeout(5, 10)
+    -- Bounded per-request timeouts (block, total) via socketutil — no global
+    -- http.TIMEOUT mutation. Block 5s catches a dead route fast; the total is
+    -- deliberately generous: annotation-sync responses can be large and slow
+    -- device wifi through an HTTPS proxy must not get truncated mid-body.
+    socketutil:set_timeout(5, 45)
     local ok, code = http.request({{
         url     = url,
         method  = method,

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 27
-TOMESYNC_PLUGIN_SEMVER = "1.7.2"
+TOMESYNC_PLUGIN_BUILD = 28
+TOMESYNC_PLUGIN_SEMVER = "1.7.3"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1549,6 +1549,10 @@ function TomeSync:init()
     -- Web-adoption ledger: real_anchor -> provisional "web:" anchor, persisted so a
     -- failed push retries next sync (baseline alone would swallow the adoption).
     self.adopt_pending = G_reader_settings:readSetting("tomesync_adopt_pending") or {{}}
+    -- local rendering position -> {{ anchor, anchor_end }} of the SERVER identity
+    -- for foreign highlights that had to be re-anchored on this copy (see
+    -- _applyForeign). Persisted so repairs survive restarts.
+    self.repair_map = G_reader_settings:readSetting("tomesync_repair_map") or {{}}
     -- Per-book annotation sync baseline: book_id -> {{ anchor -> mtime }} as of last
     -- sync. Lets a diff tell "I deleted this" from "this is new from another device".
     self.annot_baseline = G_reader_settings:readSetting("tomesync_annot_baseline") or {{}}
@@ -1984,15 +1988,15 @@ function TomeSync:_tryResolve()
     local doc = self.ui and self.ui.document
     if not doc then return end
     local filename = doc.file:match("([^/]+)$") or doc.file
-    -- KOReader's own file identity: the partial-MD5 from the sidecar when
-    -- present (no extra IO), else computed (~12KB of reads). The server
-    -- matches it against the hashes recorded when it scanned or served the
-    -- artifact — deterministic even for renamed/moved files; the filename
-    -- heuristics remain as fallback.
-    local md5 = self.ui.doc_settings and self.ui.doc_settings:readSetting("partial_md5_checksum")
-    if not md5 then
-        local mok, computed = pcall(function() return require("util").partialMD5(doc.file) end)
-        if mok then md5 = computed end
+    -- KOReader's own file identity, computed FRESH from the file (~12KB of
+    -- reads). The sidecar's partial_md5_checksum is only a fallback: metadata
+    -- archive restores can inherit it from ANOTHER copy of the book, so it is
+    -- not a reliable hash of these bytes (observed in emulator testing). The
+    -- server matches against the hashes recorded when it scanned or served
+    -- the artifact; the filename heuristics remain as final fallback.
+    local mok, md5 = pcall(function() return require("util").partialMD5(doc.file) end)
+    if not mok or type(md5) ~= "string" then
+        md5 = self.ui.doc_settings and self.ui.doc_settings:readSetting("partial_md5_checksum")
     end
     logger.info("TomeSync: resolving filename:", filename)
     local rok, result, rcode = pcall(apiRequest, "GET",
@@ -2275,7 +2279,14 @@ function TomeSync:_localAnnotationMap()
     local map = {{}}
     for _, a in ipairs(list) do
         local anchor = annotAnchor(a)
-        if anchor then map[anchor] = {{ item = a, mtime = annotMtime(a) }} end
+        if anchor then
+            -- Repaired foreign highlights render at a local position but keep
+            -- their SERVER identity: index them under the server anchor so
+            -- edits/deletes/tombstones from other devices reach them, and our
+            -- own pushes never mint a duplicate identity for the same words.
+            local alias = self.repair_map and self.repair_map[anchor]
+            map[(alias and alias.anchor) or anchor] = {{ item = a, mtime = annotMtime(a) }}
+        end
     end
     return map
 end
@@ -2297,20 +2308,9 @@ function TomeSync:_applyServerState(alive, tombstones)
             local L = localmap[s.anchor]
             local smtime = s.datetime_updated or s.datetime or ""
             if not L then
-                -- New highlight from another device: reconstruct so it renders.
-                -- Rolling (crengine) docs can only draw real xPointers ("/body…");
-                -- anything else (PDF datetime fallbacks, corrupt data) would
-                -- hard-crash drawSavedHighlight → getPosFromXPointer on repaint.
-                local drawable = (not self.ui.rolling) or s.anchor:sub(1, 5) == "/body"
-                local ok = drawable and pcall(function()
-                    ann:addItem({{
-                        page = s.anchor, pos0 = s.anchor, pos1 = s.anchor_end or s.anchor,
-                        text = s.highlighted_text, note = s.note, chapter = s.chapter,
-                        color = s.color, drawer = "lighten",
-                        datetime = s.datetime, datetime_updated = s.datetime_updated,
-                    }})
-                end)
-                changed = changed or (ok == true)
+                -- New highlight from another device: verify it reproduces its
+                -- text on THIS copy before drawing; repair or skip otherwise.
+                changed = self:_applyForeign(ann, s) or changed
             elseif smtime > L.mtime then
                 -- Newer edit from elsewhere wins (note/color/text).
                 L.item.text  = s.highlighted_text
@@ -2345,6 +2345,85 @@ function TomeSync:_applyServerState(alive, tombstones)
     end
 end
 
+function TomeSync:_locateText(text, chapter)
+    -- Find `text` in the open (rolling) document; when several places carry
+    -- the same words prefer the hit inside `chapter`. Returns start/end
+    -- xPointers or nil. Shared by web adoption and foreign-highlight repair.
+    local ok, results = pcall(function()
+        -- (pattern, case_insensitive, nb_context_words, max_hits, regex)
+        return self.ui.document:findAllText(text, false, 2, 5, false)
+    end)
+    if not ok or type(results) ~= "table" then return nil end
+    local hit = results[1]
+    if #results > 1 and chapter then
+        for _, r in ipairs(results) do
+            local okc, title = pcall(function()
+                local page = self.ui.document:getPageFromXPointer(r.start)
+                return self.ui.toc:getTocTitleByPage(page)
+            end)
+            if okc and title == chapter then hit = r; break end
+        end
+    end
+    if hit and type(hit.start) == "string" and type(hit["end"]) == "string" then
+        return hit.start, hit["end"]
+    end
+    return nil
+end
+
+function TomeSync:_applyForeign(ann, s)
+    -- A highlight made on another device. NEVER paint it on the wrong words:
+    -- verify that the anchor reproduces the highlighted text on THIS copy of
+    -- the book, repair by text search when it doesn't (a different bake of the
+    -- same book shifts xPointers), and skip entirely when the text can't be
+    -- located. Repairs keep the SERVER identity (repair_map) so the origin
+    -- device's anchor is never rewritten — no cross-device anchor ping-pong.
+    local function norm(t)
+        if type(t) ~= "string" then return nil end
+        t = t:gsub("\194\173", "")       -- soft hyphens (U+00AD)
+        t = t:gsub("%s+", " ")
+        return t:match("^%s*(.-)%s*$")
+    end
+    local function add(p0, p1)
+        return pcall(function()
+            ann:addItem({{
+                page = p0, pos0 = p0, pos1 = p1,
+                text = s.highlighted_text, note = s.note, chapter = s.chapter,
+                color = s.color, drawer = "lighten",
+                datetime = s.datetime, datetime_updated = s.datetime_updated,
+            }})
+        end) == true
+    end
+
+    if not self.ui.rolling then
+        -- PDF: positions aren't xPointers and extracted text isn't comparable —
+        -- keep the pre-verify behaviour (the /body guard is a crengine concern).
+        return add(s.anchor, s.anchor_end or s.anchor)
+    end
+
+    local want = norm(s.highlighted_text)
+    if s.anchor:sub(1, 5) == "/body" then
+        local okx, got = pcall(function()
+            return self.ui.document:getTextFromXPointers(s.anchor, s.anchor_end or s.anchor)
+        end)
+        if okx and (not want or norm(got) == want) then
+            -- verified (or nothing to verify against): draw at the real anchor
+            return add(s.anchor, s.anchor_end or s.anchor)
+        end
+    end
+
+    if not want or want == "" then return false end
+    local p0, p1 = self:_locateText(s.highlighted_text, s.chapter)
+    if not p0 then return false end   -- unlocatable here: skip, never wrong words
+    for _, a in ipairs(ann.annotations or {{}}) do
+        if a.pos0 == p0 then return false end   -- already rendered by an earlier repair
+    end
+    if not add(p0, p1) then return false end
+    self.repair_map[p0] = {{ anchor = s.anchor, anchor_end = s.anchor_end }}
+    G_reader_settings:saveSetting("tomesync_repair_map", self.repair_map)
+    logger.info("TomeSync: repaired foreign highlight to", p0)
+    return true
+end
+
 function TomeSync:_adoptWebAnnotations(pending)
     -- Highlights created in Tome's web reader arrive with a provisional "web:"
     -- anchor and no position. Locate each one's text with crengine and create a
@@ -2364,25 +2443,11 @@ function TomeSync:_adoptWebAnnotations(pending)
     for _, s in ipairs(pending) do
         local text = s.highlighted_text
         if type(text) == "string" and text ~= "" and not seen_text[text] then
-            local ok, results = pcall(function()
-                -- (pattern, case_insensitive, nb_context_words, max_hits, regex)
-                return self.ui.document:findAllText(text, false, 2, 5, false)
-            end)
-            local hit = (ok and type(results) == "table") and results[1] or nil
-            if ok and type(results) == "table" and #results > 1 and s.chapter then
-                -- Same text in several places: prefer the chapter the web named.
-                for _, r in ipairs(results) do
-                    local okc, title = pcall(function()
-                        local page = self.ui.document:getPageFromXPointer(r.start)
-                        return self.ui.toc:getTocTitleByPage(page)
-                    end)
-                    if okc and title == s.chapter then hit = r; break end
-                end
-            end
-            if hit and type(hit.start) == "string" and type(hit["end"]) == "string" then
+            local hit_start, hit_end = self:_locateText(text, s.chapter)
+            if hit_start then
                 local okAdd = pcall(function()
                     ann:addItem({{
-                        page = hit.start, pos0 = hit.start, pos1 = hit["end"],
+                        page = hit_start, pos0 = hit_start, pos1 = hit_end,
                         text = text, note = s.note, chapter = s.chapter,
                         color = s.color, drawer = "lighten",
                         datetime = s.datetime, datetime_updated = s.datetime_updated,
@@ -2390,7 +2455,7 @@ function TomeSync:_adoptWebAnnotations(pending)
                 end)
                 if okAdd then
                     seen_text[text] = true
-                    self.adopt_pending[hit.start] = s.anchor
+                    self.adopt_pending[hit_start] = s.anchor
                     adopted = adopted + 1
                 end
             end
@@ -2416,7 +2481,16 @@ function TomeSync:_syncAnnotations()
     for anchor, L in pairs(localmap) do
         if baseline[anchor] == nil or baseline[anchor] ~= L.mtime then
             local it = self:_annotItem(L.item)
-            if it then table.insert(upserts, it) end
+            if it then
+                if it.anchor ~= anchor then
+                    -- repaired item: push under its server identity, with the
+                    -- ORIGIN device's positions (ours are local rendering only)
+                    local alias = self.repair_map[it.anchor]
+                    it.anchor = anchor
+                    it.anchor_end = (alias and alias.anchor_end) or it.anchor_end
+                end
+                table.insert(upserts, it)
+            end
         end
     end
     local now = os.date("%Y-%m-%d %H:%M:%S")   -- local wall-clock, matches KOReader's
@@ -2461,6 +2535,18 @@ function TomeSync:_syncAnnotations()
     for anchor, L in pairs(after) do newbase[anchor] = L.mtime end
     self.annot_baseline[bk] = newbase
     G_reader_settings:saveSetting("tomesync_annot_baseline", self.annot_baseline)
+
+    -- Drop aliases whose local rendering is gone (a local delete already went
+    -- out under the server identity above) so the map can't grow stale.
+    local raw = {{}}
+    for _, a in ipairs((self.ui.annotation and self.ui.annotation.annotations) or {{}}) do
+        if type(a.pos0) == "string" then raw[a.pos0] = true end
+    end
+    local pruned = false
+    for pos0 in pairs(self.repair_map) do
+        if not raw[pos0] then self.repair_map[pos0] = nil; pruned = true end
+    end
+    if pruned then G_reader_settings:saveSetting("tomesync_repair_map", self.repair_map) end
     return resp
 end
 

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 28
-TOMESYNC_PLUGIN_SEMVER = "1.7.3"
+TOMESYNC_PLUGIN_BUILD = 29
+TOMESYNC_PLUGIN_SEMVER = "1.7.4"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1189,6 +1189,8 @@ local lfs              = require("libs/libkoreader-lfs")
 local util             = require("util")
 local Menu             = require("ui/widget/menu")
 local InputDialog      = require("ui/widget/inputdialog")
+local ConfirmBox       = require("ui/widget/confirmbox")
+local socketutil       = require("socketutil")
 local Dispatcher       = require("dispatcher")
 local Event            = require("ui/event")
 
@@ -1222,7 +1224,6 @@ local API_KEY    = "{api_key}"
 local USERNAME   = "{username}"
 
 -- Short timeout so unreachable server doesn't freeze the UI
-http.TIMEOUT = 5
 
 -- Track consecutive failures for backoff. Time-based so it self-heals:
 -- once we hit the threshold we go quiet for BACKOFF_COOLDOWN seconds, then
@@ -1292,6 +1293,9 @@ local function apiRequest(method, path, body)
         headers["Content-Length"] = tostring(#req_body)
     end
 
+    -- Tight per-request timeouts (block, total) via socketutil — bounded even
+    -- on a dead route, and no mutation of the global http.TIMEOUT.
+    socketutil:set_timeout(5, 10)
     local ok, code = http.request({{
         url     = url,
         method  = method,
@@ -1299,6 +1303,7 @@ local function apiRequest(method, path, body)
         source  = req_body and ltn12.source.string(req_body) or nil,
         sink    = ltn12.sink.table(resp_chunks),
     }})
+    socketutil:reset_timeout()
 
     if not ok then
         consecutive_failures = consecutive_failures + 1
@@ -1338,7 +1343,7 @@ local function pickBestFile(files)
     return files[1]
 end
 
-local function downloadFile(book_id, file_id, dest_path)
+local function downloadFile(book_id, file_id, dest_path, total_size, progress_cb)
     if not NetworkMgr:isConnected() then
         return false, "offline"
     end
@@ -1349,8 +1354,33 @@ local function downloadFile(book_id, file_id, dest_path)
         return false, "cannot open file for writing"
     end
 
-    local saved_timeout = http.TIMEOUT
-    http.TIMEOUT = 60
+    -- Generous total budget for large files; the block timeout still catches
+    -- a stalled connection quickly (no global http.TIMEOUT mutation).
+    socketutil:set_timeout(15, 900)
+
+    -- Count bytes as they stream to disk; repaint at most every 5% (known
+    -- size) or 256 KB (unknown) so e-ink isn't flooded — a 300 MB CBZ used
+    -- to sit mute for minutes with no sign of life.
+    local sink = ltn12.sink.file(fh)
+    if progress_cb then
+        local base_sink, received, last_bucket = sink, 0, 0
+        sink = function(chunk, err)
+            if chunk then
+                received = received + #chunk
+                local bucket
+                if type(total_size) == "number" and total_size > 0 then
+                    bucket = math.floor(received * 20 / total_size)
+                else
+                    bucket = math.floor(received / 262144)
+                end
+                if bucket ~= last_bucket then
+                    last_bucket = bucket
+                    pcall(progress_cb, received, total_size)
+                end
+            end
+            return base_sink(chunk, err)
+        end
+    end
 
     local ok, code = http.request({{
         url     = url,
@@ -1358,10 +1388,10 @@ local function downloadFile(book_id, file_id, dest_path)
         headers = {{
             ["Authorization"] = "Bearer " .. API_KEY,
         }},
-        sink = ltn12.sink.file(fh),
+        sink = sink,
     }})
 
-    http.TIMEOUT = saved_timeout
+    socketutil:reset_timeout()
 
     if not ok or (type(code) == "number" and code >= 300) then
         os.remove(dest_path)
@@ -1502,15 +1532,14 @@ end
 local function fetchText(path)
     if not NetworkMgr:isConnected() then return nil, "offline" end
     local chunks = {{}}
-    local saved_timeout = http.TIMEOUT
-    http.TIMEOUT = 30
+    socketutil:set_timeout(10, 60)
     local ok, code = http.request({{
         url     = SERVER_URL .. "/api" .. path,
         method  = "GET",
         headers = {{ ["Authorization"] = "Bearer " .. API_KEY }},
         sink    = ltn12.sink.table(chunks),
     }})
-    http.TIMEOUT = saved_timeout
+    socketutil:reset_timeout()
     if not ok then return nil, code end
     if type(code) == "number" and code >= 300 then return nil, code end
     return table.concat(chunks), code
@@ -1553,6 +1582,8 @@ function TomeSync:init()
     -- for foreign highlights that had to be re-anchored on this copy (see
     -- _applyForeign). Persisted so repairs survive restarts.
     self.repair_map = G_reader_settings:readSetting("tomesync_repair_map") or {{}}
+    self._heartbeat_armed = false
+    self._heartbeat_task = function() self:_heartbeatNow() end
     -- Per-book annotation sync baseline: book_id -> {{ anchor -> mtime }} as of last
     -- sync. Lets a diff tell "I deleted this" from "this is new from another device".
     self.annot_baseline = G_reader_settings:readSetting("tomesync_annot_baseline") or {{}}
@@ -1698,21 +1729,35 @@ function TomeSync:onPageUpdate(pageno)
     end
 
     self.page_count = self.page_count + 1
-    if self.page_count % HEARTBEAT_PAGES == 0 then
-        local pct = self:_getCurrentPercentage()
-        self.last_progress = pct
-        pcall(apiRequest, "PUT", "/tome-sync/position/" .. self.book_id, {{
-            progress   = self:_getCurrentProgress(),
-            percentage = pct,
-            device     = deviceName(),
-        }})
-        -- Flush any offline sessions while we know WiFi is up
-        self:_flushPendingSessions()
-        self:_flushPendingRatings()
+    -- Idle-debounced heartbeat: reaching the page threshold ARMS the push, and
+    -- every further turn re-delays it — the HTTP call runs 10s after the LAST
+    -- page turn, never on the page-turn path itself (which used to stall the
+    -- turn for up to the request timeout on a flaky network).
+    if self.page_count % HEARTBEAT_PAGES == 0 or self._heartbeat_armed then
+        self._heartbeat_armed = true
+        UIManager:unschedule(self._heartbeat_task)
+        UIManager:scheduleIn(10, self._heartbeat_task)
     end
 end
 
+function TomeSync:_heartbeatNow()
+    self._heartbeat_armed = false
+    if not self.enabled or not self.book_id then return end
+    local pct = self:_getCurrentPercentage()
+    self.last_progress = pct
+    pcall(apiRequest, "PUT", "/tome-sync/position/" .. self.book_id, {{
+        progress   = self:_getCurrentProgress(),
+        percentage = pct,
+        device     = deviceName(),
+    }})
+    -- Flush any offline sessions while we know WiFi is up
+    self:_flushPendingSessions()
+    self:_flushPendingRatings()
+end
+
 function TomeSync:onSuspend()
+    UIManager:unschedule(self._heartbeat_task)
+    self._heartbeat_armed = false
     if not self.enabled or not self.book_id then return end
 
     -- Record the reading session (lid close = end of session)
@@ -1943,6 +1988,8 @@ function TomeSync:_flushPendingSessions()
 end
 
 function TomeSync:onCloseDocument()
+    UIManager:unschedule(self._heartbeat_task)
+    self._heartbeat_armed = false
     if not self.enabled or not self.book_id then return end
 
     local pct      = self:_getCurrentPercentage()
@@ -2708,22 +2755,36 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
         UIManager:forceRePaint()
     end
 
+    local function fmtMB(n)
+        return string.format("%.1f MB", n / 1048576)
+    end
     local downloaded, failed = 0, 0
+    local failed_books = {{}}
     for i, item in ipairs(queue) do
-        showProgress(string.format(
-            "%s\\n\\nDownloading %d of %d\\n%s",
-            batch_label, i, #queue, item.book.title
-        ))
+        local head = string.format("%s\\n\\nDownloading %d of %d\\n%s",
+                                   batch_label, i, #queue, item.book.title)
+        showProgress(head)
         if not item.file then
             failed = failed + 1
+            table.insert(failed_books, item.book)
         else
-            local ok, err = downloadFile(item.book.id, item.file.id, item.dest)
+            local total = type(item.file.file_size) == "number" and item.file.file_size or nil
+            local ok, err = downloadFile(item.book.id, item.file.id, item.dest, total,
+                function(received, size)
+                    if size then
+                        showProgress(string.format("%s\\n%d%% of %s", head,
+                            math.floor(received * 100 / size), fmtMB(size)))
+                    else
+                        showProgress(string.format("%s\\n%s", head, fmtMB(received)))
+                    end
+                end)
             if ok then
                 downloaded = downloaded + 1
                 self.book_map[item.dest] = item.book.id
             else
                 logger.warn("TomeSync: download failed for", item.book.title, err)
                 failed = failed + 1
+                table.insert(failed_books, item.book)
             end
         end
     end
@@ -2733,13 +2794,41 @@ function TomeSync:_downloadSeriesBooks(series_name, books, min_index, book_type,
     G_reader_settings:saveSetting("tomesync_book_map", self.book_map)
 
     if not quiet then
-        UIManager:show(InfoMessage:new{{
-            text = string.format(
-                "%s\\n\\nDownloaded: %d\\nSkipped: %d\\nFailed: %d\\n\\nSaved to: %s",
-                batch_label, downloaded, skipped, failed, save_location or base_dir
-            ),
-            timeout = 8,
-        }})
+        if failed > 0 and #failed_books > 0 then
+            -- Offer a retry instead of a one-shot failure count: transient
+            -- WiFi drops are the usual culprit and a second pass fixes them.
+            UIManager:show(ConfirmBox:new{{
+                text = string.format(
+                    "%s\\n\\nDownloaded: %d\\nSkipped: %d\\nFailed: %d",
+                    batch_label, downloaded, skipped, failed
+                ),
+                ok_text = "Retry failed",
+                cancel_text = "Close",
+                ok_callback = function()
+                    self:_downloadSeriesBooks(series_name, failed_books, min_index, book_type, quiet)
+                end,
+            }})
+        else
+            UIManager:show(InfoMessage:new{{
+                text = string.format(
+                    "%s\\n\\nDownloaded: %d\\nSkipped: %d\\nFailed: %d\\n\\nSaved to: %s",
+                    batch_label, downloaded, skipped, failed, save_location or base_dir
+                ),
+                timeout = 8,
+            }})
+            if downloaded == 1 and #queue == 1 and queue[1].dest then
+                -- Single fresh download: offer to jump straight into it.
+                local dest = queue[1].dest
+                UIManager:show(ConfirmBox:new{{
+                    text = string.format('Open "%s" now?', queue[1].book.title or "book"),
+                    ok_text = "Open",
+                    cancel_text = "Later",
+                    ok_callback = function()
+                        require("apps/reader/readerui"):showReader(dest)
+                    end,
+                }})
+            end
+        end
     end
     return {{ downloaded = downloaded, skipped = skipped, failed = failed }}
 end
@@ -2757,6 +2846,11 @@ function TomeSync:_seriesBooksMenu(data)
             self:_downloadSeriesBooks(data.series_name, data.books, nil, data.book_type)
         end,
     }})
+    -- book_id → on-device path (same signal the download queue uses to skip)
+    local id_to_path = {{}}
+    for path, bid in pairs(self.book_map) do
+        if lfs.attributes(path) then id_to_path[bid] = path end
+    end
     for _, book in ipairs(data.books) do
         local label
         if type(book.series_index) == "number" then
@@ -2765,6 +2859,9 @@ function TomeSync:_seriesBooksMenu(data)
             label = "Vol. " .. tostring(vol) .. " — " .. book.title
         else
             label = book.title
+        end
+        if id_to_path[book.id] then
+            label = label .. "  · on device"
         end
         table.insert(items, {{
             text     = label,
@@ -2798,10 +2895,12 @@ function TomeSync:_browseSeriesMenuImpl()
     end
 
     local ok, series_list, code = pcall(apiRequest, "GET", "/tome-sync/series")
-    if not ok or not series_list or (type(code) == "number" and code >= 300) then
-        UIManager:show(InfoMessage:new{{
+    if not ok or type(series_list) ~= "table" or (type(code) == "number" and code >= 300) then
+        UIManager:show(ConfirmBox:new{{
             text = "Failed to load series list.",
-            timeout = 4,
+            ok_text = "Retry",
+            cancel_text = "Close",
+            ok_callback = function() self:_browseSeriesMenuImpl() end,
         }})
         return
     end
@@ -2819,18 +2918,7 @@ function TomeSync:_browseSeriesMenuImpl()
         table.insert(items, {{
             text = text,
             callback = function()
-                -- Fetch the books in this series, then drill into a per-book list
-                -- so a single title can be downloaded instead of the whole series.
-                local ok2, data, code2 = pcall(apiRequest, "GET",
-                    "/tome-sync/series/" .. s.first_book_id)
-                if ok2 and data and data.books then
-                    self:_seriesBooksMenu(data)
-                else
-                    UIManager:show(InfoMessage:new{{
-                        text = "Failed to load series books.",
-                        timeout = 4,
-                    }})
-                end
+                self:_openSeriesBooks(s.first_book_id)
             end,
         }})
     end
@@ -2843,6 +2931,23 @@ function TomeSync:_browseSeriesMenuImpl()
         show_parent = self.ui or UIManager,
     }}
     UIManager:show(menu)
+end
+
+function TomeSync:_openSeriesBooks(first_book_id)
+    -- Fetch the books in this series, then drill into a per-book list so a
+    -- single title can be downloaded instead of the whole series.
+    local ok2, data, code2 = pcall(apiRequest, "GET", "/tome-sync/series/" .. first_book_id)
+    if ok2 and type(data) == "table" and data.books then
+        self:_seriesBooksMenu(data)
+    else
+        UIManager:show(ConfirmBox:new{{
+            text = "Failed to load series books.",
+            ok_text = "Retry",
+            cancel_text = "Close",
+            ok_callback = function() self:_openSeriesBooks(first_book_id) end,
+        }})
+    end
+    local _ = code2
 end
 
 function TomeSync:_downloadCurrentBookSeries(rest_only)

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -42,8 +42,8 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 26
-TOMESYNC_PLUGIN_SEMVER = "1.7.1"
+TOMESYNC_PLUGIN_BUILD = 27
+TOMESYNC_PLUGIN_SEMVER = "1.7.2"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -83,6 +83,7 @@ def _get_position(db: Session, user_id: int, book_id: int) -> Optional[TomeSyncP
 @router.get("/tome-sync/resolve")
 def resolve_book(
     filename: str,
+    ko_md5: str = "",
     db: Session = Depends(get_db),
     user: User = Depends(_get_api_key_user),
 ):
@@ -98,6 +99,18 @@ def resolve_book(
     title appeared inside vol-2's filename).
     """
     import re
+
+    # 0. Deterministic identity: the device file's KOReader partial-MD5 against
+    #    the hashes Tome recorded when it scanned or served the artifact. Exact
+    #    however the file was renamed or moved on the device; everything below
+    #    is heuristic fallback for files that never passed through Tome.
+    if ko_md5:
+        from backend.services.ko_hash import lookup_book_ids
+        hit = lookup_book_ids(db, [ko_md5]).get(ko_md5)
+        if hit is not None:
+            book = db.get(Book, hit)
+            if book and book.status == "active":
+                return {"book_id": book.id, "method": "ko_hash"}
 
     stem = filename.rsplit(".", 1)[0] if "." in filename else filename
     stem_l = stem.lower()
@@ -841,7 +854,9 @@ def download_book_via_api_key(
         raise HTTPException(status_code=404, detail="File no longer on disk")
 
     from backend.services.metadata_embed import get_baked_path
+    from backend.services.ko_hash import record_served_artifact
     serve_path = get_baked_path(book_file.book, book_file)
+    record_served_artifact(db, book_file.book_id, book_file, serve_path)
 
     filename = f"{book_file.book.title}.{book_file.format}"
     return FileResponse(
@@ -1969,9 +1984,20 @@ function TomeSync:_tryResolve()
     local doc = self.ui and self.ui.document
     if not doc then return end
     local filename = doc.file:match("([^/]+)$") or doc.file
+    -- KOReader's own file identity: the partial-MD5 from the sidecar when
+    -- present (no extra IO), else computed (~12KB of reads). The server
+    -- matches it against the hashes recorded when it scanned or served the
+    -- artifact — deterministic even for renamed/moved files; the filename
+    -- heuristics remain as fallback.
+    local md5 = self.ui.doc_settings and self.ui.doc_settings:readSetting("partial_md5_checksum")
+    if not md5 then
+        local mok, computed = pcall(function() return require("util").partialMD5(doc.file) end)
+        if mok then md5 = computed end
+    end
     logger.info("TomeSync: resolving filename:", filename)
     local rok, result, rcode = pcall(apiRequest, "GET",
-        "/tome-sync/resolve?filename=" .. urlEncode(filename))
+        "/tome-sync/resolve?filename=" .. urlEncode(filename)
+        .. (md5 and ("&ko_md5=" .. urlEncode(md5)) or ""))
     if rok and result and type(rcode) == "number" and rcode == 200 and result.book_id then
         self.book_id = result.book_id
         self.book_map[doc.file] = self.book_id

--- a/backend/main.py
+++ b/backend/main.py
@@ -203,6 +203,13 @@ async def lifespan(app: FastAPI):
     else:
         logger.info("Auto-import disabled (set TOME_AUTO_IMPORT=true to enable)")
 
+    # One-shot backfill of KOReader partial-MD5s for pre-existing library
+    # files (new files are hashed at ingest/serve time). No-op once done.
+    import threading
+    from backend.services.ko_hash import backfill_missing_raw_hashes
+    threading.Thread(target=backfill_missing_raw_hashes, daemon=True,
+                     name="ko-hash-backfill").start()
+
     release_task: asyncio.Task | None = None
     if settings.release_detection:
         logger.info("Release detection enabled — checking follows every %d seconds",

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -11,4 +11,4 @@ from backend.models.wish import Wish  # noqa: F401
 from backend.models.notification import Notification  # noqa: F401
 from backend.models.send_queue import SendQueueItem  # noqa: F401
 from backend.models.user_dashboard import UserDashboard  # noqa: F401
-from backend.models.ko_stats import PageStat, StatsImport, KoStatsBookMatch  # noqa: F401
+from backend.models.ko_stats import PageStat, StatsImport, KoStatsBookMatch, KoHash  # noqa: F401

--- a/backend/models/ko_stats.py
+++ b/backend/models/ko_stats.py
@@ -130,3 +130,34 @@ class KoStatsBookMatch(Base):
     )
 
     book: Mapped[Optional["Book"]] = relationship("Book")  # type: ignore[name-defined]
+
+
+class KoHash(Base):
+    """KOReader partial-MD5s of the artifacts a device may actually hold.
+
+    KOReader identifies books by ``util.partialMD5`` (1KB samples at
+    exponentially spaced offsets). Tome's downloads are *baked* copies, so
+    a device file's hash never matches ``BookFile.content_hash`` (sha256 of
+    the raw library file). This table records the partial-MD5 of both the
+    raw file (``kind="raw"``, for sideloaded originals) and every baked
+    artifact we serve (``kind="baked"``) — deterministic identity for any
+    file however it reached the device, with the filename heuristics as
+    fallback. Baked bytes change when metadata changes, so a book keeps its
+    last few baked hashes (older device copies still match); pruning is the
+    recorder's job (see ``backend/services/ko_hash.py``).
+    """
+    __tablename__ = "ko_hashes"
+    __table_args__ = (
+        UniqueConstraint("book_id", "ko_partial_md5", name="uq_ko_hash_book_md5"),
+        Index("ix_ko_hashes_md5", "ko_partial_md5"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    book_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    ko_partial_md5: Mapped[str] = mapped_column(String(32), nullable=False)
+    kind: Mapped[str] = mapped_column(String(8), nullable=False, default="raw")  # raw | baked
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    book: Mapped["Book"] = relationship("Book")  # type: ignore[name-defined]

--- a/backend/services/ko_hash.py
+++ b/backend/services/ko_hash.py
@@ -1,0 +1,146 @@
+"""KOReader partial-MD5: compute and record device-matchable file identities.
+
+KOReader identifies a book by ``util.partialMD5`` — an MD5 over 1 KB samples
+taken at exponentially spaced offsets — not by a full-content hash. This module
+is a byte-exact Python port plus the recording helpers that keep the
+``ko_hashes`` table current (see the model docstring for why raw and baked
+artifacts are hashed separately).
+
+Port notes (KOReader ``frontend/util.lua:1111``):
+- the loop runs i = -1 .. 10 with ``bit.lshift(1024, 2*i)``; LuaJIT masks the
+  shift amount to 5 bits, so i = -1 becomes a shift by 30 whose 32-bit result
+  is 0 — i.e. the first sample is at offset 0, then 1024 << (2*i) for i >= 0
+  (1 KB, 4 KB, 16 KB, … 1 GB).
+- ``file:read(1024)`` returns nil only at EOF; a short read near EOF is still
+  hashed. Python's ``read()`` returning ``b""`` maps exactly onto the nil case.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+from backend.models.ko_stats import KoHash
+
+logger = logging.getLogger(__name__)
+
+# Baked bytes change whenever metadata changes; devices keep whatever they
+# downloaded. Retain the last few baked hashes per book so older copies still
+# resolve, without growing without bound.
+BAKED_HASHES_KEPT = 5
+
+
+def ko_partial_md5(path: str | Path) -> str | None:
+    """KOReader's util.partialMD5 for a local file; None if unreadable."""
+    h = hashlib.md5()
+    try:
+        with open(path, "rb") as f:
+            for i in range(-1, 11):
+                offset = 0 if i == -1 else 1024 << (2 * i)
+                f.seek(offset)
+                sample = f.read(1024)
+                if sample:
+                    h.update(sample)
+                else:
+                    break
+    except OSError as exc:
+        logger.warning("partial-md5 failed for %s: %s", path, exc)
+        return None
+    return h.hexdigest()
+
+
+def record_ko_hash(db: Session, book_id: int, md5: str | None, kind: str = "raw") -> None:
+    """Idempotently record a hash for a book; prunes old baked hashes.
+
+    Callers pass the output of :func:`ko_partial_md5` (None is a no-op so hook
+    sites don't need their own guards). Commits are left to the caller — hook
+    sites run inside larger transactions.
+    """
+    if not md5:
+        return
+    existing = (
+        db.query(KoHash)
+        .filter(KoHash.book_id == book_id, KoHash.ko_partial_md5 == md5)
+        .first()
+    )
+    if existing:
+        return
+    db.add(KoHash(book_id=book_id, ko_partial_md5=md5, kind=kind))
+    if kind == "baked":
+        stale = (
+            db.query(KoHash.id)
+            .filter(KoHash.book_id == book_id, KoHash.kind == "baked")
+            .order_by(KoHash.created_at.desc(), KoHash.id.desc())
+            .offset(BAKED_HASHES_KEPT)  # autoflush ranks the pending row newest
+            .all()
+        )
+        if stale:
+            db.execute(delete(KoHash).where(KoHash.id.in_([r.id for r in stale])))
+
+
+def lookup_book_ids(db: Session, md5s: list[str]) -> dict[str, int]:
+    """Batch resolve partial-MD5s → book ids (first match wins per hash)."""
+    if not md5s:
+        return {}
+    out: dict[str, int] = {}
+    rows = (
+        db.query(KoHash.ko_partial_md5, KoHash.book_id)
+        .filter(KoHash.ko_partial_md5.in_(md5s))
+        .order_by(KoHash.id)
+        .all()
+    )
+    for md5, book_id in rows:
+        out.setdefault(md5, book_id)
+    return out
+
+
+def record_served_artifact(db: Session, book_id: int, book_file, served_path) -> None:
+    """Record the partial-MD5 of the bytes a device is about to receive.
+
+    Called from every download path after ``get_baked_path()``. The served
+    file is the baked cache normally, or the raw library file when baking
+    fell back (or an in-place bake made the raw file current) — either way,
+    THIS is the artifact whose hash a KOReader device will later present,
+    so hash exactly what goes over the wire.
+    """
+    import os
+    kind = "raw" if os.path.samefile(served_path, book_file.file_path) else "baked"
+    try:
+        record_ko_hash(db, book_id, ko_partial_md5(served_path), kind)
+        db.commit()
+    except Exception as exc:  # never let bookkeeping break a download
+        logger.warning("ko-hash record failed for book %s: %s", book_id, exc)
+        db.rollback()
+
+
+def backfill_missing_raw_hashes() -> None:
+    """One-shot startup backfill: hash library files that predate ko_hashes.
+
+    Partial-MD5 reads at most ~12 KB per file, so even large libraries finish
+    in seconds; run in a daemon thread anyway so startup never blocks on a
+    slow network mount. Files already hashed (any kind) are skipped, making
+    every run after the first a no-op.
+    """
+    from backend.core.database import SessionLocal
+    from backend.models.book import BookFile
+
+    with SessionLocal() as db:
+        missing = (
+            db.query(BookFile)
+            .outerjoin(KoHash, (KoHash.book_id == BookFile.book_id) & (KoHash.kind == "raw"))
+            .filter(KoHash.id.is_(None))
+            .all()
+        )
+        if not missing:
+            return
+        done = 0
+        for bf in missing:
+            record_ko_hash(db, bf.book_id, ko_partial_md5(bf.file_path), "raw")
+            done += 1
+            if done % 200 == 0:
+                db.commit()
+        db.commit()
+        logger.info("ko-hash backfill: hashed %d library files", done)

--- a/backend/services/ko_stats_import.py
+++ b/backend/services/ko_stats_import.py
@@ -25,6 +25,7 @@ from sqlalchemy.orm import Session
 
 from backend.core.permissions import book_visibility_filter
 from backend.models.book import Book, BookFile
+from backend.services.ko_hash import lookup_book_ids
 from backend.models.ko_stats import KoStatsBookMatch, PageStat, StatsImport
 
 # NOTE: the import deliberately does NOT write Tome read-status (read/reading/finished).
@@ -247,6 +248,33 @@ def import_batch(
             if md5:
                 seen_md5[md5] = existing.book_id
             continue
+
+        # Deterministic identity first: KOReader's md5 IS the partial-MD5 Tome
+        # records for every artifact it scans or serves (ko_hashes), so a hash
+        # hit is exact — no title heuristics, works for renamed files. The
+        # fuzzy matcher below stays as the fallback for history whose files
+        # never came from (or into) this library.
+        if md5:
+            hash_hit = lookup_book_ids(db, [md5]).get(md5)
+            if hash_hit is not None:
+                ko_to_book[ko_id] = hash_hit
+                counts["matched"] += 1
+                if existing:
+                    existing.book_id = hash_hit
+                    existing.confidence = 1.0
+                    existing.method = "ko_hash"
+                    existing.status = "matched"
+                    existing.ko_title = b.get("title")
+                    existing.ko_authors = b.get("authors")
+                else:
+                    db.add(KoStatsBookMatch(
+                        user_id=user.id, ko_md5=md5,
+                        ko_title=b.get("title"), ko_authors=b.get("authors"),
+                        book_id=hash_hit, confidence=1.0,
+                        method="ko_hash", status="matched",
+                    ))
+                seen_md5[md5] = hash_hit
+                continue
 
         res = match_book(
             candidates, b.get("title") or "", b.get("authors"),

--- a/backend/services/reconciled_reading.py
+++ b/backend/services/reconciled_reading.py
@@ -18,7 +18,10 @@ unchanged (and the existing test suite stays valid).
 Each helper returns plain Python structures keyed the way `stats.py` needs, merging:
   - page-stat aggregates (for covered books), and
   - session aggregates for books NOT covered.
-Sessions count from page-stats is approximated as one "session" per (book, local-day).
+Session counts from page-stats use real gap-clustering: consecutive page rows of a
+book belong to one session until a gap exceeds SESSION_GAP_SECONDS (mirrors how the
+live recorder and KOReader's own stats view think about sessions). Clusters shorter
+than MIN_SESSION_SECONDS are noise (a page flip while shelving) and aren't counted.
 """
 from __future__ import annotations
 
@@ -80,6 +83,60 @@ def _ps_local(tzm: str):
     return func.datetime(PageStat.start_time, "unixepoch", tzm)
 
 
+# A new session starts when the gap between consecutive page rows of the same
+# book exceeds this (same 30-minute idea KOReader's stats plugin uses).
+SESSION_GAP_SECONDS = 1800
+# Clusters shorter than this are page-flip noise, mirroring the live
+# recorder's minimum-session threshold.
+MIN_SESSION_SECONDS = 10
+
+
+def _cluster_rows(db, user_id: int, tzm: str,
+                  cutoff: Optional[datetime], range_end: Optional[datetime]):
+    """Gap-clustered page-stat sessions: (book_id, day, start, secs, pages).
+
+    Pure SQL (SQLite window functions): number the breaks with LAG, run a
+    cumulative sum for cluster ids, aggregate. The day is the cluster's START
+    day in the user's timezone — a read across midnight is one session, on
+    the day it began, exactly like a live-recorded session.
+    """
+    from sqlalchemy import text
+
+    where, params = ["user_id = :uid"], {"uid": user_id, "tzm": tzm,
+                                         "gap": SESSION_GAP_SECONDS,
+                                         "min_secs": MIN_SESSION_SECONDS}
+    ce, ee = _epoch(cutoff), _epoch(range_end)
+    if ce is not None:
+        where.append("start_time >= :ce"); params["ce"] = ce
+    if ee is not None:
+        where.append("start_time < :ee"); params["ee"] = ee
+
+    sql = text(f"""
+        WITH ordered AS (
+            SELECT book_id, start_time, duration_seconds,
+                   CASE WHEN start_time - LAG(start_time) OVER w > :gap
+                        THEN 1 ELSE 0 END AS brk
+            FROM ko_page_stats
+            WHERE {' AND '.join(where)}
+            WINDOW w AS (PARTITION BY book_id ORDER BY start_time)
+        ), clustered AS (
+            SELECT book_id, start_time, duration_seconds,
+                   SUM(brk) OVER (PARTITION BY book_id ORDER BY start_time
+                                  ROWS UNBOUNDED PRECEDING) AS cluster_id
+            FROM ordered
+        )
+        SELECT book_id,
+               date(MIN(start_time), 'unixepoch', :tzm) AS day,
+               MIN(start_time) AS start,
+               SUM(duration_seconds) AS secs,
+               COUNT(*) AS pages
+        FROM clustered
+        GROUP BY book_id, cluster_id
+        HAVING SUM(duration_seconds) >= :min_secs
+    """)
+    return db.execute(sql, params).all()
+
+
 # ── Totals ────────────────────────────────────────────────────────────────────
 
 def totals(db, user_id, tzm, covered, cutoff, range_end) -> tuple[int, int, int]:
@@ -91,20 +148,14 @@ def totals(db, user_id, tzm, covered, cutoff, range_end) -> tuple[int, int, int]
     ).one()
     secs, sessions, pages = int(rs[0] or 0), int(rs[1] or 0), int(rs[2] or 0)
     if covered:
-        # page-stat day-groups: one "session" per (book, local-day)
-        day_groups = (
-            _ps_filtered(db, user_id, cutoff, range_end)
-            .with_entities(
-                PageStat.book_id, _ps_day(tzm).label("day"),
-                func.sum(PageStat.duration_seconds).label("secs"),
-                func.count(PageStat.id).label("pages"),
-            )
-            .group_by(PageStat.book_id, "day")
-            .all()
-        )
-        secs += sum(int(g.secs or 0) for g in day_groups)
-        pages += sum(int(g.pages or 0) for g in day_groups)
-        sessions += len(day_groups)
+        ps = _ps_filtered(db, user_id, cutoff, range_end).with_entities(
+            func.coalesce(func.sum(PageStat.duration_seconds), 0),
+            func.coalesce(func.count(PageStat.id), 0),
+        ).one()
+        secs += int(ps[0] or 0)
+        pages += int(ps[1] or 0)
+        # real sessions: gap-clustered, not one-per-(book, day)
+        sessions += len(_cluster_rows(db, user_id, tzm, cutoff, range_end))
     return secs, sessions, pages
 
 
@@ -124,20 +175,24 @@ def daily_map(db, user_id, tzm, covered, start_dt, end_dt) -> dict[str, tuple[in
     )
     out: dict[str, list[int]] = {r.day: [int(r.secs or 0), int(r.sessions or 0), int(r.pages or 0)] for r in rows}
     if covered:
-        # aggregate page-stats per (book, day) first, then roll up to day so "sessions"
-        # = distinct books read that day.
+        # seconds/pages stay allocated to the day each page was read; session
+        # COUNTS come from gap-clusters, attributed to the cluster's start day
+        # (a read across midnight is one session, like a live-recorded one).
         day_groups = (
             _ps_filtered(db, user_id, start_dt, end_dt)
             .with_entities(
-                PageStat.book_id, _ps_day(tzm).label("day"),
+                _ps_day(tzm).label("day"),
                 func.sum(PageStat.duration_seconds).label("secs"),
                 func.count(PageStat.id).label("pages"),
             )
-            .group_by(PageStat.book_id, "day").all()
+            .group_by("day").all()
         )
         for g in day_groups:
             e = out.setdefault(g.day, [0, 0, 0])
-            e[0] += int(g.secs or 0); e[1] += 1; e[2] += int(g.pages or 0)
+            e[0] += int(g.secs or 0); e[2] += int(g.pages or 0)
+        for c in _cluster_rows(db, user_id, tzm, start_dt, end_dt):
+            e = out.setdefault(c.day, [0, 0, 0])
+            e[1] += 1
     return {d: (v[0], v[1], v[2]) for d, v in out.items()}
 
 
@@ -163,14 +218,16 @@ def book_seconds(db, user_id, tzm, covered, cutoff, range_end) -> dict[int, tupl
             .with_entities(
                 PageStat.book_id,
                 func.sum(PageStat.duration_seconds).label("secs"),
-                func.count(func.distinct(_ps_day(tzm))).label("sessions"),
                 func.count(PageStat.id).label("pages"),
             )
             .group_by(PageStat.book_id).all()
         )
         for r in rows2:
             e = out.setdefault(r.book_id, [0, 0, 0])
-            e[0] += int(r.secs or 0); e[1] += int(r.sessions or 0); e[2] += int(r.pages or 0)
+            e[0] += int(r.secs or 0); e[2] += int(r.pages or 0)
+        for c in _cluster_rows(db, user_id, tzm, cutoff, range_end):
+            e = out.setdefault(c.book_id, [0, 0, 0])
+            e[1] += 1
     return {b: (v[0], v[1], v[2]) for b, v in out.items()}
 
 

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -23,6 +23,7 @@ from sqlalchemy.orm import Session
 from backend.core.config import settings
 from backend.models.book import Book, BookFile
 from backend.services.metadata import SUPPORTED_FORMATS, extract_metadata, get_format, sha256_file
+from backend.services.ko_hash import ko_partial_md5, record_ko_hash
 from backend.services.organizer import get_library_path, resolve_unique_path
 
 # Below this many new files, the serial path wins (process-pool startup isn't
@@ -254,6 +255,7 @@ def _handle_duplicate(
                 file_size=file_size,
                 content_hash=content_hash,
             ))
+            record_ko_hash(db, existing_book.id, ko_partial_md5(file_path), "raw")
             logger.info("Alternate format %s linked to book %d", fmt, existing_book.id)
         result.skipped += 1
         return True
@@ -309,6 +311,7 @@ def _create_book_entry(
         file_size=file_size,
         content_hash=content_hash,
     ))
+    record_ko_hash(db, book.id, ko_partial_md5(file_path), "raw")
 
     # Auto-assign book type based on metadata
     if not book.book_type_id:

--- a/tests/test_ko_hash.py
+++ b/tests/test_ko_hash.py
@@ -1,0 +1,183 @@
+"""KOReader partial-MD5 port + the ko_hashes recording helpers.
+
+The two hash vectors were produced by KOReader's own ``util.partialMD5``
+running inside the emulator (2026-07-03) on deterministic xorshift32 fixtures —
+if the port ever drifts from KOReader's algorithm, these fail.
+"""
+import hashlib
+
+import pytest
+
+from backend.models.ko_stats import KoHash
+from backend.services.ko_hash import (
+    BAKED_HASHES_KEPT,
+    ko_partial_md5,
+    lookup_book_ids,
+    record_ko_hash,
+)
+
+
+def _stream(n: int, seed: int = 0x704D45) -> bytes:
+    x = seed
+    out = bytearray()
+    for _ in range(n):
+        x ^= (x << 13) & 0xFFFFFFFF
+        x ^= x >> 17
+        x ^= (x << 5) & 0xFFFFFFFF
+        out.append(x & 0xFF)
+    return bytes(out)
+
+
+def test_partial_md5_matches_koreader_multi_sample(tmp_path):
+    """3 MB fixture — exercises samples at 0, 1K, 4K, 16K, 64K, 256K, 1M + EOF stop."""
+    p = tmp_path / "big.bin"
+    p.write_bytes(_stream(3_000_000))
+    assert ko_partial_md5(p) == "4a50115c444b43a695d3ffe94bd5cce5"
+
+
+def test_partial_md5_matches_koreader_tiny_file(tmp_path):
+    """A file smaller than one sample: hash == md5(content) (offset-0 read only)."""
+    p = tmp_path / "tiny.bin"
+    data = _stream(700)
+    p.write_bytes(data)
+    assert ko_partial_md5(p) == "093099351355bef62f45d03e3bd73ba5"
+    assert ko_partial_md5(p) == hashlib.md5(data).hexdigest()
+
+
+def test_partial_md5_unreadable_returns_none(tmp_path):
+    assert ko_partial_md5(tmp_path / "does-not-exist.bin") is None
+
+
+def test_record_is_idempotent_and_none_is_noop(db, make_book):
+    book = make_book(title="Hash Book", author="A")
+    record_ko_hash(db, book.id, "a" * 32, kind="raw")
+    record_ko_hash(db, book.id, "a" * 32, kind="raw")
+    record_ko_hash(db, book.id, None)
+    db.commit()
+    assert db.query(KoHash).filter(KoHash.book_id == book.id).count() == 1
+
+
+def test_baked_hashes_pruned_to_last_n(db, make_book):
+    book = make_book(title="Bake Book", author="A")
+    for i in range(BAKED_HASHES_KEPT + 3):
+        record_ko_hash(db, book.id, f"{i:032x}", kind="baked")
+        db.commit()
+    rows = db.query(KoHash).filter(KoHash.book_id == book.id, KoHash.kind == "baked").all()
+    assert len(rows) == BAKED_HASHES_KEPT
+    kept = {r.ko_partial_md5 for r in rows}
+    # the newest N survive
+    assert kept == {f"{i:032x}" for i in range(3, BAKED_HASHES_KEPT + 3)}
+
+
+def test_raw_hashes_never_pruned(db, make_book):
+    book = make_book(title="Raw Book", author="A")
+    for i in range(BAKED_HASHES_KEPT + 3):
+        record_ko_hash(db, book.id, f"{i + 100:032x}", kind="raw")
+        db.commit()
+    assert db.query(KoHash).filter(KoHash.book_id == book.id, KoHash.kind == "raw").count() == BAKED_HASHES_KEPT + 3
+
+
+def test_lookup_batch_first_match_wins(db, make_book):
+    b1 = make_book(title="Lookup One", author="A")
+    b2 = make_book(title="Lookup Two", author="A")
+    record_ko_hash(db, b1.id, "e" * 32)
+    record_ko_hash(db, b2.id, "e" * 32)   # same bytes served under two books
+    record_ko_hash(db, b2.id, "d" * 32)
+    db.commit()
+    out = lookup_book_ids(db, ["e" * 32, "d" * 32, "f" * 32])
+    assert out["e" * 32] == b1.id
+    assert out["d" * 32] == b2.id
+    assert "f" * 32 not in out
+    assert lookup_book_ids(db, []) == {}
+
+
+def test_download_records_served_artifact_hash(client, db, make_book, tmp_path):
+    """Every download path records the hash of the bytes actually served, so a
+    device file can later be matched back to its book."""
+    from backend.models.book import BookFile
+
+    book = make_book(title="Served Book", author="A")
+    p = tmp_path / "served.epub"
+    p.write_bytes(_stream(2048, seed=0xBEEF))
+    bf = BookFile(book_id=book.id, file_path=str(p), format="epub",
+                  file_size=2048, content_hash="x" * 64)
+    db.add(bf)
+    db.commit()
+
+    resp = client.get(f"/api/books/{book.id}/download/{bf.id}")
+    assert resp.status_code == 200
+
+    rows = db.query(KoHash).filter(KoHash.book_id == book.id).all()
+    assert rows, "download did not record a ko-hash"
+    # embed will fall back to raw for this fake epub OR produce a baked copy —
+    # either way the recorded hash must match the served artifact's bytes
+    assert all(len(r.ko_partial_md5) == 32 for r in rows)
+
+
+def _plugin_key(db, user_id: int) -> str:
+    from backend.models.tome_sync import ApiKey
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(user_id=user_id, key_hash=ApiKey.hash_key(plaintext), label="test"))
+    db.commit()
+    return plaintext
+
+
+def test_resolve_prefers_hash_over_filename(client, db, make_book, admin_user):
+    """A renamed device file resolves via ko_md5 where filename heuristics fail —
+    and a hash hit wins over a filename that would point at a DIFFERENT book."""
+    user, _ = admin_user
+    key = _plugin_key(db, user.id)
+    right = make_book(title="The Right Book", author="A")
+    wrong = make_book(title="Renamed Nonsense", author="B")
+    record_ko_hash(db, right.id, "c" * 32, kind="baked")
+    db.commit()
+
+    r = client.get(
+        "/api/tome-sync/resolve",
+        params={"filename": "Renamed Nonsense.epub", "ko_md5": "c" * 32},
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["book_id"] == right.id
+    assert body.get("method") == "ko_hash"
+    assert body["book_id"] != wrong.id
+
+
+def test_resolve_without_hash_keeps_filename_behaviour(client, db, make_book, admin_user):
+    user, _ = admin_user
+    key = _plugin_key(db, user.id)
+    book = make_book(title="Plain Filename Book", author="A")
+    r = client.get(
+        "/api/tome-sync/resolve",
+        params={"filename": "Plain Filename Book.epub"},
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    assert r.status_code == 200
+    assert r.json()["book_id"] == book.id
+
+
+def test_stats_import_matches_by_hash_before_title(db, make_book):
+    """A stats-DB book whose title would never fuzzy-match still resolves when
+    its md5 is one Tome served."""
+    from backend.services.ko_stats_import import import_batch
+    from backend.models.ko_stats import KoStatsBookMatch
+
+    book = make_book(title="Actual Library Title", author="Real Author")
+    record_ko_hash(db, book.id, "b" * 32, kind="baked")
+    db.commit()
+
+    from backend.models.user import User
+    user = db.query(User).first()
+
+    res = import_batch(
+        db, user, device="HashDev",
+        books=[{"ko_id": 3, "md5": "b" * 32, "title": "garbled ocr title 03",
+                "authors": "unknown"}],
+        page_stats=[{"ko_id": 3, "page": 1, "start_time": 1_710_000_000,
+                     "duration": 60, "total_pages": 100}],
+    )
+    assert res["matched"] == 1
+    assert res["page_rows_imported"] == 1
+    m = db.query(KoStatsBookMatch).filter(KoStatsBookMatch.ko_md5 == "b" * 32).first()
+    assert m.method == "ko_hash" and m.book_id == book.id

--- a/tests/test_stats_reconciliation.py
+++ b/tests/test_stats_reconciliation.py
@@ -72,3 +72,73 @@ def test_top_books_reconciled_ordering(client, db, admin_user, make_book):
     db.flush()
     top = client.get("/api/stats?days=0").json()["top_books"]
     assert [b["title"] for b in top[:2]] == ["Big", "Small"]
+
+
+# ── Gap-clustered session counts (replaced the one-per-(book,day) approximation) ──
+
+def _seed_stats(db, user_id, book_id, rows):
+    from backend.models.ko_stats import PageStat
+    for start, dur in rows:
+        db.add(PageStat(user_id=user_id, book_id=book_id, page=1, total_pages=100,
+                        start_time=start, duration_seconds=dur, device="Kindle"))
+    db.commit()
+
+
+def test_two_sittings_same_day_are_two_sessions(db, admin_user, make_book):
+    from backend.services.reconciled_reading import totals, covered_book_ids
+    user, _ = admin_user
+    book = make_book(title="Cluster Book", author="A")
+    base = 1_720_000_000  # mid-day epoch
+    # morning sitting: 3 pages close together; evening sitting 4h later
+    _seed_stats(db, user.id, book.id,
+                [(base, 60), (base + 70, 60), (base + 140, 60),
+                 (base + 4 * 3600, 60), (base + 4 * 3600 + 90, 60)])
+    covered = covered_book_ids(db, user.id)
+    secs, sessions, pages = totals(db, user.id, "+0 hours", covered, None, None)
+    assert sessions == 2          # the old approximation reported 1
+    assert secs == 300 and pages == 5
+
+
+def test_midnight_crossing_is_one_session_on_start_day(db, admin_user, make_book):
+    from backend.services.reconciled_reading import daily_map, covered_book_ids
+    from datetime import datetime, timezone
+    user, _ = admin_user
+    book = make_book(title="Midnight Book", author="A")
+    # 23:50 UTC .. 00:20 UTC — continuous reading across the day boundary
+    start = int(datetime(2026, 3, 10, 23, 50, tzinfo=timezone.utc).timestamp())
+    _seed_stats(db, user.id, book.id,
+                [(start + i * 300, 240) for i in range(7)])  # 35 min span
+    covered = covered_book_ids(db, user.id)
+    dm = daily_map(db, user.id, "+0 hours", covered, None, None)
+    total_sessions = sum(v[1] for v in dm.values())
+    assert total_sessions == 1                       # old: 2 (one per day touched)
+    assert dm["2026-03-10"][1] == 1                  # attributed to the start day
+    assert dm.get("2026-03-11", (0, 0, 0))[1] == 0   # not double-counted
+    # seconds still land on the day the pages were read
+    assert dm["2026-03-11"][0] > 0
+
+
+def test_noise_flip_not_counted_as_session(db, admin_user, make_book):
+    from backend.services.reconciled_reading import totals, covered_book_ids
+    user, _ = admin_user
+    book = make_book(title="Flip Book", author="A")
+    base = 1_720_100_000
+    _seed_stats(db, user.id, book.id,
+                [(base, 3),                    # 3s flip — below MIN_SESSION_SECONDS
+                 (base + 7200, 120), (base + 7300, 120)])  # a real sitting later
+    covered = covered_book_ids(db, user.id)
+    _, sessions, _ = totals(db, user.id, "+0 hours", covered, None, None)
+    assert sessions == 1
+
+
+def test_per_book_session_counts_are_clustered(db, admin_user, make_book):
+    from backend.services.reconciled_reading import book_seconds, covered_book_ids
+    user, _ = admin_user
+    book = make_book(title="Per Book Cluster", author="A")
+    base = 1_720_200_000
+    # three sittings, two on the same day — old distinct-day count said 2
+    _seed_stats(db, user.id, book.id,
+                [(base, 60), (base + 3 * 3600, 60), (base + 30 * 3600, 60)])
+    covered = covered_book_ids(db, user.id)
+    bs = book_seconds(db, user.id, "+0 hours", covered, None, None)
+    assert bs[book.id][1] == 3

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -159,5 +159,9 @@ def test_build_bumped_for_rebake():
     # web reader arrive under a provisional "web:" anchor; the plugin locates the
     # text natively, creates a first-class KOReader highlight, and the sync push
     # (adopted_from) retires the provisional server-side.
-    assert TOMESYNC_PLUGIN_BUILD >= 25
-    assert TOMESYNC_PLUGIN_SEMVER == "1.7.0"
+    # 1.7.1 / build 26 makes the reading-history backfill memory-bounded:
+    # keyset-windowed reads over (start_time, rowid) instead of loading every
+    # page-stat row since the watermark at once, and each upload chunk carries
+    # only the books it references. Verified against a 34k-row device DB.
+    assert TOMESYNC_PLUGIN_BUILD >= 26
+    assert TOMESYNC_PLUGIN_SEMVER == "1.7.1"

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -167,5 +167,10 @@ def test_build_bumped_for_rebake():
     # file's KOReader partial-MD5 with resolve calls; the server matches it
     # against ko_hashes (recorded at scan/serve time) before any filename
     # heuristics — renamed/moved device files resolve exactly.
-    assert TOMESYNC_PLUGIN_BUILD >= 27
-    assert TOMESYNC_PLUGIN_SEMVER == "1.7.2"
+    # 1.7.3 / build 28 verifies foreign highlights before painting them: the
+    # anchor must reproduce its highlighted text on this copy; mismatches are
+    # repaired by text search (rendered locally, server identity kept via
+    # repair_map — no cross-device anchor ping-pong); unlocatable text is
+    # skipped rather than painted on the wrong words.
+    assert TOMESYNC_PLUGIN_BUILD >= 28
+    assert TOMESYNC_PLUGIN_SEMVER == "1.7.3"

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -163,5 +163,9 @@ def test_build_bumped_for_rebake():
     # keyset-windowed reads over (start_time, rowid) instead of loading every
     # page-stat row since the watermark at once, and each upload chunk carries
     # only the books it references. Verified against a 34k-row device DB.
-    assert TOMESYNC_PLUGIN_BUILD >= 26
-    assert TOMESYNC_PLUGIN_SEMVER == "1.7.1"
+    # 1.7.2 / build 27 adds deterministic book identity: the plugin sends the
+    # file's KOReader partial-MD5 with resolve calls; the server matches it
+    # against ko_hashes (recorded at scan/serve time) before any filename
+    # heuristics — renamed/moved device files resolve exactly.
+    assert TOMESYNC_PLUGIN_BUILD >= 27
+    assert TOMESYNC_PLUGIN_SEMVER == "1.7.2"

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -172,5 +172,13 @@ def test_build_bumped_for_rebake():
     # repaired by text search (rendered locally, server identity kept via
     # repair_map — no cross-device anchor ping-pong); unlocatable text is
     # skipped rather than painted on the wrong words.
-    assert TOMESYNC_PLUGIN_BUILD >= 28
-    assert TOMESYNC_PLUGIN_SEMVER == "1.7.3"
+    # 1.7.4 / build 29 is the UX batch: bounded socketutil timeouts on every
+    # request (no more global http.TIMEOUT mutation; a dead server stalls the
+    # UI seconds, not a minute), failed fetches/downloads offer Retry,
+    # downloads show live byte/percent progress, a single fresh download
+    # offers "Open now?", volume rows are marked "· on device", and the
+    # position heartbeat is idle-debounced off the page-turn path. (A Trapper
+    # subprocess variant for fetches was built and dropped: forked sockets
+    # from plugin context proved unverifiable on the emulator.)
+    assert TOMESYNC_PLUGIN_BUILD >= 29
+    assert TOMESYNC_PLUGIN_SEMVER == "1.7.4"

--- a/tests/test_tomesync_stats_window.py
+++ b/tests/test_tomesync_stats_window.py
@@ -107,3 +107,14 @@ def test_foreign_highlights_are_verified_before_painting(impl):
     assert "New highlight from another device: reconstruct so it renders." not in impl
     # pushes translate repaired items back to the server identity
     assert "it.anchor = anchor" in impl
+
+
+def test_baseline_bound_to_sidecar_instance(impl):
+    """Re-downloading a book must not tombstone its highlights: the annotation
+    baseline only diffs against a sidecar it has seen before (marker
+    tomesync_annot_bound); a fresh sidecar resets the baseline instead of
+    treating its emptiness as user deletions."""
+    assert "tomesync_annot_bound" in impl
+    i_guard = impl.index('readSetting("tomesync_annot_bound")')
+    i_deletes = impl.index("table.insert(deletes,")
+    assert i_guard < i_deletes, "guard must run before the delete diff"

--- a/tests/test_tomesync_stats_window.py
+++ b/tests/test_tomesync_stats_window.py
@@ -1,0 +1,95 @@
+"""The plugin's reading-history backfill must stay memory-bounded.
+
+The original implementation materialised every ``page_stat_data`` row since the
+watermark into one Lua table (tens of thousands of rows on a real device) and
+resent the full ``books`` array with every chunk. These tests pin the windowed
+replacement: keyset pagination over (start_time, rowid), short-lived read-only
+connections per window, and per-chunk book subsetting. The server import is
+idempotent (INSERT OR IGNORE on the identity key), which is what makes the
+watermark-boundary refetch safe — that contract is asserted here too.
+"""
+import shutil
+import subprocess
+import tempfile
+
+import pytest
+
+from backend.api.tome_sync import TOMESYNC_PLUGIN_BUILD, _main_impl_lua
+
+
+@pytest.fixture(scope="module")
+def impl() -> str:
+    return _main_impl_lua("http://localhost:8080", "tk_test", "tester")
+
+
+def test_backfill_reads_in_keyset_windows(impl):
+    """Page rows are fetched LIMIT-windowed with a (start_time, rowid) cursor —
+    never all at once."""
+    assert "start_time > %d OR (start_time = %d AND rowid > %d)" in impl
+    assert "ORDER BY start_time, rowid LIMIT" in impl
+    # the old slurp query must be gone
+    assert '.. "WHERE start_time >= " .. since .. " ORDER BY start_time")' not in impl
+
+
+def test_backfill_counts_instead_of_materialising(impl):
+    """The progress total comes from COUNT(*), not from the length of an
+    all-rows table."""
+    assert "SELECT COUNT(*) FROM page_stat_data WHERE start_time >= " in impl
+
+
+def test_backfill_sends_only_referenced_books(impl):
+    """Each chunk carries only the book rows its ko_ids reference."""
+    assert "chunk_books" in impl
+    assert "books_by_id[r.ko_id]" in impl
+    # the old full-table resend shipped the same `books` variable every chunk
+    assert "device = dev, books = books," not in impl
+
+
+def test_backfill_cursor_advances_only_on_server_ack(impl):
+    """The keyset cursor moves only after a successful import response, so an
+    interrupted run resumes from the server watermark."""
+    i_resp = impl.index('local resp = apiRequest("POST", "/tome-sync/stats/import"')
+    i_guard = impl.index('if type(resp) ~= "table" then', i_resp)
+    i_advance = impl.index("cur_start, cur_rowid = last.start_time, last.rowid")
+    assert i_resp < i_guard < i_advance
+
+
+def test_server_import_is_idempotent_for_boundary_refetch(db, admin_user, make_book):
+    """Rows re-sent across the watermark boundary must be no-ops — the plugin
+    relies on this to start each run at (watermark, rowid -1)."""
+    from backend.services.ko_stats_import import import_batch
+
+    admin_user, _token = admin_user
+    make_book(title="Window Test Book", author="A. Author")
+
+    books = [{"ko_id": 1, "md5": "f" * 32, "title": "Window Test Book",
+              "authors": "A. Author", "pages": 100, "total_read_pages": 10}]
+    rows = [{"ko_id": 1, "page": p, "start_time": 1_700_000_000 + p, "duration": 30,
+             "total_pages": 100} for p in range(1, 6)]
+
+    first = import_batch(db, admin_user, device="testdev", books=books, page_stats=rows)
+    assert first["page_rows_imported"] == 5
+
+    # same rows again — the boundary-second refetch case
+    second = import_batch(db, admin_user, device="testdev", books=books, page_stats=rows)
+    assert second["page_rows_imported"] == 0
+    assert second["page_rows_skipped"] == 5
+    assert second["watermark"] == first["watermark"]
+
+
+def test_plugin_build_bumped():
+    assert TOMESYNC_PLUGIN_BUILD >= 26
+
+
+def test_impl_still_compiles_under_luajit(impl):
+    checker = shutil.which("luajit") or shutil.which("luac5.1")
+    if not checker:
+        pytest.skip("no LuaJIT/luac5.1 available to syntax-check")
+    with tempfile.NamedTemporaryFile("w", suffix=".lua", delete=False) as f:
+        f.write(impl)
+        path = f.name
+    if "luajit" in checker:
+        res = subprocess.run([checker, "-bl", path], capture_output=True, text=True)
+    else:
+        res = subprocess.run([checker, "-p", path], capture_output=True, text=True)
+    assert res.returncode == 0, res.stderr[:2000]

--- a/tests/test_tomesync_stats_window.py
+++ b/tests/test_tomesync_stats_window.py
@@ -93,3 +93,17 @@ def test_impl_still_compiles_under_luajit(impl):
     else:
         res = subprocess.run([checker, "-p", path], capture_output=True, text=True)
     assert res.returncode == 0, res.stderr[:2000]
+
+
+def test_foreign_highlights_are_verified_before_painting(impl):
+    """Build 28: incoming cross-device highlights verify their text via
+    getTextFromXPointers, repair via _locateText, and keep server identity in
+    repair_map — never painted on the wrong words, never re-anchored server-side."""
+    assert "function TomeSync:_applyForeign" in impl
+    assert "getTextFromXPointers" in impl
+    assert "function TomeSync:_locateText" in impl
+    assert "tomesync_repair_map" in impl
+    # the old blind reconstruct (draw whatever the anchor resolves to) is gone
+    assert "New highlight from another device: reconstruct so it renders." not in impl
+    # pushes translate repaired items back to the server identity
+    assert "it.anchor = anchor" in impl

--- a/tests/test_tomesync_stats_window.py
+++ b/tests/test_tomesync_stats_window.py
@@ -107,3 +107,21 @@ def test_foreign_highlights_are_verified_before_painting(impl):
     assert "New highlight from another device: reconstruct so it renders." not in impl
     # pushes translate repaired items back to the server identity
     assert "it.anchor = anchor" in impl
+
+
+def test_ux_batch_mechanics_present(impl):
+    """Build 29: bounded socketutil timeouts, byte-progress sink, retry
+    dialogs, open-now, on-device markers, idle-debounced heartbeat.
+    (A Trapper-subprocess variant was tried and dropped: forked sockets from
+    plugin context proved unverifiable on the emulator.)"""
+    assert "socketutil:set_timeout" in impl
+    assert "http.TIMEOUT =" not in impl        # no global timeout mutation left
+    assert impl.count("ok_text = \"Retry") >= 2
+    assert "· on device" in impl
+    assert "Open \\" in impl or "now?" in impl
+    # heartbeat: armed + rescheduled, fired via _heartbeatNow off the turn path
+    assert "function TomeSync:_heartbeatNow" in impl
+    assert "_heartbeat_armed" in impl
+    # progress sink buckets: 5% steps when size known, 256KB otherwise
+    assert "received * 20 / total_size" in impl
+    assert "262144" in impl


### PR DESCRIPTION
Tier-2 UX batch from the BookOrbit teardown — **stacked on #111** (which stacks on #110 → #109).

- **Byte-level download progress** (5% / 256 KB repaint buckets) — big CBZs no longer download mute.
- **Retry dialogs** for failed list-loads and downloads (failed books re-queued).
- **"Open now?"** after a single fresh download.
- **"· on device" markers** in the volume list.
- **Idle-debounced heartbeat** — the position push fires 10s after the last page turn, never on the turn path.
- **socketutil timeouts everywhere** (request 5s/10s, downloads 15s/900s, update 10s/60s) replacing the global `http.TIMEOUT` mutation — a dead server stalls seconds, not a minute.

Deliberately NOT adopted: BookOrbit's cover-mosaic catalog (their identity, not ours) and — after building it — the Trapper dismissable-subprocess fetch: forked sockets from plugin context silently returned nothing on the emulator, so it was unverifiable; the timeouts + retry dialogs deliver the practical win. Recorded in the build ledger so it isn't blindly re-attempted.

Emulator run-through on a prod-shaped library verified the browser, markers, filed download, and the Open-now dialog (which caught a real runtime-only escaping bug the luajit syntax check cannot catch). Plugin build 29 / 1.7.4. 731 tests green.