### PR TITLE
feat(highlights): only-notes filter, file export, shortcuts, spotlight shuffle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- **Highlights page polish.** The deferred cluster from the original
+  commonplace-book release: an **only-notes filter** (show just the highlights
+  carrying your own notes — composes with search and on-this-day), a real
+  **file export** (download all matching highlights as a Markdown file, next to
+  the existing copy-to-clipboard), **keyboard shortcuts** (`/` search, `Esc`
+  clear, `c` collapse all, `n` only-notes, `e` export — listed in the `?`
+  help), and a **shuffle button** on the Home tab's highlight spotlight that
+  re-rolls to a different quote.
+
+### Fixed
+- **The Highlights "copy all as Markdown" export never worked.** It requested
+  more highlights than the API's page cap allowed, got a 422, and failed
+  without any feedback. The cap is raised, the export stays under it, and a
+  failure now shows an error toast instead of silently doing nothing.
+
 ## [1.8.0] — 2026-07-05 — "Spine"
 
 ### Added

--- a/backend/api/annotations.py
+++ b/backend/api/annotations.py
@@ -69,7 +69,10 @@ def _month_day(dt: Optional[str]) -> Optional[str]:
 def list_annotations(
     q: Optional[str] = Query(None, description="case-insensitive text search"),
     on_this_day: bool = Query(False),
-    limit: int = Query(200, ge=1, le=1000),
+    only_notes: bool = Query(False, description="only highlights carrying a note"),
+    # 10k ceiling: the export paths ask for everything at once, and a request
+    # over the cap is a 422, not a truncation — see the Markdown export.
+    limit: int = Query(200, ge=1, le=10_000),
     offset: int = Query(0, ge=0),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -95,6 +98,9 @@ def list_annotations(
                 Book.title.ilike(like),
             )
         )
