### PR TITLE
Hardcover sync (one-way) + half-star ratings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- **Hardcover sync.** Link your personal Hardcover account in Settings and Tome
+  pushes your ratings and reading progress to it — one-way, opt-in, and nothing
+  is ever deleted on Hardcover. Ratings go out shortly after you change them;
+  progress goes out in batches as print-edition pages (`round(pct × pages)`),
+  and books whose edition has no page count sync status-only. Matching is
+  ISBN-first with a strictly-guarded, volume-aware title+author search
+  fallback that prefers the community's record over catalogue stubs. A
+  dedicated **Hardcover page** (sidebar) shows every synced book with its
+  cover and exact matched record, filterable by state, with per-book
+  actions: pick the right record manually (search modal), re-match, or
+  exclude. Matched books also link to their Hardcover record from the book
+  page's Details grid. Tokens are stored encrypted, and when
+  Hardcover's annual January-1 token reset hits you get a notification to
+  re-link. Server kill switch: `TOME_HARDCOVER_SYNC_ENABLED` (the existing
+  `TOME_HARDCOVER_TOKEN` stays metadata-only).
+- **Half-star ratings.** Book and series ratings now take 4.5-style values —
+  the star widgets select halves by clicking the left or right side of a star.
+  Existing whole-star ratings are untouched. KOReader's native rating stays
+  whole-star: the plugin (build 31) rounds a pulled half-star for the device
+  without ever pushing the rounded value back over your half-star.
+- **Page numbers on the book page.** Once a book is matched on Hardcover, the
+  progress bar shows a font-size-agnostic "p. 142 of 384" from the print
+  edition's page count alongside the percentage.
+
 ### Changed
 - **Dark themes got a contrast pass.** Hairline borders were sitting at an
   alpha where most panels had none to speak of; they're a step stronger now

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -495,9 +495,11 @@ def get_series(
 
         vol_ratings = [all_ratings[b.id] for b in series_books if b.id in all_ratings]
         explicit = series_ratings.get(series_name)
+        # Derived average rounds to the nearest HALF star — ratings are
+        # half-step values now, and the star widgets can render halves.
         display_rating = (
             explicit if explicit is not None
-            else (round(sum(vol_ratings) / len(vol_ratings)) if vol_ratings else None)
+            else (round(sum(vol_ratings) / len(vol_ratings) * 2) / 2 if vol_ratings else None)
         )
 
         result.append({

--- a/backend/api/hardcover.py
+++ b/backend/api/hardcover.py
@@ -1,0 +1,373 @@
+"""Hardcover sync API — per-user link/unlink, settings, status, manual sync.
+
+All JWT-authed (Settings UI). The sync itself lives in
+backend/services/hardcover_sync.py; these endpoints only manage the per-user
+credential + opt-in state and expose reconcile status. 404 when the feature is
+killed server-side so the UI hides the section entirely.
+"""
+import logging
+from datetime import datetime
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import case, func
+from sqlalchemy.orm import Session
+
+from backend.core.config import settings
+from backend.core.crypto import encrypt_secret
+from backend.core.database import get_db
+from backend.core.security import get_current_user
+from backend.models.book import Book
+from backend.models.user import User
+from backend.models.user_book_status import UserBookStatus
+from backend.services import hardcover_sync
+
+logger = logging.getLogger(__name__)
+
+
+def _require_enabled() -> None:
+    if not settings.hardcover_sync_enabled:
+        raise HTTPException(status_code=404, detail="Hardcover sync is disabled")
+
+
+# Kill switch runs for every route in this router — an endpoint added later
+# can't ship without it.
+router = APIRouter(prefix="/hardcover", tags=["hardcover"],
+                   dependencies=[Depends(_require_enabled)])
+
+
+@router.get("/status")
+def hardcover_status(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if not current_user.hardcover_token:
+        return {"linked": False}
+
+    # One pass with conditional aggregates — this endpoint is polled every few
+    # seconds while a sync runs, so no per-count re-scans.
+    unmatched, matched, errored, last_synced = (
+        db.query(
+            func.coalesce(func.sum(case(
+                (Book.hardcover_match_method.in_(["none", "excluded"]), 1), else_=0)), 0),
+            func.coalesce(func.sum(case(
+                (Book.hardcover_book_id.isnot(None), 1), else_=0)), 0),
+            func.coalesce(func.sum(case(
+                (UserBookStatus.hardcover_error.isnot(None), 1), else_=0)), 0),
+            func.max(UserBookStatus.hardcover_synced_at),
+        )
+        .select_from(UserBookStatus)
+        .join(Book, UserBookStatus.book_id == Book.id)
+        .filter(UserBookStatus.user_id == current_user.id, Book.status == "active")
+        .one()
+    )
+    return {
+        "linked": True,
+        "username": current_user.hardcover_username,
+        "token_status": current_user.hardcover_token_status,
+        "sync_enabled": current_user.hardcover_sync_enabled,
+        "linked_at": current_user.hardcover_linked_at.isoformat() if current_user.hardcover_linked_at else None,
+        "last_synced_at": last_synced.isoformat() if last_synced else None,
+        "unmatched_count": unmatched,
+        "matched_count": matched,
+        "error_count": errored,
+        "sync_running": hardcover_sync.is_manual_sync_running(current_user.id),
+    }
+
+
+class LinkRequest(BaseModel):
+    token: str
+
+
+@router.post("/link")
+async def hardcover_link(
+    body: LinkRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Validate the user's personal token against Hardcover and store it
+    (encrypted). Linking is the sync opt-in — sync_enabled flips on; the
+    toggle below can pause it without unlinking."""
+    token = body.token.strip()
+    if not token:
+        raise HTTPException(status_code=422, detail="Token must not be empty")
+    # Hardcover requires the literal "Bearer " prefix in the authorization
+    # header (verified against the live API); people paste both forms.
+    if not token.lower().startswith("bearer "):
+        token = "Bearer " + token
+    try:
+        identity = await hardcover_sync.verify_token(token)
+    except hardcover_sync.HardcoverAuthError:
+        raise HTTPException(status_code=400, detail="Hardcover rejected this token")
+    except hardcover_sync.HardcoverRateLimited:
+        raise HTTPException(status_code=429, detail="Hardcover is rate limiting — try again in a minute")
+    except hardcover_sync.HardcoverAPIError as exc:
+        raise HTTPException(status_code=502, detail=f"Could not reach Hardcover: {exc}")
+
+    current_user.hardcover_token = encrypt_secret(token)
+    current_user.hardcover_user_id = identity["id"]
+    current_user.hardcover_username = identity["username"]
+    current_user.hardcover_token_status = "ok"
+    current_user.hardcover_linked_at = datetime.utcnow()
+    current_user.hardcover_sync_enabled = True
+    db.commit()
+    # Linking is the opt-in — start the initial backfill right away instead of
+    # making the user find "Sync now" or wait out the interval.
+    started = hardcover_sync.start_manual_sync(current_user.id)
+    return {"linked": True, "username": identity["username"], "sync_started": started}
+
+
+@router.delete("/link", status_code=204)
+def hardcover_unlink(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Remove the stored token. Per-row sync snapshots stay — re-linking the
+    same account resumes exactly where it left off."""
+    current_user.hardcover_token = None
+    current_user.hardcover_user_id = None
+    current_user.hardcover_username = None
+    current_user.hardcover_token_status = None
+    current_user.hardcover_linked_at = None
+    current_user.hardcover_sync_enabled = False
+    db.commit()
+
+
+class SyncSettingsRequest(BaseModel):
+    sync_enabled: bool
+
+
+@router.put("/settings")
+def hardcover_settings(
+    body: SyncSettingsRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    if not current_user.hardcover_token:
+        raise HTTPException(status_code=400, detail="Link a Hardcover account first")
+    current_user.hardcover_sync_enabled = body.sync_enabled
+    db.commit()
+    return {"sync_enabled": current_user.hardcover_sync_enabled}
+
+
+@router.post("/sync-now")
+async def hardcover_sync_now(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Kick off one reconcile pass for this user in the background. An explicit
+    click is the signal to spend requests on second chances: it un-parks rows
+    that hit the failure cap AND clears failed match markers so unmatched books
+    are looked up again (Hardcover's catalogue grows — a miss last month can be
+    a hit today)."""
+    if not current_user.hardcover_token:
+        raise HTTPException(status_code=400, detail="Link a Hardcover account first")
+    if current_user.hardcover_token_status != "ok":
+        raise HTTPException(status_code=400, detail="Token expired — re-link your Hardcover account")
+
+    db.query(UserBookStatus).filter(
+        UserBookStatus.user_id == current_user.id,
+        UserBookStatus.hardcover_fail_count > 0,
+    ).update({"hardcover_fail_count": 0})
+    # Match markers live on Book (shared): clearing them re-attempts the match
+    # for everyone, which is a retry, not data loss.
+    unmatched_ids = [
+        bid for (bid,) in db.query(Book.id)
+        .join(UserBookStatus, UserBookStatus.book_id == Book.id)
+        .filter(
+            UserBookStatus.user_id == current_user.id,
+            Book.hardcover_match_method == "none",
+        )
+    ]
+    if unmatched_ids:
+        db.query(Book).filter(Book.id.in_(unmatched_ids)).update(
+            {"hardcover_match_method": None, "hardcover_matched_at": None},
+            synchronize_session=False,
+        )
+    db.commit()
+    hardcover_sync.reset_backoff(current_user.id)
+
+    started = hardcover_sync.start_manual_sync(current_user.id)
+    return {"started": started}
+
+
+@router.get("/books")
+def hardcover_books(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Every sync-candidate book (my status rows) with its match state — the
+    data source for the Hardcover page. States: matched | unmatched (tried,
+    no result) | excluded (user opted out) | pending (not attempted yet)."""
+    rows = (
+        db.query(Book, UserBookStatus)
+        .join(UserBookStatus, UserBookStatus.book_id == Book.id)
+        .filter(UserBookStatus.user_id == current_user.id, Book.status == "active")
+        .order_by(Book.series.asc().nullslast(), Book.series_index.asc().nullslast(), Book.title)
+        .all()
+    )
+    out = []
+    for b, row in rows:
+        if b.hardcover_book_id is not None:
+            state = "matched"
+        elif b.hardcover_match_method == "excluded":
+            state = "excluded"
+        elif b.hardcover_match_method == "none":
+            state = "unmatched"
+        else:
+            state = "pending"
+        out.append({
+            "book_id": b.id,
+            "title": b.title,
+            "series": b.series,
+            "series_index": b.series_index,
+            "author": b.author,
+            "isbn": b.isbn,
+            "cover_path": b.cover_path,
+            "state": state,
+            "slug": b.hardcover_slug,
+            "method": b.hardcover_match_method,
+            "pages": b.hardcover_pages,
+            "status": row.status,
+            "rating": row.rating,
+            "progress_pct": row.progress_pct,
+            "synced_at": row.hardcover_synced_at.isoformat() if row.hardcover_synced_at else None,
+            "error": row.hardcover_error,
+        })
+    return out
+
+
+async def _clear_book_match_state(db: Session, book: Book, current_user: User) -> bool:
+    """Shared by rematch and manual match: best-effort delete the profile entry
+    WE created for the acting user, then reset the book-level match and every
+    user's push state (the match is book-level — after it changes, everyone's
+    stored user_book ids point at the old record)."""
+    row = (
+        db.query(UserBookStatus)
+        .filter(UserBookStatus.user_id == current_user.id, UserBookStatus.book_id == book.id)
+        .first()
+    )
+    removed = False
+    if row and row.hardcover_user_book_id and current_user.hardcover_token_status == "ok":
+        token = hardcover_sync.user_token(current_user)
+        if token:
+            async with httpx.AsyncClient(timeout=15) as client:
+                removed = await hardcover_sync.delete_user_book(
+                    client, token, row.hardcover_user_book_id)
+
+    book.hardcover_book_id = None
+    book.hardcover_edition_id = None
+    book.hardcover_pages = None
+    book.hardcover_slug = None
+    book.hardcover_matched_at = None
+    book.hardcover_match_method = None
+    db.query(UserBookStatus).filter(UserBookStatus.book_id == book.id).update({
+        "hardcover_user_book_id": None,
+        "hardcover_read_id": None,
+        "hardcover_synced_rating": None,
+        "hardcover_synced_pct": None,
+        "hardcover_synced_status": None,
+        "hardcover_error": None,
+        "hardcover_fail_count": 0,
+    })
+    return removed
+
+
+class RematchRequest(BaseModel):
+    mode: str = "retry"  # retry | exclude
+
+
+@router.post("/books/{book_id}/rematch")
+async def hardcover_rematch(
+    book_id: int,
+    body: RematchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Repair a wrong match (mode=retry) or stop syncing a book (mode=exclude).
+
+    Best-effort deletes the entry WE created on the caller's Hardcover profile,
+    clears the stored match, and — since the match is book-level — resets every
+    user's push state for this book so nobody keeps writing to the old record.
+    retry lets the next cycle re-match (do it after fixing metadata/ISBN);
+    exclude stops matching attempts until a retry un-excludes it.
+    """
+    if body.mode not in ("retry", "exclude"):
+        raise HTTPException(status_code=422, detail="mode must be 'retry' or 'exclude'")
+    if not current_user.hardcover_token:
+        raise HTTPException(status_code=400, detail="Link a Hardcover account first")
+    book = db.get(Book, book_id)
+    if not book or book.status != "active":
+        raise HTTPException(status_code=404, detail="Book not found")
+
+    removed = await _clear_book_match_state(db, book, current_user)
+    if body.mode == "exclude":
+        book.hardcover_match_method = "excluded"
+        book.hardcover_matched_at = datetime.utcnow()
+    db.commit()
+    if body.mode == "retry":
+        hardcover_sync.nudge()
+    return {"ok": True, "mode": body.mode, "removed_from_profile": removed}
+
+
+@router.get("/search")
+async def hardcover_search(
+    q: str,
+    current_user: User = Depends(get_current_user),
+):
+    """Raw Hardcover book search for the manual match picker (same pattern as
+    the wishlist follow's series search, scoped to the user's own token)."""
+    token = hardcover_sync.user_token(current_user)
+    if not token or current_user.hardcover_token_status != "ok":
+        raise HTTPException(status_code=400, detail="Link a Hardcover account first")
+    if not q.strip():
+        return []
+    try:
+        return await hardcover_sync.search_candidates(token, q.strip())
+    except hardcover_sync.HardcoverAuthError:
+        raise HTTPException(status_code=400, detail="Token expired — re-link your Hardcover account")
+    except hardcover_sync.HardcoverRateLimited:
+        raise HTTPException(status_code=429, detail="Hardcover is rate limiting — try again in a minute")
+    except hardcover_sync.HardcoverAPIError as exc:
+        raise HTTPException(status_code=502, detail=f"Could not reach Hardcover: {exc}")
+
+
+class ManualMatchRequest(BaseModel):
+    hardcover_book_id: int
+
+
+@router.post("/books/{book_id}/match")
+async def hardcover_manual_match(
+    book_id: int,
+    body: ManualMatchRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Pin a user-chosen Hardcover record onto a Tome book. Clears the old
+    match (removing the profile entry we created) first; method 'manual' is
+    never auto-cleared, so the pick sticks until the user changes it."""
+    token = hardcover_sync.user_token(current_user)
+    if not token or current_user.hardcover_token_status != "ok":
+        raise HTTPException(status_code=400, detail="Link a Hardcover account first")
+    book = db.get(Book, book_id)
+    if not book or book.status != "active":
+        raise HTTPException(status_code=404, detail="Book not found")
+
+    await _clear_book_match_state(db, book, current_user)
+    try:
+        await hardcover_sync.resolve_manual_match(token, book, body.hardcover_book_id)
+    except hardcover_sync.HardcoverAuthError:
+        db.rollback()
+        raise HTTPException(status_code=400, detail="Token expired — re-link your Hardcover account")
+    except hardcover_sync.HardcoverAPIError as exc:
+        db.rollback()
+        raise HTTPException(status_code=502, detail=str(exc))
+    db.commit()
+    hardcover_sync.nudge()
+    return {
+        "ok": True,
+        "hardcover_book_id": book.hardcover_book_id,
+        "slug": book.hardcover_slug,
+        "pages": book.hardcover_pages,
+    }

--- a/backend/api/series.py
+++ b/backend/api/series.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
 from backend.core.database import get_db
+from backend.core.ratings import validate_rating
 from backend.core.security import get_current_user
 from backend.core.permissions import require_role, is_admin
 from backend.models.series_meta import Arc, SeriesMeta
@@ -273,15 +274,15 @@ NO_SERIES_SENTINEL = "__unserialized__"
 
 class SeriesRatingOut(BaseModel):
     series_name: str
-    rating: Optional[int] = None        # explicit series rating
+    rating: Optional[float] = None      # explicit series rating (half-star steps)
     review: Optional[str] = None
     volume_average: Optional[float] = None  # avg of the user's volume ratings
     rated_volumes: int = 0
-    display: Optional[int] = None        # explicit if set, else rounded average
+    display: Optional[float] = None      # explicit if set, else rounded average
 
 
 class SeriesRatingIn(BaseModel):
-    rating: Optional[int] = None         # 1–5, or null to clear
+    rating: Optional[float] = None       # 1–5 in half-star steps, or null to clear
     review: Optional[str] = None
 
 
@@ -302,7 +303,8 @@ def _series_rating_out(db: Session, user: User, name: str) -> "SeriesRatingOut":
         .one()
     )
     explicit = row.rating if row else None
-    display = explicit if explicit is not None else (round(avg) if avg is not None else None)
+    # Derived average rounds to the nearest HALF star (widgets render halves).
+    display = explicit if explicit is not None else (round(avg * 2) / 2 if avg is not None else None)
     return SeriesRatingOut(
         series_name=name,
         rating=explicit,
@@ -335,8 +337,7 @@ def set_series_rating(
     current_user: User = Depends(get_current_user),
 ):
     _reject_no_series(name)
-    if body.rating is not None and not (1 <= body.rating <= 5):
-        raise HTTPException(400, "rating must be between 1 and 5, or null to clear")
+    validate_rating(body.rating)
     from datetime import datetime
     raw = body.model_dump(exclude_unset=True)
     row = (

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -672,7 +672,7 @@ def get_stats(
             {
                 "book_id": r.id, "title": r.title, "author": r.author,
                 "has_cover": bool(r.cover_path), "category": r.category,
-                "rating": int(r.rating),
+                "rating": float(r.rating),  # half-star steps — do NOT truncate
                 "seconds": int(book_seconds_all.get(r.id, (0, 0, 0))[0]),
                 "rated_at": (r.rated_at or r.updated_at).isoformat() if (r.rated_at or r.updated_at) else None,
             }
@@ -682,10 +682,12 @@ def get_stats(
     )
 
     dist_counts = {i: 0 for i in range(1, 6)}
-    cat_acc: dict[str, list[int]] = {}
+    cat_acc: dict[str, list[float]] = {}
     for b in rated_books:
         if 1 <= b["rating"] <= 5:
-            dist_counts[b["rating"]] += 1
+            # Histogram keeps whole-star buckets; halves round up (4.5 → 5★),
+            # matching the display rounding elsewhere. Averages stay exact.
+            dist_counts[min(5, int(b["rating"] + 0.5))] += 1
         cat_acc.setdefault(b["category"], []).append(b["rating"])
     rating_distribution = [{"rating": i, "count": dist_counts[i]} for i in range(1, 6)]
     rating_by_category = [
@@ -709,7 +711,7 @@ def get_stats(
         ):
             series_sample[sname] = bid
     series_ratings = [
-        {"series": s.series_name, "rating": int(s.rating),
+        {"series": s.series_name, "rating": float(s.rating),  # half-star steps
          "sample_book_id": series_sample.get(s.series_name)}
         for s in series_rating_rows
     ]

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -21,6 +21,7 @@ from backend.core.config import settings
 from backend.core.database import get_db
 from backend.core.urls import public_base_url
 from backend.core.permissions import book_visibility_filter, user_can_see_book
+from backend.core.ratings import validate_rating
 from backend.core.security import get_current_user
 from backend.models.user import User
 from backend.models.book import Book, BookFile
@@ -29,6 +30,7 @@ from backend.models.tome_sync import Annotation, AnnotationTombstone, ApiKey, Re
 from backend.models.ko_stats import StatsImport
 from backend.models.send_queue import SendQueueItem
 from backend.services.book_progress import apply_progress_to_status
+from backend.services.hardcover_sync import nudge as hardcover_nudge
 
 router = APIRouter(tags=["tome-sync"])
 logger = logging.getLogger(__name__)
@@ -42,8 +44,11 @@ logger = logging.getLogger(__name__)
 # build than 13 — otherwise a device that updated to 1.2.1's build-13 impl and
 # later points at a main/1.3.0 server (also 13) would not re-download main's
 # richer impl. Hence 14.
-TOMESYNC_PLUGIN_BUILD = 30
-TOMESYNC_PLUGIN_SEMVER = "1.7.4"
+# BUILD 31: half-star ratings — rating_baseline entries split into
+# {remote, device} so a Tome half-star rounded onto the whole-star sidecar is
+# never pushed back as a "local edit" (old {rating=...} entries migrate on read).
+TOMESYNC_PLUGIN_BUILD = 31
+TOMESYNC_PLUGIN_SEMVER = "1.8.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -288,8 +293,11 @@ def get_rating(
 
 
 class PutRatingRequest(PydanticBaseModel):
-    rating: Optional[int] = None  # 1–5, or null to clear
-    review: Optional[str] = None  # free-text, or null to clear
+    # The plugin only ever sends whole stars (KOReader's sidecar rating is an
+    # int), but the field is float for symmetry with the web endpoint's
+    # half-star steps.
+    rating: Optional[float] = None  # 1–5 in half-star steps, or null to clear
+    review: Optional[str] = None    # free-text, or null to clear
 
 
 @router.put("/tome-sync/rating/{book_id}")
@@ -302,8 +310,7 @@ def put_rating(
     book = db.get(Book, book_id)
     if not book or book.status != "active":
         raise HTTPException(status_code=404, detail="Book not found")
-    if body.rating is not None and not (1 <= body.rating <= 5):
-        raise HTTPException(status_code=400, detail="rating must be 1-5, or null to clear")
+    validate_rating(body.rating)
 
     row = (
         db.query(UserBookStatus)
@@ -316,10 +323,13 @@ def put_rating(
 
     # The plugin always sends both fields (nil → JSON null), so set both. A null
     # clears, matching the web endpoint's semantics.
+    rating_changed = body.rating != row.rating
     row.rating = body.rating
     row.rated_at = datetime.utcnow() if body.rating is not None else None
     row.review = body.review or None
     db.commit()
+    if rating_changed:
+        hardcover_nudge()
     return {"ok": True, "rating": row.rating, "review": row.review}
 
 
@@ -2160,6 +2170,30 @@ end
 --   both changed (tie)    -> Tome wins (single source of truth)
 -- `summary.status` (reading/complete/abandoned) is left untouched — reading
 -- status already syncs via TomeSyncPosition.
+--
+-- Half-stars (build 31): Tome ratings can be 4.5 etc.; KOReader's sidecar is
+-- whole-star, so a pulled half-star is rounded to the NEAREST star for the
+-- device (halves round up: 4.5 → 5). The baseline
+-- therefore keeps TWO values per book — `remote` (Tome's exact value) and
+-- `device` (what we wrote to the sidecar) — so the rounded copy is never
+-- mistaken for a local edit and pushed back (which would destroy the half-star
+-- server-side). Old single-value baselines ({{rating=...}}) migrate on read.
+
+local function ratingBase(tbl, key)
+    local base = tbl[key] or {{}}
+    if base.rating ~= nil and base.remote == nil and base.device == nil then
+        base.remote, base.device = base.rating, base.rating
+        base.rating = nil
+    end
+    return base
+end
+
+local function deviceStars(rating)
+    -- Sidecar value for a (possibly half-star) Tome rating: nearest whole
+    -- star, halves rounding UP (4.5 → 5).
+    if type(rating) ~= "number" then return rating end
+    return math.floor(rating + 0.5)
+end
 
 -- Read the live sidecar summary's rating/review for the open book.
 function TomeSync:_localRating()
@@ -2182,24 +2216,28 @@ function TomeSync:_pullRatingAtOpen()
     local remote_review = jval(status.review)
 
     local key  = tostring(self.book_id)
-    local base = self.rating_baseline[key] or {{}}
-    local local_changed  = (loc.rating ~= base.rating) or (loc.review ~= base.review)
-    local remote_changed = (remote_rating ~= base.rating) or (remote_review ~= base.review)
+    local base = ratingBase(self.rating_baseline, key)
+    -- Local edits compare against what we last WROTE to the sidecar (whole
+    -- stars); remote changes compare against Tome's exact value. A pulled 4.5
+    -- rounded to 4 on the device is neither.
+    local local_changed  = (loc.rating ~= base.device) or (loc.review ~= base.review)
+    local remote_changed = (remote_rating ~= base.remote) or (remote_review ~= base.review)
 
     if remote_changed then
         -- Tome changed (and, on a both-changed tie, Tome wins): write the sidecar.
+        local device_rating = deviceStars(remote_rating)
         local _, summary = self:_localRating()
-        summary.rating   = remote_rating
+        summary.rating   = device_rating
         summary.note     = remote_review
         summary.modified = os.date("%Y-%m-%d")
         self.ui.doc_settings:saveSetting("summary", summary)
-        if type(remote_rating) == "number" then
+        if type(device_rating) == "number" then
             pcall(function()
                 require("ui/widget/booklist")
-                    .setBookInfoCacheProperty(self.ui.document.file, "rating", remote_rating)
+                    .setBookInfoCacheProperty(self.ui.document.file, "rating", device_rating)
             end)
         end
-        base.rating, base.review = remote_rating, remote_review
+        base.remote, base.device, base.review = remote_rating, device_rating, remote_review
         self.rating_baseline[key] = base
         G_reader_settings:saveSetting("tomesync_rating_baseline", self.rating_baseline)
         -- Tome's value supersedes any device rating still queued for this book.
@@ -2226,8 +2264,9 @@ function TomeSync:_putRating(book_id, rating, review)
         return false
     end
     local key = tostring(book_id)
-    local base = self.rating_baseline[key] or {{}}
-    base.rating, base.review = rating, review
+    local base = ratingBase(self.rating_baseline, key)
+    -- A device push is whole-star, so remote and device coincide.
+    base.remote, base.device, base.review = rating, rating, review
     self.rating_baseline[key] = base
     G_reader_settings:saveSetting("tomesync_rating_baseline", self.rating_baseline)
     return true
@@ -2280,8 +2319,10 @@ function TomeSync:_pushRatingOnLeave()
     if not self.enabled or not self.book_id then return end
     local loc = self:_localRating()
     if not loc then return end
-    local base = self.rating_baseline[tostring(self.book_id)] or {{}}
-    if loc.rating == base.rating and loc.review == base.review then return end
+    local base = ratingBase(self.rating_baseline, tostring(self.book_id))
+    -- Compare against what we wrote to the sidecar (whole stars): a rounded
+    -- half-star pull must not read as a local edit.
+    if loc.rating == base.device and loc.review == base.review then return end
     self:_pushRating(loc.rating, loc.review)
 end
 

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -8,8 +8,10 @@ from sqlalchemy.orm import Session
 
 from backend import __version__
 from backend.core.database import get_db
+from backend.core.ratings import validate_rating
 from backend.core.security import get_current_user
 from backend.core.permissions import require_role
+from backend.services.hardcover_sync import nudge as hardcover_nudge
 from backend.models.user import User, UserPermission
 from backend.models.user_book_status import UserBookStatus
 from backend.models.tome_sync import ReadingSession, TomeSyncPosition
@@ -25,7 +27,7 @@ class StatusOut(BaseModel):
     status: str
     progress_pct: Optional[float]
     cfi: Optional[str] = None
-    rating: Optional[int] = None
+    rating: Optional[float] = None
     review: Optional[str] = None
     updated_at: Optional[str]
 
@@ -39,8 +41,8 @@ class StatusIn(BaseModel):
 
 
 class RatingIn(BaseModel):
-    rating: Optional[int] = None  # 1–5, or null to clear the rating
-    review: Optional[str] = None  # free-text; null leaves it unchanged
+    rating: Optional[float] = None  # 1–5 in half-star steps, or null to clear
+    review: Optional[str] = None    # free-text; null leaves it unchanged
 
 
 def _status_out(row: UserBookStatus) -> StatusOut:
@@ -79,8 +81,7 @@ def set_book_rating(
     Rating and review live on the same per-user-per-book row as reading status,
     so rating a book you've never opened just creates an 'unread' row.
     """
-    if body.rating is not None and not (1 <= body.rating <= 5):
-        raise HTTPException(400, "rating must be between 1 and 5, or null to clear")
+    validate_rating(body.rating)
     from backend.models.book import Book
     if not db.get(Book, book_id):
         raise HTTPException(404, "Book not found")
@@ -91,6 +92,7 @@ def set_book_rating(
         row = UserBookStatus(user_id=current_user.id, book_id=book_id, status="unread")
         db.add(row)
 
+    rating_changed = "rating" in raw and body.rating != row.rating
     if "rating" in raw:
         row.rating = body.rating
         row.rated_at = datetime.utcnow() if body.rating is not None else None
@@ -98,6 +100,8 @@ def set_book_rating(
         row.review = (body.review or None)
     db.commit()
     db.refresh(row)
+    if rating_changed:
+        hardcover_nudge()
     return _status_out(row)
 
 
@@ -123,6 +127,7 @@ def set_book_status(
         # the user un-finishes the book.
         if body.status == "read" and row.status != "read":
             row.finished_at = datetime.utcnow()
+            hardcover_nudge()
         elif body.status != "read":
             row.finished_at = None
         row.status = body.status

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -62,6 +62,13 @@ class Settings(BaseSettings):
     release_detection: bool = False        # env TOME_RELEASE_DETECTION
     release_check_interval: int = 86400    # env TOME_RELEASE_CHECK_INTERVAL, seconds
 
+    # Hardcover sync (one-way Tome → Hardcover, ratings + reading progress).
+    # Kill switch only: the feature is inert until a user links their PERSONAL
+    # Hardcover API token in Settings (TOME_HARDCOVER_TOKEN above stays
+    # metadata-fetch-only and is never used for sync).
+    hardcover_sync_enabled: bool = True    # env TOME_HARDCOVER_SYNC_ENABLED
+    hardcover_sync_interval: int = 1800    # env TOME_HARDCOVER_SYNC_INTERVAL, seconds between reconcile cycles
+
     # Send-to-KOReader inbox (env TOME_SEND_TO_KOREADER). On by default since
     # v1.7.0 ("Signature") after real-hardware validation; the web UI queues a
     # book to be pulled onto KOReader by the TomeSync plugin's inbox (no

--- a/backend/core/crypto.py
+++ b/backend/core/crypto.py
@@ -1,0 +1,46 @@
+"""Symmetric encryption for secrets that must be replayable (not hashable).
+
+Used for per-user Hardcover API tokens: unlike Tome's own API keys (stored as
+SHA-256 hashes), a third-party token has to be sent back out verbatim, so it is
+encrypted at rest with a Fernet key derived from the server secret. Rotating
+TOME_SECRET_KEY therefore invalidates stored tokens — callers must treat a
+failed decrypt as "not linked" and ask the user to re-link.
+"""
+import base64
+import hashlib
+import logging
+from typing import Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from backend.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+_fernet: Optional[Fernet] = None
+
+
+def _get_fernet() -> Fernet:
+    global _fernet
+    if _fernet is None:
+        # Fernet wants a urlsafe-base64 32-byte key; derive one deterministically
+        # from the resolved server secret (env var or {data_dir}/secret.key).
+        digest = hashlib.sha256(settings.resolve_secret_key().encode()).digest()
+        _fernet = Fernet(base64.urlsafe_b64encode(digest))
+    return _fernet
+
+
+def encrypt_secret(plaintext: str) -> str:
+    return _get_fernet().encrypt(plaintext.encode()).decode()
+
+
+def decrypt_secret(ciphertext: Optional[str]) -> Optional[str]:
+    """Decrypt, returning None for empty input or an undecryptable value
+    (e.g. after a TOME_SECRET_KEY rotation) — never raising."""
+    if not ciphertext:
+        return None
+    try:
+        return _get_fernet().decrypt(ciphertext.encode()).decode()
+    except (InvalidToken, ValueError):
+        logger.warning("Stored secret failed to decrypt (secret key rotated?)")
+        return None

--- a/backend/core/ratings.py
+++ b/backend/core/ratings.py
@@ -1,0 +1,26 @@
+"""Half-star rating validation, shared by every rating write path.
+
+Ratings are 1.0–5.0 in 0.5 steps (floats; 0.5 values are exactly representable
+in binary so equality checks are safe). Legacy whole-star Integer rows coexist:
+SQLite NUMERIC affinity stores halves as REAL, and Python treats 4 == 4.0 /
+hash(4) == hash(4.0), so mixed values compare, sort, group, and average
+correctly everywhere.
+"""
+import math
+
+from fastapi import HTTPException
+
+RATING_ERROR = "rating must be between 1 and 5 in half-star steps, or null to clear"
+
+
+def validate_rating(rating: float | None) -> None:
+    """Raise 400 unless rating is None or a valid half-star value."""
+    if rating is None:
+        return
+    # Pydantic floats accept Infinity/NaN by default; int(inf) would raise
+    # OverflowError (a 500) before the range check ran.
+    if not math.isfinite(rating):
+        raise HTTPException(400, RATING_ERROR)
+    doubled = rating * 2
+    if doubled != int(doubled) or not (1 <= rating <= 5):
+        raise HTTPException(400, RATING_ERROR)

--- a/backend/main.py
+++ b/backend/main.py
@@ -33,6 +33,7 @@ from backend.api import notifications as notifications_api
 from backend.api import oidc as oidc_api
 from backend.api import goals as goals_api
 from backend.api import annotations as annotations_api
+from backend.api import hardcover as hardcover_api
 from backend.models.kosync import KOSyncUser, KOSyncProgress, OPDSPendingLink, ReadingHistory  # noqa: F401
 from backend.models.opds_pin import OpdsPin  # noqa: F401
 from backend.models.tome_sync import ApiKey, ReadingSession, TomeSyncPosition  # noqa: F401
@@ -181,6 +182,40 @@ async def lifespan(app: FastAPI):
             conn.execute(text("ALTER TABLE wishes ADD COLUMN latest_known_title VARCHAR(512)"))
             conn.execute(text("ALTER TABLE wishes ADD COLUMN latest_release_date VARCHAR(10)"))
             conn.commit()
+        # Hardcover sync — per-user credentials (users), book-level match
+        # identity (books), and per-user-per-book push state (user_book_status).
+        # All nullable, so existing rows are untouched. Note ratings themselves
+        # need no migration: the rating columns keep their INTEGER declaration
+        # and SQLite's NUMERIC affinity stores new half-star values as REAL.
+        if "hardcover_token" not in user_cols:
+            conn.execute(text("ALTER TABLE users ADD COLUMN hardcover_token TEXT"))
+            conn.execute(text("ALTER TABLE users ADD COLUMN hardcover_user_id INTEGER"))
+            conn.execute(text("ALTER TABLE users ADD COLUMN hardcover_username VARCHAR(255)"))
+            conn.execute(text("ALTER TABLE users ADD COLUMN hardcover_token_status VARCHAR(16)"))
+            conn.execute(text("ALTER TABLE users ADD COLUMN hardcover_linked_at DATETIME"))
+            conn.execute(text("ALTER TABLE users ADD COLUMN hardcover_sync_enabled BOOLEAN NOT NULL DEFAULT 0"))
+            conn.commit()
+        if "hardcover_book_id" not in cols:
+            conn.execute(text("ALTER TABLE books ADD COLUMN hardcover_book_id INTEGER"))
+            conn.execute(text("ALTER TABLE books ADD COLUMN hardcover_edition_id INTEGER"))
+            conn.execute(text("ALTER TABLE books ADD COLUMN hardcover_pages INTEGER"))
+            conn.execute(text("ALTER TABLE books ADD COLUMN hardcover_match_method VARCHAR(16)"))
+            conn.execute(text("ALTER TABLE books ADD COLUMN hardcover_matched_at DATETIME"))
+            conn.commit()
+        if "hardcover_slug" not in cols:
+            conn.execute(text("ALTER TABLE books ADD COLUMN hardcover_slug VARCHAR(255)"))
+            conn.commit()
+        ubs_cols = {r[1] for r in conn.execute(text("PRAGMA table_info(user_book_status)")).fetchall()}
+        if ubs_cols and "hardcover_user_book_id" not in ubs_cols:
+            conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_user_book_id INTEGER"))
+            conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_read_id INTEGER"))
+            conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_synced_rating FLOAT"))
+            conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_synced_pct FLOAT"))
+            conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_synced_status VARCHAR(16)"))
+            conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_synced_at DATETIME"))
+            conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_error VARCHAR(255)"))
+            conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_fail_count INTEGER NOT NULL DEFAULT 0"))
+            conn.commit()
     ReadingGoal.__table__.create(bind=engine, checkfirst=True)
     init_fts(engine)
     backfill_fts(engine)
@@ -216,10 +251,16 @@ async def lifespan(app: FastAPI):
                     settings.release_check_interval)
         release_task = asyncio.create_task(_release_check_loop())
 
+    # Hardcover sync worker (inert until a user links a personal token).
+    hardcover_task: asyncio.Task | None = None
+    if settings.hardcover_sync_enabled:
+        from backend.services.hardcover_sync import hardcover_sync_loop
+        hardcover_task = asyncio.create_task(hardcover_sync_loop())
+
     yield
 
     # Shutdown: cancel the background tasks cleanly
-    for task in (auto_import_task, release_task):
+    for task in (auto_import_task, release_task, hardcover_task):
         if task is not None:
             task.cancel()
             try:
@@ -623,6 +664,7 @@ def create_app() -> FastAPI:
     app.include_router(bindery.router, prefix="/api/bindery", tags=["bindery"])
     app.include_router(api_tokens.router, prefix="/api")
     app.include_router(series_api.router, prefix="/api")
+    app.include_router(hardcover_api.router, prefix="/api")
     app.include_router(send_to_device.router, prefix="/api")
     # Wishlist + notifications — static paths registered before /{id} routes
     app.include_router(wishlist_api.router, prefix="/api")

--- a/backend/models/book.py
+++ b/backend/models/book.py
@@ -28,6 +28,24 @@ class Book(Base):
     # ingest (or backfilled by the admin word-count job). NULL for PDF/CBZ or
     # not-yet-parsed books. Feeds words-read / true-WPM stats (Phase 4).
     word_count: Mapped[Optional[int]] = mapped_column(Integer)
+    # Hardcover identity — book-level because a title's Hardcover book/edition is
+    # user-independent. Matched lazily by the sync worker (ISBN first, strict
+    # title+author search as fallback). match_method "none" + matched_at set =
+    # "tried and failed"; re-tried only after a metadata edit bumps updated_at.
+    # hardcover_pages is the matched edition's page count, captured at match time
+    # — Tome stores no page counts of its own, and progress→pages math must use
+    # the edition's own pagination anyway.
+    hardcover_book_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    hardcover_edition_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    hardcover_pages: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    # isbn13 | isbn10 | search | manual (user-pinned, never auto-cleared) |
+    # none (tried+failed, auto-retryable) | excluded (user said never) |
+    # NULL (not attempted yet — "pending" in the API)
+    hardcover_match_method: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
+    hardcover_matched_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    # The matched record's URL slug — lets the UI link to hardcover.app/books/{slug}
+    # so users can AUDIT what their books matched to and re-match wrong ones.
+    hardcover_slug: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     cover_path: Mapped[Optional[str]] = mapped_column(Text)
     content_hash: Mapped[Optional[str]] = mapped_column(String(64), index=True)
     book_type_id: Mapped[Optional[int]] = mapped_column(Integer, ForeignKey("book_types.id"), nullable=True)

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import List, TYPE_CHECKING
-from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from backend.core.database import Base
@@ -30,6 +30,20 @@ class User(Base):
     auth_source: Mapped[str] = mapped_column(String(16), nullable=False, default="local")
     oidc_sub: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
     oidc_issuer: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # Hardcover sync (opt-in, per-user). The token is the user's personal
+    # hardcover.app API token — it must be replayable against their GraphQL API,
+    # so it is stored Fernet-encrypted with a key derived from TOME_SECRET_KEY
+    # (see backend/core/crypto.py), never hashed. Independent of the server-wide
+    # read-only TOME_HARDCOVER_TOKEN used for metadata fetch. Hardcover tokens
+    # expire every January 1 — token_status flips to "expired" on a 401 and the
+    # user is notified to re-link.
+    hardcover_token: Mapped[str | None] = mapped_column(Text, nullable=True)
+    hardcover_user_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    hardcover_username: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    hardcover_token_status: Mapped[str | None] = mapped_column(String(16), nullable=True)  # ok | expired | invalid
+    hardcover_linked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    # Linking and syncing are separate opt-ins: a linked user can pause pushes.
+    hardcover_sync_enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False

--- a/backend/models/user_book_status.py
+++ b/backend/models/user_book_status.py
@@ -16,13 +16,29 @@ class UserBookStatus(Base):
     status: Mapped[str] = mapped_column(String(16), default="unread", nullable=False)
     progress_pct: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     cfi: Mapped[Optional[str]] = mapped_column(String(512), nullable=True)
-    # Per-user rating (1–5 stars) + optional free-text review. NULL = unrated.
-    # Held here because this row is already the per-user-per-book record. The
-    # optional hardcover_* columns are reserved so a future Hardcover sync is
-    # additive — see docs/plans (ratings POC).
-    rating: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    # Per-user rating in half-star steps (1.0–5.0) + optional free-text review.
+    # NULL = unrated. Declared Float but the physical SQLite column keeps its
+    # original INTEGER declaration: NUMERIC affinity stores 4.5 as REAL
+    # losslessly, and legacy whole-star rows read back as ints that compare/hash
+    # equal to their float forms — no data migration, mixed values coexist.
+    # Half-step validation lives in the endpoints (users.py, series.py,
+    # tome_sync.py).
+    rating: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     review: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     rated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    # Hardcover sync state (per user+book). synced_* is the snapshot of what was
+    # last pushed successfully — the worker is a stateless reconciler that syncs
+    # iff current values differ from the snapshot, so nothing is ever lost to a
+    # crashed cycle. user_book_id / read_id are Hardcover's own row ids, captured
+    # after the first write to avoid a lookup per push.
+    hardcover_user_book_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    hardcover_read_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    hardcover_synced_rating: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    hardcover_synced_pct: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+    hardcover_synced_status: Mapped[Optional[str]] = mapped_column(String(16), nullable=True)
+    hardcover_synced_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    hardcover_error: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    hardcover_fail_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     # When the book was marked read. updated_at is NOT a finish date — it moves
     # on every rating/review/CFI write (onupdate), so it must not be displayed
     # as one. Stamped by apply_progress_to_status / the status endpoint on the

--- a/backend/models/user_series_rating.py
+++ b/backend/models/user_series_rating.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 
 from backend.core.database import Base
@@ -23,7 +23,9 @@ class UserSeriesRating(Base):
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     series_name: Mapped[str] = mapped_column(String(512), nullable=False, index=True)
-    rating: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    # Half-star steps (1.0–5.0). Same mixed int/float story as
+    # UserBookStatus.rating — legacy whole-star ints coexist untouched.
+    rating: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
     review: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     rated_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
     updated_at: Mapped[datetime] = mapped_column(

--- a/backend/schemas/book.py
+++ b/backend/schemas/book.py
@@ -64,6 +64,12 @@ class BookDetailOut(BookOut):
     content_hash: Optional[str] = None
     added_by: Optional[int] = None
     updated_at: datetime
+    # Matched Hardcover edition's page count (set by the sync matcher). Lets the
+    # UI show a font-size-agnostic "page ~X of Y" from progress_pct.
+    hardcover_pages: Optional[int] = None
+    # Matched record's slug — the book page shows a "Hardcover" details entry
+    # linking to hardcover.app/books/{slug} when set.
+    hardcover_slug: Optional[str] = None
     # Wishlist: populated on upload/ingest when the new book matches open wishes.
     # list of wish IDs (not book IDs) — frontend uses this to prompt "Fulfill N wishes?".
     # None means matcher was not run or no matches found.

--- a/backend/services/book_progress.py
+++ b/backend/services/book_progress.py
@@ -56,6 +56,8 @@ def apply_progress_to_status(
             finished_at=datetime.utcnow() if finished else None,
         )
         db.add(status_row)
+        if finished:
+            _nudge_hardcover()
         return status_row
 
     # Resume position tracks the latest report even on finished books.
@@ -75,7 +77,16 @@ def apply_progress_to_status(
         status_row.status = "read"
         status_row.progress_pct = 1.0
         status_row.finished_at = datetime.utcnow()
+        _nudge_hardcover()
     elif status_row.status == "unread" and pct > 0:
         status_row.status = "reading"
 
     return status_row
+
+
+def _nudge_hardcover() -> None:
+    """Finishing a book is the socially meaningful event — ask the Hardcover
+    sync worker for a near-term (debounced) push instead of waiting out the
+    batch interval. Lazy import keeps this module dependency-light."""
+    from backend.services.hardcover_sync import nudge
+    nudge()

--- a/backend/services/hardcover_sync.py
+++ b/backend/services/hardcover_sync.py
@@ -1,0 +1,882 @@
+"""One-way Tome → Hardcover sync of ratings and reading progress.
+
+Design (docs/plans/hardcover-sync-plan.md):
+
+- Per-user opt-in: the user links their PERSONAL hardcover.app API token in
+  Settings (stored Fernet-encrypted; see backend/core/crypto.py) and can pause
+  pushes with a separate toggle. The server-wide TOME_HARDCOVER_TOKEN is
+  metadata-fetch-only and never used here.
+- The worker is a stateless reconciler: a row needs sync iff its current
+  rating/status/progress differ from the ``hardcover_synced_*`` snapshot on
+  UserBookStatus. No dirty flags — a crashed cycle loses nothing, and the
+  first-link backfill is just a big diff.
+- Matching is book-level (``Book.hardcover_*``): ISBN exact lookup first (one
+  query returns book id + edition id + pages), then a title+author search
+  gated by a strict similarity guard — a wrong match writes reading data onto
+  a stranger's book on a public profile, so we refuse rather than guess.
+- Progress is page-based on Hardcover: ``round(pct × edition pages)``. Books
+  whose matched edition has no page count get status-only sync.
+- Rate limit: Hardcover allows 60 req/min. All users share one worker queue
+  with ≥1.1 s spacing and a per-cycle request cap, so a first-link backlog
+  spreads out instead of hammering a beta API.
+- Beta-API posture: every response is checked structurally; anything odd is a
+  per-row error with exponential backoff (in-memory next-attempt map), never an
+  exception out of the worker. A 401 marks the token expired (they reset every
+  Jan 1), notifies the user once, and pauses their sync until re-linked.
+
+Nothing is ever deleted or cleared on Hardcover: rating clears and unread/
+shelved statuses are not propagated.
+"""
+import asyncio
+import difflib
+import logging
+import time
+from datetime import datetime
+from typing import Optional
+
+import httpx
+from sqlalchemy.orm import Session
+
+from backend.core.config import settings
+from backend.core.crypto import decrypt_secret
+from backend.models.book import Book
+from backend.models.notification import Notification
+from backend.models.user import User
+from backend.models.user_book_status import UserBookStatus
+
+logger = logging.getLogger(__name__)
+
+HARDCOVER_URL = "https://api.hardcover.app/v1/graphql"
+
+# Hardcover user_book status ids. unread/shelved are deliberately unmapped —
+# they are never pushed.
+STATUS_ID = {"reading": 2, "read": 3}
+
+MIN_REQUEST_SPACING = 1.1      # seconds between requests, all users combined (60/min limit)
+MAX_REQUESTS_PER_CYCLE = 300   # cap so a 2000-book backlog spreads over cycles
+MAX_ROW_FAILS = 10             # park a row after this many consecutive failures
+NUDGE_DEBOUNCE = 30            # seconds of quiet after a rating nudge before syncing
+
+# Similarity floor for the search fallback (mirrors metadata_rank's top tier).
+TITLE_SIM_MIN = 0.85
+AUTHOR_SIM_MIN = 0.7
+
+# ── GraphQL documents ─────────────────────────────────────────────────────────
+# Pinned to the beta schema as of 2026-07. Responses are parsed defensively;
+# schema drift surfaces as a per-row error, not a crash.
+
+Q_ME = "query { me { id username } }"
+
+Q_EDITION_BY_ISBN = """
+query EditionByIsbn($isbn: String!) {
+    editions(where: {_or: [{isbn_13: {_eq: $isbn}}, {isbn_10: {_eq: $isbn}}]}, limit: 1) {
+        id
+        title
+        pages
+        book_id
+        book { id title pages slug }
+    }
+}
+"""
+
+M_DELETE_USER_BOOK = """
+mutation DeleteUserBook($id: Int!) {
+    delete_user_book(id: $id) { id }
+}
+"""
+
+Q_READS = """
+query Reads($ubId: Int!) {
+    user_book_reads(where: {user_book_id: {_eq: $ubId}}, order_by: {id: desc}, limit: 1) {
+        id
+    }
+}
+"""
+
+Q_SEARCH = """
+query SearchBook($q: String!) {
+    search(query: $q, query_type: "Book", per_page: 5) {
+        results
+    }
+}
+"""
+
+Q_BOOK_EDITION = """
+query BookEdition($id: Int!) {
+    books(where: {id: {_eq: $id}}, limit: 1) {
+        id
+        pages
+        slug
+        editions(limit: 1, order_by: {users_count: desc}) { id pages }
+    }
+}
+"""
+
+Q_USER_BOOK = """
+query UserBook($uid: Int!, $bid: Int!) {
+    user_books(where: {user_id: {_eq: $uid}, book_id: {_eq: $bid}}, limit: 1) {
+        id
+        status_id
+        user_book_reads(order_by: {id: desc}, limit: 1) { id }
+    }
+}
+"""
+
+M_INSERT_USER_BOOK = """
+mutation InsertUserBook($object: UserBookCreateInput!) {
+    insert_user_book(object: $object) { id error }
+}
+"""
+
+M_UPDATE_USER_BOOK = """
+mutation UpdateUserBook($id: Int!, $object: UserBookUpdateInput!) {
+    update_user_book(id: $id, object: $object) { id error }
+}
+"""
+
+M_INSERT_READ = """
+mutation InsertRead($ubId: Int!, $read: DatesReadInput!) {
+    insert_user_book_read(user_book_id: $ubId, user_book_read: $read) { id error }
+}
+"""
+
+M_UPDATE_READ = """
+mutation UpdateRead($id: Int!, $object: DatesReadInput!) {
+    update_user_book_read(id: $id, object: $object) { id error }
+}
+"""
+
+
+# ── Errors ────────────────────────────────────────────────────────────────────
+
+class HardcoverAuthError(Exception):
+    """Token rejected (401/403) — expired (Jan-1 reset) or revoked."""
+
+
+class HardcoverRateLimited(Exception):
+    """429 — abort the cycle; the reconciler picks up next cycle."""
+
+
+class HardcoverAPIError(Exception):
+    """Any other failure talking to Hardcover (per-row, backoff-able)."""
+
+
+# ── Throttle (module-level: one budget for the whole process) ─────────────────
+
+_throttle_lock = asyncio.Lock()
+_last_request_ts = 0.0
+
+
+async def _gql(client: httpx.AsyncClient, token: str, query: str,
+               variables: Optional[dict] = None) -> dict:
+    """One throttled GraphQL call. Returns the ``data`` dict."""
+    global _last_request_ts
+    async with _throttle_lock:
+        wait = _last_request_ts + MIN_REQUEST_SPACING - time.monotonic()
+        if wait > 0:
+            await asyncio.sleep(wait)
+        _last_request_ts = time.monotonic()
+    try:
+        resp = await client.post(
+            HARDCOVER_URL,
+            json={"query": query, "variables": variables or {}},
+            # The stored token INCLUDES the "Bearer " prefix — Hardcover
+            # requires it (verified live; a bare token gets "Malformed
+            # Authorization header"). The link endpoint normalizes pasted
+            # tokens to this form.
+            headers={"authorization": token},
+        )
+    except httpx.HTTPError as exc:
+        raise HardcoverAPIError(f"network: {exc}") from exc
+    if resp.status_code == 429:
+        raise HardcoverRateLimited()
+    if resp.status_code in (401, 403):
+        raise HardcoverAuthError()
+    if resp.status_code >= 400:
+        raise HardcoverAPIError(f"HTTP {resp.status_code}")
+    body = resp.json()
+    if body.get("errors"):
+        msg = body["errors"][0].get("message", "GraphQL error")
+        # Hasura reports auth problems as 200 + errors too.
+        if "JWT" in msg or "auth" in msg.lower():
+            raise HardcoverAuthError()
+        raise HardcoverAPIError(msg)
+    return body.get("data") or {}
+
+
+# ── Token / identity ──────────────────────────────────────────────────────────
+
+def user_token(user: User) -> Optional[str]:
+    return decrypt_secret(user.hardcover_token)
+
+
+async def verify_token(token: str) -> dict:
+    """Validate a token and return {'id', 'username'}. Raises on failure."""
+    async with httpx.AsyncClient(timeout=15) as client:
+        data = await _gql(client, token, Q_ME)
+    me = data.get("me")
+    if isinstance(me, list):           # Hasura session queries return a list
+        me = me[0] if me else None
+    if not isinstance(me, dict) or me.get("id") is None:
+        raise HardcoverAPIError("me query returned no user")
+    return {"id": int(me["id"]), "username": me.get("username") or ""}
+
+
+# ── ISBN helpers ──────────────────────────────────────────────────────────────
+
+def normalize_isbn(raw: Optional[str]) -> Optional[str]:
+    """Strip separators; return a 10/13-char ISBN or None."""
+    if not raw:
+        return None
+    cleaned = "".join(ch for ch in raw if ch.isdigit() or ch in "xX")
+    return cleaned.upper() if len(cleaned) in (10, 13) else None
+
+
+def isbn10_to_13(isbn10: str) -> Optional[str]:
+    if len(isbn10) != 10:
+        return None
+    core = "978" + isbn10[:9]
+    if not core.isdigit():
+        return None
+    check = (10 - sum(int(d) * (3 if i % 2 else 1) for i, d in enumerate(core)) % 10) % 10
+    return core + str(check)
+
+
+def isbn_variants(raw: Optional[str]) -> list[str]:
+    """The stored ISBN plus its 13-digit form when the stored one is a 10."""
+    isbn = normalize_isbn(raw)
+    if not isbn:
+        return []
+    variants = [isbn]
+    if len(isbn) == 10:
+        thirteen = isbn10_to_13(isbn)
+        if thirteen:
+            variants.append(thirteen)
+    return variants
+
+
+# ── Matching ──────────────────────────────────────────────────────────────────
+
+def _sim(a: str, b: str) -> float:
+    return difflib.SequenceMatcher(None, a.lower().strip(), b.lower().strip()).ratio()
+
+
+def _norm_title(t: str) -> str:
+    """Normalize for comparison: lowercase, drop commas/periods, squeeze spaces
+    (so "Black Summoner, Vol. 2" ≈ "Black Summoner Vol 2")."""
+    t = t.lower().replace(",", " ").replace(".", " ").replace(":", " ")
+    return " ".join(t.split())
+
+
+def _vol_in_title(title: str) -> Optional[float]:
+    """Volume number carried by a candidate title ("…, Vol. 2", "… Volume 3",
+    "… v04", "… #5"), or None."""
+    import re
+    m = (re.search(r"vol(?:ume)?\.?\s*(\d+(?:\.\d+)?)", title, re.IGNORECASE)
+         or re.search(r"\bv(\d{1,3})\b", title, re.IGNORECASE)
+         or re.search(r"#\s*(\d+(?:\.\d+)?)", title))
+    return float(m.group(1)) if m else None
+
+
+def _split_authors(author: Optional[str]) -> list[str]:
+    """Tome stores multi-author books as one string ("A and B", "A & B",
+    "A, B"); candidate author_names are individual. Compare part-wise."""
+    if not author:
+        return []
+    import re
+    parts = re.split(r"\s+(?:and|&)\s+|\s*[,;]\s*", author)
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _fmt_index(idx: float) -> str:
+    return str(int(idx)) if float(idx).is_integer() else str(idx)
+
+
+def _is_manga_title(title: str) -> bool:
+    return "(manga)" in title.lower() or "manga vol" in title.lower()
+
+
+def _isbn_hit_plausible(book, hc_title: str) -> bool:
+    """Sanity-check an ISBN edition hit against what we think the book is.
+
+    ISBN is the strongest identity signal, so this stays permissive — it only
+    rejects contradictions: a manga/novel format mismatch, a volume number in
+    the catalogue title that disagrees with ours, or a title with essentially
+    no resemblance (ISBN pointing at an unrelated book)."""
+    if not hc_title:
+        return True  # nothing to check against
+    tome_is_manga = bool(book.book_type and book.book_type.slug == "manga")
+    if _is_manga_title(hc_title) != tome_is_manga:
+        return False
+    want_vol = book.series_index if book.series else None
+    cand_vol = _vol_in_title(hc_title)
+    if want_vol is not None and cand_vol is not None and cand_vol != want_vol:
+        return False
+    if want_vol is None and cand_vol is not None:
+        return False  # standalone book, numbered catalogue title
+    references = [book.title]
+    if book.series:
+        references.append(book.series)
+        if want_vol is not None:
+            references.append(f"{book.series} Vol. {_fmt_index(want_vol)}")
+    best = max(_sim(_norm_title(hc_title), _norm_title(r)) for r in references)
+    return best >= 0.5
+
+
+async def match_book(client: httpx.AsyncClient, token: str, book: Book) -> bool:
+    """Resolve a Tome book to a Hardcover book/edition, in place (no commit).
+
+    Sets hardcover_book_id/edition_id/pages/match_method/matched_at. A failed
+    match records method='none' + matched_at so it is not retried until the
+    book's metadata changes (matched_at < updated_at).
+    """
+    book.hardcover_matched_at = datetime.utcnow()
+
+    # 1. ISBN exact — one query yields book id, edition id, and pages. The hit
+    # still has to pass a volume/format sanity check against the edition's own
+    # title: stored ISBNs can be for the wrong edition (legacy auto-apply
+    # damage — the reason /scribe audit editions exists) and catalogue mappings
+    # can be off; observed live, a vol-2 ISBN resolved to "Volume 10". A
+    # failing hit falls through to the guarded search instead of corrupting a
+    # neighbouring volume's record.
+    for isbn in isbn_variants(book.isbn):
+        data = await _gql(client, token, Q_EDITION_BY_ISBN, {"isbn": isbn})
+        editions = data.get("editions") or []
+        if editions:
+            ed = editions[0]
+            hc_title = (ed.get("book") or {}).get("title") or ed.get("title") or ""
+            if not _isbn_hit_plausible(book, hc_title):
+                logger.info(
+                    "Hardcover: ISBN %s resolves to %r, which fails the volume/format "
+                    "check for %r — falling back to search", isbn, hc_title, book.title)
+                continue
+            book.hardcover_book_id = ed.get("book_id") or (ed.get("book") or {}).get("id")
+            book.hardcover_edition_id = ed.get("id")
+            book.hardcover_pages = ed.get("pages") or (ed.get("book") or {}).get("pages")
+            book.hardcover_slug = (ed.get("book") or {}).get("slug")
+            book.hardcover_match_method = "isbn13" if len(isbn) == 13 else "isbn10"
+            return True
+
+    # 2. Title+author search, strictly guarded. Refuse rather than guess.
+    #
+    # Volume-awareness (verified against the live catalogue): Hardcover keeps
+    # per-volume records ("Black Summoner, Vol. 2") while Tome LN/manga volumes
+    # often all share the bare series title — searching the bare title would
+    # collapse every volume onto one Hardcover book and corrupt its progress.
+    # So when the book has a series index, the query and the expected title
+    # carry the volume, and a candidate's own volume marker must agree.
+    want_vol = book.series_index if book.series else None
+    if book.series and want_vol is not None:
+        expected = f"{book.series} Vol. {_fmt_index(want_vol)}"
+    else:
+        expected = book.title
+    primary_author = (_split_authors(book.author) or [None])[0]
+
+    def _with_author(q: str) -> str:
+        return q if not primary_author else f"{q} {primary_author}"
+
+    queries = [_with_author(expected)]
+    if want_vol == 1:
+        # First volumes often live under the bare series title (no volume
+        # marker) and do NOT surface for "… Vol. 1" queries — search both
+        # forms and let the guards + ranking pick (observed live).
+        queries.append(_with_author(book.series))
+
+    tome_is_manga = bool(book.book_type and book.book_type.slug == "manga")
+    author_parts = _split_authors(book.author)
+
+    hits, seen_ids = [], set()
+    for q in queries:
+        data = await _gql(client, token, Q_SEARCH, {"q": q})
+        for hit in ((data.get("search") or {}).get("results") or {}).get("hits") or []:
+            hid = (hit.get("document") or {}).get("id")
+            if hid is not None and hid not in seen_ids:
+                seen_ids.add(hid)
+                hits.append(hit)
+    best = None
+    for hit in hits:
+        doc = hit.get("document") or {}
+        cand_title = doc.get("title") or ""
+        if not cand_title or doc.get("id") is None:
+            continue
+        # Format guard: never cross the manga/novel line — the variants score
+        # deceptively high on title similarity ("X (Manga) Vol 2" vs "X Vol 2").
+        if _is_manga_title(cand_title) != tome_is_manga:
+            continue
+        # Volume guard: the number is authoritative in both directions. An
+        # unmarked candidate is acceptable only for volume 1 (series-titled
+        # first-volume records) or for standalone books.
+        cand_vol = _vol_in_title(cand_title)
+        if want_vol is not None:
+            if cand_vol is not None and cand_vol != want_vol:
+                continue
+            if cand_vol is None and want_vol != 1:
+                continue
+        elif cand_vol is not None:
+            continue  # standalone book must not match a numbered volume
+        title_sim = max(
+            _sim(_norm_title(cand_title), _norm_title(expected)),
+            _sim(_norm_title(cand_title), _norm_title(book.title)),
+        )
+        if title_sim < TITLE_SIM_MIN:
+            continue
+        names = doc.get("author_names") or []
+        if author_parts and names:
+            pair_sim = max(
+                (_sim(n, p) for n in names for p in author_parts), default=0.0
+            )
+            if pair_sim < AUTHOR_SIM_MIN:
+                continue
+        # Everything past the guards is plausibly the right book — prefer the
+        # record the community actually uses over user-created stubs (observed
+        # live: a coverless "Black Summoner -, Vol. 1" stub outscoring the real
+        # record on title similarity alone). Popularity first, similarity as
+        # the tiebreak.
+        rank = (doc.get("users_count") or 0, title_sim)
+        if best is None or rank > best[0]:
+            best = (rank, doc)
+    if best:
+        doc = best[1]
+        hc_id = int(doc["id"])
+        book.hardcover_book_id = hc_id
+        book.hardcover_slug = doc.get("slug")
+        book.hardcover_match_method = "search"
+        # Second query for the representative edition + page count.
+        data = await _gql(client, token, Q_BOOK_EDITION, {"id": hc_id})
+        books = data.get("books") or []
+        if books:
+            b = books[0]
+            eds = b.get("editions") or []
+            if eds:
+                book.hardcover_edition_id = eds[0].get("id")
+                book.hardcover_pages = eds[0].get("pages") or b.get("pages")
+            else:
+                book.hardcover_pages = b.get("pages")
+        return True
+
+    book.hardcover_match_method = "none"
+    return False
+
+
+async def search_candidates(token: str, q: str, limit: int = 8) -> list[dict]:
+    """Raw (unguarded) Hardcover book search for the manual match picker —
+    these results go to human eyes, so no similarity filtering. Same pattern
+    as the wishlist follow's series search."""
+    async with httpx.AsyncClient(timeout=15) as client:
+        data = await _gql(client, token, Q_SEARCH, {"q": q})
+    hits = ((data.get("search") or {}).get("results") or {}).get("hits") or []
+    out = []
+    for hit in hits[:limit]:
+        doc = hit.get("document") or {}
+        if doc.get("id") is None:
+            continue
+        out.append({
+            "hardcover_book_id": int(doc["id"]),
+            "title": doc.get("title") or "",
+            "authors": doc.get("author_names") or [],
+            "slug": doc.get("slug"),
+            "users_count": doc.get("users_count") or 0,
+            "cover_url": (doc.get("image") or {}).get("url"),
+            "series": (doc.get("series_names") or [None])[0],
+        })
+    return out
+
+
+async def resolve_manual_match(token: str, book, hardcover_book_id: int) -> None:
+    """Pin a user-chosen Hardcover record onto a Tome book (no commit). Fetches
+    the representative edition + pages + slug; method 'manual' is never
+    auto-cleared by Sync-now or metadata edits."""
+    async with httpx.AsyncClient(timeout=15) as client:
+        data = await _gql(client, token, Q_BOOK_EDITION, {"id": hardcover_book_id})
+    books = data.get("books") or []
+    if not books:
+        raise HardcoverAPIError(f"Hardcover book {hardcover_book_id} not found")
+    b = books[0]
+    book.hardcover_book_id = hardcover_book_id
+    book.hardcover_slug = b.get("slug")
+    eds = b.get("editions") or []
+    book.hardcover_edition_id = eds[0].get("id") if eds else None
+    book.hardcover_pages = (eds[0].get("pages") if eds else None) or b.get("pages")
+    book.hardcover_match_method = "manual"
+    book.hardcover_matched_at = datetime.utcnow()
+
+
+async def delete_user_book(client: httpx.AsyncClient, token: str, user_book_id: int) -> bool:
+    """Best-effort removal of a user_book entry WE created (wrong-match repair).
+    The one deliberate exception to 'never delete on Hardcover' — it only ever
+    targets an id we stored after our own insert."""
+    try:
+        await _gql(client, token, M_DELETE_USER_BOOK, {"id": user_book_id})
+        return True
+    except (HardcoverAPIError, HardcoverAuthError, HardcoverRateLimited):
+        logger.info("Hardcover: could not delete user_book %s (already gone?)", user_book_id)
+        return False
+
+
+# ── Reconciler ────────────────────────────────────────────────────────────────
+
+def needs_sync(row: UserBookStatus) -> bool:
+    """Does this row differ from its last-pushed snapshot?
+
+    Rating clears (rating=None after a synced value) are NOT propagated;
+    unread/shelved statuses are never pushed. Progress is FORWARD-ONLY:
+    Tome internally tracks positions last-write-wins (downward included, a
+    deliberate re-read affordance), but mirroring a regression to a public
+    profile has no upside — and it would let a stale device's wake-push
+    rewind the user's Hardcover progress too.
+    """
+    if row.rating is not None and row.rating != row.hardcover_synced_rating:
+        return True
+    if row.status in STATUS_ID:
+        if row.status != row.hardcover_synced_status:
+            return True
+        pct = row.progress_pct or 0.0
+        if pct - (row.hardcover_synced_pct or 0.0) >= 0.01:
+            return True
+    return False
+
+
+def _progress_pages(row: UserBookStatus, pages: Optional[int]) -> Optional[int]:
+    if not pages or pages <= 0:
+        return None
+    pct = 1.0 if row.status == "read" else (row.progress_pct or 0.0)
+    return max(0, min(pages, round(pct * pages)))
+
+
+def _mutation_result(data: dict, key: str) -> dict:
+    """Pull {id, error} out of a mutation response, tolerating shape drift."""
+    result = data.get(key)
+    if not isinstance(result, dict):
+        raise HardcoverAPIError(f"{key}: unexpected response shape")
+    if result.get("error"):
+        raise HardcoverAPIError(f"{key}: {result['error']}")
+    return result
+
+
+async def _push_row(client: httpx.AsyncClient, token: str, user: User,
+                    row: UserBookStatus, book: Book) -> None:
+    """Push one row's diff to Hardcover. Raises on failure; caller records it."""
+    status_id = STATUS_ID.get(row.status)
+
+    # Ensure the Hardcover user_book row exists and we hold its id.
+    if row.hardcover_user_book_id is None:
+        data = await _gql(client, token, Q_USER_BOOK,
+                          {"uid": user.hardcover_user_id, "bid": book.hardcover_book_id})
+        existing = data.get("user_books") or []
+        if existing:
+            row.hardcover_user_book_id = existing[0]["id"]
+            reads = existing[0].get("user_book_reads") or []
+            if reads:
+                row.hardcover_read_id = reads[0]["id"]
+        else:
+            obj: dict = {"book_id": book.hardcover_book_id}
+            if status_id is not None:
+                obj["status_id"] = status_id
+            if book.hardcover_edition_id:
+                obj["edition_id"] = book.hardcover_edition_id
+            data = await _gql(client, token, M_INSERT_USER_BOOK, {"object": obj})
+            result = _mutation_result(data, "insert_user_book")
+            new_id = result.get("id") or (result.get("user_book") or {}).get("id")
+            if new_id is None:
+                raise HardcoverAPIError("insert_user_book returned no id")
+            row.hardcover_user_book_id = int(new_id)
+            row.hardcover_synced_status = row.status if status_id else None
+
+    # Rating and/or status in one mutation.
+    update_obj: dict = {}
+    if row.rating is not None and row.rating != row.hardcover_synced_rating:
+        update_obj["rating"] = float(row.rating)
+    if status_id is not None and row.status != row.hardcover_synced_status:
+        update_obj["status_id"] = status_id
+    if update_obj:
+        data = await _gql(client, token, M_UPDATE_USER_BOOK,
+                          {"id": row.hardcover_user_book_id, "object": update_obj})
+        _mutation_result(data, "update_user_book")
+        if "rating" in update_obj:
+            row.hardcover_synced_rating = row.rating
+        if "status_id" in update_obj:
+            row.hardcover_synced_status = row.status
+
+    # Progress (page-based, forward-only — see needs_sync). No pages on the
+    # edition → status-only sync.
+    if status_id is not None:
+        pages = _progress_pages(row, book.hardcover_pages)
+        pct = 1.0 if row.status == "read" else (row.progress_pct or 0.0)
+        if pages is not None and pct - (row.hardcover_synced_pct or 0.0) >= 0.01:
+            read_obj: dict = {"progress_pages": pages}
+            if book.hardcover_edition_id:
+                read_obj["edition_id"] = book.hardcover_edition_id
+            if row.status == "read" and row.finished_at:
+                read_obj["finished_at"] = row.finished_at.strftime("%Y-%m-%d")
+            if row.hardcover_read_id is None:
+                # insert_user_book auto-creates an initial read row (observed
+                # live) — adopt it rather than inserting a duplicate.
+                data = await _gql(client, token, Q_READS,
+                                  {"ubId": row.hardcover_user_book_id})
+                reads = data.get("user_book_reads") or []
+                if reads:
+                    row.hardcover_read_id = int(reads[0]["id"])
+            if row.hardcover_read_id is None:
+                data = await _gql(client, token, M_INSERT_READ,
+                                  {"ubId": row.hardcover_user_book_id, "read": read_obj})
+                result = _mutation_result(data, "insert_user_book_read")
+                if result.get("id") is not None:
+                    row.hardcover_read_id = int(result["id"])
+            else:
+                data = await _gql(client, token, M_UPDATE_READ,
+                                  {"id": row.hardcover_read_id, "object": read_obj})
+                _mutation_result(data, "update_user_book_read")
+            row.hardcover_synced_pct = pct
+        elif pages is None:
+            # Status-only book (no page data): status went out above; snapshot
+            # the pct anyway so needs_sync stops firing on progress churn.
+            row.hardcover_synced_pct = pct
+
+    row.hardcover_synced_at = datetime.utcnow()
+    row.hardcover_error = None
+    row.hardcover_fail_count = 0
+
+
+def mark_token_expired(db: Session, user: User) -> None:
+    """Flip token status and notify once."""
+    if user.hardcover_token_status == "expired":
+        return
+    user.hardcover_token_status = "expired"
+    db.add(Notification(
+        user_id=user.id,
+        kind="hardcover_token_expired",
+        title="Hardcover token expired",
+        body="Hardcover API tokens reset every January 1. Re-link your account "
+             "in Settings to resume syncing ratings and progress.",
+        link="/settings",
+    ))
+    db.commit()
+
+
+# In-memory retry schedule for failed rows: (user_id, book_id) -> monotonic ts.
+# Single-process, resets on restart (harmless — rows just retry sooner).
+_next_attempt: dict[tuple[int, int], float] = {}
+
+
+class _Budget:
+    def __init__(self, limit: int):
+        self.limit = limit
+        self.used = 0
+
+    def spend(self) -> bool:
+        self.used += 1
+        return self.used <= self.limit
+
+    @property
+    def exhausted(self) -> bool:
+        return self.used > self.limit
+
+
+async def sync_user(db: Session, client: httpx.AsyncClient, user: User,
+                    budget: _Budget) -> dict:
+    """Reconcile one user's diffs. Returns counters."""
+    token = user_token(user)
+    stats = {"pushed": 0, "failed": 0, "skipped_unmatched": 0}
+    if not token:
+        return stats
+
+    from sqlalchemy import or_
+    rows = (
+        db.query(UserBookStatus, Book)
+        .join(Book, UserBookStatus.book_id == Book.id)
+        .filter(
+            UserBookStatus.user_id == user.id,
+            Book.status == "active",
+            # Cheap prefilter: rows that can never need a sync (unrated +
+            # unread/shelved) stay in the DB. needs_sync() in Python remains
+            # the authority for everything this overselects.
+            or_(
+                UserBookStatus.rating.isnot(None),
+                UserBookStatus.status.in_(tuple(STATUS_ID)),
+            ),
+        )
+        .all()
+    )
+    now = time.monotonic()
+    for row, book in rows:
+        if not needs_sync(row):
+            continue
+        if row.hardcover_fail_count >= MAX_ROW_FAILS:
+            continue  # parked until manual "Sync now" (which resets fail counts)
+        key = (user.id, row.book_id)
+        if _next_attempt.get(key, 0) > now:
+            continue
+        # No-request skips must not consume budget.
+        if book.hardcover_book_id is None:
+            if book.hardcover_match_method == "excluded":
+                continue  # user said "never sync this book"
+            if (book.hardcover_match_method == "none"
+                    and book.hardcover_matched_at
+                    and book.hardcover_matched_at >= book.updated_at):
+                stats["skipped_unmatched"] += 1
+                continue
+        if not budget.spend():
+            logger.info("Hardcover sync: request budget reached, deferring rest of cycle")
+            break
+
+        try:
+            # Match lazily; re-try failed matches only after a metadata edit.
+            if book.hardcover_book_id is None:
+                matched = await match_book(client, token, book)
+                db.commit()  # persist the match (or the 'none') immediately
+                if not matched:
+                    # Re-stamp matched_at AFTER the commit. The ORM flush above
+                    # just bumped updated_at (onupdate) PAST the in-flight
+                    # matched_at — left alone, the "don't retry until a
+                    # metadata edit" guard would never hold and every cycle
+                    # would re-match (and re-bill) every unmatched book
+                    # forever. Column-level onupdate fires on ANY UPDATE of the
+                    # row, so pin updated_at to itself to suppress it.
+                    db.query(Book).filter(Book.id == book.id).update(
+                        {"hardcover_matched_at": datetime.utcnow(),
+                         "updated_at": Book.updated_at},
+                        synchronize_session=False,
+                    )
+                    db.commit()
+                    stats["skipped_unmatched"] += 1
+                    continue
+            await _push_row(client, token, user, row, book)
+            db.commit()
+            stats["pushed"] += 1
+        except HardcoverAuthError:
+            db.rollback()
+            mark_token_expired(db, user)
+            logger.info("Hardcover sync: token expired for user %s", user.username)
+            break
+        except HardcoverRateLimited:
+            db.rollback()
+            raise
+        except HardcoverAPIError as exc:
+            db.rollback()
+            row.hardcover_error = str(exc)[:255]
+            row.hardcover_fail_count = (row.hardcover_fail_count or 0) + 1
+            db.commit()
+            # Fresh clock — `now` was captured before the throttled loop and
+            # can be minutes stale, which would silently shorten the backoff.
+            _next_attempt[key] = time.monotonic() + min(
+                86400, 60 * (2 ** row.hardcover_fail_count))
+            stats["failed"] += 1
+    return stats
+
+
+async def run_sync_cycle(reason: str = "interval", only_user_id: Optional[int] = None) -> dict:
+    """One reconcile pass over all linked, enabled users."""
+    from backend.core.database import SessionLocal
+
+    budget = _Budget(MAX_REQUESTS_PER_CYCLE)
+    totals = {"users": 0, "pushed": 0, "failed": 0, "skipped_unmatched": 0, "exhausted": False}
+    with SessionLocal() as db:
+        q = db.query(User).filter(
+            User.hardcover_token.isnot(None),
+            User.hardcover_token_status == "ok",
+            User.hardcover_sync_enabled.is_(True),
+            User.is_active.is_(True),
+        )
+        if only_user_id is not None:
+            q = q.filter(User.id == only_user_id)
+        users = q.all()
+        if not users:
+            return totals
+        async with httpx.AsyncClient(timeout=20) as client:
+            for user in users:
+                totals["users"] += 1
+                try:
+                    stats = await sync_user(db, client, user, budget)
+                except HardcoverRateLimited:
+                    logger.warning("Hardcover sync: rate limited — ending cycle early")
+                    break
+                for k in ("pushed", "failed", "skipped_unmatched"):
+                    totals[k] += stats[k]
+    totals["exhausted"] = budget.exhausted
+    if totals["pushed"] or totals["failed"]:
+        logger.info("Hardcover sync (%s): %s", reason, totals)
+    return totals
+
+
+# ── Manual sync (Settings "Sync now") ─────────────────────────────────────────
+
+_manual_running: set[int] = set()
+
+
+def is_manual_sync_running(user_id: int) -> bool:
+    return user_id in _manual_running
+
+
+def reset_backoff(user_id: int) -> None:
+    for key in [k for k in _next_attempt if k[0] == user_id]:
+        _next_attempt.pop(key, None)
+
+
+def start_manual_sync(user_id: int) -> bool:
+    """Fire one background reconcile for a single user. Returns False if one
+    is already running for them. Must be called from a running event loop
+    (async endpoint)."""
+    if user_id in _manual_running:
+        return False
+    _manual_running.add(user_id)
+
+    async def _run() -> None:
+        try:
+            # Drain: a large first-link backfill spans several budget-capped
+            # cycles; keep going until a cycle completes without exhausting its
+            # budget. Terminates because every push advances a snapshot and
+            # every failure earns a backoff skip; the iteration cap is a
+            # backstop, not the mechanism.
+            for _ in range(50):
+                totals = await run_sync_cycle("manual", only_user_id=user_id)
+                if not totals.get("exhausted"):
+                    break
+                await asyncio.sleep(5)
+        finally:
+            _manual_running.discard(user_id)
+
+    asyncio.create_task(_run())
+    return True
+
+
+# ── Worker loop + nudges ──────────────────────────────────────────────────────
+
+_wake_requested_at: float = 0.0
+_last_cycle_at: float = 0.0
+
+
+def nudge() -> None:
+    """Request a near-term sync (rating changed / book finished). Called from
+    sync request handlers (threadpool) — a bare float assignment is safe."""
+    global _wake_requested_at
+    _wake_requested_at = time.monotonic()
+
+
+async def hardcover_sync_loop() -> None:
+    """Background task: interval reconcile + debounced nudge wake-ups.
+
+    Drain mode: a cycle that ran out of request budget with work remaining
+    (big backfill) resumes on the next 15s tick instead of waiting out the
+    full interval."""
+    global _last_cycle_at
+    _last_cycle_at = time.monotonic()  # don't fire immediately on boot
+    drain_pending = False
+    while True:
+        try:
+            await asyncio.sleep(15)
+            now = time.monotonic()
+            due_interval = now - _last_cycle_at >= settings.hardcover_sync_interval
+            due_nudge = (
+                _wake_requested_at > _last_cycle_at
+                and now - _wake_requested_at >= NUDGE_DEBOUNCE
+            )
+            if due_interval or due_nudge or drain_pending:
+                _last_cycle_at = now
+                reason = "drain" if drain_pending and not (due_interval or due_nudge) \
+                    else ("nudge" if due_nudge and not due_interval else "interval")
+                totals = await run_sync_cycle(reason)
+                drain_pending = bool(totals.get("exhausted"))
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Unhandled error in Hardcover sync loop")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { SettingsPage } from '@/pages/SettingsPage'
 import { StatsPage } from '@/pages/StatsPage'
 import { BinderyPage } from '@/pages/BinderyPage'
 import { WishlistPage } from '@/pages/WishlistPage'
+import { HardcoverPage } from '@/pages/HardcoverPage'
 import { HighlightsPage } from '@/pages/HighlightsPage'
 import { api } from '@/lib/api'
 import { applyTheme, getStoredTheme } from '@/lib/theme'
@@ -152,6 +153,14 @@ function AppRoutes() {
           element={
             <ProtectedRoute>
               <WishlistPage />
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/hardcover"
+          element={
+            <ProtectedRoute>
+              <HardcoverPage />
             </ProtectedRoute>
           }
         />

--- a/frontend/src/components/HardcoverSync.tsx
+++ b/frontend/src/components/HardcoverSync.tsx
@@ -1,0 +1,242 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { BookMarked, ExternalLink, Loader2, RefreshCw, AlertTriangle } from 'lucide-react'
+import { api } from '@/lib/api'
+import { useToast } from '@/contexts/ToastContext'
+import { cn } from '@/lib/utils'
+
+interface HardcoverStatus {
+  linked: boolean
+  username?: string | null
+  token_status?: string | null
+  sync_enabled?: boolean
+  linked_at?: string | null
+  last_synced_at?: string | null
+  unmatched_count?: number
+  matched_count?: number
+  error_count?: number
+  sync_running?: boolean
+}
+
+/**
+ * Settings card: link a personal Hardcover account and push ratings + reading
+ * progress one-way to it. Linking is the opt-in; the toggle pauses without
+ * unlinking. Match auditing/fixing lives on the dedicated /hardcover page —
+ * this card only manages the connection. Renders nothing when the server has
+ * the feature killed (404) — the parent section hides with us via onAvailable.
+ */
+export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => void }) {
+  const { toast } = useToast()
+  const [status, setStatus] = useState<HardcoverStatus | null>(null)
+  const [available, setAvailable] = useState(true)
+  const [token, setToken] = useState('')
+  const [busy, setBusy] = useState(false)
+  const pollRef = useRef<number | null>(null)
+
+  const refresh = useCallback(async () => {
+    try {
+      const s = await api.get<HardcoverStatus>('/hardcover/status')
+      setStatus(s)
+      return s
+    } catch (err) {
+      // The kill switch answers 404 "Hardcover sync is disabled" — hide the
+      // whole card. Other failures (network blip) keep it visible.
+      if (err instanceof Error && /disabled/i.test(err.message)) {
+        setAvailable(false)
+        onAvailable?.(false)
+      }
+      return null
+    }
+  }, [onAvailable])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  // Poll while a manual sync runs so counts/last-synced update live.
+  useEffect(() => {
+    if (!status?.sync_running) return
+    pollRef.current = window.setInterval(() => { void refresh() }, 4000)
+    return () => { if (pollRef.current) window.clearInterval(pollRef.current) }
+  }, [status?.sync_running, refresh])
+
+  if (!available) return null
+
+  async function link() {
+    if (!token.trim()) return
+    setBusy(true)
+    try {
+      const r = await api.post<{ username: string }>('/hardcover/link', { token: token.trim() })
+      toast.success(`Linked as @${r.username} — initial sync started`)
+      setToken('')
+      await refresh()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not link Hardcover account')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function unlink() {
+    setBusy(true)
+    try {
+      await api.delete('/hardcover/link')
+      await refresh()
+    } catch {
+      toast.error('Could not unlink')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function toggleSync(next: boolean) {
+    const prev = status
+    setStatus(s => s ? { ...s, sync_enabled: next } : s) // optimistic
+    try {
+      await api.put('/hardcover/settings', { sync_enabled: next })
+    } catch {
+      setStatus(prev)
+      toast.error('Could not update sync setting')
+    }
+  }
+
+  async function syncNow() {
+    try {
+      const r = await api.post<{ started: boolean }>('/hardcover/sync-now', {})
+      if (r.started) {
+        toast.info('Sync started — pushing your ratings and progress to Hardcover')
+        setStatus(s => s ? { ...s, sync_running: true } : s)
+      } else {
+        toast.info('A sync is already running')
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not start sync')
+    }
+  }
+
+  const expired = status?.linked && status.token_status !== 'ok'
+
+  return (
+    <div className="mt-4 rounded-xl border border-border bg-card overflow-hidden">
+      <div className="p-5 space-y-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-start gap-3">
+            <div className="p-1.5 rounded-lg bg-primary/10 mt-0.5 shrink-0">
+              <BookMarked className="w-3.5 h-3.5 text-primary" />
+            </div>
+            <div>
+              <p className="text-sm font-medium text-foreground">Hardcover Sync</p>
+              <p className="text-xs text-muted-foreground mt-0.5">
+                Push your ratings and reading progress to your Hardcover profile — one-way,
+                nothing is ever deleted there. Needs your personal API token (separate from
+                the server's metadata token).
+              </p>
+            </div>
+          </div>
+          <a
+            href="https://hardcover.app/account/api"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="shrink-0 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
+          >
+            Get token <ExternalLink className="w-3 h-3" />
+          </a>
+        </div>
+
+        {!status ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="w-3.5 h-3.5 animate-spin" /> Loading…
+          </div>
+        ) : !status.linked || expired ? (
+          <div className="space-y-3">
+            {expired && (
+              <div className="flex items-center gap-2 rounded-lg bg-warning/10 border border-warning/20 px-3 py-2">
+                <AlertTriangle className="w-3.5 h-3.5 text-warning shrink-0" />
+                <p className="text-xs text-warning font-medium">
+                  Your Hardcover token expired (they reset every January 1). Paste a fresh one to resume syncing.
+                </p>
+              </div>
+            )}
+            <div className="flex gap-2">
+              <input
+                type="password"
+                value={token}
+                onChange={e => setToken(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') void link() }}
+                placeholder="Paste your Hardcover API token"
+                className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
+              />
+              <button
+                onClick={() => void link()}
+                disabled={busy || !token.trim()}
+                className="px-3 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity inline-flex items-center gap-2"
+              >
+                {busy && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                {expired ? 'Re-link' : 'Link account'}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm text-foreground">
+                Linked as <span className="font-medium">@{status.username}</span>
+                {status.last_synced_at && (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    last synced {new Date(status.last_synced_at + 'Z').toLocaleString()}
+                  </span>
+                )}
+              </p>
+              <button
+                onClick={() => void unlink()}
+                disabled={busy}
+                className="text-xs text-muted-foreground hover:text-destructive transition-colors"
+              >
+                Unlink
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm text-foreground">Sync automatically</p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Ratings push shortly after you change them; progress goes out in batches.
+                </p>
+              </div>
+              <button
+                role="switch"
+                aria-checked={status.sync_enabled}
+                onClick={() => void toggleSync(!status.sync_enabled)}
+                className={cn(
+                  'relative w-9 h-5 rounded-full transition-colors shrink-0',
+                  status.sync_enabled ? 'bg-primary' : 'bg-muted-foreground/30'
+                )}
+              >
+                <span className={cn(
+                  'absolute left-0 top-0.5 w-4 h-4 rounded-full bg-white transition-transform',
+                  status.sync_enabled ? 'translate-x-[18px]' : 'translate-x-0.5'
+                )} />
+              </button>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-3">
+              <button
+                onClick={() => void syncNow()}
+                disabled={!!status.sync_running}
+                className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border text-xs font-medium text-foreground hover:bg-muted transition-colors disabled:opacity-50"
+              >
+                <RefreshCw className={cn('w-3.5 h-3.5', status.sync_running && 'animate-spin')} />
+                {status.sync_running ? 'Syncing…' : 'Sync now'}
+              </button>
+              {/* Match auditing/fixing lives on the dedicated page */}
+              <Link to="/hardcover" className="text-xs text-primary hover:underline">
+                {status.matched_count ?? 0} synced
+                {(status.unmatched_count ?? 0) > 0 && ` · ${status.unmatched_count} not matched`}
+                {(status.error_count ?? 0) > 0 && ` · ${status.error_count} errors`}
+                {' '}— manage →
+              </Link>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/SeriesRating.tsx
+++ b/frontend/src/components/SeriesRating.tsx
@@ -1,8 +1,7 @@
 import { useEffect, useState } from 'react'
-import { Star } from 'lucide-react'
 import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
-import { cn } from '@/lib/utils'
+import { StarRating } from '@/components/StarRating'
 
 interface SeriesRatingData {
   series_name: string
@@ -21,7 +20,6 @@ interface SeriesRatingData {
 export function SeriesRating({ seriesName, isUnserialized }: { seriesName: string; isUnserialized?: boolean }) {
   const { toast } = useToast()
   const [data, setData] = useState<SeriesRatingData | null>(null)
-  const [hover, setHover] = useState<number | null>(null)
 
   useEffect(() => {
     if (isUnserialized || !seriesName) return
@@ -55,31 +53,16 @@ export function SeriesRating({ seriesName, isUnserialized }: { seriesName: strin
 
   return (
     <div className="mt-2 flex items-center gap-2.5">
-      <div className="flex items-center gap-0.5" onMouseLeave={() => setHover(null)}>
-        {[1, 2, 3, 4, 5].map(n => {
-          // Show the explicit rating if set, else the (rounded) volume average.
-          // When the fill is derived from the average — not your own series
-          // rating — render it muted so it reads "computed, tap to make it yours".
-          const shown = hover ?? rating ?? data!.display ?? 0
-          const active = shown >= n
-          const derived = hover == null && rating == null && data!.display != null
-          return (
-            <button
-              key={n}
-              type="button"
-              aria-label={`${n} star${n > 1 ? 's' : ''}`}
-              onMouseEnter={() => setHover(n)}
-              onClick={() => save(rating === n ? null : n)}
-              className="p-0.5 transition-transform hover:scale-110"
-            >
-              <Star className={cn(
-                'w-5 h-5 transition-colors',
-                active ? cn('fill-rating text-rating', derived && 'opacity-40') : 'text-muted-foreground/40',
-              )} />
-            </button>
-          )
-        })}
-      </div>
+      {/* Show the explicit rating if set, else the volume average. A derived
+          fill renders muted ("computed, tap to make it yours") — and because
+          `selected` is only the explicit rating, clicking a derived value SETS
+          it rather than clearing nothing. */}
+      <StarRating
+        value={rating ?? data.display}
+        selected={rating}
+        onChange={save}
+        derived={rating == null && data.display != null}
+      />
       <span className="text-xs text-muted-foreground">{hint}</span>
     </div>
   )

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -5,7 +5,7 @@ import {
   BookOpen, Plus, Pencil, Trash2,
   ChevronLeft, ChevronRight, Bookmark, Library as LibraryIcon, Layers, Home, BarChart3,
   Settings, Shield, LogOut, ChevronsUpDown, Lock, X, BookPlus, ExternalLink,
-  Sun, Moon, MoonStar, Flame, Coffee, Check, Sparkles, Users, Quote,
+  Sun, Moon, MoonStar, Flame, Coffee, Check, Sparkles, Users, Quote, BookMarked,
   type LucideIcon,
 } from 'lucide-react'
 import { api } from '@/lib/api'
@@ -516,6 +516,20 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                 >
                   <Sparkles className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
                   <span className="truncate">Wishlist</span>
+                </Link>
+              )}
+              {isMember(user) && (
+                <Link
+                  to="/hardcover"
+                  className={cn(
+                    'group flex items-center gap-2 w-full px-2 py-1.5 rounded-lg text-sm transition-all touch-feedback',
+                    location.pathname === '/hardcover'
+                      ? 'bg-primary/10 text-primary font-medium'
+                      : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                  )}
+                >
+                  <BookMarked className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
+                  <span className="truncate">Hardcover</span>
                 </Link>
               )}
               {isAdmin(user) && (

--- a/frontend/src/components/StarRating.tsx
+++ b/frontend/src/components/StarRating.tsx
@@ -1,0 +1,95 @@
+import { useState } from 'react'
+import { Star } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+interface StarRatingProps {
+  /** The fill to display (may be a derived value, e.g. a volume average). */
+  value: number | null
+  /**
+   * The user's own explicit value, used for click-to-clear toggling. Defaults
+   * to `value`; pass it separately when `value` can be derived so clicking a
+   * derived fill SETS it instead of clearing nothing.
+   */
+  selected?: number | null
+  onChange?: (v: number | null) => void
+  /** Render the fill muted — it's computed, not the user's own rating. */
+  derived?: boolean
+  /** Display-only: no hover, no clicks, renders spans instead of buttons. */
+  readOnly?: boolean
+  /** Size/color classes for each star (default 'w-5 h-5'). */
+  starClassName?: string
+  className?: string
+}
+
+/**
+ * Interactive 5-star rating in half-star steps: the left half of each star
+ * selects n−0.5, the right half n. Clicking the currently-selected value
+ * clears it. Half fills render via a clipped overlay star.
+ */
+export function StarRating({
+  value, selected, onChange, derived = false, readOnly = false,
+  starClassName = 'w-5 h-5', className,
+}: StarRatingProps) {
+  const [hover, setHover] = useState<number | null>(null)
+  const toggleBase = selected === undefined ? value : selected
+
+  function candidate(n: number, e: React.MouseEvent<HTMLButtonElement>): number {
+    const rect = e.currentTarget.getBoundingClientRect()
+    return e.clientX - rect.left < rect.width / 2 ? n - 0.5 : n
+  }
+
+  const shown = (readOnly ? null : hover) ?? value ?? 0
+
+  const star = (n: number) => {
+    const fill = Math.min(1, Math.max(0, shown - (n - 1))) // 0 | 0.5 | 1
+    return (
+      <>
+        <Star className={cn(starClassName, 'text-muted-foreground/40 transition-colors')} />
+        {fill > 0 && (
+          <span
+            className={cn('pointer-events-none absolute inset-0', !readOnly && 'p-0.5')}
+            style={fill >= 1 ? undefined : { clipPath: 'inset(0 50% 0 0)' }}
+          >
+            <Star className={cn(
+              starClassName, 'fill-rating text-rating transition-colors',
+              derived && hover == null && 'opacity-40',
+            )} />
+          </span>
+        )}
+      </>
+    )
+  }
+
+  if (readOnly) {
+    return (
+      <span
+        className={cn('inline-flex items-center gap-px', className)}
+        aria-label={value != null ? `Rated ${value} of 5` : undefined}
+      >
+        {[1, 2, 3, 4, 5].map(n => (
+          <span key={n} className="relative inline-flex">{star(n)}</span>
+        ))}
+      </span>
+    )
+  }
+
+  return (
+    <div className={cn('flex items-center gap-0.5', className)} onMouseLeave={() => setHover(null)}>
+      {[1, 2, 3, 4, 5].map(n => (
+        <button
+          key={n}
+          type="button"
+          aria-label={`${n} star${n > 1 ? 's' : ''}`}
+          onMouseMove={e => setHover(candidate(n, e))}
+          onClick={e => {
+            const v = candidate(n, e)
+            onChange?.(toggleBase === v ? null : v)
+          }}
+          className="relative p-0.5 transition-transform hover:scale-110"
+        >
+          {star(n)}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/stats/widgets/taste.tsx
+++ b/frontend/src/components/stats/widgets/taste.tsx
@@ -17,8 +17,9 @@ import {
   Tooltip,
   CartesianGrid,
 } from 'recharts'
-import { Star, FileText } from 'lucide-react'
-import { cn, formatDuration } from '@/lib/utils'
+import { FileText } from 'lucide-react'
+import { formatDuration } from '@/lib/utils'
+import { StarRating } from '@/components/StarRating'
 import { useChartColors } from '@/lib/useChartAccent'
 import { ChartTooltip, type StatsResponse } from '@/components/stats/shared'
 
@@ -29,13 +30,9 @@ function Empty({ text = 'No ratings yet.' }: { text?: string }) {
 }
 
 function Stars({ value }: { value: number }) {
-  return (
-    <span className="inline-flex shrink-0">
-      {[1, 2, 3, 4, 5].map((i) => (
-        <Star key={i} className={cn('h-3 w-3', i <= value ? 'fill-amber-400 text-amber-400' : 'text-muted-foreground/30')} />
-      ))}
-    </span>
-  )
+  // Half-star aware (ratings are 0.5 steps now); uses the themed rating token
+  // like every other star row instead of hardcoded amber.
+  return <StarRating value={value} readOnly starClassName="h-3 w-3" className="shrink-0" />
 }
 
 function Cover({ id, has, alt }: { id: number | null; has: boolean; alt: string }) {

--- a/frontend/src/lib/books.ts
+++ b/frontend/src/lib/books.ts
@@ -43,6 +43,10 @@ export interface BookDetail extends Book {
   content_hash: string | null
   added_by: number | null
   updated_at: string
+  // Matched Hardcover edition's page count — font-size-agnostic "page X of Y"
+  hardcover_pages?: number | null
+  // Matched Hardcover record's slug — Details grid links to it
+  hardcover_slug?: string | null
 }
 
 export interface MetadataCandidate {

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -4,7 +4,7 @@ import {
   Camera, Download, Edit2, Save, X,
   Calendar, Globe, Hash, Building2, FileText, Trash2, Loader2,
   Sparkles, Library, Check, BookMarked, ChevronLeft, ChevronRight, Home,
-  Tag as TagIcon, StickyNote, ChevronDown, Archive, Star, AlignLeft,
+  Tag as TagIcon, StickyNote, ChevronDown, Archive, AlignLeft,
   Plus, TrendingUp, TrendingDown, Minus, Info
 } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
@@ -14,6 +14,7 @@ import { MetadataFetchModal } from '@/components/MetadataFetchModal'
 import { CoverPickerModal } from '@/components/CoverPickerModal'
 import { SendButton } from '@/components/SendButton'
 import { BookAnimation } from '@/components/BookAnimation'
+import { StarRating } from '@/components/StarRating'
 import { CoverImage } from '@/components/CoverImage'
 import { AutocompleteInput } from '@/components/AutocompleteInput'
 import { api } from '@/lib/api'
@@ -125,7 +126,6 @@ export function BookDetailPage() {
   const [statusSaving, setStatusSaving] = useState(false)
   const [statusPopKey, setStatusPopKey] = useState(0)
   const [rating, setRating] = useState<number | null>(null)
-  const [hoverRating, setHoverRating] = useState<number | null>(null)
   const [review, setReview] = useState('')       // saved review text
   const [reviewDraft, setReviewDraft] = useState('')  // in-progress edit
   const [editingReview, setEditingReview] = useState(false)
@@ -622,6 +622,13 @@ export function BookDetailPage() {
           </div>
           <span className="text-xs text-muted-foreground tabular-nums shrink-0">
             {Math.round(progressPct * 100)}%
+            {book?.hardcover_pages != null && book.hardcover_pages > 0 && (
+              // Print-edition pagination (from the matched Hardcover edition) —
+              // font-size agnostic, unlike the device's reflowed page count.
+              <span className="ml-1 opacity-60">
+                · p. {Math.max(1, Math.round(progressPct * book.hardcover_pages))} of {book.hardcover_pages}
+              </span>
+            )}
             {kosyncDevice && (
               <span className="ml-1 opacity-60">· {kosyncDevice}</span>
             )}
@@ -635,31 +642,7 @@ export function BookDetailPage() {
   const ratingBlock = (
     <div className="mb-5">
       <div className="flex items-center gap-2.5">
-        <div
-          className="flex items-center gap-0.5"
-          onMouseLeave={() => setHoverRating(null)}
-        >
-          {[1, 2, 3, 4, 5].map(n => {
-            const active = (hoverRating ?? rating ?? 0) >= n
-            return (
-              <button
-                key={n}
-                type="button"
-                aria-label={`${n} star${n > 1 ? 's' : ''}`}
-                onMouseEnter={() => setHoverRating(n)}
-                onClick={() => saveRating(rating === n ? null : n)}
-                className="p-0.5 transition-transform hover:scale-110"
-              >
-                <Star
-                  className={cn(
-                    'w-5 h-5 transition-colors',
-                    active ? 'fill-rating text-rating' : 'text-muted-foreground/40'
-                  )}
-                />
-              </button>
-            )
-          })}
-        </div>
+        <StarRating value={rating} onChange={saveRating} />
         <span className="text-xs text-muted-foreground">
           {rating ? `You rated this ${rating}/5` : 'Rate this book'}
         </span>
@@ -826,6 +809,22 @@ export function BookDetailPage() {
         <MetaField icon={<AlignLeft className="w-3.5 h-3.5" />} label="Words"
           value={book.word_count != null ? `${book.word_count.toLocaleString()} words` : ''}
           editing={false} onChange={() => {}} />
+        {/* Hardcover match — only when the sync matcher has linked this book */}
+        {!editing && book.hardcover_slug && (
+          <div className="flex items-start gap-2">
+            <span className="text-muted-foreground mt-0.5 shrink-0"><BookMarked className="w-3.5 h-3.5" /></span>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-muted-foreground/70 mb-0.5">Hardcover</p>
+              <a
+                href={`https://hardcover.app/books/${book.hardcover_slug}`}
+                target="_blank" rel="noopener noreferrer"
+                className="text-sm text-primary hover:underline truncate block"
+              >
+                {book.hardcover_slug}
+              </a>
+            </div>
+          </div>
+        )}
         {/* Book Type */}
         <div className="flex items-start gap-2">
           <span className="text-muted-foreground mt-0.5 shrink-0"><TagIcon className="w-3.5 h-3.5" /></span>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -13,6 +13,7 @@ import { useToast } from '@/contexts/ToastContext'
 import { useSidebarLists } from '@/lib/sidebarLists'
 import { BookCard, type ViewMode } from '@/components/BookCard'
 import { SeriesStackCard } from '@/components/SeriesStackCard'
+import { StarRating } from '@/components/StarRating'
 import { SeriesRating } from '@/components/SeriesRating'
 import { SeriesFollowButton } from '@/components/SeriesFollowButton'
 import { UpcomingReleases } from '@/components/UpcomingReleases'
@@ -1686,11 +1687,7 @@ export function DashboardPage() {
                             </div>
                             {!isUnserialized && s.author && <span className="text-[10px] text-muted-foreground truncate">{s.author}</span>}
                             {!isUnserialized && s.rating != null && (
-                              <span className="inline-flex items-center gap-px mt-0.5" aria-label={`Rated ${s.rating} of 5`}>
-                                {[1, 2, 3, 4, 5].map(n => (
-                                  <Star key={n} className={cn('w-3 h-3', n <= s.rating! ? 'fill-rating text-rating' : 'text-muted-foreground/30')} />
-                                ))}
-                              </span>
+                              <StarRating value={s.rating} readOnly starClassName="w-3 h-3" className="mt-0.5" />
                             )}
                             {!isUnserialized && s.description && (
                               <p className="text-[10px] text-muted-foreground leading-snug line-clamp-2 mt-0.5">{s.description}</p>

--- a/frontend/src/pages/HardcoverPage.tsx
+++ b/frontend/src/pages/HardcoverPage.tsx
@@ -1,0 +1,554 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import {
+  BookMarked, ExternalLink, Layers, Loader2, RefreshCw, Search, X, AlertTriangle, ChevronLeft,
+} from 'lucide-react'
+import { AppShell } from '@/components/AppShell'
+import { CoverImage } from '@/components/CoverImage'
+import { SeriesStackCard } from '@/components/SeriesStackCard'
+import type { Book } from '@/lib/books'
+import { api } from '@/lib/api'
+import { useToast } from '@/contexts/ToastContext'
+import { cn } from '@/lib/utils'
+
+interface HardcoverStatus {
+  linked: boolean
+  username?: string | null
+  token_status?: string | null
+  sync_enabled?: boolean
+  last_synced_at?: string | null
+  sync_running?: boolean
+}
+
+interface HcBook {
+  book_id: number
+  title: string
+  series: string | null
+  series_index: number | null
+  author: string | null
+  isbn: string | null
+  cover_path: string | null
+  state: 'matched' | 'unmatched' | 'excluded' | 'pending'
+  slug: string | null
+  method: string | null
+  pages: number | null
+  status: string
+  rating: number | null
+  progress_pct: number | null
+  synced_at: string | null
+  error: string | null
+}
+
+interface Candidate {
+  hardcover_book_id: number
+  title: string
+  authors: string[]
+  slug: string | null
+  users_count: number
+  cover_url: string | null
+  series: string | null
+}
+
+type Filter = 'all' | 'matched' | 'unmatched' | 'excluded' | 'errors'
+
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'matched', label: 'Synced' },
+  { key: 'unmatched', label: 'Not matched' },
+  { key: 'excluded', label: 'Excluded' },
+  { key: 'errors', label: 'Errors' },
+]
+
+function displayTitle(b: HcBook): string {
+  // Series-titled volumes ("Black Summoner") need the volume to be readable.
+  if (b.series && b.series_index != null) {
+    return `${b.title === b.series ? b.series : b.title} · Vol. ${b.series_index}`
+  }
+  return b.title
+}
+
+const STATE_LABEL: Record<HcBook['state'], string> = {
+  matched: 'Synced',
+  unmatched: 'Not matched',
+  excluded: 'Excluded',
+  pending: 'Not synced yet',
+}
+
+const GROUP_KEY = 'tome_hardcover_group'
+
+// SeriesStackCard consumes the dashboard's Book shape — adapt an HcBook group.
+function toBookShape(rep: HcBook, volumes: HcBook[]): Book {
+  return {
+    id: rep.book_id,
+    title: rep.title,
+    subtitle: null,
+    author: rep.author,
+    series: rep.series,
+    series_index: rep.series_index,
+    year: null,
+    language: null,
+    word_count: null,
+    status: 'active',
+    content_type: 'volume',
+    cover_path: rep.cover_path,
+    added_at: '',
+    files: [],
+    tags: [],
+    library_ids: [],
+    book_type_id: null,
+    stack_cover_ids: volumes.slice(1, 3).filter(v => v.cover_path).map(v => v.book_id),
+  }
+}
+
+type Cell =
+  | { kind: 'book'; b: HcBook }
+  | { kind: 'stack'; volumes: HcBook[] }
+
+export function HardcoverPage() {
+  const { toast } = useToast()
+  const [status, setStatus] = useState<HardcoverStatus | null>(null)
+  const [unavailable, setUnavailable] = useState(false)
+  const [books, setBooks] = useState<HcBook[] | null>(null)
+  const [filter, setFilter] = useState<Filter>('all')
+  const [query, setQuery] = useState('')
+  const [grouped, setGrouped] = useState(() => localStorage.getItem(GROUP_KEY) === 'true')
+  const [expandedSeries, setExpandedSeries] = useState<string | null>(null)
+
+  function persistGroup(v: boolean) {
+    setGrouped(v)
+    localStorage.setItem(GROUP_KEY, String(v))
+    setExpandedSeries(null)
+  }
+  // Picker modal state
+  const [pickFor, setPickFor] = useState<HcBook | null>(null)
+  const [pickQuery, setPickQuery] = useState('')
+  const [pickResults, setPickResults] = useState<Candidate[] | null>(null)
+  const [pickBusy, setPickBusy] = useState(false)
+
+  const loadStatus = useCallback(async () => {
+    try {
+      const s = await api.get<HardcoverStatus>('/hardcover/status')
+      setStatus(s)
+      return s
+    } catch (err) {
+      if (err instanceof Error && /disabled/i.test(err.message)) setUnavailable(true)
+      return null
+    }
+  }, [])
+
+  const loadBooks = useCallback(async () => {
+    try {
+      setBooks(await api.get<HcBook[]>('/hardcover/books'))
+    } catch { /* status handler surfaces errors */ }
+  }, [])
+
+  const load = useCallback(async () => {
+    const s = await loadStatus()
+    if (s?.linked) await loadBooks()
+  }, [loadStatus, loadBooks])
+
+  useEffect(() => { void load() }, [load])
+
+  // Poll only the cheap status while a manual sync runs; refetch the full book
+  // list once when the run finishes (not every tick).
+  useEffect(() => {
+    if (!status?.sync_running) return
+    const t = window.setInterval(async () => {
+      const s = await loadStatus()
+      if (s && !s.sync_running) void loadBooks()
+    }, 4000)
+    return () => window.clearInterval(t)
+  }, [status?.sync_running, loadStatus, loadBooks])
+
+  const filtered = useMemo(() => {
+    if (!books) return []
+    let out = books
+    if (filter === 'errors') out = out.filter(b => b.error != null)
+    else if (filter !== 'all') out = out.filter(b => b.state === filter)
+    const q = query.trim().toLowerCase()
+    if (q) {
+      out = out.filter(b =>
+        b.title.toLowerCase().includes(q)
+        || (b.series ?? '').toLowerCase().includes(q)
+        || (b.author ?? '').toLowerCase().includes(q))
+    }
+    return out
+  }, [books, filter, query])
+
+  // Grouped view: fold same-series volumes into one stacked card (matching the
+  // All Books "Group series" toggle); an expanded series shows its volumes.
+  const cells = useMemo<Cell[]>(() => {
+    if (expandedSeries) {
+      return filtered.filter(b => b.series === expandedSeries).map(b => ({ kind: 'book', b }))
+    }
+    if (!grouped) return filtered.map(b => ({ kind: 'book', b }))
+    const bySeries = new Map<string, HcBook[]>()
+    const out: Cell[] = []
+    for (const b of filtered) {
+      if (!b.series) { out.push({ kind: 'book', b }); continue }
+      let group = bySeries.get(b.series)
+      if (!group) {
+        group = []
+        bySeries.set(b.series, group)
+        out.push({ kind: 'stack', volumes: group })
+      }
+      group.push(b)
+    }
+    // Single-volume "stacks" render as plain cards.
+    return out.map(c => (c.kind === 'stack' && c.volumes.length === 1)
+      ? { kind: 'book' as const, b: c.volumes[0] } : c)
+  }, [filtered, grouped, expandedSeries])
+
+  const counts = useMemo(() => {
+    const c = { all: books?.length ?? 0, matched: 0, unmatched: 0, excluded: 0, errors: 0 }
+    for (const b of books ?? []) {
+      if (b.state === 'matched') c.matched++
+      else if (b.state === 'unmatched') c.unmatched++
+      else if (b.state === 'excluded') c.excluded++
+      if (b.error) c.errors++
+    }
+    return c
+  }, [books])
+
+  async function syncNow() {
+    try {
+      const r = await api.post<{ started: boolean }>('/hardcover/sync-now', {})
+      toast.info(r.started ? 'Sync started' : 'A sync is already running')
+      setStatus(s => s ? { ...s, sync_running: true } : s)
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not start sync')
+    }
+  }
+
+  async function rematch(b: HcBook, mode: 'retry' | 'exclude') {
+    try {
+      await api.post(`/hardcover/books/${b.book_id}/rematch`, { mode })
+      toast.info(mode === 'retry'
+        ? 'Match cleared — re-matching on the next sync'
+        : 'Excluded from Hardcover sync')
+      await load()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Action failed')
+    }
+  }
+
+  async function openPicker(b: HcBook) {
+    setPickFor(b)
+    const base = b.series && b.series_index != null
+      ? `${b.series} Vol. ${b.series_index}` : b.title
+    const q = b.author ? `${base} ${b.author}` : base
+    setPickQuery(q)
+    setPickResults(null)
+    await runPickSearch(q)
+  }
+
+  async function runPickSearch(q: string) {
+    setPickBusy(true)
+    try {
+      setPickResults(await api.get<Candidate[]>(`/hardcover/search?q=${encodeURIComponent(q)}`))
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Search failed')
+      setPickResults([])
+    } finally {
+      setPickBusy(false)
+    }
+  }
+
+  async function pin(c: Candidate) {
+    if (!pickFor) return
+    setPickBusy(true)
+    try {
+      await api.post(`/hardcover/books/${pickFor.book_id}/match`, { hardcover_book_id: c.hardcover_book_id })
+      toast.success(`Matched to “${c.title}”`)
+      setPickFor(null)
+      await load()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Could not set match')
+    } finally {
+      setPickBusy(false)
+    }
+  }
+
+  if (unavailable) {
+    return (
+      <AppShell>
+        <div className="p-8 text-sm text-muted-foreground">Hardcover sync is disabled on this server.</div>
+      </AppShell>
+    )
+  }
+
+  return (
+    <AppShell>
+      <div className="p-4 sm:p-6 lg:p-8 max-w-6xl mx-auto">
+        <div className="flex items-center gap-3 mb-1">
+          <BookMarked className="w-5 h-5 text-primary" />
+          <h1 className="font-display text-2xl text-foreground">Hardcover</h1>
+        </div>
+        <p className="text-sm text-muted-foreground mb-6">
+          What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books.
+        </p>
+
+        {!status ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="w-4 h-4 animate-spin" /> Loading…
+          </div>
+        ) : !status.linked ? (
+          <div className="rounded-xl border border-border bg-card p-6 text-sm text-foreground/90 max-w-xl">
+            <p className="mb-2">No Hardcover account linked yet.</p>
+            <p className="text-muted-foreground">
+              Link your personal API token in{' '}
+              <Link to="/settings" className="text-primary hover:underline">Settings → Hardcover</Link>{' '}
+              — syncing starts right after.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-2 mb-5">
+              <button
+                onClick={() => void syncNow()}
+                disabled={!!status.sync_running}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border text-sm font-medium text-foreground hover:bg-muted transition-colors disabled:opacity-50"
+              >
+                <RefreshCw className={cn('w-4 h-4', status.sync_running && 'animate-spin')} />
+                {status.sync_running ? 'Syncing…' : 'Sync now'}
+              </button>
+              <span className="text-xs text-muted-foreground mr-2">
+                @{status.username}
+                {status.last_synced_at && ` · last synced ${new Date(status.last_synced_at + 'Z').toLocaleString()}`}
+              </span>
+              <div className="flex items-center gap-1 ml-auto">
+                <button
+                  onClick={() => persistGroup(!grouped)}
+                  title={grouped ? 'Show individual volumes' : 'Group volumes by series'}
+                  aria-pressed={grouped}
+                  className={cn(
+                    'flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border transition-all mr-1',
+                    grouped
+                      ? 'border-primary/40 bg-primary/10 text-primary'
+                      : 'border-border text-muted-foreground hover:text-foreground hover:bg-muted'
+                  )}
+                >
+                  <Layers className="w-3.5 h-3.5" />
+                  <span className="hidden sm:inline">Group series</span>
+                </button>
+                {FILTERS.map(f => {
+                  const n = counts[f.key]
+                  if (f.key !== 'all' && n === 0) return null
+                  return (
+                    <button
+                      key={f.key}
+                      onClick={() => setFilter(f.key)}
+                      className={cn(
+                        'px-2.5 py-1 rounded-md text-xs font-medium border transition-colors',
+                        filter === f.key
+                          ? 'bg-primary/10 border-primary/40 text-primary'
+                          : 'border-border text-muted-foreground hover:text-foreground hover:bg-muted'
+                      )}
+                    >
+                      {f.label} <span className="opacity-60">{n}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              <div className="relative">
+                <Search className="w-3.5 h-3.5 absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  value={query}
+                  onChange={e => setQuery(e.target.value)}
+                  placeholder="Filter…"
+                  className="pl-7 pr-2 py-1.5 w-40 rounded-md border border-border bg-background text-xs text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
+                />
+              </div>
+            </div>
+
+            {expandedSeries && (
+              <div className="flex items-center gap-2 mb-4">
+                <button
+                  onClick={() => setExpandedSeries(null)}
+                  className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-border text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                >
+                  <ChevronLeft className="w-3.5 h-3.5" /> All books
+                </button>
+                <span className="text-sm font-medium text-foreground">{expandedSeries}</span>
+              </div>
+            )}
+
+            {books == null ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="w-4 h-4 animate-spin" /> Loading books…
+              </div>
+            ) : cells.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No books in this view.</p>
+            ) : (
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+                {cells.map(cell => cell.kind === 'stack' ? (
+                  <SeriesStackCard
+                    key={`stack-${cell.volumes[0].series}`}
+                    book={toBookShape(cell.volumes[0], cell.volumes)}
+                    count={cell.volumes.length}
+                    view="small"
+                    onOpen={() => setExpandedSeries(cell.volumes[0].series)}
+                  />
+                ) : (() => { const b = cell.b; return (
+                  <div key={b.book_id} className="rounded-xl border border-border bg-card overflow-hidden flex flex-col">
+                    <Link to={`/books/${b.book_id}`} className="relative block aspect-[2/3] bg-muted">
+                      <CoverImage
+                        src={`/api/books/${b.book_id}/cover`}
+                        alt={b.title}
+                        imgClassName="absolute inset-0 w-full h-full object-cover"
+                        iconClassName="w-8 h-8"
+                      />
+                      <span className={cn(
+                        'absolute top-1.5 left-1.5 px-1.5 py-0.5 rounded text-[10px] font-medium',
+                        b.error ? 'bg-warning/90 text-black'
+                          : b.state === 'matched' ? 'bg-success/90 text-black'
+                          : b.state === 'excluded' ? 'bg-muted-foreground/80 text-black'
+                          : 'bg-black/60 text-white'
+                      )}>
+                        {b.error ? 'Error' : STATE_LABEL[b.state]}
+                      </span>
+                    </Link>
+                    <div className="p-2.5 flex flex-col gap-1 grow">
+                      <p className="text-xs font-medium text-foreground leading-snug line-clamp-2">{displayTitle(b)}</p>
+                      {b.slug ? (
+                        <a
+                          href={`https://hardcover.app/books/${b.slug}`}
+                          target="_blank" rel="noopener noreferrer"
+                          className="text-[11px] text-primary hover:underline inline-flex items-center gap-0.5 truncate"
+                        >
+                          <span className="truncate">{b.slug}</span>
+                          <ExternalLink className="w-3 h-3 shrink-0" />
+                        </a>
+                      ) : (
+                        <p className="text-[11px] text-muted-foreground truncate">
+                          {b.state === 'excluded' ? 'not syncing' : b.isbn ?? 'no ISBN'}
+                        </p>
+                      )}
+                      {b.error && (
+                        <p className="text-[11px] text-warning inline-flex items-center gap-1">
+                          <AlertTriangle className="w-3 h-3 shrink-0" />
+                          <span className="truncate" title={b.error}>{b.error}</span>
+                        </p>
+                      )}
+                      <div className="mt-auto pt-1.5 flex items-center gap-2 text-[11px]">
+                        <button
+                          onClick={() => void openPicker(b)}
+                          className="text-primary hover:underline"
+                          title="Search Hardcover and pick the record yourself"
+                        >
+                          Pick
+                        </button>
+                        {b.state === 'matched' && (
+                          <button
+                            onClick={() => void rematch(b, 'retry')}
+                            className="text-muted-foreground hover:text-foreground"
+                            title="Remove our entry from Hardcover and re-match automatically"
+                          >
+                            Re-match
+                          </button>
+                        )}
+                        {b.state === 'excluded' ? (
+                          <button
+                            onClick={() => void rematch(b, 'retry')}
+                            className="text-muted-foreground hover:text-foreground"
+                            title="Start matching this book again"
+                          >
+                            Include
+                          </button>
+                        ) : (
+                          <button
+                            onClick={() => void rematch(b, 'exclude')}
+                            className="text-muted-foreground hover:text-destructive"
+                            title="Never sync this book"
+                          >
+                            Exclude
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                ) })())}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Pick-a-record modal */}
+      {pickFor && (
+        <div
+          className="fixed inset-0 z-50 bg-black/50 flex items-start justify-center p-4 pt-[10vh]"
+          onClick={() => setPickFor(null)}
+        >
+          <div
+            className="w-full max-w-lg rounded-xl border border-border bg-card shadow-xl overflow-hidden"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="p-4 border-b border-border">
+              <div className="flex items-center justify-between gap-2 mb-3">
+                <p className="text-sm font-medium text-foreground truncate">
+                  Match “{displayTitle(pickFor)}” to…
+                </p>
+                <button onClick={() => setPickFor(null)} aria-label="Close"
+                        className="text-muted-foreground hover:text-foreground">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="flex gap-2">
+                <input
+                  value={pickQuery}
+                  onChange={e => setPickQuery(e.target.value)}
+                  onKeyDown={e => { if (e.key === 'Enter') void runPickSearch(pickQuery) }}
+                  autoFocus
+                  placeholder="Search Hardcover…"
+                  className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none"
+                />
+                <button
+                  onClick={() => void runPickSearch(pickQuery)}
+                  disabled={pickBusy}
+                  className="px-3 py-2 rounded-md border border-border text-sm text-foreground hover:bg-muted disabled:opacity-50"
+                >
+                  Search
+                </button>
+              </div>
+            </div>
+            <div className="max-h-[50vh] overflow-y-auto">
+              {pickResults == null ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground p-4">
+                  <Loader2 className="w-4 h-4 animate-spin" /> Searching…
+                </div>
+              ) : pickResults.length === 0 ? (
+                <p className="text-sm text-muted-foreground p-4">No results — try a different query.</p>
+              ) : (
+                <ul className="divide-y divide-border">
+                  {pickResults.map(c => (
+                    <li key={c.hardcover_book_id}>
+                      <button
+                        onClick={() => void pin(c)}
+                        disabled={pickBusy}
+                        className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-muted/60 transition-colors disabled:opacity-50"
+                      >
+                        {c.cover_url ? (
+                          <img src={c.cover_url} alt="" className="w-9 h-14 object-cover rounded-sm shrink-0" />
+                        ) : (
+                          <span className="w-9 h-14 rounded-sm bg-muted shrink-0" />
+                        )}
+                        <span className="min-w-0">
+                          <span className="block text-sm text-foreground truncate">{c.title}</span>
+                          <span className="block text-xs text-muted-foreground truncate">
+                            {c.authors.join(', ') || 'unknown author'}
+                            {c.users_count > 0 && ` · ${c.users_count} reader${c.users_count === 1 ? '' : 's'}`}
+                          </span>
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </AppShell>
+  )
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react'
 import { DOCS, docsLink } from '@/lib/docs'
 import { ThemeToggle } from '@/components/ThemeToggle'
+import { HardcoverSync } from '@/components/HardcoverSync'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import {
@@ -362,6 +363,8 @@ export function SettingsPage() {
   const [deviceDeleting, setDeviceDeleting] = useState<number | null>(null)
   const [deviceError, setDeviceError] = useState<string | null>(null)
   const [setupGuideOpen, setSetupGuideOpen] = useState(false)
+  // Hardcover sync section hides itself when the server has the feature off
+  const [hardcoverAvailable, setHardcoverAvailable] = useState(true)
 
   useEffect(() => {
     api.get<{ configured: boolean }>('/smtp-status').then(r => {
@@ -1271,6 +1274,14 @@ export function SettingsPage() {
             </div>
           </div>
         </section>
+
+        {/* ── Hardcover ────────────────────────────────────────────────── */}
+        {hardcoverAvailable && (
+          <section>
+            <SectionHeader title="Hardcover" />
+            <HardcoverSync onAvailable={setHardcoverAvailable} />
+          </section>
+        )}
 
         {/* ── API Tokens ───────────────────────────────────────────────── */}
         <section>

--- a/tests/test_half_star_ratings.py
+++ b/tests/test_half_star_ratings.py
@@ -1,0 +1,134 @@
+"""Half-star ratings: validation, and legacy-int / new-float coexistence.
+
+The rating columns keep their original INTEGER declaration; SQLite NUMERIC
+affinity stores 4.5 as REAL. These tests pin the mixed-type behaviors the
+migration relies on (avg/filter/sort/group across int and float rows).
+"""
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import func, text
+
+from backend.core.ratings import validate_rating
+from backend.models.user_book_status import UserBookStatus
+from backend.models.user_series_rating import UserSeriesRating
+
+
+# ── validator ─────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("ok", [1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 1.0, 5.0, None])
+def test_validate_rating_accepts_half_steps(ok):
+    validate_rating(ok)  # must not raise
+
+
+@pytest.mark.parametrize("bad", [0, 0.5, 5.5, 4.3, 4.25, -1, 100,
+                                 float("inf"), float("-inf"), float("nan")])
+def test_validate_rating_rejects(bad):
+    # inf/nan must 400 like any bad value, not OverflowError into a 500
+    # (Pydantic floats accept Infinity/NaN by default).
+    with pytest.raises(HTTPException):
+        validate_rating(bad)
+
+
+# ── endpoint validation ───────────────────────────────────────────────────────
+
+def test_put_rating_half_star_roundtrip(client, make_book):
+    book = make_book(title="Halves")
+    r = client.put(f"/api/books/{book.id}/rating", json={"rating": 4.5})
+    assert r.status_code == 200
+    assert r.json()["rating"] == 4.5
+    # whole star still works and comes back whole-valued
+    r = client.put(f"/api/books/{book.id}/rating", json={"rating": 3})
+    assert r.status_code == 200
+    assert r.json()["rating"] == 3
+
+
+@pytest.mark.parametrize("bad", [4.3, 0.5, 5.5, 0])
+def test_put_rating_rejects_off_step(client, make_book, bad):
+    book = make_book(title=f"Bad {bad}")
+    r = client.put(f"/api/books/{book.id}/rating", json={"rating": bad})
+    assert r.status_code == 400
+
+
+def test_series_rating_half_star(client, make_book):
+    make_book(title="Vol 1", series="Halved", series_index=1)
+    r = client.put("/api/series/Halved/rating", json={"rating": 3.5})
+    assert r.status_code == 200
+    assert r.json()["rating"] == 3.5
+    assert r.json()["display"] == 3.5
+    r = client.put("/api/series/Halved/rating", json={"rating": 4.3})
+    assert r.status_code == 400
+
+
+# ── mixed int/float coexistence (the migration's core claim) ─────────────────
+
+def test_legacy_integer_column_stores_halves_losslessly(db):
+    """The PROD shape: the physical column was created as INTEGER (old model).
+    SQLite NUMERIC affinity must store 4.5 as REAL, not truncate it, and
+    aggregate/compare mixed rows correctly."""
+    db.execute(text("CREATE TABLE _legacy_rating_probe (id INTEGER PRIMARY KEY, rating INTEGER)"))
+    db.execute(text("INSERT INTO _legacy_rating_probe (rating) VALUES (4)"))
+    db.execute(text("INSERT INTO _legacy_rating_probe (rating) VALUES (4.5)"))
+    types = {r[0] for r in db.execute(text("SELECT typeof(rating) FROM _legacy_rating_probe"))}
+    assert types == {"integer", "real"}
+    vals = [r[0] for r in db.execute(
+        text("SELECT rating FROM _legacy_rating_probe ORDER BY rating DESC"))]
+    assert vals == [4.5, 4]
+    avg = db.execute(text("SELECT avg(rating) FROM _legacy_rating_probe")).scalar()
+    assert avg == pytest.approx(4.25)
+    above4 = db.execute(
+        text("SELECT count(*) FROM _legacy_rating_probe WHERE rating > 4")).scalar()
+    assert above4 == 1
+    db.execute(text("DROP TABLE _legacy_rating_probe"))
+
+
+def test_mixed_int_and_float_rows_coexist(db, admin_user, make_book):
+    """The fresh-DB shape (column declared FLOAT by create_all): whole-star and
+    half-star rows aggregate/filter/sort uniformly through the ORM."""
+    user, _ = admin_user
+    b1 = make_book(title="Legacy Int")
+    b2 = make_book(title="New Half")
+    db.add(UserBookStatus(user_id=user.id, book_id=b1.id, status="read", rating=4))
+    db.add(UserBookStatus(user_id=user.id, book_id=b2.id, status="read", rating=4.5))
+    db.flush()
+
+    # avg, comparison filters, and sorting all treat them uniformly.
+    avg = db.query(func.avg(UserBookStatus.rating)).filter(
+        UserBookStatus.user_id == user.id).scalar()
+    assert avg == pytest.approx(4.25)
+
+    at_least_4 = db.query(UserBookStatus).filter(
+        UserBookStatus.user_id == user.id, UserBookStatus.rating >= 4).count()
+    assert at_least_4 == 2
+    above_4 = db.query(UserBookStatus).filter(
+        UserBookStatus.user_id == user.id, UserBookStatus.rating > 4).count()
+    assert above_4 == 1
+
+    ordered = [r.rating for r in db.query(UserBookStatus).filter(
+        UserBookStatus.user_id == user.id).order_by(UserBookStatus.rating.desc())]
+    assert ordered == [4.5, 4]
+
+    # Python-side grouping: int and float keys collapse (4 == 4.0, same hash).
+    assert len({4, 4.0}) == 1
+
+
+def test_series_volume_average_with_mixed_ratings(client, db, admin_user, make_book):
+    user, _ = admin_user
+    v1 = make_book(title="Mix Vol 1", series="MixSeries", series_index=1)
+    v2 = make_book(title="Mix Vol 2", series="MixSeries", series_index=2)
+    db.add(UserBookStatus(user_id=user.id, book_id=v1.id, status="read", rating=3))
+    db.add(UserBookStatus(user_id=user.id, book_id=v2.id, status="read", rating=4.5))
+    db.flush()
+
+    r = client.get("/api/series/MixSeries/rating")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["volume_average"] == pytest.approx(3.75)
+    assert body["rated_volumes"] == 2
+
+
+def test_series_rating_model_accepts_float(db, admin_user):
+    user, _ = admin_user
+    db.add(UserSeriesRating(user_id=user.id, series_name="S", rating=2.5))
+    db.flush()
+    row = db.query(UserSeriesRating).filter_by(user_id=user.id, series_name="S").one()
+    assert row.rating == 2.5

--- a/tests/test_hardcover_sync.py
+++ b/tests/test_hardcover_sync.py
@@ -1,0 +1,749 @@
+"""Hardcover sync — crypto, ISBN helpers, matcher guard, reconciler, endpoints."""
+import httpx
+import pytest
+import respx
+
+from backend.models.notification import Notification
+from backend.models.user_book_status import UserBookStatus
+from backend.services import hardcover_sync as hs
+from backend.services.hardcover_sync import HARDCOVER_URL
+
+
+@pytest.fixture(autouse=True)
+def _no_throttle(monkeypatch):
+    """Tests must not sleep 1.1s per mocked request."""
+    monkeypatch.setattr(hs, "MIN_REQUEST_SPACING", 0.0)
+
+
+# ── crypto ────────────────────────────────────────────────────────────────────
+
+def test_crypto_roundtrip_and_tamper():
+    from backend.core.crypto import decrypt_secret, encrypt_secret
+    ct = encrypt_secret("hc_secret_token")
+    assert ct != "hc_secret_token"
+    assert decrypt_secret(ct) == "hc_secret_token"
+    assert decrypt_secret(None) is None
+    assert decrypt_secret("") is None
+    assert decrypt_secret("garbage-not-fernet") is None
+
+
+# ── ISBN helpers ──────────────────────────────────────────────────────────────
+
+def test_normalize_isbn():
+    assert hs.normalize_isbn("978-0-306-40615-7") == "9780306406157"
+    assert hs.normalize_isbn("0-306-40615-2") == "0306406152"
+    assert hs.normalize_isbn("155404295x") == "155404295X"
+    assert hs.normalize_isbn("not an isbn") is None
+    assert hs.normalize_isbn(None) is None
+    assert hs.normalize_isbn("12345") is None
+
+
+def test_isbn10_to_13_known_pair():
+    assert hs.isbn10_to_13("0306406152") == "9780306406157"
+
+
+def test_isbn_variants_includes_13_for_a_10():
+    assert hs.isbn_variants("0-306-40615-2") == ["0306406152", "9780306406157"]
+    assert hs.isbn_variants("9780306406157") == ["9780306406157"]
+    assert hs.isbn_variants(None) == []
+
+
+# ── reconciler diff ───────────────────────────────────────────────────────────
+
+def _row(**kw) -> UserBookStatus:
+    defaults = dict(user_id=1, book_id=1, status="unread")
+    defaults.update(kw)
+    return UserBookStatus(**defaults)
+
+
+def test_needs_sync_rating_change():
+    assert hs.needs_sync(_row(rating=4.5))
+    assert not hs.needs_sync(_row(rating=4.5, hardcover_synced_rating=4.5))
+    # legacy int snapshot vs float rating: 4 == 4.0 → no push
+    assert not hs.needs_sync(_row(rating=4, hardcover_synced_rating=4.0))
+
+
+def test_needs_sync_never_propagates_rating_clear():
+    assert not hs.needs_sync(_row(rating=None, hardcover_synced_rating=4.0))
+
+
+def test_needs_sync_status_and_progress():
+    assert hs.needs_sync(_row(status="reading", progress_pct=0.2))
+    assert hs.needs_sync(_row(status="read", hardcover_synced_status="reading",
+                              progress_pct=1.0, hardcover_synced_pct=1.0))
+    assert not hs.needs_sync(_row(status="reading", hardcover_synced_status="reading",
+                                  progress_pct=0.5, hardcover_synced_pct=0.495))
+    assert hs.needs_sync(_row(status="reading", hardcover_synced_status="reading",
+                              progress_pct=0.52, hardcover_synced_pct=0.50))
+    # unread/shelved never push
+    assert not hs.needs_sync(_row(status="shelved", progress_pct=0.4))
+
+
+def test_needs_sync_progress_is_forward_only():
+    # A regression (stale device rewind, re-opened book) is never mirrored to
+    # the public profile.
+    assert not hs.needs_sync(_row(status="reading", hardcover_synced_status="reading",
+                                  progress_pct=0.62, hardcover_synced_pct=0.90))
+
+
+def test_progress_pages_math():
+    assert hs._progress_pages(_row(status="reading", progress_pct=0.5), 384) == 192
+    assert hs._progress_pages(_row(status="read", progress_pct=0.4), 384) == 384
+    assert hs._progress_pages(_row(status="reading", progress_pct=0.5), None) is None
+    assert hs._progress_pages(_row(status="reading", progress_pct=0.5), 0) is None
+    assert hs._progress_pages(_row(status="reading", progress_pct=1.5), 100) == 100
+
+
+# ── matcher ───────────────────────────────────────────────────────────────────
+
+def _search_payload(hits):
+    return {"data": {"search": {"results": {"hits": hits}}}}
+
+
+@respx.mock
+async def test_match_book_isbn_hit(make_book):
+    book = make_book(title="Dune", isbn="9780441013593")
+    respx.post(HARDCOVER_URL).mock(return_value=httpx.Response(200, json={
+        "data": {"editions": [{"id": 555, "pages": 412, "book_id": 77,
+                               "book": {"id": 77, "title": "Dune", "pages": 412}}]}
+    }))
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_book_id == 77
+    assert book.hardcover_edition_id == 555
+    assert book.hardcover_pages == 412
+    assert book.hardcover_match_method == "isbn13"
+
+
+@respx.mock
+async def test_match_book_search_guard_refuses_dissimilar(make_book):
+    book = make_book(title="A Very Specific Novel", author="Jane Author", isbn=None)
+    respx.post(HARDCOVER_URL).mock(return_value=httpx.Response(200, json=_search_payload([
+        {"document": {"id": 1, "title": "Completely Different Book",
+                      "author_names": ["Jane Author"]}},
+        {"document": {"id": 2, "title": "A Very Specific Novel",
+                      "author_names": ["Somebody Else Entirely"]}},
+    ])))
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is False
+    assert book.hardcover_match_method == "none"
+    assert book.hardcover_book_id is None
+    assert book.hardcover_matched_at is not None
+
+
+@respx.mock
+async def test_match_book_search_accepts_close_match(make_book):
+    book = make_book(title="Project Hail Mary", author="Andy Weir", isbn=None)
+
+    def responder(request):
+        body = request.read().decode()
+        if "SearchBook" in body:
+            return httpx.Response(200, json=_search_payload([
+                {"document": {"id": 90, "title": "Project Hail Mary",
+                              "author_names": ["Andy Weir"]}},
+            ]))
+        return httpx.Response(200, json={"data": {"books": [
+            {"id": 90, "pages": 476, "editions": [{"id": 901, "pages": 476}]}
+        ]}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_book_id == 90
+    assert book.hardcover_edition_id == 901
+    assert book.hardcover_pages == 476
+    assert book.hardcover_match_method == "search"
+
+
+@respx.mock
+async def test_match_book_volume_aware_search(make_book):
+    """LN volumes share a bare series title in Tome; the matcher must pick the
+    per-volume Hardcover record, never the unmarked vol-1/series record or the
+    manga variant (shapes taken from the live catalogue)."""
+    book = make_book(title="Black Summoner", author="Doufu Mayoi",
+                     series="Black Summoner", series_index=2, isbn=None)
+    seen_queries = []
+
+    def responder(request):
+        import json
+        body = json.loads(request.read())
+        if "SearchBook" in body["query"]:
+            seen_queries.append(body["variables"]["q"])
+            return httpx.Response(200, json=_search_payload([
+                {"document": {"id": 2213196, "title": "Black Summoner",
+                              "author_names": ["Doufu Mayoi"]}},           # unmarked vol-1 record
+                {"document": {"id": 1661771, "title": "Black Summoner (Manga) Vol 2",
+                              "author_names": ["Gin Ammo"]}},              # manga variant
+                {"document": {"id": 2624495, "title": "Black Summoner, Vol. 2",
+                              "author_names": []}},                        # the right one
+            ]))
+        return httpx.Response(200, json={"data": {"books": [
+            {"id": 2624495, "pages": 230, "editions": [{"id": 999, "pages": 230}]}
+        ]}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_book_id == 2624495
+    assert book.hardcover_pages == 230
+    # The query itself must carry the volume, not the bare shared title.
+    assert "Vol. 2" in seen_queries[0]
+
+
+@respx.mock
+async def test_match_book_splits_multi_author_strings(make_book):
+    """Tome's 'A and B' author string must match individual author_names."""
+    book = make_book(title="Cloud FinOps", author="J.R. Storment and Mike Fuller", isbn=None)
+
+    def responder(request):
+        body = request.read().decode()
+        if "SearchBook" in body:
+            return httpx.Response(200, json=_search_payload([
+                {"document": {"id": 77, "title": "Cloud FinOps",
+                              "author_names": ["J.R. Storment", "Mike Fuller"]}},
+            ]))
+        return httpx.Response(200, json={"data": {"books": [
+            {"id": 77, "pages": 457, "editions": [{"id": 771, "pages": 457}]}
+        ]}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_book_id == 77
+    assert book.hardcover_match_method == "search"
+
+
+@respx.mock
+async def test_match_book_standalone_rejects_numbered_volume(make_book):
+    book = make_book(title="Dune", author="Frank Herbert", isbn=None)
+    respx.post(HARDCOVER_URL).mock(return_value=httpx.Response(200, json=_search_payload([
+        {"document": {"id": 5, "title": "Dune Vol. 3", "author_names": ["Frank Herbert"]}},
+    ])))
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is False
+    assert book.hardcover_match_method == "none"
+
+
+@respx.mock
+async def test_match_book_prefers_popular_record_over_stub(make_book):
+    """Vol-1 case observed live: the '… Vol. 1' query surfaces only a
+    user-created stub (users_count 1, no author); the real record has the bare
+    series title and only appears for the bare query. Both query forms must be
+    searched and the community record preferred."""
+    book = make_book(title="Black Summoner", author="Doufu Mayoi",
+                     series="Black Summoner", series_index=1, isbn=None)
+    import json as _json
+    queries = []
+
+    def responder(request):
+        body = _json.loads(request.read())
+        if "SearchBook" in body["query"]:
+            q = body["variables"]["q"]
+            queries.append(q)
+            if "Vol. 1" in q:
+                return httpx.Response(200, json=_search_payload([
+                    {"document": {"id": 2624493, "title": "Black Summoner -, Vol. 1",
+                                  "author_names": [], "users_count": 1}},
+                ]))
+            return httpx.Response(200, json=_search_payload([
+                {"document": {"id": 2213196, "title": "Black Summoner",
+                              "author_names": ["Doufu Mayoi"], "users_count": 58}},
+            ]))
+        return httpx.Response(200, json={"data": {"books": [
+            {"id": 2213196, "pages": 230, "editions": [{"id": 555, "pages": 230}]}
+        ]}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_book_id == 2213196   # the real record wins
+    assert len(queries) == 2                    # both query forms were searched
+
+
+@respx.mock
+async def test_match_book_isbn_hit_sanity_checked(make_book):
+    """A stored ISBN resolving to the WRONG volume (legacy wrong-edition ISBNs,
+    or a bad catalogue mapping — observed live: vol 2's ISBN → 'Volume 10')
+    must fall through to the guarded search instead of matching."""
+    book = make_book(title="Black Summoner", author="Doufu Mayoi",
+                     series="Black Summoner", series_index=2, isbn="9781718375666")
+
+    def responder(request):
+        body = request.read().decode()
+        if "EditionByIsbn" in body:
+            return httpx.Response(200, json={"data": {"editions": [
+                {"id": 32716494, "title": None, "pages": 246, "book_id": 2440311,
+                 "book": {"id": 2440311, "title": "Black Summoner: Volume 10", "pages": 246}}
+            ]}})
+        if "SearchBook" in body:
+            return httpx.Response(200, json=_search_payload([
+                {"document": {"id": 2624495, "title": "Black Summoner, Vol. 2",
+                              "author_names": []}},
+            ]))
+        return httpx.Response(200, json={"data": {"books": [
+            {"id": 2624495, "pages": 230, "editions": [{"id": 999, "pages": 230}]}
+        ]}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_book_id == 2624495
+    assert book.hardcover_match_method == "search"
+
+
+def test_isbn_hit_plausible(make_book):
+    vol2 = make_book(title="Black Summoner", series="Black Summoner", series_index=2)
+    assert not hs._isbn_hit_plausible(vol2, "Black Summoner: Volume 10")
+    assert hs._isbn_hit_plausible(vol2, "Black Summoner: Volume 2")
+    assert hs._isbn_hit_plausible(vol2, "Black Summoner")   # unnumbered title: permissive
+    assert not hs._isbn_hit_plausible(vol2, "Black Summoner (Manga) Vol 2")
+    standalone = make_book(title="Dune")
+    assert not hs._isbn_hit_plausible(standalone, "Dune Vol. 3")
+    assert not hs._isbn_hit_plausible(standalone, "A Totally Unrelated Cookbook")
+    assert hs._isbn_hit_plausible(standalone, "Dune")
+    assert hs._isbn_hit_plausible(standalone, "")           # nothing to check
+
+
+def test_vol_and_author_helpers():
+    assert hs._vol_in_title("Black Summoner, Vol. 2") == 2
+    assert hs._vol_in_title("Overlord Volume 14") == 14
+    assert hs._vol_in_title("Berserk v03") == 3
+    assert hs._vol_in_title("Dune") is None
+    assert hs._split_authors("J.R. Storment and Mike Fuller") == ["J.R. Storment", "Mike Fuller"]
+    assert hs._split_authors("A, B & C") == ["A", "B", "C"]
+    assert hs._split_authors(None) == []
+    assert hs._is_manga_title("Black Summoner (Manga) Vol 2")
+    assert not hs._is_manga_title("Black Summoner, Vol. 2")
+
+
+# ── push flow ─────────────────────────────────────────────────────────────────
+
+@respx.mock
+async def test_push_row_full_flow(db, admin_user, make_book):
+    user, _ = admin_user
+    user.hardcover_user_id = 42
+    book = make_book(title="Dune", isbn="9780441013593")
+    book.hardcover_book_id = 77
+    book.hardcover_edition_id = 555
+    book.hardcover_pages = 400
+    row = UserBookStatus(user_id=user.id, book_id=book.id, status="reading",
+                         progress_pct=0.5, rating=4.5)
+    db.add(row)
+    db.flush()
+
+    seen = []
+
+    def responder(request):
+        body = request.read().decode()
+        seen.append(body)
+        if "mutation InsertUserBook" in body:
+            return httpx.Response(200, json={"data": {"insert_user_book": {"id": 1001, "error": None}}})
+        if "mutation UpdateUserBook" in body:
+            return httpx.Response(200, json={"data": {"update_user_book": {"id": 1001, "error": None}}})
+        if "mutation InsertRead" in body:
+            return httpx.Response(200, json={"data": {"insert_user_book_read": {"id": 2002, "error": None}}})
+        if "query UserBook" in body:
+            return httpx.Response(200, json={"data": {"user_books": []}})
+        return httpx.Response(200, json={"data": {}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        await hs._push_row(client, "tok", user, row, book)
+
+    assert row.hardcover_user_book_id == 1001
+    assert row.hardcover_read_id == 2002
+    assert row.hardcover_synced_rating == 4.5
+    assert row.hardcover_synced_status == "reading"
+    assert row.hardcover_synced_pct == 0.5
+    assert row.hardcover_error is None
+    # progress_pages must be page-based: round(0.5 × 400) = 200
+    assert any('"progress_pages": 200' in b or '"progress_pages":200' in b for b in seen)
+
+
+@respx.mock
+async def test_push_row_adopts_auto_created_read(db, admin_user, make_book):
+    """insert_user_book auto-creates an initial read row on Hardcover (observed
+    live) — the push must adopt it, not insert a duplicate."""
+    user, _ = admin_user
+    user.hardcover_user_id = 42
+    book = make_book(title="Dune")
+    book.hardcover_book_id = 77
+    book.hardcover_pages = 400
+    row = UserBookStatus(user_id=user.id, book_id=book.id, status="reading", progress_pct=0.5)
+    db.add(row)
+    db.flush()
+
+    def responder(request):
+        body = request.read().decode()
+        assert "mutation InsertRead" not in body, "must adopt the auto-created read, not insert"
+        if "query UserBook" in body:
+            return httpx.Response(200, json={"data": {"user_books": []}})
+        if "mutation InsertUserBook" in body:
+            return httpx.Response(200, json={"data": {"insert_user_book": {"id": 1001, "error": None}}})
+        if "query Reads" in body:
+            return httpx.Response(200, json={"data": {"user_book_reads": [{"id": 3003}]}})
+        if "mutation UpdateRead" in body:
+            return httpx.Response(200, json={"data": {"update_user_book_read": {"id": 3003, "error": None}}})
+        return httpx.Response(200, json={"data": {}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        await hs._push_row(client, "tok", user, row, book)
+    assert row.hardcover_read_id == 3003
+    assert row.hardcover_synced_pct == 0.5
+
+
+@respx.mock
+async def test_push_row_status_only_without_pages(db, admin_user, make_book):
+    user, _ = admin_user
+    user.hardcover_user_id = 42
+    book = make_book(title="Obscure Book")
+    book.hardcover_book_id = 88
+    book.hardcover_pages = None
+    row = UserBookStatus(user_id=user.id, book_id=book.id, status="reading", progress_pct=0.3)
+    db.add(row)
+    db.flush()
+
+    def responder(request):
+        body = request.read().decode()
+        assert "mutation InsertRead" not in body and "mutation UpdateRead" not in body, \
+            "page-less book must not push progress reads"
+        if "query UserBook" in body:
+            return httpx.Response(200, json={"data": {"user_books": [
+                {"id": 1001, "status_id": None, "user_book_reads": []}]}})
+        if "mutation UpdateUserBook" in body:
+            return httpx.Response(200, json={"data": {"update_user_book": {"id": 1001, "error": None}}})
+        return httpx.Response(200, json={"data": {}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        await hs._push_row(client, "tok", user, row, book)
+    assert row.hardcover_synced_status == "reading"
+    assert row.hardcover_synced_pct == 0.3  # snapshotted so needs_sync stops firing
+    assert not hs.needs_sync(row)
+
+
+# ── auth failure → expired + one notification ────────────────────────────────
+
+def test_mark_token_expired_notifies_once(db, admin_user):
+    user, _ = admin_user
+    user.hardcover_token = "enc"
+    user.hardcover_token_status = "ok"
+    hs.mark_token_expired(db, user)
+    hs.mark_token_expired(db, user)
+    assert user.hardcover_token_status == "expired"
+    notes = db.query(Notification).filter_by(user_id=user.id, kind="hardcover_token_expired").all()
+    assert len(notes) == 1
+
+
+# ── API endpoints ─────────────────────────────────────────────────────────────
+
+def test_link_flow_and_status(client, db, admin_user, monkeypatch):
+    user, _ = admin_user
+
+    async def fake_verify(token):
+        # Hardcover needs the literal "Bearer " prefix; the endpoint normalizes
+        # a bare pasted token (verified against the live API).
+        assert token == "Bearer hc_tok"
+        return {"id": 42, "username": "benedict"}
+
+    monkeypatch.setattr(hs, "verify_token", fake_verify)
+    started_for: list[int] = []
+    monkeypatch.setattr(hs, "start_manual_sync", lambda uid: started_for.append(uid) or True)
+
+    r = client.get("/api/hardcover/status")
+    assert r.status_code == 200 and r.json() == {"linked": False}
+
+    r = client.post("/api/hardcover/link", json={"token": "hc_tok"})
+    assert r.status_code == 200
+    assert r.json()["username"] == "benedict"
+    # Linking kicks off the initial backfill itself.
+    assert r.json()["sync_started"] is True
+    assert started_for == [user.id]
+    assert user.hardcover_sync_enabled is True
+    assert user.hardcover_user_id == 42
+    # token stored encrypted (with the normalized Bearer prefix), decrypts back
+    from backend.core.crypto import decrypt_secret
+    assert "hc_tok" not in (user.hardcover_token or "")
+    assert decrypt_secret(user.hardcover_token) == "Bearer hc_tok"
+
+    r = client.get("/api/hardcover/status")
+    body = r.json()
+    assert body["linked"] is True
+    assert body["username"] == "benedict"
+    assert body["token_status"] == "ok"
+
+    r = client.put("/api/hardcover/settings", json={"sync_enabled": False})
+    assert r.status_code == 200 and r.json()["sync_enabled"] is False
+
+    r = client.delete("/api/hardcover/link")
+    assert r.status_code == 204
+    assert user.hardcover_token is None
+    assert client.get("/api/hardcover/status").json() == {"linked": False}
+
+
+def test_link_rejects_bad_token(client, monkeypatch):
+    async def fake_verify(token):
+        raise hs.HardcoverAuthError()
+
+    monkeypatch.setattr(hs, "verify_token", fake_verify)
+    r = client.post("/api/hardcover/link", json={"token": "bad"})
+    assert r.status_code == 400
+
+
+def test_sync_now_requires_link(client):
+    r = client.post("/api/hardcover/sync-now")
+    assert r.status_code == 400
+
+
+def test_sync_now_resets_parked_rows(client, db, admin_user, make_book, monkeypatch):
+    user, _ = admin_user
+    from backend.core.crypto import encrypt_secret
+    user.hardcover_token = encrypt_secret("t")
+    user.hardcover_token_status = "ok"
+    book = make_book(title="Parked")
+    row = UserBookStatus(user_id=user.id, book_id=book.id, status="read",
+                         hardcover_fail_count=10, hardcover_error="boom")
+    db.add(row)
+    db.flush()
+
+    monkeypatch.setattr(hs, "start_manual_sync", lambda uid: True)
+    r = client.post("/api/hardcover/sync-now")
+    assert r.status_code == 200 and r.json()["started"] is True
+    db.refresh(row)
+    assert row.hardcover_fail_count == 0
+
+
+def _link_test_user(user):
+    from backend.core.crypto import encrypt_secret
+    user.hardcover_token = encrypt_secret("Bearer t")
+    user.hardcover_token_status = "ok"
+    user.hardcover_user_id = 42
+
+
+def test_hardcover_books_page_endpoint(client, db, admin_user, make_book):
+    """The /hardcover page's data source: every status-row book with its state."""
+    user, _ = admin_user
+    _link_test_user(user)
+    matched = make_book(title="Black Summoner", series="Black Summoner", series_index=10)
+    matched.hardcover_book_id = 2440311
+    matched.hardcover_slug = "black-summoner-volume-10"
+    matched.hardcover_match_method = "isbn13"
+    unmatched = make_book(title="Obscure Zine")
+    unmatched.hardcover_match_method = "none"
+    from datetime import datetime as _dt
+    unmatched.hardcover_matched_at = _dt.utcnow()
+    pending = make_book(title="Fresh Upload")
+    for i, b in enumerate((matched, unmatched, pending)):
+        db.add(UserBookStatus(user_id=user.id, book_id=b.id, status="reading",
+                              progress_pct=0.1 * (i + 1)))
+    db.flush()
+
+    r = client.get("/api/hardcover/books")
+    assert r.status_code == 200
+    by_id = {i["book_id"]: i for i in r.json()}
+    assert by_id[matched.id]["state"] == "matched"
+    assert by_id[matched.id]["slug"] == "black-summoner-volume-10"
+    assert by_id[matched.id]["series_index"] == 10       # volume is renderable
+    assert by_id[unmatched.id]["state"] == "unmatched"
+    assert by_id[pending.id]["state"] == "pending"
+
+
+def test_matches_visible_in_books_endpoint(client, db, admin_user, make_book):
+    user, _ = admin_user
+    _link_test_user(user)
+    book = make_book(title="Dune", author="Frank Herbert")
+    book.hardcover_book_id = 77
+    book.hardcover_slug = "dune"
+    book.hardcover_match_method = "isbn13"
+    book.hardcover_pages = 412
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="read"))
+    db.flush()
+
+    items = client.get("/api/hardcover/books").json()
+    mine = [i for i in items if i["book_id"] == book.id]
+    assert mine and mine[0]["slug"] == "dune" and mine[0]["method"] == "isbn13"
+
+
+def test_rematch_retry_clears_match_and_deletes_profile_entry(client, db, admin_user, make_book, monkeypatch):
+    user, _ = admin_user
+    _link_test_user(user)
+    book = make_book(title="Wrongly Matched")
+    book.hardcover_book_id = 999
+    book.hardcover_slug = "wrong-record"
+    book.hardcover_match_method = "search"
+    row = UserBookStatus(user_id=user.id, book_id=book.id, status="reading",
+                         progress_pct=0.5, hardcover_user_book_id=1234,
+                         hardcover_read_id=55, hardcover_synced_pct=0.5,
+                         hardcover_synced_status="reading")
+    db.add(row)
+    db.flush()
+
+    deleted: list[int] = []
+
+    async def fake_delete(client_, token, ub_id):
+        deleted.append(ub_id)
+        return True
+
+    monkeypatch.setattr(hs, "delete_user_book", fake_delete)
+    r = client.post(f"/api/hardcover/books/{book.id}/rematch", json={"mode": "retry"})
+    assert r.status_code == 200
+    assert r.json()["removed_from_profile"] is True
+    assert deleted == [1234]
+    db.refresh(book); db.refresh(row)
+    assert book.hardcover_book_id is None
+    assert book.hardcover_match_method is None       # eligible for re-match
+    assert row.hardcover_user_book_id is None
+    assert row.hardcover_synced_pct is None          # will re-push after re-match
+
+
+def test_rematch_exclude_stops_sync_attempts(client, db, admin_user, make_book, monkeypatch):
+    user, _ = admin_user
+    _link_test_user(user)
+    book = make_book(title="Not On Hardcover")
+    row = UserBookStatus(user_id=user.id, book_id=book.id, status="read", rating=5)
+    db.add(row)
+    db.flush()
+
+    async def fake_delete(client_, token, ub_id):
+        raise AssertionError("nothing to delete")
+
+    monkeypatch.setattr(hs, "delete_user_book", fake_delete)
+    r = client.post(f"/api/hardcover/books/{book.id}/rematch", json={"mode": "exclude"})
+    assert r.status_code == 200
+    db.refresh(book)
+    assert book.hardcover_match_method == "excluded"
+    # appears in the page's book list, flagged
+    items = client.get("/api/hardcover/books").json()
+    assert any(i["book_id"] == book.id and i["state"] == "excluded" for i in items)
+    # and Sync-now must NOT clear the exclusion (only 'none' markers)
+    monkeypatch.setattr(hs, "start_manual_sync", lambda uid: True)
+    client.post("/api/hardcover/sync-now")
+    db.refresh(book)
+    assert book.hardcover_match_method == "excluded"
+
+
+@respx.mock
+async def test_failed_match_not_retried_next_cycle(db, admin_user, make_book):
+    """Regression: the failed-match commit bumps Book.updated_at (onupdate)
+    PAST the in-flight matched_at — the retry guard must still hold, or every
+    cycle re-matches (and re-bills) every unmatched book forever."""
+    user, _ = admin_user
+    _link_test_user(user)
+    book = make_book(title="Never On Hardcover", author="Nobody")
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="read", rating=4))
+    db.flush()
+
+    route = respx.post(HARDCOVER_URL).mock(
+        return_value=httpx.Response(200, json=_search_payload([])))
+    async with httpx.AsyncClient() as client:
+        stats1 = await hs.sync_user(db, client, user, hs._Budget(50))
+        calls_after_first = route.call_count
+        stats2 = await hs.sync_user(db, client, user, hs._Budget(50))
+    assert stats1["skipped_unmatched"] == 1
+    assert stats2["skipped_unmatched"] == 1
+    assert route.call_count == calls_after_first, "second cycle must not re-match"
+
+
+@respx.mock
+async def test_sync_user_skips_excluded_without_requests(db, admin_user, make_book):
+    user, _ = admin_user
+    _link_test_user(user)
+    book = make_book(title="Excluded Book")
+    book.hardcover_match_method = "excluded"
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="read", rating=4))
+    db.flush()
+
+    route = respx.post(HARDCOVER_URL).mock(
+        return_value=httpx.Response(200, json={"data": {}}))
+    budget = hs._Budget(10)
+    async with httpx.AsyncClient() as client:
+        stats = await hs.sync_user(db, client, user, budget)
+    assert stats["pushed"] == 0
+    assert budget.used == 0          # skip must not consume budget
+    assert not route.called          # and must make zero API calls
+
+
+def test_manual_match_search_endpoint(client, db, admin_user, monkeypatch):
+    user, _ = admin_user
+    _link_test_user(user)
+
+    async def fake_search(token, q, limit=8):
+        assert q == "black summoner"
+        return [{"hardcover_book_id": 785858, "title": "Black Summoner: Volume 1",
+                 "authors": ["Doufu Mayoi"], "slug": "black-summoner-volume-1",
+                 "users_count": 12, "cover_url": None, "series": "Black Summoner"}]
+
+    monkeypatch.setattr(hs, "search_candidates", fake_search)
+    r = client.get("/api/hardcover/search", params={"q": "black summoner"})
+    assert r.status_code == 200
+    assert r.json()[0]["hardcover_book_id"] == 785858
+
+
+def test_manual_match_pins_record_and_clears_old_state(client, db, admin_user, make_book, monkeypatch):
+    user, _ = admin_user
+    _link_test_user(user)
+    book = make_book(title="Black Summoner", series="Black Summoner", series_index=1)
+    book.hardcover_book_id = 2624493            # the stub it wrongly matched
+    book.hardcover_slug = "stub-record"
+    book.hardcover_match_method = "search"
+    row = UserBookStatus(user_id=user.id, book_id=book.id, status="reading",
+                         progress_pct=0.42, hardcover_user_book_id=111,
+                         hardcover_synced_pct=0.42, hardcover_synced_status="reading")
+    db.add(row)
+    db.flush()
+
+    deleted: list[int] = []
+
+    async def fake_delete(client_, token, ub_id):
+        deleted.append(ub_id)
+        return True
+
+    async def fake_resolve(token, b, hc_id):
+        assert hc_id == 785858
+        b.hardcover_book_id = hc_id
+        b.hardcover_slug = "black-summoner-volume-1"
+        b.hardcover_edition_id = 30789992
+        b.hardcover_pages = 227
+        b.hardcover_match_method = "manual"
+        from datetime import datetime as _dt
+        b.hardcover_matched_at = _dt.utcnow()
+
+    monkeypatch.setattr(hs, "delete_user_book", fake_delete)
+    monkeypatch.setattr(hs, "resolve_manual_match", fake_resolve)
+
+    r = client.post(f"/api/hardcover/books/{book.id}/match", json={"hardcover_book_id": 785858})
+    assert r.status_code == 200
+    assert r.json()["slug"] == "black-summoner-volume-1"
+    assert deleted == [111]                     # old profile entry removed
+    db.refresh(book); db.refresh(row)
+    assert book.hardcover_book_id == 785858
+    assert book.hardcover_match_method == "manual"
+    assert row.hardcover_user_book_id is None   # push state reset → re-pushes to the pick
+    assert row.hardcover_synced_pct is None
+    # 'manual' is not auto-cleared by Sync-now (only 'none' markers are)
+    monkeypatch.setattr(hs, "start_manual_sync", lambda uid: True)
+    client.post("/api/hardcover/sync-now")
+    db.refresh(book)
+    assert book.hardcover_match_method == "manual"
+
+
+def test_sync_now_retries_unmatched_books(client, db, admin_user, make_book, monkeypatch):
+    user, _ = admin_user
+    from datetime import datetime
+    from backend.core.crypto import encrypt_secret
+    user.hardcover_token = encrypt_secret("t")
+    user.hardcover_token_status = "ok"
+    book = make_book(title="Missed Last Month")
+    book.hardcover_match_method = "none"
+    book.hardcover_matched_at = datetime.utcnow()
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="read"))
+    db.flush()
+
+    monkeypatch.setattr(hs, "start_manual_sync", lambda uid: True)
+    r = client.post("/api/hardcover/sync-now")
+    assert r.status_code == 200
+    db.refresh(book)
+    # Explicit click clears the failed-match marker so the matcher tries again.
+    assert book.hardcover_match_method is None
+    assert book.hardcover_matched_at is None

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -186,5 +186,8 @@ def test_build_bumped_for_rebake():
     # device re-fetches regardless of which 26 it took; 27-29 are the
     # foundations-stack builds (identity+clustering, verify/repair, UX batch),
     # and the paging guard's semantics are folded into _applyForeign.
-    assert TOMESYNC_PLUGIN_BUILD >= 30
-    assert TOMESYNC_PLUGIN_SEMVER == "1.7.4"
+    # 1.8.0 / build 31 introduces half-star ratings server-side: the plugin's
+    # rating_baseline splits into {remote, device} so a Tome half-star rounded
+    # onto the whole-star sidecar is never pushed back as a "local edit".
+    assert TOMESYNC_PLUGIN_BUILD >= 31
+    assert TOMESYNC_PLUGIN_SEMVER == "1.8.0"


### PR DESCRIPTION
## What

One-way **Tome → Hardcover** sync of ratings and reading progress, plus half-star ratings across Tome.

### Hardcover sync
- **Per-user opt-in**: link your personal Hardcover API token in Settings (Fernet-encrypted at rest). The server-wide `TOME_HARDCOVER_TOKEN` stays metadata-fetch-only and is never used for sync. `TOME_HARDCOVER_SYNC_ENABLED` is the operator kill switch (router-level dependency).
- **Stateless reconciler**: pushes rows whose rating/status/progress differ from the last-pushed snapshot — no dirty flags, crash-safe, first-link backfill is just a big diff. Ratings/finish events take a 30 s-debounced fast path; progress batches on a 30-min cycle with drain mode for large backfills. 60 req/min respected (1.1 s global spacing, 300-req cycle cap, per-row exponential backoff). A 401 marks the token expired (Hardcover's Jan-1 reset) and notifies once.
- **Matching**: ISBN-first (sanity-checked against the catalogue title — wrong-edition ISBNs fall through), then a volume-aware, manga/novel-guarded, author-splitting title search that prefers the community's record over catalogue stubs. Progress is page-based (`round(pct × edition pages)`, forward-only); page-less editions sync status-only.
- **Wrong-match toolbox**: new **Hardcover** sidebar page lists every sync candidate with cover, state badge, and a link to the exact matched record; per-book **Pick** (manual search-and-pin, never auto-cleared), **Re-match**, and **Exclude**. Series stacking mirrors All Books. Book detail links to the matched record and shows a font-size-agnostic "p. X of Y".

### Half-star ratings
- Rating columns go Integer→Float with **no data migration** — SQLite NUMERIC affinity stores halves losslessly and legacy whole-star rows coexist (both schema shapes pinned by tests).
- Shared 0.5-step validator on all rating endpoints; new `StarRating` widget (click left/right star half) everywhere ratings render; stats no longer truncate halves.
- KOReader plugin build 31 (1.8.0): rating baseline splits into `{remote, device}` so a half-star rounded onto the whole-star sidecar is never echoed back as a local edit.

## Verification

- **Live API**: full flow verified against a dedicated test Hardcover account (`tome-development`) — token verify, ISBN + search matching, user_book/read mutations, half-star rating visible on the profile, page math, wrong-match repair. Several beta-API realities were discovered and fixed this way (required `Bearer ` prefix, auto-created read rows, per-volume records, stub-record ranking).
- **Tests**: 800 backend tests green (70+ new), frontend `tsc -b` build clean, plugin Lua compiles under LuaJIT.
- **8-angle review pass** pre-PR; all confirmed findings fixed with regression tests (notably: the failed-match retry guard was defeated by `updated_at`'s `onupdate` — every cycle would have re-matched every unmatched book forever).
- Plugin build 31 will be validated on real hardware post-merge (maintainer).

## Known semantics (intentional, documented)

- Exclude/re-match operate on the **book-level** match, so they affect every user syncing that book (single-decision semantics; revisit if it ever bites).
- Build-30 plugins pull raw half-stars into the whole-star sidecar until they self-update — cosmetic only, no echo/corruption, self-heals on update.
- Rating *clears* and unread/shelved statuses are never propagated; nothing is deleted on Hardcover except entries we created, during explicit wrong-match repair.

## Follow-ups (deferred)

- Shared Hardcover client module (metadata_fetch + sync currently each own URL/auth/429 handling); ISBN util consolidation; shared Switch component; normalized "pages read" stats tile.