### PR TITLE
fix(mobile): app-feel pass — kill the website gestures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to Tome are documented here. Format loosely follows
   the ribbon is also available as a regular tile in the dashboard gallery.
 
 ### Fixed
+- **The mobile app no longer feels like a draggable website.** On phones the
+  whole viewport could be rubber-banded past its edges, double-tap zoomed, and
+  a long press selected interface text — classic browser-tab behavior. The app
+  now suppresses edge bounce and scroll chaining, removes double-tap zoom (taps
+  fire immediately), disables text selection on interface chrome for touch
+  devices (text fields and the reader keep it), and sizes the shell to the
+  real visible viewport instead of overhanging behind mobile browser toolbars.
 - **The notifications panel no longer renders behind sticky page content.** The
   top bar sat at the same layer as page-level sticky toolbars (and below the new
   timeline axis), so the open notification dropdown was cut by the Stats

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -63,8 +63,10 @@ export function AppShell({
   // freshens the lists in the background, it never blanks them.
   useEffect(() => { loadLibraries(); loadSavedFilters() }, [])
 
+  // h-dvh, not h-screen: 100vh overshoots the visible area under mobile
+  // browser toolbars, leaving the page itself pannable by the overhang.
   return (
-    <div className="h-screen bg-background flex flex-col overflow-hidden">
+    <div className="h-dvh bg-background flex flex-col overflow-hidden">
       <AppHeader
         onMenuClick={() => setMobileSidebarOpen(true)}
         search={
@@ -102,7 +104,7 @@ export function AppShell({
           mobileOpen={mobileSidebarOpen}
           onMobileClose={() => setMobileSidebarOpen(false)}
         />
-        <main className="flex-1 overflow-y-auto min-w-0">{children}</main>
+        <main className="flex-1 overflow-y-auto min-w-0 overscroll-contain">{children}</main>
       </div>
     </div>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -360,6 +360,39 @@ html {
   -webkit-tap-highlight-color: transparent;
 }
 
+/* ── App-feel on touch devices ─────────────────────────────────────────────
+   Native browser gestures are what make the PWA feel like a website: the
+   whole viewport rubber-bands past its edges, double-tap zooms, and a long
+   press selects UI text. Kill each at the source. Pinch-zoom is handled by
+   the viewport meta (respected on Android and in the installed iOS app; a
+   Safari *tab* always allows it for accessibility). */
+html,
+body {
+  /* No scroll chaining out of the document: stops the edge bounce and
+     Android's pull-to-refresh. The app shell scrolls internally anyway. */
+  overscroll-behavior: none;
+  /* Pan and pinch stay native, double-tap-to-zoom (and its 350ms tap delay)
+     goes — taps should feel immediate, like buttons, everywhere. */
+  touch-action: manipulation;
+}
+@media (pointer: coarse) {
+  /* UI chrome is not prose: a long press on a label or a cover should do
+     nothing, not start a text selection / image callout. Text entry and the
+     reader keep native behavior (the EPUB reader renders in its own iframe,
+     so highlight-by-selection is untouched). */
+  body {
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+  input,
+  textarea,
+  [contenteditable] {
+    -webkit-user-select: text;
+    user-select: text;
+  }
+}
+
 /* Touch feedback for interactive elements */
 .touch-feedback {
   transition: transform 0.2s var(--spring);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1011,8 +1011,9 @@ export function DashboardPage() {
     </div>
   )
 
+  // h-dvh, not h-screen — see AppShell: 100vh overhangs mobile toolbars.
   return (
-    <div className="h-screen bg-background flex flex-col overflow-hidden">
+    <div className="h-dvh bg-background flex flex-col overflow-hidden">
       {/* ── Navbar (shared with the standalone pages via AppShell) ───────── */}
       <AppHeader
         onMenuClick={() => setMobileSidebarOpen(true)}
@@ -1076,7 +1077,7 @@ export function DashboardPage() {
           onMobileClose={() => setMobileSidebarOpen(false)}
         />
 
-        <main className="flex-1 overflow-y-auto px-4 py-4 min-w-0">
+        <main className="flex-1 overflow-y-auto px-4 py-4 min-w-0 overscroll-contain">
           {/* Section heading */}
           {activeLibraryName && (
             <h2 className="text-lg font-semibold mb-3">{activeLibraryName}</h2>


### PR DESCRIPTION
The PWA felt like a website on phones (reported against Focus mode, but it applied app-wide): you could rubber-band the whole viewport past its edges, double-tap zoom, and long-press-select interface text — and the `h-screen` shell overhung the visible area behind mobile browser toolbars, which made the page itself pannable.

## What

- **`html`/`body`**: `overscroll-behavior: none` (no edge bounce, no scroll chaining, no Android pull-to-refresh) + `touch-action: manipulation` (no double-tap zoom, taps fire without the legacy delay).
- **Touch devices only** (`@media (pointer: coarse)`): `user-select: none` + `-webkit-touch-callout: none` on interface chrome; `input`/`textarea`/`[contenteditable]` opt back into text selection. Desktop behavior is completely unchanged.
- **App shells** (`AppShell`, `DashboardPage`): `h-screen` → `h-dvh` so the shell matches the *visible* viewport under mobile browser toolbars; main scrollers get `overscroll-contain`.

## Notes

- The EPUB reader renders inside its own iframe (foliate), so highlight-by-text-selection is unaffected by the chrome-level `user-select: none`.
- Pinch-zoom: the viewport meta (already present) handles Android and the installed iOS app; a regular iOS Safari *tab* always permits pinch for accessibility — nothing any site can do about that one.
- The reader already uses `fixed inset-0`, so it needed no dvh change.

## Verification

- Emulated iPhone 13 viewport: all computed styles land (`overscroll-behavior: none`, `touch-action: manipulation`, chrome `user-select: none` with inputs back to `text`, `main` at `contain`, dvh root exactly matching `innerHeight`); desktop context confirmed at `user-select: auto`.
- Frontend `npm run build` (tsc) clean.
- The actual gesture feel (bounce/zoom on real hardware) needs a quick pass on your phone — emulation can't reproduce iOS gesture physics.

---

**Update (551dde1):** a screen recording from the real device showed the actual headline symptom — the content area pans sideways and rubber-bands back. Root cause: WebKit counts the Focus rotary's **pre-transform** 540px stage as scrollable overflow (Chromium uses the post-transform size, which is why emulation initially missed it), giving the main scroller ~150px of horizontal scroll on a phone. Fixed by clamping the app's main scrollers with `overflow-x-hidden`; verified on Playwright **WebKit** (iPhone 13 viewport) that `scrollLeft` is pinned to 0.
