### PR TITLE
UI polish: home hierarchy, dark contrast, sidebar, loading states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Changed
+- **Dark themes got a contrast pass.** Hairline borders were sitting at an
+  alpha where most panels had none to speak of; they're a step stronger now
+  across Dark, Ember and Black, secondary text is brighter, and the rosewood
+  accent carries a little more color so buttons and progress bars don't read
+  grey-brown. Light and Amber are untouched.
+- **The Home dashboard has one primary surface now.** The quick-stats strip
+  lost its box (the figures sit on the page), the right rail became a quiet
+  tinted panel, and the content column is the single bordered, elevated card —
+  before, all three wore identical chrome and nothing led the page.
+- **Rating stars stepped back into the palette.** The gold is a notch quieter
+  in every theme — a shelf of five-star rows was the loudest color on the page.
+- **Top bar: quieter search, louder Upload.** The search box no longer wears a
+  fill and a border at rest (it sharpens on focus instead), and Upload — the
+  bar's one real action — is now a solid accent button rather than another
+  neutral chip.
+- **The sidebar recedes like the rail.** It takes the same quiet tint as the
+  Home right rail, framing the content column instead of sharing its
+  background, and empty libraries no longer show a ghost "0" count.
+- **The Home Reading Log now reads like a log, not a ticker tape.** Back-to-back
+  sessions of the same book collapse into one row ("3 sessions · 1h 08m"),
+  entries group under day headers (Today / Yesterday / date), each row shows
+  the session's clock time instead of repeating "yesterday" down the column,
+  and rows link to the book.
+- **Less badge noise on Home.** The format badge (EPUB/CBZ) no longer stamps
+  every cover in Continue Reading / Recently Finished / Recently Added — on a
+  one-format shelf it said nothing ten times over. Library grids keep it,
+  since that's where formats actually differ.
+- **Focus mode loads into a skeleton of itself** — a cover-and-text placeholder
+  in the hero's real layout — instead of flashing a bare centered "Loading…"
+  and teleporting the page in afterwards.
+- **Reading DNA bars no longer masquerade as sliders.** The round thumb-on-track
+  marker (which begged to be dragged) is gone; each trait now renders as a
+  center-origin gauge filling toward the pole you lean to.
+- **The top-bar sync chip identifies itself.** The anonymous colored dot next
+  to "12h ago" is now a sync icon, tinted by how fresh the last KOReader sync
+  is (green = minutes ago, amber = recent, grey = stale).
+- **Grouped library counts say "titles" instead of "entries"** — with Group
+  series on, "31 entries" read like a book count and never matched one; a
+  series stack plus standalones are 31 titles.
+
 ### Added
 - **The KOReader series browser got a quality pass** (plugin build 29). Big
   downloads show live progress (percent of file size) instead of sitting mute;
@@ -94,6 +135,10 @@ All notable changes to Tome are documented here. Format loosely follows
   Small "i" hints explain the progress and reading-intensity charts in plain language.
 
 ### Fixed
