### PR TITLE
chore(release): v1.8.0 "Spine"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [1.8.0] — 2026-07-05 — "Spine"
+
 ### Added
 - **Hardcover sync.** Link your personal Hardcover account in Settings and Tome
   pushes your ratings and reading progress to it — one-way, opt-in, and nothing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tome"
-version = "1.7.0"
+version = "1.8.0"
 description = "Self-hosted ebook library"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Cuts **v1.8.0 "Spine"**.

- Stamps `CHANGELOG.md` `[Unreleased]` → `## [1.8.0] — 2026-07-05 — "Spine"`.
- Bumps `pyproject.toml` to `1.8.0` (read by `__version__` / `/api/health`).

Plugin already at build 31 / semver 1.8.0. No code changes — release stamp only.

The hand-written GitHub release notes (Highlights / Also / Fixed / Security / Upgrading) are prepared separately and applied when the tag is created.