### PR TITLE
fix(hardcover): language-aware, audio-averse edition pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ All notable changes to Tome are documented here. Format loosely follows
   progress bar shows a font-size-agnostic "p. 142 of 384" from the print
   edition's page count alongside the percentage.
 
+### Fixed
+- **Hardcover sync could pin a translation's or the audiobook's edition.**
+  Publishers reuse one catalogue across translations and audio, so a stored
+  ISBN sometimes names the German edition (or the audiobook) of the right
+  book — your Hardcover profile then showed the German cover and title.
+  Edition selection is now language-aware and audio-averse everywhere a match
+  is made (ISBN, search, and manual pick): the book match is kept, but the
+  pinned edition must agree with the book's language and prefers text
+  editions with page data. Existing wrong matches repair via the Hardcover
+  page's per-book "Re-match".
+
 ### Changed
 - **Dark themes got a contrast pass.** Hairline borders were sitting at an
   alpha where most panels had none to speak of; they're a step stronger now

--- a/backend/services/hardcover_sync.py
+++ b/backend/services/hardcover_sync.py
@@ -14,6 +14,10 @@ Design (docs/plans/hardcover-sync-plan.md):
   query returns book id + edition id + pages), then a title+author search
   gated by a strict similarity guard — a wrong match writes reading data onto
   a stranger's book on a public profile, so we refuse rather than guess.
+- The pinned EDITION is language-aware and audio-averse: an ISBN that names a
+  translation's or the audiobook's edition (publishers share catalogues across
+  both) still matches the book, but the edition is re-picked to agree with the
+  Tome book's language and to have pages.
 - Progress is page-based on Hardcover: ``round(pct × edition pages)``. Books
   whose matched edition has no page count get status-only sync.
 - Rate limit: Hardcover allows 60 req/min. All users share one worker queue
@@ -61,6 +65,10 @@ NUDGE_DEBOUNCE = 30            # seconds of quiet after a rating nudge before sy
 TITLE_SIM_MIN = 0.85
 AUTHOR_SIM_MIN = 0.7
 
+# Hardcover reading_format_id for audiobook editions. Audio editions carry
+# ISBNs too (Podium!) and have no page counts — never pin one.
+AUDIO_FORMAT_ID = 2
+
 # ── GraphQL documents ─────────────────────────────────────────────────────────
 # Pinned to the beta schema as of 2026-07. Responses are parsed defensively;
 # schema drift surfaces as a per-row error, not a crash.
@@ -74,6 +82,8 @@ query EditionByIsbn($isbn: String!) {
         title
         pages
         book_id
+        reading_format_id
+        language { code2 }
         book { id title pages slug }
     }
 }