+- **Sidebar Libraries/Shelves no longer flicker when switching pages.** Every
+  page (Home, Stats, Highlights, Wishlist, Bindery) refetched the lists from
+  scratch on navigation, blanking the sections for a beat. The lists are now
+  cached across page mounts and refreshed silently in the background.
 - **Re-downloading a book no longer deletes its synced highlights.** A fresh
   copy of a book starts with an empty annotation sidecar; the sync used to read
   that as "the user deleted every highlight" and pushed the deletions to the

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -41,7 +41,9 @@ export function AppHeader({ onMenuClick, search, actions, onUploadClick }: {
           {onUploadClick && isMember(user) && (
             <button
               onClick={onUploadClick}
-              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card hover:bg-muted transition-all touch-feedback"
+              // The bar's one real action — solid accent so it anchors the right
+              // cluster instead of blending into the neutral chips around it.
+              className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold bg-primary text-primary-foreground hover:bg-primary/90 transition-all touch-feedback"
             >
               <Upload className="w-3.5 h-3.5" />
               <span className="hidden sm:inline">Upload</span>
@@ -71,7 +73,9 @@ export function HeaderSearch({ value, onChange, onClear, onSubmit, inputRef, pla
         aria-label="Search books"
         // On phones the box can shrink to a sliver (page actions squeeze it) and
         // the placeholder clips mid-letter — hide it there; the icon says enough.
-        className="w-full h-8 pl-9 pr-8 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground max-sm:placeholder:text-transparent focus:outline-none focus:ring-1 focus:ring-ring"
+        // Rests quiet (tinted fill, no border), sharpens on focus — filled AND
+        // bordered at rest made it the heaviest element in the whole bar.
+        className="w-full h-8 pl-9 pr-8 rounded-lg bg-muted/60 border border-transparent text-sm placeholder:text-muted-foreground max-sm:placeholder:text-transparent transition-colors hover:bg-muted focus:bg-card focus:border-border focus:outline-none focus:ring-1 focus:ring-ring"
         placeholder={placeholder}
         value={value}
         onChange={e => onChange(e.target.value)}

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -2,8 +2,7 @@ import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
-import { api } from '@/lib/api'
-import type { Library, SavedFilter } from '@/lib/books'
+import { useSidebarLists } from '@/lib/sidebarLists'
 import { Sidebar } from '@/components/Sidebar'
 import { AppHeader, HeaderSearch } from '@/components/AppHeader'
 import { UploadModal } from '@/components/UploadModal'
@@ -32,8 +31,7 @@ export function AppShell({
   const navigate = useNavigate()
   const { user } = useAuth()
   const { toast } = useToast()
-  const [libraries, setLibraries] = useState<Library[]>([])
-  const [savedFilters, setSavedFilters] = useState<SavedFilter[]>([])
+  const { libraries, savedFilters, loadLibraries, loadSavedFilters } = useSidebarLists(user?.id)
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [uploadOpen, setUploadOpen] = useState(false)
   const [searchInput, setSearchInput] = useState('')
@@ -61,8 +59,8 @@ export function AppShell({
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [])
 
-  const loadLibraries = () => { api.get<Library[]>('/libraries').then(setLibraries).catch(() => {}) }
-  const loadSavedFilters = () => { api.get<SavedFilter[]>('/saved-filters').then(setSavedFilters).catch(() => {}) }
+  // Cached across page mounts (see useSidebarLists) — this refetch only
+  // freshens the lists in the background, it never blanks them.
   useEffect(() => { loadLibraries(); loadSavedFilters() }, [])
 
   return (

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -34,6 +34,9 @@ interface BookCardProps {
   index?: number
   // Set as data-flip-id on the root so a parent grid can FLIP-animate reflows
   flipId?: string
+  // Home rows are usually all one format — the badge is noise there, so those
+  // callers turn it off. Library grids keep it (that's where formats differ).
+  showFormatBadge?: boolean
 }
 
 /** Compact read-only star rating for cards. Renders nothing when unrated. */
@@ -55,7 +58,7 @@ function RatingStars({ rating, size = 11 }: { rating?: number | null; size?: num
 export function BookCard({
   book, view, selected, focused, onSelect,
   onTagClick: _onTagClick, onSeriesClick, onAuthorClick,
-  readingStatus, progressPct, rating, flipId,
+  readingStatus, progressPct, rating, flipId, showFormatBadge = true,
 }: BookCardProps) {
   const navigate = useNavigate()
   const bookTypes = useBookTypes()
@@ -165,7 +168,7 @@ export function BookCard({
             <RatingStars rating={rating} size={12} />
           </div>
         ) : null}
-        {book.files.length > 0 && (
+        {showFormatBadge && book.files.length > 0 && (
           <span className="shrink-0 text-[10px] font-medium uppercase px-1.5 py-0.5 rounded bg-muted border border-border text-muted-foreground">
             {book.files[0].format}
           </span>
@@ -254,7 +257,7 @@ export function BookCard({
         )}
 
         {/* Format badge — top right */}
-        {book.files.length > 0 && (
+        {showFormatBadge && book.files.length > 0 && (
           <span className="absolute top-1.5 right-1.5 px-1.5 py-0.5 rounded text-[9px] font-semibold uppercase bg-background/70 backdrop-blur-sm text-foreground/90 border border-border/50">
             {book.files[0].format}
           </span>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -291,7 +291,9 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
         />
       )}
       <aside className={cn(
-        'hidden md:flex shrink-0 flex-col border-r border-border bg-card/30 transition-all duration-200',
+        // Same recede tint as the Home rail — the content column is the page's
+        // one elevated surface, and the nav frames it instead of competing.
+        'hidden md:flex shrink-0 flex-col border-r border-border bg-muted/40 transition-all duration-200',
         open ? 'w-52' : 'w-10'
       )}>
         {!open && (
@@ -1086,11 +1088,11 @@ function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdi
           <Lock className="w-3 h-3 text-muted-foreground/50" />
         </span>
       )}
-      {count != null && !isPrivate && (
-        <span className={cn(
-          'text-[10px] shrink-0 group-hover:hidden group-focus-within:hidden',
-          count === 0 ? 'text-muted-foreground/40' : 'text-muted-foreground'
-        )}>{count}</span>
+      {/* A ghost "0" on an empty library was pure noise — no count reads cleaner. */}
+      {count != null && count > 0 && !isPrivate && (
+        <span className="text-[10px] shrink-0 text-muted-foreground group-hover:hidden group-focus-within:hidden">
+          {count}
+        </span>
       )}
       <div className="hidden group-hover:flex group-focus-within:flex items-center gap-0.5 shrink-0">
         {onEdit && (

--- a/frontend/src/components/SyncStatusBadge.tsx
+++ b/frontend/src/components/SyncStatusBadge.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { RefreshCw } from 'lucide-react'
 import { useKosyncStatus } from '@/hooks/useKosyncStatus'
 import { cn } from '@/lib/utils'
 
@@ -21,10 +22,12 @@ function formatRelative(iso: string | null): string {
   return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }
 
-function dotColor(diff: number): string {
-  if (diff < FRESH_MS) return 'bg-success'
-  if (diff < RECENT_MS) return 'bg-warning'
-  return 'bg-muted-foreground/40'
+// Freshness tints the sync glyph itself — a bare colored dot next to "12h ago"
+// never said what the chip was about.
+function iconColor(diff: number): string {
+  if (diff < FRESH_MS) return 'text-success'
+  if (diff < RECENT_MS) return 'text-warning'
+  return 'text-muted-foreground/60'
 }
 
 export function SyncStatusBadge() {
@@ -52,7 +55,7 @@ export function SyncStatusBadge() {
       className="inline-flex items-center gap-1.5 h-7 px-1.5 sm:px-2 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-default select-none"
       aria-label={`KOReader sync: ${label}. ${tooltip}`}
     >
-      <span className={cn('w-2 h-2 sm:w-1.5 sm:h-1.5 rounded-full', dotColor(diff))} />
+      <RefreshCw className={cn('w-3.5 h-3.5 sm:w-3 sm:h-3', iconColor(diff))} />
       <span className="font-medium tabular-nums hidden sm:inline">{label}</span>
     </div>
   )

--- a/frontend/src/components/home/FocusMode.tsx
+++ b/frontend/src/components/home/FocusMode.tsx
@@ -288,7 +288,31 @@ export function FocusMode() {
   }
 
   if (!data) {
-    return <div className="flex items-center justify-center py-40 text-muted-foreground text-sm">Loading…</div>
+    // Skeleton mirrors the hero composition (cover left, meta right) so the
+    // real content lands in place instead of replacing a centered text flash.
+    return (
+      <div className="flex flex-col lg:min-h-[calc(100vh-160px)]">
+        <div className="flex-1 flex items-start lg:items-center w-full">
+          <div className="flex flex-col gap-8 lg:flex-row lg:items-center lg:justify-center lg:gap-14 w-full max-w-[1080px] mx-auto animate-pulse">
+            <div className="w-full lg:w-auto lg:shrink-0 flex justify-center lg:justify-start">
+              <div className="rounded-xl bg-muted" style={{ width: SOLO_W, height: SOLO_H }} />
+            </div>
+            <div className="flex-1 min-w-0 max-w-[520px] w-full">
+              <div className="h-3 w-36 rounded bg-muted" />
+              <div className="mt-4 h-9 w-3/4 rounded-lg bg-muted" />
+              <div className="mt-3 h-4 w-40 rounded bg-muted" />
+              <div className="mt-6 space-y-2.5">
+                <div className="h-3.5 w-full rounded bg-muted" />
+                <div className="h-3.5 w-full rounded bg-muted" />
+                <div className="h-3.5 w-2/3 rounded bg-muted" />
+              </div>
+              <div className="mt-7 h-[7px] w-full rounded-full bg-muted" />
+              <div className="mt-7 h-12 w-44 rounded-xl bg-muted" />
+            </div>
+          </div>
+        </div>
+      </div>
+    )
   }
 
   if (!data.ready || !data.book) {

--- a/frontend/src/components/stats/ReadingDNACard.tsx
+++ b/frontend/src/components/stats/ReadingDNACard.tsx
@@ -5,10 +5,14 @@ import type { ReadingDNA, ReadingDNATrait } from './shared'
 
 const COLLAPSE_KEY = 'tome_dna_collapsed'
 
-/** A pole-to-pole spectrum bar with the reader's position marked. */
+/** A pole-to-pole spectrum bar with the reader's position marked. Rendered as a
+ *  center-origin gauge — no thumb — because the round dot on a track read as a
+ *  draggable slider and invited pointless dragging on a read-only stat. */
 function TraitBar({ trait }: { trait: ReadingDNATrait }) {
   const s = Math.max(0, Math.min(100, trait.score))
   const high = s >= 50
+  // A dead-center score still shows a small nub so the bar never looks empty.
+  const fill = Math.max(Math.abs(s - 50), 2.5)
   return (
     <div>
       <div className="flex items-center justify-between text-[11px] mb-1.5">
@@ -18,13 +22,8 @@ function TraitBar({ trait }: { trait: ReadingDNATrait }) {
       <div className="relative h-1.5 rounded-full bg-muted">
         <span className="absolute top-[-2px] bottom-[-2px] w-px bg-border left-1/2" />
         <span
-          className="absolute top-0 bottom-0 rounded-full bg-primary/45"
-          style={{ left: `${Math.min(s, 50)}%`, width: `${Math.abs(s - 50)}%` }}
-        />
-        <span
-          className="absolute top-1/2 w-3 h-3 rounded-full bg-primary border-2 border-card shadow-[0_0_0_1px_var(--border)] -translate-x-1/2 -translate-y-1/2"
-          // Clamp the marker inside the track — at 0/100 the dot half-clipped.
-          style={{ left: `${Math.min(Math.max(s, 3), 97)}%` }}
+          className="absolute top-0 bottom-0 rounded-full bg-primary"
+          style={high ? { left: '50%', width: `${fill}%` } : { right: '50%', width: `${fill}%` }}
         />
       </div>
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -56,10 +56,11 @@
   --success: oklch(0.52 0.10 155);
   --info: oklch(0.50 0.09 245);
   --warning: oklch(0.58 0.12 70);
-  /* Rating gold — muted (chroma ~0.13, same register as the rest of the palette),
-     hue 78 sits warmer than --warning (70) so it reads distinct from "Reading".
-     Light needs a deeper gold to hold contrast on near-white paper. */
-  --rating: oklch(0.64 0.13 78);
+  /* Rating gold — muted (chroma ~0.11, same register as the rest of the palette),
+     hue 76 sits warmer than --warning (70) so it reads distinct from "Reading".
+     Light needs a deeper gold to hold contrast on near-white paper. Kept a notch
+     under the old 0.13 — a five-star grid row was the loudest color on the page. */
+  --rating: oklch(0.62 0.11 76);
   --border: oklch(0.90 0.005 85);
   --input: oklch(0.88 0.005 85);
   --ring: oklch(0.45 0.115 18);
@@ -77,12 +78,12 @@
   --card-foreground: oklch(0.955 0.004 80);
   --popover: oklch(0.21 0.005 60);
   --popover-foreground: oklch(0.955 0.004 80);
-  --primary: oklch(0.63 0.10 22);
+  --primary: oklch(0.64 0.12 22);
   --primary-foreground: oklch(0.98 0.005 18);
   --secondary: oklch(0.265 0.005 60);
   --secondary-foreground: oklch(0.955 0.004 80);
   --muted: oklch(0.265 0.005 60);
-  --muted-foreground: oklch(0.71 0.008 70);
+  --muted-foreground: oklch(0.74 0.008 70);
   --accent: oklch(0.265 0.005 60);
   --accent-foreground: oklch(0.955 0.004 80);
   --destructive: oklch(0.70 0.19 28);
@@ -91,12 +92,15 @@
   --warning: oklch(0.78 0.11 75);
   /* Lighter on dark surfaces so the muted gold still reads (cf. the value
      tuned live on dark). Inherited by Ember + Black, which only override surfaces. */
-  --rating: oklch(0.72 0.12 80);
-  --border: oklch(0.95 0.008 60 / 11%);
-  --input: oklch(0.95 0.008 60 / 15%);
-  --ring: oklch(0.63 0.10 22);
-  --chart-accent: oklch(0.63 0.10 22);
-  --accent-soft: oklch(0.63 0.10 22 / 0.16);
+  --rating: oklch(0.71 0.10 79);
+  /* Border/input alpha and muted-foreground sit a step higher than light-theme
+     instinct suggests — at 11% the hairlines vanished on most panels and dark
+     read flat. 16% is still a hairline, it just survives being on a 0.21 card. */
+  --border: oklch(0.95 0.008 60 / 16%);
+  --input: oklch(0.95 0.008 60 / 20%);
+  --ring: oklch(0.64 0.12 22);
+  --chart-accent: oklch(0.64 0.12 22);
+  --accent-soft: oklch(0.64 0.12 22 / 0.16);
 }
 
 /* Ember — the warm cappuccino dark: espresso surfaces, same rosewood accent.
@@ -108,9 +112,9 @@
   --secondary: oklch(0.28 0.015 60);
   --muted: oklch(0.28 0.015 60);
   --accent: oklch(0.28 0.015 60);
-  --muted-foreground: oklch(0.71 0.015 70);
-  --border: oklch(0.95 0.015 60 / 11%);
-  --input: oklch(0.95 0.015 60 / 15%);
+  --muted-foreground: oklch(0.74 0.015 70);
+  --border: oklch(0.95 0.015 60 / 16%);
+  --input: oklch(0.95 0.015 60 / 20%);
 }
 
 /* Black — true-black OLED theme, same wine identity.
@@ -122,12 +126,12 @@
   --secondary: oklch(0.20 0.004 60);
   --muted: oklch(0.20 0.004 60);
   --accent: oklch(0.20 0.004 60);
-  --primary: oklch(0.66 0.10 22);
-  --ring: oklch(0.66 0.10 22);
-  --chart-accent: oklch(0.66 0.10 22);
-  --accent-soft: oklch(0.66 0.10 22 / 0.18);
-  --border: oklch(1 0 0 / 13%);
-  --input: oklch(1 0 0 / 17%);
+  --primary: oklch(0.67 0.12 22);
+  --ring: oklch(0.67 0.12 22);
+  --chart-accent: oklch(0.67 0.12 22);
+  --accent-soft: oklch(0.67 0.12 22 / 0.18);
+  --border: oklch(1 0 0 / 17%);
+  --input: oklch(1 0 0 / 21%);
 }
 
 /* Amber (warm parchment) theme */
@@ -151,7 +155,7 @@
   --info: oklch(0.50 0.085 245);
   --warning: oklch(0.56 0.13 65);
   /* Warm parchment runs warmer overall; deepen the gold a touch to hold contrast. */
-  --rating: oklch(0.61 0.13 74);
+  --rating: oklch(0.60 0.115 74);
   --border: oklch(0.89 0.012 70);
   --input: oklch(0.87 0.013 70);
   --ring: oklch(0.50 0.155 52);

--- a/frontend/src/lib/sidebarLists.ts
+++ b/frontend/src/lib/sidebarLists.ts
@@ -1,0 +1,45 @@
+import { useState } from 'react'
+import { api } from '@/lib/api'
+import type { Library, SavedFilter } from '@/lib/books'
+
+/**
+ * Libraries + Shelves for the sidebar, with a module-level cache of the last
+ * fetch. Every page mounts its own shell (Dashboard, Stats, Highlights,
+ * Wishlist, Bindery), so without the cache each navigation rendered the
+ * sidebar with empty sections for a beat and the lists flickered in. Seeding
+ * from the cache paints the previous lists instantly; the mount-time refetch
+ * then updates them silently.
+ *
+ * Keyed by user id — admin impersonation and re-login must not flash the
+ * previous user's libraries into the next user's first paint.
+ */
+let cache: { userId: number | null; libraries: Library[]; savedFilters: SavedFilter[] } = {
+  userId: null,
+  libraries: [],
+  savedFilters: [],
+}
+
+export function useSidebarLists(userId: number | null | undefined) {
+  const uid = userId ?? null
+  const seeded = cache.userId === uid
+  const [libraries, setLibraries] = useState<Library[]>(seeded ? cache.libraries : [])
+  const [savedFilters, setSavedFilters] = useState<SavedFilter[]>(seeded ? cache.savedFilters : [])
+
+  const remember = (patch: Partial<Pick<typeof cache, 'libraries' | 'savedFilters'>>) => {
+    if (cache.userId !== uid) cache = { userId: uid, libraries: [], savedFilters: [] }
+    Object.assign(cache, patch)
+  }
+
+  const loadLibraries = () => {
+    api.get<Library[]>('/libraries')
+      .then(d => { remember({ libraries: d }); setLibraries(d) })
+      .catch(() => {})
+  }
+  const loadSavedFilters = () => {
+    api.get<SavedFilter[]>('/saved-filters')
+      .then(d => { remember({ savedFilters: d }); setSavedFilters(d) })
+      .catch(() => {})
+  }
+
+  return { libraries, savedFilters, loadLibraries, loadSavedFilters }
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, useCallback, type ReactNode } from 'react'
-import { useSearchParams, useNavigate } from 'react-router-dom'
+import { Link, useSearchParams, useNavigate } from 'react-router-dom'
 import {
   BookOpen, X, Home, ChevronRight,
   LayoutGrid, List,
@@ -10,6 +10,7 @@ import {
 import { AppHeader, HeaderSearch } from '@/components/AppHeader'
 import { useAuth, isMember, isAdmin } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
+import { useSidebarLists } from '@/lib/sidebarLists'
 import { BookCard, type ViewMode } from '@/components/BookCard'
 import { SeriesStackCard } from '@/components/SeriesStackCard'
 import { SeriesRating } from '@/components/SeriesRating'
@@ -28,7 +29,7 @@ import { ReadingDNACard } from '@/components/stats/ReadingDNACard'
 import type { ReadingDNA } from '@/components/stats/shared'
 import { FocusMode } from '@/components/home/FocusMode'
 import { api } from '@/lib/api'
-import type { Book, Library, SavedFilter, ReadingStatus, Arc, SeriesMeta, SeriesStatus } from '@/lib/books'
+import type { Book, ReadingStatus, Arc, SeriesMeta, SeriesStatus } from '@/lib/books'
 import { formatBytes } from '@/lib/books'
 import { useBookTypes } from '@/lib/bookTypes'
 import { useShiftSelect } from '@/lib/useShiftSelect'
@@ -246,17 +247,6 @@ function formatReadingTime(seconds: number): string {
   if (h === 0) return `${m}m`
   if (m === 0) return `${h}h`
   return `${h}h ${m}m`
-}
-
-function relativeTime(isoString: string): string {
-  const now = Date.now()
-  const then = new Date(isoString).getTime()
-  const diff = Math.floor((now - then) / 1000)
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
-  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
-  if (diff < 172800) return 'yesterday'
-  return `${Math.floor(diff / 86400)}d ago`
 }
 
 export function DashboardPage() {
@@ -645,10 +635,9 @@ export function DashboardPage() {
   }
 
   // ── Sidebar data ──────────────────────────────────────────────────────────
-  const [libraries, setLibraries] = useState<Library[]>([])
-  const [savedFilters, setSavedFilters] = useState<SavedFilter[]>([])
-  function loadLibraries() { api.get<Library[]>('/libraries').then(setLibraries).catch(() => {}) }
-  function loadSavedFilters() { api.get<SavedFilter[]>('/saved-filters').then(setSavedFilters).catch(() => {}) }
+  const { libraries, savedFilters, loadLibraries, loadSavedFilters } = useSidebarLists(user?.id)
+  // Cached across page mounts (see useSidebarLists) — this refetch only
+  // freshens the lists in the background, it never blanks them.
   useEffect(() => { loadLibraries(); loadSavedFilters() }, [])
 
   // ── Books + facets ────────────────────────────────────────────────────────
@@ -1107,8 +1096,11 @@ export function DashboardPage() {
               {/* ── Quick stats + mode toggle on one row ──────────────────── */}
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:flex-wrap">
                 <div className="flex flex-wrap items-stretch gap-3 empty:hidden w-full sm:w-auto">
+                  {/* Chromeless — the figures sit on the page itself. Boxing them
+                      gave the strip the same weight as the content panel below,
+                      and the dashboard read as four equal crates. */}
                   {homeStats && (
-                    <div className="rounded-xl border border-border bg-card px-5 py-4 grid grid-cols-2 gap-x-4 gap-y-3 sm:gap-x-0 sm:flex w-full sm:w-fit">
+                    <div className="px-1 py-1 grid grid-cols-2 gap-x-4 gap-y-3 sm:gap-x-0 sm:flex w-full sm:w-fit">
                       {homeStatItems.map((s, i) => (
                         <div
                           key={s.label}
@@ -1133,8 +1125,10 @@ export function DashboardPage() {
 
               {/* ── Two-column body: content + rail ───────────────────────── */}
               <div className="flex flex-col gap-8 lg:grid lg:grid-cols-[minmax(0,1fr)_320px] lg:gap-7 lg:items-start">
-              {/* ── Main column (one connected panel, hairline-divided) ────── */}
-              <div className="rounded-2xl border border-border bg-card divide-y divide-border min-w-0 overflow-hidden">
+              {/* ── Main column (one connected panel, hairline-divided) ──────
+                  The ONE bordered, elevated surface on the page — the rail and
+                  stat strip deliberately carry less chrome so this reads primary. */}
+              <div className="rounded-2xl border border-border bg-card shadow-sm divide-y divide-border min-w-0 overflow-hidden">
 
               {/* ── Forgotten Books ───────────────────────────────────────── */}
               {(() => {
@@ -1216,6 +1210,7 @@ export function DashboardPage() {
                             readingStatus={status?.status}
                             progressPct={status?.progress_pct}
                             rating={status?.rating}
+                            showFormatBadge={false}
                           />
                         </div>
                       )
@@ -1289,6 +1284,7 @@ export function DashboardPage() {
                           selected={false}
                           readingStatus="read"
                           rating={readingStatuses[book.id]?.rating}
+                          showFormatBadge={false}
                         />
                       </div>
                     ))}
@@ -1311,6 +1307,7 @@ export function DashboardPage() {
                           readingStatus={readingStatuses[book.id]?.status}
                           progressPct={readingStatuses[book.id]?.progress_pct}
                           rating={readingStatuses[book.id]?.rating}
+                          showFormatBadge={false}
                         />
                       </div>
                     ))}
@@ -1323,22 +1320,70 @@ export function DashboardPage() {
                 <div className="flex flex-col gap-3 px-5 py-5">
                   <h2 className="text-base font-semibold text-foreground">Reading Log</h2>
                   <div className="flex flex-col gap-1">
-                    {activityLog.map((entry, i) => (
-                      <div key={i} className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-muted/50 transition-colors">
-                        <div className="relative w-8 h-11 rounded overflow-hidden shrink-0 border border-border">
-                          <CoverImage
-                            src={entry.book_cover_path ? `/api/books/${entry.book_id}/cover` : null}
-                            alt={entry.book_title}
-                            iconClassName="w-3.5 h-3.5"
-                          />
+                    {(() => {
+                      // Back-to-back sessions of the same book collapse into one row
+                      // ("3 sessions · 1h 08m") under a day header — five raw
+                      // "Press Start" lines in a row said less than one merged one.
+                      const sameDay = (a: string, b: string) => new Date(a).toDateString() === new Date(b).toDateString()
+                      const dayLabel = (iso: string) => {
+                        const d = new Date(iso)
+                        const today = new Date()
+                        const yesterday = new Date(today)
+                        yesterday.setDate(today.getDate() - 1)
+                        if (d.toDateString() === today.toDateString()) return 'Today'
+                        if (d.toDateString() === yesterday.toDateString()) return 'Yesterday'
+                        return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
+                      }
+                      type LogRow = { entry: ActivityEntry; sessions: number; seconds: number }
+                      const days: { label: string; first: string; rows: LogRow[] }[] = []
+                      for (const entry of activityLog) {
+                        let day = days[days.length - 1]
+                        if (!day || !sameDay(day.first, entry.started_at)) {
+                          day = { label: dayLabel(entry.started_at), first: entry.started_at, rows: [] }
+                          days.push(day)
+                        }
+                        const last = day.rows[day.rows.length - 1]
+                        if (last && last.entry.book_id === entry.book_id) {
+                          last.sessions += 1
+                          last.seconds += entry.duration_seconds
+                        } else {
+                          day.rows.push({ entry, sessions: 1, seconds: entry.duration_seconds })
+                        }
+                      }
+                      return days.map(day => (
+                        <div key={day.first} className="flex flex-col gap-1">
+                          <p className="px-3 pt-2 pb-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                            {day.label}
+                          </p>
+                          {day.rows.map(({ entry, sessions, seconds }) => (
+                            <Link
+                              key={entry.started_at}
+                              to={`/books/${entry.book_id}`}
+                              className="flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-muted/50 transition-colors"
+                            >
+                              <div className="relative w-8 h-11 rounded overflow-hidden shrink-0 border border-border">
+                                <CoverImage
+                                  src={entry.book_cover_path ? `/api/books/${entry.book_id}/cover` : null}
+                                  alt={entry.book_title}
+                                  iconClassName="w-3.5 h-3.5"
+                                />
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <p className="text-xs font-medium text-foreground truncate">{entry.book_title}</p>
+                                <p className="text-[10px] text-muted-foreground">
+                                  {sessions > 1
+                                    ? `${sessions} sessions · ${formatReadingTime(seconds)}`
+                                    : formatReadingTime(seconds)}
+                                </p>
+                              </div>
+                              <span className="text-[10px] text-muted-foreground shrink-0">
+                                {new Date(entry.started_at).toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}
+                              </span>
+                            </Link>
+                          ))}
                         </div>
-                        <div className="min-w-0 flex-1">
-                          <p className="text-xs font-medium text-foreground truncate">{entry.book_title}</p>
-                          <p className="text-[10px] text-muted-foreground">{formatReadingTime(entry.duration_seconds)}</p>
-                        </div>
-                        <span className="text-[10px] text-muted-foreground shrink-0">{relativeTime(entry.started_at)}</span>
-                      </div>
-                    ))}
+                      ))
+                    })()}
                   </div>
                 </div>
               )}
@@ -1349,7 +1394,7 @@ export function DashboardPage() {
                   empty:hidden — every child is conditional (no sessions / no
                   goals / no highlights), and a brand-new user would otherwise
                   see a bare bordered box. */}
-              <aside className="rounded-2xl border border-border bg-card divide-y divide-border overflow-hidden empty:hidden">
+              <aside className="rounded-2xl bg-muted/40 divide-y divide-border/60 overflow-hidden empty:hidden">
                 {readingDna && <ReadingDNACard dna={readingDna} />}
                 <HomeGoalRings />
                 <UpcomingReleases />
@@ -1732,7 +1777,9 @@ export function DashboardPage() {
               {loading
                 ? '…'
                 : (() => {
-                    const noun = (n: number) => groupActive ? (n === 1 ? 'entry' : 'entries') : (n === 1 ? 'book' : 'books')
+                    // Grouped rows are series stacks + standalones — "titles", not the
+                    // ambiguous "entries" (which read like a book count and never matched it).
+                    const noun = (n: number) => groupActive ? (n === 1 ? 'title' : 'titles') : (n === 1 ? 'book' : 'books')
                     return totalCount !== null && totalCount > books.length
                       ? `${books.length} of ${totalCount} ${noun(totalCount)}`
                       : `${books.length} ${noun(books.length)}`


### PR DESCRIPTION
A looks-and-feel batch from reviewing a prod screen recording, verified against the showcase library in light and dark.

## UX polish
- **Reading Log** — consecutive sessions of the same book collapse into one row ("3 sessions · 1h 08m") under day headers (Today / Yesterday / date); rows link to the book and show the session's clock time instead of "yesterday" repeated down the column.
- **Home rows** — format badges (EPUB/CBZ) no longer stamp every cover in Continue Reading / Recently Finished / Recently Added; on a one-format shelf they said nothing ten times over. Library grids keep them via the new `showFormatBadge` prop default.
- **Focus mode** — loads into a skeleton mirroring the hero layout (cover left, meta right) instead of a centered "Loading…" flash.
- **Reading DNA** — traits render as center-origin gauges; the round thumb-on-track read as a draggable slider on a read-only stat.
- **Top-bar sync chip** — the anonymous colored dot next to "12h ago" is now a sync icon tinted by freshness (green / amber / grey).
- **Grouped counts** — "31 entries" → "31 titles" (a series stack + standalones never matched a book count).

## Design pass
- **Home hierarchy** — chromeless stat strip, tinted borderless right rail, and the content column as the page's single bordered, elevated surface. Previously all three wore identical chrome.
- **Dark themes** (Dark / Ember / Black) — hairline borders up from 11% to 16% alpha, brighter muted text, slightly richer rosewood primary. Light and Amber untouched.
- **Rating gold** — one notch quieter in every theme; a shelf of five-star rows was the loudest color on the page.
- **Top bar** — search rests as a quiet tint and sharpens on focus; Upload is a solid accent button, the bar's one real action.
- **Sidebar** — takes the same recede tint as the rail, and empty libraries no longer show a ghost "0" count.

## Fix
- **Sidebar flicker** — Libraries/Shelves blanked for a beat on every navigation between Home, Stats, Highlights, Wishlist and Bindery, because each page's shell refetched from empty state. Lists are now cached across shell mounts in `lib/sidebarLists.ts` (keyed by user id so impersonation/re-login can't leak lists across users) and refreshed silently in the background. Verified by sampling the sidebar 80 ms after navigation across six hops.

Frontend build (`tsc -b` + vite) is clean; changelog updated.