+
+    if only_notes:
+        query = query.filter(Annotation.note.isnot(None), Annotation.note != "")
 
     # Newest highlights first (KOReader's own timestamp, falling back to id).
     rows = (
@@ -291,12 +297,17 @@ def delete_annotation(
 
 @router.get("/annotations/spotlight")
 def annotation_spotlight(
+    exclude: Optional[int] = Query(None, description="annotation id to re-roll away from"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """One highlight for the Home tab: a random highlight made on this calendar
     day in a past year, falling back to any random highlight so the card is never
     empty. `on_this_day` tells the UI which case it got.
+
+    `exclude` powers the shuffle button: pass the current highlight's id and the
+    re-roll returns a different one whenever more than one candidate exists (the
+    on-this-day preference is kept — only its current pick is excluded).
     """
     base = (
         db.query(Annotation, Book)
@@ -309,6 +320,8 @@ def annotation_spotlight(
             book_visibility_filter(db, current_user),
         )
     )
+    if exclude is not None:
+        base = base.filter(Annotation.id != exclude)
 
     today_md = _month_day(func_now_str())
     on_day_row = None
@@ -323,6 +336,10 @@ def annotation_spotlight(
         )
 
     row = on_day_row or base.order_by(func.random()).first()
+    if not row and exclude is not None:
+        # The excluded highlight was the only one — better the same again
+        # than an empty card.
+        return annotation_spotlight(exclude=None, db=db, current_user=current_user)
     if not row:
         return {"highlight": None, "on_this_day": False}
     a, b = row

--- a/frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/KeyboardShortcutsModal.tsx
@@ -43,6 +43,16 @@ const SECTIONS: ShortcutSection[] = [
       { keys: ['ArrowRight', 'ArrowDown'], description: 'Next page' },
     ],
   },
+  {
+    title: 'Highlights',
+    rows: [
+      { keys: ['/'], description: 'Focus search' },
+      { keys: ['Escape'], description: 'Clear search' },
+      { keys: ['c'], description: 'Collapse / expand all books' },
+      { keys: ['n'], description: 'Toggle only-notes filter' },
+      { keys: ['e'], description: 'Download Markdown export' },
+    ],
+  },
 ]
 
 function KeyBadge({ label }: { label: string }) {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,7 +5,7 @@ import {
   LayoutGrid, List,
   ChevronUp, ChevronDown, SlidersHorizontal, Loader2,
   Library as LibraryIcon, CheckSquare, XSquare, Download, Pencil,
-  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star, Quote, Moon,
+  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star, Quote, Moon, Shuffle,
 } from 'lucide-react'
 import { AppHeader, HeaderSearch } from '@/components/AppHeader'
 import { useAuth, isMember, isAdmin } from '@/contexts/AuthContext'
@@ -103,6 +103,7 @@ interface ForgottenBook {
 interface HighlightSpotlight {
   on_this_day: boolean
   highlight: {
+    id: number
     book_id: number
     book_title: string
     book_author: string | null
@@ -1406,9 +1407,24 @@ export function DashboardPage() {
                         <Quote className="w-4 h-4 text-primary/60" />
                         {spotlight.on_this_day ? 'On this day' : 'From your highlights'}
                       </h2>
-                      <a href="/highlights" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-                        All →
-                      </a>
+                      <div className="flex items-center gap-2">
+                        <button
+                          onClick={() => {
+                            const cur = spotlight.highlight?.id
+                            api.get<HighlightSpotlight>(
+                              `/annotations/spotlight${cur ? `?exclude=${cur}` : ''}`
+                            ).then(setSpotlight).catch(() => {})
+                          }}
+                          title="Show another highlight"
+                          aria-label="Show another highlight"
+                          className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          <Shuffle className="w-3.5 h-3.5" />
+                        </button>
+                        <a href="/highlights" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
+                          All →
+                        </a>
+                      </div>
                     </header>
                     <a href={`/books/${spotlight.highlight.book_id}`} className="block group">
                       <p className="text-sm text-foreground leading-relaxed border-l-2 border-primary/40 pl-3 italic line-clamp-4">

--- a/frontend/src/pages/HighlightsPage.tsx
+++ b/frontend/src/pages/HighlightsPage.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { Link } from 'react-router-dom'
 import {
   Search, Quote, StickyNote, Loader2, BookOpen,
   CalendarHeart, Copy, X, ChevronDown, Info, ChevronsDownUp, ChevronsUpDown, Trash2,
+  Download,
 } from 'lucide-react'
 import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
@@ -186,7 +187,9 @@ export function HighlightsPage() {
   const [search, setSearch] = useState('')
   const [debounced, setDebounced] = useState('')
   const [onThisDay, setOnThisDay] = useState(false)
+  const [onlyNotes, setOnlyNotes] = useState(false)
   const [collapsed, setCollapsed] = useState<Set<number>>(new Set())
+  const searchRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
     const t = setTimeout(() => setDebounced(search.trim()), 250)
@@ -197,10 +200,11 @@ export function HighlightsPage() {
     const p = new URLSearchParams()
     if (debounced) p.set('q', debounced)
     if (onThisDay) p.set('on_this_day', '1')
+    if (onlyNotes) p.set('only_notes', '1')
     p.set('limit', String(PAGE_SIZE))
     p.set('offset', String(offset))
     return p
-  }, [debounced, onThisDay])
+  }, [debounced, onThisDay, onlyNotes])
 
   // Reset + first page whenever the query/filter changes.
   useEffect(() => {
@@ -250,16 +254,47 @@ export function HighlightsPage() {
     setCollapsed(allCollapsed ? new Set() : new Set(groups.map(g => g.book_id)))
   }
 
-  async function copyAll() {
-    // Export everything that matches, not just the loaded pages.
+  // Export everything that matches the current filters, not just loaded pages.
+  // 10000 matches the server's limit cap — anything above it is a 422, which
+  // is how the old limit=2000 silently broke this export against the previous
+  // le=1000 cap.
+  async function fetchAllMatching(): Promise<HighlightsResponse> {
     const p = new URLSearchParams()
     if (debounced) p.set('q', debounced)
     if (onThisDay) p.set('on_this_day', '1')
-    p.set('limit', '2000')
-    const d = await api.get<HighlightsResponse>(`/annotations?${p.toString()}`)
-    const md = groupByBook(d.items).map(groupToMarkdown).join('\n\n')
-    await navigator.clipboard.writeText(md)
-    toast.success(`Copied ${d.items.length} highlights as Markdown`)
+    if (onlyNotes) p.set('only_notes', '1')
+    p.set('limit', '10000')
+    return api.get<HighlightsResponse>(`/annotations?${p.toString()}`)
+  }
+
+  async function copyAll() {
+    try {
+      const d = await fetchAllMatching()
+      const md = groupByBook(d.items).map(groupToMarkdown).join('\n\n')
+      await navigator.clipboard.writeText(md)
+      toast.success(`Copied ${d.items.length} highlights as Markdown`)
+    } catch (e) {
+      toast.error((e as Error).message ?? 'Export failed')
+    }
+  }
+
+  async function downloadAll() {
+    try {
+      const d = await fetchAllMatching()
+      const md = groupByBook(d.items).map(groupToMarkdown).join('\n\n') + '\n'
+      const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `tome-highlights-${new Date().toISOString().slice(0, 10)}.md`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+      toast.success(`Downloaded ${d.items.length} highlights`)
+    } catch (e) {
+      toast.error((e as Error).message ?? 'Export failed')
+    }
   }
 
   async function copyGroup(g: BookGroup) {
@@ -294,20 +329,58 @@ export function HighlightsPage() {
     }
   }
 
+  // Keyboard shortcuts: "/" focuses search, Esc clears it, "c" toggles
+  // collapse-all, "n" only-notes, "e" downloads the export. Plain keys are
+  // ignored while typing (Esc still works, matching the other pages).
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const el = e.target as HTMLElement
+      const typing = el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' || el.isContentEditable
+      if (e.key === 'Escape' && typing) {
+        setSearch('')
+        searchRef.current?.blur()
+        return
+      }
+      if (typing || e.metaKey || e.ctrlKey || e.altKey) return
+      if (e.key === '/') {
+        e.preventDefault()
+        searchRef.current?.focus()
+      } else if (e.key === 'c') {
+        toggleAll()
+      } else if (e.key === 'n') {
+        setOnlyNotes(v => !v)
+      } else if (e.key === 'e') {
+        void downloadAll()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  })
+
   const isEmpty = !loading && !error && groups.length === 0
-  const neverSynced = isEmpty && !debounced && !onThisDay
+  const neverSynced = isEmpty && !debounced && !onThisDay && !onlyNotes
 
   return (
     <AppShell
       actions={groups.length > 0 ? (
-        <button
-          onClick={copyAll}
-          title="Copy all as Markdown"
-          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border hover:bg-muted transition-all"
-        >
-          <Copy className="w-3.5 h-3.5" />
-          <span className="hidden sm:inline">Export</span>
-        </button>
+        <div className="flex items-center gap-1.5">
+          <button
+            onClick={copyAll}
+            title="Copy all as Markdown"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border hover:bg-muted transition-all"
+          >
+            <Copy className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline">Copy</span>
+          </button>
+          <button
+            onClick={downloadAll}
+            title="Download as Markdown file"
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border hover:bg-muted transition-all"
+          >
+            <Download className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline">Export</span>
+          </button>
+        </div>
       ) : undefined}
     >
       <div className="max-w-3xl mx-auto px-4 py-6 space-y-5">
@@ -324,6 +397,7 @@ export function HighlightsPage() {
           <div className="relative flex-1">
             <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground/60" />
             <input
+              ref={searchRef}
               value={search}
               onChange={e => setSearch(e.target.value)}
               placeholder="Search your highlights…"
@@ -350,6 +424,19 @@ export function HighlightsPage() {
           >
             <CalendarHeart className="w-3.5 h-3.5" />
             On this day
+          </button>
+          <button
+            onClick={() => setOnlyNotes(v => !v)}
+            title="Only highlights that carry one of your notes"
+            className={cn(
+              'flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium border transition-all whitespace-nowrap',
+              onlyNotes
+                ? 'bg-primary/10 border-primary/30 text-primary'
+                : 'border-border text-muted-foreground hover:bg-muted'
+            )}
+          >
+            <StickyNote className="w-3.5 h-3.5" />
+            <span className="hidden sm:inline">Only notes</span>
           </button>
           {groups.length > 0 && !searching && (
             <button

--- a/tests/test_annotations_aggregate.py
+++ b/tests/test_annotations_aggregate.py
@@ -120,3 +120,50 @@ def test_only_own_highlights(client, db, admin_user, make_book):
     data = client.get("/api/annotations", headers=_hdr(user)).json()
     assert data["total"] == 1
     assert data["items"][0]["highlighted_text"] == "mine"
+
+
+def test_only_notes_filter(client, db, admin_user, make_book):
+    user, _ = admin_user
+    b = make_book(title="Noted")
+    _anno(db, user, b, "plain highlight", "n1")
+    _anno(db, user, b, "annotated highlight", "n2", note="my thought")
+    _anno(db, user, b, "empty-string note", "n3", note="")
+    db.commit()
+
+    r = client.get("/api/annotations", params={"only_notes": "1"}, headers=_hdr(user)).json()
+    assert r["total"] == 1
+    assert r["items"][0]["note"] == "my thought"
+    # composes with search
+    r = client.get("/api/annotations", params={"only_notes": "1", "q": "thought"},
+                   headers=_hdr(user)).json()
+    assert r["total"] == 1
+    r = client.get("/api/annotations", params={"only_notes": "1", "q": "plain"},
+                   headers=_hdr(user)).json()
+    assert r["total"] == 0
+
+
+def test_spotlight_exclude_rerolls_to_a_different_highlight(client, db, admin_user, make_book):
+    user, _ = admin_user
+    b = make_book(title="Spot")
+    _anno(db, user, b, "first", "s1")
+    _anno(db, user, b, "second", "s2")
+    db.commit()
+
+    first = client.get("/api/annotations/spotlight", headers=_hdr(user)).json()["highlight"]
+    for _ in range(5):
+        other = client.get("/api/annotations/spotlight",
+                           params={"exclude": first["id"]}, headers=_hdr(user)).json()["highlight"]
+        assert other["id"] != first["id"]
+
+
+def test_spotlight_exclude_with_single_highlight_returns_it_again(client, db, admin_user, make_book):
+    user, _ = admin_user
+    b = make_book(title="Solo")
+    _anno(db, user, b, "the only one", "s1")
+    db.commit()
+
+    got = client.get("/api/annotations/spotlight", headers=_hdr(user)).json()["highlight"]
+    again = client.get("/api/annotations/spotlight",
+                       params={"exclude": got["id"]}, headers=_hdr(user)).json()["highlight"]
+    # Better the same highlight than an empty card.
+    assert again is not None and again["id"] == got["id"]


### PR DESCRIPTION
The four polish items deferred from the original commonplace-book release (PR #76), plus a real bug the verification pass surfaced.

- **Only-notes filter**: toggle next to "On this day" showing just the highlights carrying a note (`only_notes` on `GET /api/annotations`; composes with search and on-this-day).
- **File export**: download all matching highlights as `tome-highlights-YYYY-MM-DD.md`, alongside the existing clipboard copy.
- **Keyboard shortcuts** on /highlights: `/` search, `Esc` clear, `c` collapse all, `n` only-notes, `e` export — listed in the `?` help modal.
- **Spotlight shuffle**: re-roll button on the Home highlight card; `GET /annotations/spotlight?exclude=<id>` returns a different highlight whenever more than one exists (a sole highlight comes back rather than emptying the card).

**Fixed along the way**: "copy all as Markdown" has been broken since the page shipped — it requested `limit=2000` against the endpoint's `le=1000` cap, got a 422, and failed with no feedback (no catch, no toast). Cap raised to 10000, both exports stay under it, failures now toast.

Verification: suite green (3 new endpoint tests); Playwright drive on the live dev app — filter 28→18→28 highlights, `/` focuses search, the export downloads a real .md file (the step that caught the 422), shuffle swaps the home quote.