@@ -107,7 +117,13 @@ query BookEdition($id: Int!) {
         id
         pages
         slug
-        editions(limit: 1, order_by: {users_count: desc}) { id pages }
+        editions(limit: 30, order_by: {users_count: desc}) {
+            id
+            pages
+            users_count
+            reading_format_id
+            language { code2 }
+        }
     }
 }
 """
@@ -296,6 +312,58 @@ def _is_manga_title(title: str) -> bool:
     return "(manga)" in title.lower() or "manga vol" in title.lower()
 
 
+_LANG_NAMES = {
+    "english": "en", "german": "de", "deutsch": "de", "japanese": "ja",
+    "french": "fr", "spanish": "es", "italian": "it", "chinese": "zh",
+    "korean": "ko", "portuguese": "pt",
+}
+
+
+def _lang2(raw: Optional[str]) -> Optional[str]:
+    """Tome's Book.language down to a 2-letter code ('en-US' → 'en',
+    'English' → 'en'), or None when unknown."""
+    if not raw:
+        return None
+    s = raw.strip().lower()
+    if s in _LANG_NAMES:
+        return _LANG_NAMES[s]
+    return s[:2] if len(s) >= 2 else None
+
+
+def _edition_lang(ed: dict) -> Optional[str]:
+    code = ((ed.get("language") or {}).get("code2") or "").strip().lower()
+    return code or None
+
+
+def _edition_acceptable(ed: dict, want_lang: Optional[str]) -> bool:
+    """Is this specific edition safe to pin? Audio editions never are (no page
+    counts, and the profile shows the audiobook cover); a known language must
+    not contradict the Tome book's known language."""
+    if ed.get("reading_format_id") == AUDIO_FORMAT_ID:
+        return False
+    ed_lang = _edition_lang(ed)
+    return want_lang is None or ed_lang is None or ed_lang == want_lang
+
+
+def _pick_edition(editions: list[dict], want_lang: Optional[str]) -> Optional[dict]:
+    """Choose the edition to pin on a matched Hardcover book: language match
+    first (unknown language beats a contradicting one), then non-audio, then
+    the edition the community actually uses, then one with page data."""
+    def score(ed: dict) -> tuple:
+        ed_lang = _edition_lang(ed)
+        if want_lang and ed_lang == want_lang:
+            lang_rank = 2
+        elif ed_lang is None or want_lang is None:
+            lang_rank = 1
+        else:
+            lang_rank = 0
+        non_audio = 0 if ed.get("reading_format_id") == AUDIO_FORMAT_ID else 1
+        return (lang_rank, non_audio, ed.get("users_count") or 0,
+                1 if ed.get("pages") else 0)
+    candidates = [e for e in editions if e.get("id") is not None]
+    return max(candidates, key=score) if candidates else None
+
+
 def _isbn_hit_plausible(book, hc_title: str) -> bool:
     """Sanity-check an ISBN edition hit against what we think the book is.
 
@@ -321,6 +389,31 @@ def _isbn_hit_plausible(book, hc_title: str) -> bool:
             references.append(f"{book.series} Vol. {_fmt_index(want_vol)}")
     best = max(_sim(_norm_title(hc_title), _norm_title(r)) for r in references)
     return best >= 0.5
+
+
+async def _adopt_best_edition(client: httpx.AsyncClient, token: str, book: Book) -> bool:
+    """Fetch the matched Hardcover book's editions and pin the best one
+    (language-aware, audio-averse). Returns False when nothing usable came
+    back so the caller can keep its own fallback. Auth/rate-limit errors
+    propagate; a plain API error is just 'no better edition'."""
+    try:
+        data = await _gql(client, token, Q_BOOK_EDITION, {"id": book.hardcover_book_id})
+    except HardcoverAPIError:
+        return False
+    books = data.get("books") or []
+    if not books:
+        return False
+    b = books[0]
+    if not book.hardcover_slug:
+        book.hardcover_slug = b.get("slug")
+    ed = _pick_edition(b.get("editions") or [], _lang2(book.language))
+    if ed is None:
+        book.hardcover_edition_id = None
+        book.hardcover_pages = b.get("pages")
+        return True
+    book.hardcover_edition_id = ed.get("id")
+    book.hardcover_pages = ed.get("pages") or b.get("pages")
+    return True
 
 
 async def match_book(client: httpx.AsyncClient, token: str, book: Book) -> bool:
@@ -351,10 +444,24 @@ async def match_book(client: httpx.AsyncClient, token: str, book: Book) -> bool:
                     "check for %r — falling back to search", isbn, hc_title, book.title)
                 continue
             book.hardcover_book_id = ed.get("book_id") or (ed.get("book") or {}).get("id")
-            book.hardcover_edition_id = ed.get("id")
-            book.hardcover_pages = ed.get("pages") or (ed.get("book") or {}).get("pages")
             book.hardcover_slug = (ed.get("book") or {}).get("slug")
             book.hardcover_match_method = "isbn13" if len(isbn) == 13 else "isbn10"
+            # The ISBN nails the BOOK, but its own edition may be one we must
+            # not pin: publishers reuse a catalogue across translations and
+            # audio (observed live: Podium ISBNs on English books resolving to
+            # the German-translation edition — the user's profile then shows
+            # the German cover), so a wrong-language or audio edition falls
+            # back to a language-aware pick among the book's editions.
+            if _edition_acceptable(ed, _lang2(book.language)):
+                book.hardcover_edition_id = ed.get("id")
+                book.hardcover_pages = ed.get("pages") or (ed.get("book") or {}).get("pages")
+            elif not await _adopt_best_edition(client, token, book):
+                logger.info(
+                    "Hardcover: ISBN %s edition %s is wrong-language/audio for %r "
+                    "and no better edition could be fetched — pinning it anyway",
+                    isbn, ed.get("id"), book.title)
+                book.hardcover_edition_id = ed.get("id")
+                book.hardcover_pages = ed.get("pages") or (ed.get("book") or {}).get("pages")
             return True
 
     # 2. Title+author search, strictly guarded. Refuse rather than guess.
@@ -441,17 +548,8 @@ async def match_book(client: httpx.AsyncClient, token: str, book: Book) -> bool:
         book.hardcover_book_id = hc_id
         book.hardcover_slug = doc.get("slug")
         book.hardcover_match_method = "search"
-        # Second query for the representative edition + page count.
-        data = await _gql(client, token, Q_BOOK_EDITION, {"id": hc_id})
-        books = data.get("books") or []
-        if books:
-            b = books[0]
-            eds = b.get("editions") or []
-            if eds:
-                book.hardcover_edition_id = eds[0].get("id")
-                book.hardcover_pages = eds[0].get("pages") or b.get("pages")
-            else:
-                book.hardcover_pages = b.get("pages")
+        # Second query picks the edition to pin (language-aware, audio-averse).
+        await _adopt_best_edition(client, token, book)
         return True
 
     book.hardcover_match_method = "none"
@@ -494,9 +592,9 @@ async def resolve_manual_match(token: str, book, hardcover_book_id: int) -> None
     b = books[0]
     book.hardcover_book_id = hardcover_book_id
     book.hardcover_slug = b.get("slug")
-    eds = b.get("editions") or []
-    book.hardcover_edition_id = eds[0].get("id") if eds else None
-    book.hardcover_pages = (eds[0].get("pages") if eds else None) or b.get("pages")
+    ed = _pick_edition(b.get("editions") or [], _lang2(book.language))
+    book.hardcover_edition_id = ed.get("id") if ed else None
+    book.hardcover_pages = (ed.get("pages") if ed else None) or b.get("pages")
     book.hardcover_match_method = "manual"
     book.hardcover_matched_at = datetime.utcnow()
 

--- a/tests/test_hardcover_sync.py
+++ b/tests/test_hardcover_sync.py
@@ -291,6 +291,162 @@ async def test_match_book_isbn_hit_sanity_checked(make_book):
     assert book.hardcover_match_method == "search"
 
 
+@respx.mock
+async def test_match_book_isbn_wrong_language_edition_repicks(make_book):
+    """Observed live (Eric Ugland / The Good Guys): the stored Podium ISBN
+    resolves to the GERMAN-translation edition of the correct book. The book
+    match must stick, but the pinned edition must be re-picked to the one
+    matching the Tome book's language — else the user's Hardcover profile
+    shows the German cover and title."""
+    book = make_book(title="Heir Today, Pawn Tomorrow", author="Eric Ugland",
+                     series="The Good Guys", series_index=2,
+                     isbn="9781649712400", language="en")
+
+    def responder(request):
+        body = request.read().decode()
+        if "EditionByIsbn" in body:
+            return httpx.Response(200, json={"data": {"editions": [
+                {"id": 30978966, "title": "Heute Erbe, morgen Schachfigur",
+                 "pages": 322, "book_id": 637923, "reading_format_id": 1,
+                 "language": {"code2": "de"},
+                 "book": {"id": 637923, "title": "Heir Today, Pawn Tomorrow",
+                          "pages": 254, "slug": "heir-today-pawn-tomorrow"}}
+            ]}})
+        return httpx.Response(200, json={"data": {"books": [
+            {"id": 637923, "pages": 254, "slug": "heir-today-pawn-tomorrow",
+             "editions": [
+                 {"id": 30615792, "pages": 254, "users_count": 28,
+                  "reading_format_id": 1, "language": {"code2": "en"}},
+                 {"id": 30978966, "pages": 322, "users_count": 0,
+                  "reading_format_id": 1, "language": {"code2": "de"}},
+                 {"id": 31793774, "pages": None, "users_count": 0,
+                  "reading_format_id": 2, "language": None},
+             ]}
+        ]}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_book_id == 637923
+    assert book.hardcover_match_method == "isbn13"
+    assert book.hardcover_edition_id == 30615792     # English, not the ISBN's German
+    assert book.hardcover_pages == 254
+
+
+@respx.mock
+async def test_match_book_isbn_audio_edition_repicks(make_book):
+    """An ISBN naming the audiobook edition must not pin it (no pages, audio
+    cover on the profile) — re-pick a text edition of the same book."""
+    book = make_book(title="Dune", isbn="9780441013593", language="en")
+
+    def responder(request):
+        body = request.read().decode()
+        if "EditionByIsbn" in body:
+            return httpx.Response(200, json={"data": {"editions": [
+                {"id": 1, "title": "Dune", "pages": None, "book_id": 77,
+                 "reading_format_id": 2, "language": {"code2": "en"},
+                 "book": {"id": 77, "title": "Dune", "pages": 412, "slug": "dune"}}
+            ]}})
+        return httpx.Response(200, json={"data": {"books": [
+            {"id": 77, "pages": 412, "slug": "dune", "editions": [
+                {"id": 2, "pages": 412, "users_count": 900,
+                 "reading_format_id": 1, "language": {"code2": "en"}},
+                {"id": 1, "pages": None, "users_count": 1200,
+                 "reading_format_id": 2, "language": {"code2": "en"}},
+            ]}
+        ]}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_edition_id == 2            # text edition beats popular audio
+    assert book.hardcover_pages == 412
+
+
+@respx.mock
+async def test_match_book_isbn_repick_fetch_failure_keeps_isbn_edition(make_book):
+    """If the edition re-pick query fails, degrade to the old behaviour (pin
+    the ISBN's own edition) rather than losing the match."""
+    book = make_book(title="Dune", isbn="9780441013593", language="en")
+
+    def responder(request):
+        body = request.read().decode()
+        if "EditionByIsbn" in body:
+            return httpx.Response(200, json={"data": {"editions": [
+                {"id": 5, "title": "Der Wüstenplanet", "pages": 800, "book_id": 77,
+                 "reading_format_id": 1, "language": {"code2": "de"},
+                 "book": {"id": 77, "title": "Dune", "pages": 412, "slug": "dune"}}
+            ]}})
+        return httpx.Response(200, json={"errors": [{"message": "boom"}]})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_book_id == 77
+    assert book.hardcover_edition_id == 5
+    assert book.hardcover_pages == 800
+
+
+@respx.mock
+async def test_match_book_search_picks_language_matching_edition(make_book):
+    """The search path must not blindly take the most-used edition — a German
+    Tome book pins the German edition even when the English one is bigger."""
+    book = make_book(title="Der Wüstenplanet", author="Frank Herbert",
+                     isbn=None, language="de")
+
+    def responder(request):
+        body = request.read().decode()
+        if "SearchBook" in body:
+            return httpx.Response(200, json=_search_payload([
+                {"document": {"id": 77, "title": "Der Wüstenplanet",
+                              "author_names": ["Frank Herbert"]}},
+            ]))
+        return httpx.Response(200, json={"data": {"books": [
+            {"id": 77, "pages": 412, "slug": "dune", "editions": [
+                {"id": 2, "pages": 412, "users_count": 900,
+                 "reading_format_id": 1, "language": {"code2": "en"}},
+                {"id": 9, "pages": 800, "users_count": 3,
+                 "reading_format_id": 1, "language": {"code2": "de"}},
+            ]}
+        ]}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        assert await hs.match_book(client, "tok", book) is True
+    assert book.hardcover_edition_id == 9
+    assert book.hardcover_pages == 800
+
+
+def test_edition_picker_helpers():
+    assert hs._lang2("en") == "en"
+    assert hs._lang2("en-US") == "en"
+    assert hs._lang2("English") == "en"
+    assert hs._lang2("Deutsch") == "de"
+    assert hs._lang2(None) is None
+    assert hs._lang2("  ") is None
+
+    de = {"id": 1, "reading_format_id": 1, "language": {"code2": "de"}, "users_count": 50, "pages": 300}
+    en = {"id": 2, "reading_format_id": 1, "language": {"code2": "en"}, "users_count": 5, "pages": 250}
+    unk = {"id": 3, "reading_format_id": 1, "language": None, "users_count": 80, "pages": 260}
+    audio = {"id": 4, "reading_format_id": 2, "language": {"code2": "en"}, "users_count": 999, "pages": None}
+    # language match wins over popularity and over unknown
+    assert hs._pick_edition([de, en, unk, audio], "en")["id"] == 2
+    # unknown want-language: unknown/known tie on language, popularity decides
+    assert hs._pick_edition([de, unk], None)["id"] == 3
+    # language outranks format: if the only right-language edition is the
+    # audiobook, it still beats a wrong-language text edition
+    assert hs._pick_edition([de, audio], "en")["id"] == 4
+    # within one language, text always beats audio regardless of popularity
+    assert hs._pick_edition([en, audio], "en")["id"] == 2
+    assert hs._pick_edition([], "en") is None
+
+    assert hs._edition_acceptable(en, "en")
+    assert hs._edition_acceptable(unk, "en")      # unknown language: permissive
+    assert hs._edition_acceptable(en, None)
+    assert not hs._edition_acceptable(de, "en")
+    assert not hs._edition_acceptable(audio, "en")
+
+
 def test_isbn_hit_plausible(make_book):
     vol2 = make_book(title="Black Summoner", series="Black Summoner", series_index=2)
     assert not hs._isbn_hit_plausible(vol2, "Black Summoner: Volume 10")


### PR DESCRIPTION
## Problem

Hardcover sync pinned wrong-language (and previously audiobook) **editions** of correctly matched books. Observed on prod: the Good Guys volumes matched the right Hardcover records, but the stored Podium ISBNs resolve to the German *Die guten Jungs* editions (Podium publishes both under one catalogue), so the profile showed German covers and titles ("Heute Erbe, morgen Schachfigur" et al.). Verified live: `9781649712400` → edition `30978966` (`de`) of `heir-today-pawn-tomorrow`.

## Fix

Edition selection is now language-aware and audio-averse at every pin site:

- **ISBN path** — the ISBN still establishes book identity, but if its own edition contradicts the Tome book's `language` or is an audiobook (`reading_format_id = 2`), the edition is re-picked from the book's full edition list. Fetch failure degrades to the old pin-the-ISBN-edition behaviour rather than losing the match.
- **Search path + manual match** — same picker instead of unconditionally taking the most-used edition (which can be audio or another language).
- **Picker ranking** — language match > non-audio > `users_count` > has page data. Deliberate tie-break: language outranks format (within one language, text always beats audio).

Existing wrong matches repair via the Hardcover page's per-book **Re-match** once deployed — on prod exactly three books are affected (audited every ISBN match against the live API).

## Tests

- 5 new tests, including a replica of the live German-edition case and the audio-edition case with real API response shapes
- Full suite: 805 passed