### PR TITLE
Reading Timeline — your reading life as a ribbon (new Stats tab)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ All notable changes to Tome are documented here. Format loosely follows
   the ribbon is also available as a regular tile in the dashboard gallery.
 
 ### Fixed
+- **The notifications panel no longer renders behind sticky page content.** The
+  top bar sat at the same layer as page-level sticky toolbars (and below the new
+  timeline axis), so the open notification dropdown was cut by the Stats
+  toolbar. The top bar now stacks above content-level sticky elements.
 - **Chapter maps now extract from EPUB2 books.** Older EPUBs keep their table
   of contents in an NCX file rather than an EPUB3 nav document; chapter
   extraction ignored the NCX, so classics and older rips silently produced no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- **Reading Timeline — your reading life on one ribbon.** A new Timeline tab on
+  Reading Stats draws every book you've ever read as a bar in time: one lane
+  per series (named in a frozen rail on the left), volumes as numbered bars
+  spanning first to last active day, and the intensity of each day's reading
+  shaded inside the bar. Lifetime data, including imported KOReader history,
+  reconciled the same way as the rest of stats. Zoom from a year-at-a-glance
+  down to month detail, hover any bar for the cover and totals, click through
+  to the book. The tab renders full-bleed — edge to edge, viewport-tall — and
+  the ribbon is also available as a regular tile in the dashboard gallery.
+
 ### Fixed
 - **Chapter maps now extract from EPUB2 books.** Older EPUBs keep their table
   of contents in an NCX file rather than an EPUB3 nav document; chapter

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -1179,7 +1179,14 @@ def get_reading_timeline(
         if secs > 0 and day is not None:
             per_book[book_id][day] = secs
 
-    meta = {b.id: b for b in db.query(Book).filter(Book.id.in_(per_book.keys())).all()}
+    meta = {
+        b.id: b
+        for b in db.query(Book).filter(
+            Book.id.in_(per_book.keys()),
+            Book.status == "active",
+            book_visibility_filter(db, current_user),
+        )
+    }
     statuses = {
         s.book_id: s
         for s in db.query(UserBookStatus).filter(
@@ -1190,7 +1197,7 @@ def get_reading_timeline(
     books = []
     for book_id, days in per_book.items():
         b = meta.get(book_id)
-        if b is None or not days:  # deleted book — its sessions linger; skip
+        if b is None or not days:  # deleted/hidden book — its sessions linger; skip
             continue
         if sum(days.values()) < 60:  # sub-minute lifetime totals are page-flip noise
             continue
@@ -1203,8 +1210,6 @@ def get_reading_timeline(
             "series": b.series,
             "series_index": b.series_index,
             "has_cover": bool(b.cover_path),
-            "status": st.status if st else "unread",
-            "progress_pct": st.progress_pct if st else None,
             "finished_on": st.finished_at.strftime("%Y-%m-%d") if st and st.finished_at else None,
             "first_day": ordered[0][0],
             "last_day": ordered[-1][0],

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -1158,6 +1158,63 @@ def get_completion_estimates(
     return result
 
 
+@router.get("/stats/timeline")
+def get_reading_timeline(
+    tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Lifetime reading timeline: every book with recorded reading and its active
+    days, reconciled across live sessions and imported KOReader page-stats.
+    Day bucketing is the canonical reading day (4h rollover)."""
+    tzm = date_modifier(tz_offset)
+    covered = rr.covered_book_ids(db, current_user.id)
+    day_secs = rr.book_day_seconds(db, current_user.id, tzm, covered)
+    today = effective_today(tz_offset).isoformat()
+    if not day_secs:
+        return {"books": [], "today": today}
+
+    per_book: dict[int, dict[str, int]] = defaultdict(dict)
+    for (book_id, day), secs in day_secs.items():
+        if secs > 0 and day is not None:
+            per_book[book_id][day] = secs
+
+    meta = {b.id: b for b in db.query(Book).filter(Book.id.in_(per_book.keys())).all()}
+    statuses = {
+        s.book_id: s
+        for s in db.query(UserBookStatus).filter(
+            UserBookStatus.user_id == current_user.id,
+            UserBookStatus.book_id.in_(per_book.keys()),
+        )
+    }
+    books = []
+    for book_id, days in per_book.items():
+        b = meta.get(book_id)
+        if b is None or not days:  # deleted book — its sessions linger; skip
+            continue
+        if sum(days.values()) < 60:  # sub-minute lifetime totals are page-flip noise
+            continue
+        ordered = sorted(days.items())
+        st = statuses.get(book_id)
+        books.append({
+            "book_id": book_id,
+            "title": b.title,
+            "author": b.author,
+            "series": b.series,
+            "series_index": b.series_index,
+            "has_cover": bool(b.cover_path),
+            "status": st.status if st else "unread",
+            "progress_pct": st.progress_pct if st else None,
+            "finished_on": st.finished_at.strftime("%Y-%m-%d") if st and st.finished_at else None,
+            "first_day": ordered[0][0],
+            "last_day": ordered[-1][0],
+            "total_seconds": sum(days.values()),
+            "days": [{"date": d, "seconds": s} for d, s in ordered],
+        })
+    books.sort(key=lambda x: (x["first_day"], x["book_id"]))
+    return {"books": books, "today": today}
+
+
 @router.get("/stats/sessions")
 def list_sessions(
     offset: int = Query(0, ge=0),

--- a/backend/services/reconciled_reading.py
+++ b/backend/services/reconciled_reading.py
@@ -255,6 +255,29 @@ def book_month_seconds(db, user_id, tzm, covered, start_dt) -> dict[tuple[int, s
     return out
 
 
+def book_day_seconds(db, user_id, tzm, covered) -> dict[tuple[int, str], int]:
+    """(book_id, 'YYYY-MM-DD') -> seconds, all time. For the reading timeline."""
+    rs_day = func.date(ReadingSession.started_at, tzm)
+    rows = (
+        _rs_filtered(db, user_id, covered, None, None)
+        .filter(ReadingSession.book_id.isnot(None))
+        .with_entities(ReadingSession.book_id, rs_day.label("d"),
+                       func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("secs"))
+        .group_by(ReadingSession.book_id, "d").all()
+    )
+    out: dict[tuple[int, str], int] = {(r.book_id, r.d): int(r.secs or 0) for r in rows}
+    if covered:
+        rows2 = (
+            _ps_filtered(db, user_id, None, None)
+            .with_entities(PageStat.book_id, _ps_day(tzm).label("d"),
+                           func.coalesce(func.sum(PageStat.duration_seconds), 0).label("secs"))
+            .group_by(PageStat.book_id, "d").all()
+        )
+        for r in rows2:
+            out[(r.book_id, r.d)] = out.get((r.book_id, r.d), 0) + int(r.secs or 0)
+    return out
+
+
 # ── Hour × day-of-week ──────────────────────────────────────────────────────────
 
 def hour_dow(db, user_id, tzm, covered, cutoff, range_end) -> dict[tuple[int, int], tuple[int, int]]:

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -19,8 +19,10 @@ export function AppHeader({ onMenuClick, search, actions, onUploadClick }: {
   onUploadClick?: () => void
 }) {
   const { user } = useAuth()
+  // z-40: above content-level stickies (page toolbars at z-20, timeline axis at
+  // z-30) so the notification dropdown isn't cut, below modals at z-50.
   return (
-    <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-20 shrink-0 safe-top">
+    <header className="border-b border-border bg-card/50 backdrop-blur-sm sticky top-0 z-40 shrink-0 safe-top">
       <div className="px-4 h-14 flex items-center gap-3">
         <button
           className="md:hidden flex items-center justify-center w-8 h-8 text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-muted shrink-0"

--- a/frontend/src/components/stats/TimelineRibbon.tsx
+++ b/frontend/src/components/stats/TimelineRibbon.tsx
@@ -9,6 +9,7 @@ import { Minus, Plus } from 'lucide-react'
 import { api } from '@/lib/api'
 import { formatDate, formatDuration } from '@/lib/utils'
 import { useChartColors } from '@/lib/useChartAccent'
+import { useAuth } from '@/contexts/AuthContext'
 
 interface TimelineBook {
   book_id: number
@@ -17,8 +18,6 @@ interface TimelineBook {
   series: string | null
   series_index: number | null
   has_cover: boolean
-  status: string
-  progress_pct: number | null
   finished_on: string | null
   first_day: string
   last_day: string
@@ -102,11 +101,12 @@ function buildLanes(books: TimelineBook[]): LaneGroup[] {
   return lanes
 }
 
-const fmtIndex = (si: number) => (Number.isInteger(si) ? String(si) : String(si))
-
 // Session-lived cache: switching tabs remounts the widget; the ribbon should
 // reappear instantly, not re-fetch and flash its loading state every visit.
+// Keyed by user id — logout/login and admin impersonation don't full-reload
+// the SPA, so an unkeyed cache would flash the previous account's timeline.
 let cachedData: TimelineResponse | null = null
+let cachedForUser: number | null = null
 
 const ZOOM_KEY = 'tome_timeline_zoom'
 const initialZoom = () => {
@@ -117,7 +117,9 @@ const initialZoom = () => {
 }
 
 export function TimelineRibbon({ standalone = false }: { standalone?: boolean } = {}) {
-  const [data, setData] = useState<TimelineResponse | null>(cachedData)
+  const { user } = useAuth()
+  const cacheHit = user != null && user.id === cachedForUser ? cachedData : null
+  const [data, setData] = useState<TimelineResponse | null>(cacheHit)
   const [failed, setFailed] = useState(false)
   const [zoom, setZoomState] = useState(initialZoom)
   const setZoom = (fn: (z: number) => number) =>
@@ -136,11 +138,13 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
       .get<TimelineResponse>(`/stats/timeline?tz_offset=${new Date().getTimezoneOffset()}`)
       .then((d) => {
         cachedData = d
+        cachedForUser = user?.id ?? null
         setData(d)
       })
       .catch(() => {
-        if (!cachedData) setFailed(true)
+        if (!cacheHit) setFailed(true)
       })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const lanes = useMemo(() => (data && data.books.length ? buildLanes(data.books) : null), [data])
@@ -308,7 +312,7 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
                         ))}
                         {showIndex && (
                           <span className="absolute left-1 top-1/2 -translate-y-1/2 text-[9px] font-semibold leading-none text-foreground/80">
-                            {fmtIndex(b.series_index!)}
+                            {String(b.series_index)}
                           </span>
                         )}
                       </button>
@@ -324,7 +328,7 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
       {hover && (
         <div
           className="pointer-events-none fixed z-50 flex max-w-[300px] gap-2.5 rounded-lg border border-border bg-card px-3 py-2 text-xs shadow-xl"
-          style={{ left: Math.min(hover.x + 14, window.innerWidth - 320), top: hover.y + 16 }}
+          style={{ left: Math.min(hover.x + 14, window.innerWidth - 320), top: Math.min(hover.y + 16, window.innerHeight - 110) }}
         >
           {hover.b.has_cover && (
             <img src={`/api/books/${hover.b.book_id}/cover`} alt="" className="h-14 w-10 shrink-0 rounded object-cover" />

--- a/frontend/src/components/stats/TimelineRibbon.tsx
+++ b/frontend/src/components/stats/TimelineRibbon.tsx
@@ -1,0 +1,356 @@
+// Reading Timeline — your reading life as a horizontal ribbon. One lane per
+// series (standalones get their own), named in a frozen left rail; every book
+// is a bar spanning its first to last active day, daily ticks inside carrying
+// that day's minutes as intensity (one hue, sequential). Data is lifetime and
+// reconciled (imported KOReader history included), from GET /stats/timeline.
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Minus, Plus } from 'lucide-react'
+import { api } from '@/lib/api'
+import { formatDate, formatDuration } from '@/lib/utils'
+import { useChartColors } from '@/lib/useChartAccent'
+
+interface TimelineBook {
+  book_id: number
+  title: string
+  author: string | null
+  series: string | null
+  series_index: number | null
+  has_cover: boolean
+  status: string
+  progress_pct: number | null
+  finished_on: string | null
+  first_day: string
+  last_day: string
+  total_seconds: number
+  days: { date: string; seconds: number }[]
+}
+
+interface TimelineResponse {
+  books: TimelineBook[]
+  today: string
+}
+
+const DAY_MS = 86400000
+const dayNum = (d: string) => Math.floor(Date.parse(`${d}T00:00:00Z`) / DAY_MS)
+
+const RAIL_W = 200
+const AXIS_H = 26
+const SUB_H = 22 // one sub-lane (bar row) inside a lane
+const BAR_H = 16
+const ZOOMS = [1.5, 3, 6, 12] // px per day
+
+interface Placed {
+  book: TimelineBook
+  sub: number // sub-lane within the group, 0 for almost everything
+}
+
+interface LaneGroup {
+  key: string
+  label: string
+  author: string | null
+  placed: Placed[]
+  subCount: number
+  firstDay: number
+  lastDay: number
+  totalSeconds: number
+}
+
+// Group books into series lanes; a lane grows sub-lanes only when two volumes
+// were genuinely read in overlapping windows (re-reads, parallel volumes).
+function buildLanes(books: TimelineBook[]): LaneGroup[] {
+  const groups = new Map<string, TimelineBook[]>()
+  for (const b of books) {
+    const key = b.series ? `s:${b.series}` : `b:${b.book_id}`
+    const g = groups.get(key)
+    if (g) g.push(b)
+    else groups.set(key, [b])
+  }
+  const lanes: LaneGroup[] = []
+  for (const [key, members] of groups) {
+    members.sort((a, z) => (a.first_day < z.first_day ? -1 : 1))
+    const subEnds: number[] = []
+    const placed: Placed[] = []
+    for (const b of members) {
+      const start = dayNum(b.first_day)
+      const end = dayNum(b.last_day)
+      // <= so finishing one volume and starting the next on the same day
+      // chains onto one row; only genuinely parallel reads stack.
+      let sub = subEnds.findIndex((e) => e <= start)
+      if (sub === -1) {
+        sub = subEnds.length
+        subEnds.push(end)
+      } else {
+        subEnds[sub] = end
+      }
+      placed.push({ book: b, sub })
+    }
+    lanes.push({
+      key,
+      label: members[0].series ?? members[0].title,
+      author: members[0].author,
+      placed,
+      subCount: subEnds.length,
+      firstDay: dayNum(members[0].first_day),
+      lastDay: Math.max(...members.map((b) => dayNum(b.last_day))),
+      totalSeconds: members.reduce((s, b) => s + b.total_seconds, 0),
+    })
+  }
+  // Most recently active on top: the view opens scrolled to today, so the
+  // top-right corner — the first thing seen — is the reading happening now.
+  lanes.sort((a, z) => z.lastDay - a.lastDay || z.firstDay - a.firstDay)
+  return lanes
+}
+
+const fmtIndex = (si: number) => (Number.isInteger(si) ? String(si) : String(si))
+
+// Session-lived cache: switching tabs remounts the widget; the ribbon should
+// reappear instantly, not re-fetch and flash its loading state every visit.
+let cachedData: TimelineResponse | null = null
+
+const ZOOM_KEY = 'tome_timeline_zoom'
+const initialZoom = () => {
+  const raw = localStorage.getItem(ZOOM_KEY)
+  if (raw === null) return 2 // Number(null) is 0 — don't let a fresh browser start zoomed out
+  const z = Number(raw)
+  return Number.isInteger(z) && z >= 0 && z < ZOOMS.length ? z : 2
+}
+
+export function TimelineRibbon({ standalone = false }: { standalone?: boolean } = {}) {
+  const [data, setData] = useState<TimelineResponse | null>(cachedData)
+  const [failed, setFailed] = useState(false)
+  const [zoom, setZoomState] = useState(initialZoom)
+  const setZoom = (fn: (z: number) => number) =>
+    setZoomState((z) => {
+      const next = fn(z)
+      localStorage.setItem(ZOOM_KEY, String(next))
+      return next
+    })
+  const [hover, setHover] = useState<{ b: TimelineBook; x: number; y: number } | null>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const colors = useChartColors()
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    api
+      .get<TimelineResponse>(`/stats/timeline?tz_offset=${new Date().getTimezoneOffset()}`)
+      .then((d) => {
+        cachedData = d
+        setData(d)
+      })
+      .catch(() => {
+        if (!cachedData) setFailed(true)
+      })
+  }, [])
+
+  const lanes = useMemo(() => (data && data.books.length ? buildLanes(data.books) : null), [data])
+
+  // Panel width, live — zooming out floors at fit-width so the ribbon never
+  // leaves dead space to the right of today on a wide screen.
+  const [containerW, setContainerW] = useState(0)
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const ro = new ResizeObserver(() => setContainerW(el.clientWidth))
+    ro.observe(el)
+    setContainerW(el.clientWidth)
+    return () => ro.disconnect()
+  }, [data])
+
+  const model = useMemo(() => {
+    if (!data || !lanes) return null
+    const minDay = Math.min(...lanes.map((l) => l.firstDay)) - 2
+    const maxDay = dayNum(data.today) + 2
+    const fit = containerW > RAIL_W + 100 ? (containerW - RAIL_W - 1) / (maxDay - minDay) : 0
+    const ppd = Math.max(ZOOMS[zoom], fit)
+    const months: { x: number; label: string }[] = []
+    const first = new Date(minDay * DAY_MS)
+    const cur = new Date(Date.UTC(first.getUTCFullYear(), first.getUTCMonth() + 1, 1))
+    while (Math.floor(cur.getTime() / DAY_MS) < maxDay) {
+      const m = cur.getUTCMonth()
+      months.push({
+        x: (Math.floor(cur.getTime() / DAY_MS) - minDay) * ppd,
+        label: m === 0 ? String(cur.getUTCFullYear()) : cur.toLocaleString(undefined, { month: 'short', timeZone: 'UTC' }),
+      })
+      cur.setUTCMonth(m + 1)
+    }
+    // Intensity reference: p90 of daily totals, so one marathon day doesn't
+    // flatten every other tick to invisible.
+    const daySecs = data.books.flatMap((b) => b.days.map((d) => d.seconds)).sort((a, z) => a - z)
+    const ref = daySecs[Math.floor(daySecs.length * 0.9)] || 1
+    return {
+      minDay,
+      ppd,
+      width: (maxDay - minDay) * ppd,
+      todayX: (dayNum(data.today) - minDay) * ppd,
+      months,
+      ref,
+    }
+  }, [data, lanes, zoom, containerW])
+
+  // Land on the recent end — that's where the reading is.
+  useEffect(() => {
+    const el = scrollRef.current
+    if (el && model) el.scrollLeft = el.scrollWidth
+  }, [model === null]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (failed) return <Empty text="Couldn't load the timeline." />
+  if (!data) return <Empty text="Loading your reading life…" pulse />
+  if (!model || !lanes) return <Empty text="No reading history yet — sessions and imported KOReader history land here." />
+
+  const ppd = model.ppd
+  const atFitFloor = ppd > ZOOMS[zoom] + 0.001 // preset already below fit — zooming out changes nothing
+
+  return (
+    // Standalone hugs its content (the page shows background below a short
+    // ribbon); as a tile it fills the card body it was given.
+    <div className={`relative flex min-h-0 flex-col gap-1.5 ${standalone ? 'h-auto max-h-full' : 'h-full'}`}>
+      <div className="flex items-center justify-end gap-1">
+        {standalone && (
+          <div className="mr-auto flex items-baseline gap-2">
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Reading Timeline</h3>
+            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">lifetime</span>
+          </div>
+        )}
+        <button
+          onClick={() => setZoom((z) => Math.max(0, z - 1))}
+          disabled={zoom === 0 || atFitFloor}
+          aria-label="Zoom out"
+          className="rounded-md border border-border p-1 text-muted-foreground hover:text-foreground disabled:opacity-40"
+        >
+          <Minus className="h-3.5 w-3.5" />
+        </button>
+        <button
+          onClick={() => setZoom((z) => Math.min(ZOOMS.length - 1, z + 1))}
+          disabled={zoom === ZOOMS.length - 1}
+          aria-label="Zoom in"
+          className="rounded-md border border-border p-1 text-muted-foreground hover:text-foreground disabled:opacity-40"
+        >
+          <Plus className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      <div ref={scrollRef} className="min-h-0 flex-1 overflow-auto rounded-lg border border-border" onMouseLeave={() => setHover(null)}>
+        <div style={{ width: RAIL_W + model.width }}>
+          {/* axis row — sticky against vertical scroll; corner sticky both ways */}
+          <div className="sticky top-0 z-30 flex border-b border-border bg-card" style={{ height: AXIS_H }}>
+            <div className="sticky left-0 z-10 shrink-0 border-r border-border bg-card" style={{ width: RAIL_W }} />
+            <div className="relative" style={{ width: model.width }}>
+              {model.months
+                .filter((m) => m.x < model.width - 42)
+                .map((m) => (
+                  <span
+                    key={m.x}
+                    className={`absolute top-1.5 pl-1.5 text-[10px] leading-none ${m.label.length === 4 ? 'font-semibold text-foreground' : 'text-muted-foreground'}`}
+                    style={{ left: m.x }}
+                  >
+                    {m.label}
+                  </span>
+                ))}
+            </div>
+          </div>
+
+          {lanes.map((lane) => {
+            const laneH = Math.max(lane.subCount * SUB_H + 6, 36)
+            const padTop = (laneH - lane.subCount * SUB_H) / 2
+            return (
+              <div key={lane.key} className="flex border-b border-border/60" style={{ height: laneH }}>
+                <div
+                  className="sticky left-0 z-20 flex shrink-0 flex-col justify-center overflow-hidden border-r border-border bg-card px-2.5"
+                  style={{ width: RAIL_W }}
+                >
+                  <span className="truncate text-[11px] font-medium leading-tight">{lane.label}</span>
+                  <span className="truncate text-[10px] leading-tight text-muted-foreground">
+                    {lane.placed.length > 1 ? `${lane.placed.length} vols · ` : ''}
+                    {formatDuration(lane.totalSeconds)}
+                  </span>
+                </div>
+                <div className="relative" style={{ width: model.width }}>
+                  {/* month grid + today, per lane so the rail stays clean */}
+                  {model.months.map((m) => (
+                    <div key={m.x} className="absolute bottom-0 top-0 w-px bg-border/60" style={{ left: m.x }} />
+                  ))}
+                  <div className="absolute bottom-0 top-0 w-px" style={{ left: model.todayX, background: colors.accent, opacity: 0.5 }} />
+
+                  {lane.placed.map(({ book: b, sub }) => {
+                    const d0 = dayNum(b.first_day)
+                    const x = (d0 - model.minDay) * ppd
+                    const barW = Math.max((dayNum(b.last_day) - d0 + 1) * ppd, 8)
+                    const showIndex = b.series && b.series_index != null && barW >= 22
+                    return (
+                      <button
+                        key={b.book_id}
+                        onClick={() => navigate(`/books/${b.book_id}`)}
+                        onMouseMove={(e) => setHover({ b, x: e.clientX, y: e.clientY })}
+                        onMouseLeave={() => setHover(null)}
+                        aria-label={`${b.title} — ${formatDuration(b.total_seconds)} between ${b.first_day} and ${b.last_day}`}
+                        className="group absolute block cursor-pointer overflow-hidden rounded-[4px] border transition-transform hover:-translate-y-px"
+                        style={{
+                          left: x,
+                          top: padTop + sub * SUB_H + (SUB_H - BAR_H) / 2,
+                          width: barW,
+                          height: BAR_H,
+                          background: `color-mix(in oklab, ${colors.accent} 15%, transparent)`,
+                          borderColor: `color-mix(in oklab, ${colors.accent} 40%, transparent)`,
+                        }}
+                      >
+                        {b.days.map((d) => (
+                          <span
+                            key={d.date}
+                            className="absolute bottom-0 top-0"
+                            style={{
+                              left: (dayNum(d.date) - d0) * ppd,
+                              width: Math.max(ppd, 2),
+                              background: colors.accent,
+                              opacity: 0.3 + 0.65 * Math.min(1, Math.sqrt(d.seconds / model.ref)),
+                            }}
+                          />
+                        ))}
+                        {showIndex && (
+                          <span className="absolute left-1 top-1/2 -translate-y-1/2 text-[9px] font-semibold leading-none text-foreground/80">
+                            {fmtIndex(b.series_index!)}
+                          </span>
+                        )}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {hover && (
+        <div
+          className="pointer-events-none fixed z-50 flex max-w-[300px] gap-2.5 rounded-lg border border-border bg-card px-3 py-2 text-xs shadow-xl"
+          style={{ left: Math.min(hover.x + 14, window.innerWidth - 320), top: hover.y + 16 }}
+        >
+          {hover.b.has_cover && (
+            <img src={`/api/books/${hover.b.book_id}/cover`} alt="" className="h-14 w-10 shrink-0 rounded object-cover" />
+          )}
+          <div className="min-w-0">
+            <div className="truncate font-semibold">{hover.b.title}</div>
+            {hover.b.author && <div className="truncate text-muted-foreground">{hover.b.author}</div>}
+            <div className="mt-1 text-muted-foreground">
+              {formatDate(hover.b.first_day)} – {formatDate(hover.b.last_day)} · {hover.b.days.length}{' '}
+              {hover.b.days.length === 1 ? 'day' : 'days'}
+            </div>
+            <div className="text-muted-foreground">
+              {formatDuration(hover.b.total_seconds)}
+              {hover.b.finished_on ? ` · finished ${formatDate(hover.b.finished_on)}` : ''}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Empty({ text, pulse }: { text: string; pulse?: boolean }) {
+  return (
+    <div className={`flex h-full items-center justify-center text-sm text-muted-foreground ${pulse ? 'animate-pulse' : ''}`}>
+      {text}
+    </div>
+  )
+}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode, type MouseEvent, useMemo } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode, type MouseEvent, useMemo } from 'react'
 import ReactGridLayout, {
   useContainerWidth,
   type Layout,
@@ -16,6 +16,7 @@ import { BookAnimation } from '@/components/BookAnimation'
 import { DOCS, docsLink } from '@/lib/docs'
 import { type StatsResponse, type CompletionEstimate } from '@/components/stats/shared'
 import { ReadingDNABody } from '@/components/stats/ReadingDNACard'
+import { TimelineRibbon } from '@/components/stats/TimelineRibbon'
 import { GoalWidgetBody } from '@/components/stats/GoalWidget'
 import { listGoals, type Goal } from '@/lib/goals'
 import {
@@ -332,6 +333,13 @@ const WIDGETS: WidgetDef[] = [
     render: ({ stats }) => <SessionTimeline sessions={stats.session_timeline} />,
   },
   {
+    id: 'reading-timeline',
+    title: 'Reading Timeline',
+    size: { w: 12, h: 7, minW: 6, minH: 3 },
+    fixedWindow: 'lifetime',
+    render: () => <TimelineRibbon />,
+  },
+  {
     id: 'reading-pace',
     title: 'Reading Pace',
     size: { w: 6, h: 2, minW: 3, minH: 2 },
@@ -607,6 +615,7 @@ const WIDGET_DESC: Record<string, string> = {
   'series-spotlight': 'One series front and center — you pick which',
   'hour-dow': 'When you read — hour × weekday',
   'session-timeline': 'Daily sessions on a 24h track',
+  'reading-timeline': 'Your reading life — every book a bar in time',
   'reading-pace': 'Pages per minute over time',
   'pace-by-format': 'Speed by book format',
   'speed-trend': 'Are you getting faster?',
@@ -656,7 +665,7 @@ const GALLERY_GROUPS: { label: string; ids: string[] }[] = [
   },
   {
     label: 'Habits',
-    ids: ['hour-dow', 'reading-clock', 'reading-dna', 'session-timeline', 'reading-pace', 'pace-by-format', 'true-wpm', 'dow-bar', 'time-of-day', 'time-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'],
+    ids: ['hour-dow', 'reading-clock', 'reading-dna', 'reading-timeline', 'session-timeline', 'reading-pace', 'pace-by-format', 'true-wpm', 'dow-bar', 'time-of-day', 'time-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'],
   },
   {
     label: 'Library',
@@ -689,6 +698,8 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
   // Habits — all full width except the Pace | Pace-by-Format pair
   'hour-dow': { x: 0, y: 0, w: 12, h: 2 },
   'session-timeline': { x: 0, y: 2, w: 12, h: 3 },
+  // Timeline — its own tab, one full-bleed ribbon
+  'reading-timeline': { x: 0, y: 0, w: 12, h: 7 },
   'reading-pace': { x: 0, y: 5, w: 6, h: 3 },
   'pace-by-format': { x: 6, y: 5, w: 6, h: 3 },
   'speed-trend': { x: 0, y: 8, w: 12, h: 2 },
@@ -729,6 +740,7 @@ const TAB_DEFS: { id: string; label: string; ids: string[] }[] = [
   { id: 'habits', label: 'Habits', ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
   { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
   { id: 'taste', label: 'Taste', ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'] },
+  { id: 'timeline', label: 'Timeline', ids: ['reading-timeline'] },
   // Phase 4 word-count tiles (words-read / true-wpm / book-length) are gallery-only
   // — addable from "Add tile" but on no default board, matching the batch-2 convention.
 ]
@@ -1459,6 +1471,27 @@ const PAD_X: Record<PadWidth, string> = {
 }
 const PAD_LABEL: Record<PadWidth, string> = { none: 'None', bit: 'A bit', lot: 'A lot' }
 
+// A tab whose only tile is the Reading Timeline renders full-bleed in view mode:
+// no card, no grid, edge-to-edge and viewport-tall. Edit mode falls back to the
+// grid so the tile stays manageable like any other.
+function FullBleedTimeline() {
+  const ref = useRef<HTMLDivElement>(null)
+  const [h, setH] = useState<number | null>(null)
+  useLayoutEffect(() => {
+    const measure = () => {
+      if (ref.current) setH(Math.max(420, window.innerHeight - ref.current.getBoundingClientRect().top - 16))
+    }
+    measure()
+    window.addEventListener('resize', measure)
+    return () => window.removeEventListener('resize', measure)
+  }, [])
+  return (
+    <div ref={ref} style={{ height: h ?? 480 }}>
+      {h !== null && <TimelineRibbon standalone />}
+    </div>
+  )
+}
+
 // ── Persistence (localStorage for the POC; server-side comes later) ─────────────
 
 // v2: defaults became the real-Stats-page replica — bumping the key discards
@@ -1701,6 +1734,8 @@ export function StatsPage() {
     }
   }, [])
   const active = tabs.find((t) => t.id === activeTabId) ?? tabs[0]
+  // View-mode-only: a board holding nothing but the timeline escapes the grid.
+  const soloTimeline = !editMode && active.tiles.length === 1 && active.tiles[0].defId === 'reading-timeline'
   // genuinely no reading history (not just a quiet range): full onboarding state
   const neverRead = !!stats && stats.headline.total_sessions === 0 && stats.heatmap_daily.every((d) => d.seconds === 0)
 
@@ -2235,7 +2270,7 @@ export function StatsPage() {
 
       {/* edit mode gets extra bottom room so the last tile's resize handles have
           somewhere to scroll to */}
-      <div className={cn('py-6 transition-[padding] duration-200', PAD_X[pad], editMode && 'pb-[35vh]')}>
+      <div className={cn('py-6', editMode && 'transition-[padding] duration-200 pb-[35vh]', soloTimeline ? 'px-4' : PAD_X[pad])}>
       {/* one-time hint that the page is editable */}
       {stats && !neverRead && !hintDismissed && !editMode && (
         <div className="mb-4 flex items-center gap-2 rounded-lg border border-primary/30 bg-primary/5 px-3 py-2 text-xs">
@@ -2291,6 +2326,8 @@ export function StatsPage() {
             <p className="text-sm">This board is empty.</p>
             <p className="text-xs">{editMode ? 'Use “Add tile” to build your ' + active.label + ' board.' : 'Hit Edit, then Add tile.'}</p>
           </div>
+        ) : soloTimeline ? (
+          <FullBleedTimeline />
         ) : (
           <div ref={boardRef}>
             <FreeGrid tiles={active.tiles} layout={active.layout} ctx={{ stats, estimates, goals, reloadGoals }} editMode={editMode} onLayoutChange={setActiveLayout} onRemove={removeTile} onDuplicate={duplicateTile} onConfigChange={setConfig} />

--- a/tests/test_stats_timeline.py
+++ b/tests/test_stats_timeline.py
@@ -1,0 +1,96 @@
+"""GET /stats/timeline — lifetime per-book reading lanes for the Timeline tab.
+
+Reconciliation contract matches the rest of stats: a book with imported
+page-stats uses them for device reading (its device-origin sessions are
+ignored), web/manual sessions stay additive, session-only books fall back
+to sessions entirely.
+"""
+from datetime import datetime, timezone
+
+from backend.models.tome_sync import ReadingSession
+from backend.models.ko_stats import PageStat
+from backend.models.user_book_status import UserBookStatus
+
+
+def _epoch(y, mo, d, h=12):
+    return int(datetime(y, mo, d, h, tzinfo=timezone.utc).timestamp())
+
+
+def _add_session(db, user, book, secs, when, device=None):
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when,
+                          ended_at=when, duration_seconds=secs, pages_turned=5,
+                          device=device))
+
+
+def _add_pagestats(db, user, book, rows, day=(2026, 1, 10)):
+    base = _epoch(*day)
+    for i, secs in enumerate(rows):
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=i + 1, total_pages=100,
+                        start_time=base + i * 60, duration_seconds=secs, device="Kindle"))
+
+
+def _timeline(client):
+    r = client.get("/api/stats/timeline")
+    assert r.status_code == 200
+    return r.json()
+
+
+def test_timeline_empty(client):
+    data = _timeline(client)
+    assert data["books"] == []
+    assert data["today"]
+
+
+def test_timeline_reconciles_sources(client, db, admin_user, make_book):
+    user, _ = admin_user
+    covered = make_book(title="Kindle Book")
+    webonly = make_book(title="Web Book")
+    # covered: page-stats on two days + a device session that must NOT double-count
+    _add_pagestats(db, user, covered, [120, 80], day=(2026, 1, 10))
+    _add_pagestats(db, user, covered, [300], day=(2026, 1, 14))
+    _add_session(db, user, covered, 999, datetime(2026, 1, 10, 12))          # device-origin: ignored
+    _add_session(db, user, covered, 60, datetime(2026, 1, 12, 21), device="web")  # additive
+    # session-only book
+    _add_session(db, user, webonly, 90, datetime(2026, 2, 1, 9), device="web")
+    db.flush()
+
+    books = {b["title"]: b for b in _timeline(client)["books"]}
+    kb = books["Kindle Book"]
+    assert kb["first_day"] == "2026-01-10"
+    assert kb["last_day"] == "2026-01-14"
+    assert kb["total_seconds"] == 120 + 80 + 300 + 60          # 999 dropped
+    assert [d["date"] for d in kb["days"]] == ["2026-01-10", "2026-01-12", "2026-01-14"]
+    assert {d["date"]: d["seconds"] for d in kb["days"]}["2026-01-12"] == 60
+
+    wb = books["Web Book"]
+    assert wb["first_day"] == wb["last_day"] == "2026-02-01"
+    assert wb["total_seconds"] == 90
+
+
+def test_timeline_ordered_and_meta(client, db, admin_user, make_book):
+    user, _ = admin_user
+    late = make_book(title="Later Book")
+    early = make_book(title="Earlier Book")
+    _add_session(db, user, late, 400, datetime(2026, 3, 5, 9), device="web")
+    _add_session(db, user, early, 400, datetime(2025, 11, 2, 9), device="web")
+    db.add(UserBookStatus(user_id=user.id, book_id=late.id, status="read",
+                          finished_at=datetime(2026, 3, 6, 8)))
+    db.flush()
+
+    data = _timeline(client)
+    titles = [b["title"] for b in data["books"]]
+    assert titles == ["Earlier Book", "Later Book"]            # sorted by first activity
+    lb = data["books"][1]
+    assert lb["status"] == "read"
+    assert lb["finished_on"] == "2026-03-06"
+
+
+def test_timeline_drops_subminute_noise(client, db, admin_user, make_book):
+    user, _ = admin_user
+    noise = make_book(title="Page Flip")
+    real = make_book(title="Real Read")
+    _add_session(db, user, noise, 12, datetime(2026, 4, 1, 9), device="web")
+    _add_session(db, user, real, 300, datetime(2026, 4, 1, 9), device="web")
+    db.flush()
+    titles = [b["title"] for b in _timeline(client)["books"]]
+    assert titles == ["Real Read"]

--- a/tests/test_stats_timeline.py
+++ b/tests/test_stats_timeline.py
@@ -7,8 +7,11 @@ to sessions entirely.
 """
 from datetime import datetime, timezone
 
+from backend.core.security import hash_password, create_access_token
 from backend.models.tome_sync import ReadingSession
 from backend.models.ko_stats import PageStat
+from backend.models.library import Library
+from backend.models.user import User, UserPermission
 from backend.models.user_book_status import UserBookStatus
 
 
@@ -81,7 +84,6 @@ def test_timeline_ordered_and_meta(client, db, admin_user, make_book):
     titles = [b["title"] for b in data["books"]]
     assert titles == ["Earlier Book", "Later Book"]            # sorted by first activity
     lb = data["books"][1]
-    assert lb["status"] == "read"
     assert lb["finished_on"] == "2026-03-06"
 
 
@@ -94,3 +96,40 @@ def test_timeline_drops_subminute_noise(client, db, admin_user, make_book):
     db.flush()
     titles = [b["title"] for b in _timeline(client)["books"]]
     assert titles == ["Real Read"]
+
+
+def test_timeline_excludes_soft_deleted(client, db, admin_user, make_book):
+    user, _ = admin_user
+    gone = make_book(title="Soft Deleted")
+    _add_session(db, user, gone, 300, datetime(2026, 5, 1, 9), device="web")
+    gone.status = "deleted"
+    db.flush()
+    assert "Soft Deleted" not in [b["title"] for b in _timeline(client)["books"]]
+
+
+def test_timeline_respects_visibility(client, db, admin_user, make_book):
+    """A member's reading on a book that later moved into someone else's private
+    library disappears from their timeline — same rule as every other stats
+    surface (book_visibility_filter is the single source of truth)."""
+    admin, _ = admin_user
+    hidden = make_book(title="Private Book")
+    lib = Library(name="Admin Private", is_public=False, owner_id=admin.id)
+    db.add(lib)
+    db.flush()
+    hidden.libraries.append(lib)
+
+    member = User(username="tl_member", email="tl_member@example.com",
+                  hashed_password=hash_password("pass1234"), is_active=True,
+                  is_admin=False, role="member", must_change_password=False)
+    db.add(member)
+    db.flush()
+    db.add(UserPermission(user_id=member.id))
+    db.flush()
+    _add_session(db, member, hidden, 600, datetime(2026, 5, 2, 9), device="web")
+    db.flush()
+
+    token = create_access_token(subject=member.id)
+    r = client.get("/api/stats/timeline",
+                   headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 200
+    assert r.json()["books"] == []

--- a/website/src/pages/docs/stats.astro
+++ b/website/src/pages/docs/stats.astro
@@ -321,6 +321,7 @@ import { withBase } from '../../lib/path'
     <li><code>GET /api/stats?days=30&amp;tz_offset=-120</code> — the main bundle (everything on this page).</li>
     <li><code>GET /api/stats/completion-estimates</code> — projected finish dates for in-progress books.</li>
     <li><code>GET /api/stats/sessions</code> — paged session list, oldest first.</li>
+    <li><code>GET /api/stats/timeline</code> — lifetime per-book reading spans and active days (the Timeline board).</li>
     <li><code>DELETE /api/stats/sessions/{`{id}`}</code> — delete a misfire.</li>
     <li><code>GET /api/stats/dashboard</code> / <code>PUT /api/stats/dashboard</code> — your saved boards (opaque JSON, 256&nbsp;KB cap). This is what syncs layouts across devices.</li>
   </ul>


### PR DESCRIPTION
## What

A new **Timeline** tab on Reading Stats: your lifetime reading history drawn as a Gantt-style ribbon.

- **One lane per series**, named in a frozen left rail (volume count + total time); standalone books get their own lane.
- **Every book is a bar** from its first to last active reading day, volume number at the bar's start, and each day's minutes shaded inside the bar (single accent hue, intensity scaled against the p90 reading day so one marathon doesn't flatten everything else).
- **Lifetime & reconciled**: merges live sessions and imported KOReader page-stats with the same page-stats-win-per-book rule as the rest of stats (`book_day_seconds` beside the existing `book_month_seconds`), bucketed by the canonical 4h-rollover reading day.
- **Lanes sort by most recent activity** and the view opens at today — the first paint is what you're reading now; pan left for history.
- Hover for cover/author/span/totals, click through to the book. Finishing a volume and starting the next the same day chains onto one row; only genuinely parallel reads stack.

## Presentation

- The Timeline tab renders **full-bleed** (edge to edge, viewport-tall, panel hugs its content) whenever a board holds only the timeline in view mode; Edit mode falls back to the grid so the tile stays movable/resizable. It's also a normal gallery tile (under Habits) for any other board.
- Zoom presets (year-glance → month detail) **floored at fit-width** — the ribbon can never leave dead space right of today; zoom level persists.
- Timeline data is session-cached so switching tabs renders instantly; the page-padding animation now only runs in Edit mode (no more squeeze on tab switch); axis labels never render into the clipped right edge.

## Backend

- `GET /api/stats/timeline` (per-book active days, span, totals, status/finished metadata). Sub-minute lifetime totals are dropped as page-flip noise; sessions of deleted books are skipped.

## Tests

- `tests/test_stats_timeline.py`: source reconciliation (page-stats win, web sessions additive), day bucketing, ordering + finished metadata, noise filter. Full suite: **926 passed**. `tsc -b` + frontend build clean.
- Verified live against the dev instance (101 books, Oct 2025 → Jul 2026, imported KOReader history) in light and dark, both zoom extremes, tab-switch behaviour, hover cards, click-through.

## Docs

- New "Timeline board" section on the website stats page + API bullet. The `stats-reading-timeline` ThemedShot (light/dark/amber) follows in a commit once the showcase backend is bounced to serve the new endpoint.