### PR TITLE
fix(files): crash-safe reorganize, delete ordering, junk-whitelist purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,33 @@ All notable changes to Tome are documented here. Format loosely follows
   edition's page count alongside the percentage.
 
 ### Fixed
+- **Reorganize is crash-safe and works across filesystems.** Library Health's
+  one-click reorganise used to move every file first and write the database
+  once at the end — a crash mid-batch left every already-moved file
+  unfindable (and unhealable, since the repair tool starts from the stale
+  database path). Each move is now committed individually, so an
+  interruption loses nothing. Moves also switched to a copy-safe primitive,
+  so a library spanning mounts (mergerfs, NFS, a series folder symlinked to
+  another disk) no longer fails per-file. And when a file's canonical slot is
+  already occupied by a different file, reorganise reports a conflict instead
+  of silently renaming to "Title (2).epub" — a suffix the next health check
+  would flag again, renaming it to (3), (4)… forever.
+- **Deleting a book can no longer leave a permanent ghost row.** Files were
+  removed from disk before the database delete committed; a crash in between
+  kept the book in the library with nothing behind it — every download 404ed
+  and no scan could heal it. The order is now inverted: the row goes first,
+  and files are removed after (if that half is interrupted, the next scan
+  simply re-imports the orphaned files).
+- **"Purge empty folders" no longer eats Syncthing markers.** A folder whose
+  contents were all hidden was treated as junk and emptied — which deleted
+  `.stfolder` (halting the whole Syncthing share with "folder marker
+  missing") and could delete versioned user files in `.stversions`. The purge
+  now only removes recognised OS droppings (`.DS_Store`, `._*` AppleDouble
+  files, `Thumbs.db`, `desktop.ini`); anything else — including any hidden
+  directory, which previously crashed the endpoint mid-walk — means the
+  folder is kept. The same whitelist governs the folder cleanup after a
+  reorganise, which also no longer errors out after the moves have already
+  succeeded.
 - **Hardcover sync could pin a translation's or the audiobook's edition.**
   Publishers reuse one catalogue across translations and audio, so a stored
   ISBN sometimes names the German edition (or the audiobook) of the right

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1,6 +1,7 @@
 import csv
 import difflib
 import io
+import os
 import re
 import json
 import logging
@@ -762,32 +763,42 @@ class ReorganizeRequest(PydanticBaseModel):
     dry_run: bool = False
 
 
+# OS metadata droppings that are safe to delete when emptying a folder.
+# Anything else — .stfolder/.stversions (Syncthing), .git, unknown dotfiles —
+# means the folder is not junk and must be left alone.
+_JUNK_FILENAMES = {".ds_store", "thumbs.db", "desktop.ini"}
+
+
+def _is_junk_file(p: Path) -> bool:
+    return p.is_file() and (
+        p.name.lower() in _JUNK_FILENAMES or p.name.startswith("._")
+    )
+
+
 @router.post("/purge-empty-dirs")
 def purge_empty_dirs(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    """Walk library_dir bottom-up and remove dirs that contain only hidden files. Admin only."""
+    """Walk library_dir bottom-up and remove dirs that contain only OS junk files. Admin only."""
     require_role(current_user, "admin")
 
     removed: list[str] = []
     # Walk bottom-up so child dirs are processed before parents
-    for dirpath, dirnames, filenames in __import__('os').walk(settings.library_dir, topdown=False):
+    for dirpath, dirnames, filenames in os.walk(settings.library_dir, topdown=False):
         current = Path(dirpath)
         if current == settings.library_dir:
             continue
-        entries = list(current.iterdir())
-        non_hidden = [e for e in entries if not e.name.startswith('.')]
-        if non_hidden:
-            continue
-        # Only hidden files (e.g. .DS_Store) — delete them then remove the dir
-        for e in entries:
-            e.unlink(missing_ok=True)
         try:
+            entries = list(current.iterdir())
+            if not all(_is_junk_file(e) for e in entries):
+                continue  # real content, a subdir, or an unrecognised dotfile — keep
+            for e in entries:
+                e.unlink(missing_ok=True)
             current.rmdir()
             removed.append(str(current.relative_to(settings.library_dir)))
         except OSError:
-            pass  # not empty after all, skip
+            continue  # changed underneath us or not deletable — skip, never fail the purge
 
     if removed:
         audit(db, "purge_empty_dirs",
@@ -799,16 +810,23 @@ def purge_empty_dirs(
 
 
 def _cleanup_empty_dirs(start: Path, stop_at: Path, removed: list[str]) -> None:
-    """Remove empty dirs from start up to (but not including) stop_at."""
+    """Remove dirs containing nothing but OS junk, from start up to (but not including) stop_at."""
     current = start
     while current != stop_at and current.is_relative_to(stop_at):
-        if current.is_dir() and not any(f for f in current.iterdir() if not f.name.startswith('.')):
+        try:
+            if not current.is_dir():
+                break
+            entries = list(current.iterdir())
+            if not all(_is_junk_file(e) for e in entries):
+                break
+            for e in entries:
+                e.unlink(missing_ok=True)
             rel = str(current.relative_to(stop_at))
             current.rmdir()
             removed.append(rel)
             current = current.parent
-        else:
-            break
+        except OSError:
+            break  # cleanup is best-effort; the moves already succeeded
 
 
 @router.get("/library-health")
@@ -890,13 +908,22 @@ def reorganize_files(
         }
         actual = Path(bf.file_path)
         expected_rel = get_library_path(meta, actual.name)
-        expected_abs = resolve_unique_path(settings.library_dir, expected_rel)
+        expected_abs = settings.library_dir / expected_rel
 
-        if actual.resolve() == (settings.library_dir / expected_rel).resolve():
+        if actual.resolve() == expected_abs.resolve():
             continue  # already correct
 
         from_rel = str(actual.relative_to(settings.library_dir)) if actual.is_relative_to(settings.library_dir) else str(actual)
-        to_rel = str(expected_abs.relative_to(settings.library_dir)) if expected_abs.is_relative_to(settings.library_dir) else str(expected_abs)
+        to_rel = str(expected_rel)
+
+        # Canonical slot held by a different file: report a conflict instead of
+        # suffixing — a "Title (2).epub" fails the next health check and would
+        # ratchet to (3), (4)… on every subsequent reorganize.
+        if expected_abs.exists() and not (
+            actual.exists() and os.path.samefile(actual, expected_abs)
+        ):
+            errors.append({"file_id": bf.id, "error": f"target already occupied by another file: {to_rel}"})
+            continue
 
         if req.dry_run:
             moved.append({"file_id": bf.id, "from": from_rel, "to": to_rel})
@@ -904,16 +931,19 @@ def reorganize_files(
 
         try:
             expected_abs.parent.mkdir(parents=True, exist_ok=True)
-            actual.rename(expected_abs)
+            shutil.move(str(actual), str(expected_abs))
             affected_dirs.add(actual.parent)
             bf.file_path = str(expected_abs)
+            # Commit per file: a crash mid-batch must never leave moved files
+            # pointing at DB rows that still hold the old path.
+            db.commit()
             moved.append({"file_id": bf.id, "from": from_rel, "to": to_rel})
         except Exception as e:
+            db.rollback()
             errors.append({"file_id": bf.id, "error": str(e)})
 
     folders_removed: list[str] = []
     if not req.dry_run:
-        db.commit()
         for d in affected_dirs:
             _cleanup_empty_dirs(d, settings.library_dir, folders_removed)
         if moved:
@@ -1965,32 +1995,40 @@ def delete_book(
     if not _is_admin(current_user) and book.added_by != current_user.id:
         raise HTTPException(status_code=403, detail="You can only delete books you uploaded")
 
-    # Remove book files from disk
-    for bf in book.files:
-        fp = Path(bf.file_path)
-        if fp.exists():
-            fp.unlink(missing_ok=True)
-            # Remove parent directory if now empty
-            try:
-                fp.parent.rmdir()
-            except OSError:
-                pass
+    # Delete the row first, remove files after. A crash between the two leaves
+    # orphaned files that the next scan re-imports; the reverse order leaves a
+    # permanent ghost row (files gone, nothing on disk to heal it from).
+    deleted_id, deleted_title = book.id, book.title
+    file_paths = [Path(bf.file_path) for bf in book.files]
+    cover_file = settings.covers_dir / book.cover_path if book.cover_path else None
 
-    # Remove cover file if it exists
-    if book.cover_path:
-        cover_file = settings.covers_dir / book.cover_path
-        if cover_file.exists():
-            cover_file.unlink(missing_ok=True)
-
-    from backend.services.metadata_embed import purge_book_cache
-    purge_book_cache(book.id)
-
-    audit(db, "books.deleted", user_id=current_user.id, username=current_user.username,
-          resource_type="book", resource_id=book.id, resource_title=book.title)
     from backend.services.fts import unindex_book
     unindex_book(db, book.id)
     db.delete(book)
     db.commit()
+
+    audit(db, "books.deleted", user_id=current_user.id, username=current_user.username,
+          resource_type="book", resource_id=deleted_id, resource_title=deleted_title)
+
+    from backend.services.metadata_embed import purge_book_cache
+    purge_book_cache(deleted_id)
+
+    for fp in file_paths:
+        try:
+            fp.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("delete_book: could not remove file %s", fp)
+            continue
+        try:
+            fp.parent.rmdir()  # remove parent directory if now empty
+        except OSError:
+            pass
+
+    if cover_file is not None:
+        try:
+            cover_file.unlink(missing_ok=True)
+        except OSError:
+            logger.warning("delete_book: could not remove cover %s", cover_file)
 
 
 

--- a/tests/test_file_ops_safety.py
+++ b/tests/test_file_ops_safety.py
@@ -1,0 +1,248 @@
+"""Crash-safety / data-integrity behaviour of the file-mutating admin paths.
+
+Covers the fixes from the 2026-07-03 file-operations audit:
+- reorganize: per-file commit, shutil.move, conflict instead of suffix ratchet
+- delete_book: DB delete commits before files are unlinked (no ghost rows)
+- purge-empty-dirs / _cleanup_empty_dirs: junk whitelist, never touch
+  Syncthing markers or hidden directories, never 500 mid-walk
+"""
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from backend.models.book import Book, BookFile
+
+
+@pytest.fixture()
+def library_dir(tmp_path: Path, monkeypatch) -> Path:
+    lib = tmp_path / "library"
+    lib.mkdir()
+    monkeypatch.setattr("backend.core.config.settings.library_dir", lib)
+    return lib
+
+
+def _book_with_file(make_book, db, library_dir: Path, *, title="Solaris",
+                    author="Stanislaw Lem", series=None, series_index=None,
+                    rel_path=None, content=b"epub-bytes") -> Book:
+    """Create a Book whose BookFile points at a real file inside library_dir."""
+    rel = rel_path or f"Wrong Folder/{title}.epub"
+    abs_path = library_dir / rel
+    abs_path.parent.mkdir(parents=True, exist_ok=True)
+    abs_path.write_bytes(content)
+    book = make_book(title=title, author=author, series=series,
+                     series_index=series_index, file_path=str(abs_path))
+    db.commit()
+    return book
+
+
+# ---------------------------------------------------------------------------
+# Reorganize
+# ---------------------------------------------------------------------------
+
+class TestReorganize:
+    def test_moves_file_and_updates_db(self, client: TestClient, db, make_book, library_dir):
+        book = _book_with_file(make_book, db, library_dir)
+        bf = book.files[0]
+        old_path = Path(bf.file_path)
+
+        resp = client.post("/api/books/reorganize", json={"file_ids": [bf.id]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["moved"]) == 1
+        assert data["errors"] == []
+
+        db.refresh(bf)
+        new_path = Path(bf.file_path)
+        assert new_path != old_path
+        assert new_path.exists(), "file must exist at the committed DB path"
+        assert not old_path.exists()
+        assert new_path == library_dir / "Stanislaw Lem" / "Solaris.epub"
+
+    def test_occupied_slot_reports_conflict_instead_of_suffixing(
+        self, client: TestClient, db, make_book, library_dir
+    ):
+        # A different file already sits in the canonical slot.
+        squatter = library_dir / "Stanislaw Lem" / "Solaris.epub"
+        squatter.parent.mkdir(parents=True)
+        squatter.write_bytes(b"someone else")
+
+        book = _book_with_file(make_book, db, library_dir)
+        bf = book.files[0]
+        old_path = Path(bf.file_path)
+
+        resp = client.post("/api/books/reorganize", json={"file_ids": [bf.id]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["moved"] == []
+        assert len(data["errors"]) == 1
+        assert "occupied" in data["errors"][0]["error"]
+
+        # Nothing moved, nothing suffixed, squatter untouched.
+        assert old_path.exists()
+        assert squatter.read_bytes() == b"someone else"
+        assert not (library_dir / "Stanislaw Lem" / "Solaris (2).epub").exists()
+        db.refresh(bf)
+        assert Path(bf.file_path) == old_path
+
+    def test_dry_run_reports_conflict_too(self, client: TestClient, db, make_book, library_dir):
+        squatter = library_dir / "Stanislaw Lem" / "Solaris.epub"
+        squatter.parent.mkdir(parents=True)
+        squatter.write_bytes(b"someone else")
+        book = _book_with_file(make_book, db, library_dir)
+        bf = book.files[0]
+
+        resp = client.post("/api/books/reorganize", json={"file_ids": [bf.id], "dry_run": True})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["moved"] == []
+        assert len(data["errors"]) == 1
+
+    def test_already_correct_file_is_skipped(self, client: TestClient, db, make_book, library_dir):
+        book = _book_with_file(make_book, db, library_dir,
+                               rel_path="Stanislaw Lem/Solaris.epub")
+        bf = book.files[0]
+
+        resp = client.post("/api/books/reorganize", json={"file_ids": [bf.id]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["moved"] == []
+        assert data["errors"] == []
+
+    def test_leftover_ds_store_does_not_fail_cleanup(
+        self, client: TestClient, db, make_book, library_dir
+    ):
+        book = _book_with_file(make_book, db, library_dir)
+        bf = book.files[0]
+        old_parent = Path(bf.file_path).parent
+        (old_parent / ".DS_Store").write_bytes(b"junk")
+
+        resp = client.post("/api/books/reorganize", json={"file_ids": [bf.id]})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["moved"]) == 1
+        # Junk-only source folder is cleaned up, junk included.
+        assert not old_parent.exists()
+
+    def test_syncthing_marker_blocks_source_dir_cleanup(
+        self, client: TestClient, db, make_book, library_dir
+    ):
+        book = _book_with_file(make_book, db, library_dir)
+        bf = book.files[0]
+        old_parent = Path(bf.file_path).parent
+        marker = old_parent / ".stfolder"
+        marker.write_bytes(b"")
+
+        resp = client.post("/api/books/reorganize", json={"file_ids": [bf.id]})
+        assert resp.status_code == 200
+        assert len(resp.json()["moved"]) == 1
+        # The move happened but the marker (and its dir) survive.
+        assert marker.exists()
+
+
+# ---------------------------------------------------------------------------
+# Delete book
+# ---------------------------------------------------------------------------
+
+class TestDeleteBook:
+    def test_delete_removes_row_and_files(self, client: TestClient, db, make_book, library_dir):
+        book = _book_with_file(make_book, db, library_dir)
+        book_id = book.id
+        fp = Path(book.files[0].file_path)
+
+        resp = client.delete(f"/api/books/{book_id}")
+        assert resp.status_code == 204
+        assert db.query(Book).filter(Book.id == book_id).first() is None
+        assert not fp.exists()
+        assert not fp.parent.exists()  # emptied dir removed
+
+    def test_row_deleted_even_when_file_removal_fails(
+        self, client: TestClient, db, make_book, library_dir
+    ):
+        # Point the BookFile at a directory: unlink() raises, simulating a
+        # failing disk cleanup. The row must be gone regardless — the old
+        # order left a permanent ghost row when the crash hit the other way.
+        stubborn = library_dir / "Stubborn Dir"
+        stubborn.mkdir()
+        book = make_book(title="Ghost", file_path=str(stubborn))
+        db.commit()
+        book_id = book.id
+
+        resp = client.delete(f"/api/books/{book_id}")
+        assert resp.status_code == 204
+        assert db.query(Book).filter(Book.id == book_id).first() is None
+        assert db.query(BookFile).filter(BookFile.book_id == book_id).first() is None
+        assert stubborn.exists()  # cleanup failed, but no ghost row
+
+    def test_delete_removes_cover(self, client: TestClient, db, make_book,
+                                  library_dir, tmp_path, monkeypatch):
+        monkeypatch.setattr("backend.core.config.settings.data_dir", tmp_path / "data")
+        from backend.core.config import settings
+        settings.covers_dir.mkdir(parents=True, exist_ok=True)
+        cover = settings.covers_dir / "42.jpg"
+        cover.write_bytes(b"jpeg")
+
+        book = _book_with_file(make_book, db, library_dir)
+        book.cover_path = "42.jpg"
+        db.commit()
+
+        resp = client.delete(f"/api/books/{book.id}")
+        assert resp.status_code == 204
+        assert not cover.exists()
+
+
+# ---------------------------------------------------------------------------
+# Purge empty dirs
+# ---------------------------------------------------------------------------
+
+class TestPurgeEmptyDirs:
+    def test_removes_junk_only_and_empty_dirs(self, client: TestClient, library_dir):
+        junk_dir = library_dir / "Old Series"
+        junk_dir.mkdir()
+        (junk_dir / ".DS_Store").write_bytes(b"junk")
+        (junk_dir / "._resource").write_bytes(b"appledouble")
+        empty_dir = library_dir / "Empty"
+        empty_dir.mkdir()
+
+        resp = client.post("/api/books/purge-empty-dirs")
+        assert resp.status_code == 200
+        removed = resp.json()["removed"]
+        assert "Old Series" in removed
+        assert "Empty" in removed
+        assert not junk_dir.exists()
+        assert not empty_dir.exists()
+
+    def test_keeps_syncthing_markers(self, client: TestClient, library_dir):
+        synced = library_dir / "Synced Folder"
+        synced.mkdir()
+        (synced / ".stfolder").write_bytes(b"")
+
+        resp = client.post("/api/books/purge-empty-dirs")
+        assert resp.status_code == 200
+        assert resp.json()["removed"] == []
+        assert (synced / ".stfolder").exists()
+
+    def test_hidden_directory_does_not_500_and_survives(self, client: TestClient, library_dir):
+        # .stversions holds versioned copies of user files — must survive, and
+        # the old code 500ed trying to unlink() a directory.
+        parent = library_dir / "Series"
+        versions = parent / ".stversions"
+        versions.mkdir(parents=True)
+        keep = versions / "Book v1.epub"
+        keep.write_bytes(b"old version")
+
+        resp = client.post("/api/books/purge-empty-dirs")
+        assert resp.status_code == 200
+        assert keep.exists()
+        assert parent.exists()
+
+    def test_keeps_dirs_with_real_content(self, client: TestClient, library_dir):
+        full = library_dir / "Author"
+        full.mkdir()
+        (full / "Book.epub").write_bytes(b"content")
+        (full / ".DS_Store").write_bytes(b"junk")
+
+        resp = client.post("/api/books/purge-empty-dirs")
+        assert resp.status_code == 200
+        assert (full / "Book.epub").exists()
+        assert (full / ".DS_Store").exists()  # junk only purged when it's ALL junk


### PR DESCRIPTION
Three server-side data-integrity fixes from the 2026-07-03 file-operations audit. All in `backend/api/books.py`, no schema or API changes.

## Fixes
- **Reorganize is crash-safe and works across filesystems.** Library Health's one-click reorganise moved every file first and committed the DB once at the end — a crash mid-batch left every already-moved file unfindable (and unhealable, since the repair tool starts from the stale DB path). Each move now commits individually; moves use a copy-safe primitive so a library spanning mounts (mergerfs/NFS/symlinked series dirs) no longer fails per-file; and an occupied canonical slot reports a conflict instead of ratcheting into `Title (2)`/`(3)`/`(4)` forever.
- **Deleting a book can no longer leave a permanent ghost row.** Files were unlinked before the DB delete committed; a crash in between kept the book with nothing behind it. The order is inverted — row first, then best-effort file removal (an interrupted second half leaves scan-recoverable orphans, not a ghost row).
- **"Purge empty folders" no longer eats Syncthing markers.** An all-hidden folder was treated as junk; that deleted `.stfolder` (halting the whole Syncthing share) and could delete versioned files in `.stversions`. The purge now only removes recognised OS droppings; any hidden directory (which previously crashed the endpoint mid-walk) means the folder is kept.

## Tests
- `tests/test_file_ops_safety.py` — 13 new tests (reorganize conflict/cleanup, delete ordering with a failing unlink, purge whitelist + Syncthing markers).
- Full backend suite green (818 passed).