### PR TITLE
fix(stats): mobile header — doubled notch inset + misaligned range picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to Tome are documented here. Format loosely follows
   the ribbon is also available as a regular tile in the dashboard gallery.
 
 ### Fixed
+- **Stats on phones: dead gap and misaligned range picker.** The Stats page
+  header paid the notch inset a second time inside the app shell (the top bar
+  already covers it), opening a large empty band between the top bar and the
+  page title on the installed app; and when the timeframe picker wrapped below
+  the title on narrow screens it stayed floated right, reading as misaligned.
+  The header now sits flush and the picker takes a full, left-aligned row.
 - **The mobile app no longer feels like a draggable website.** On phones the
   page content could be dragged sideways and rubber-banded (on iOS the Focus
   view's scaled cover fan still counted its full unscaled width as scrollable

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -2027,7 +2027,10 @@ export function StatsPage() {
         .react-grid-item:has(> .cfg-popover-open) { z-index: 40; }
       `}</style>
 
-      <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-sm safe-top">
+      {/* No safe-top here: this header renders inside AppShell's scroller, below
+          the app bar that already pays the notch inset — repeating it doubled
+          the padding into a dead band on the installed PWA. */}
+      <header className="sticky top-0 z-20 border-b border-border bg-background/80 backdrop-blur-sm">
         {/* min-h + wrap: on phones the range pills don't fit beside the title row,
             so they wrap to a second line instead of overflowing the viewport */}
         <div className={cn('flex min-h-14 flex-wrap items-center gap-x-3 py-1.5 px-4')}>
@@ -2041,7 +2044,10 @@ export function StatsPage() {
           >
             <HelpCircle className="h-3.5 w-3.5" />
           </a>
-          <div className="ml-auto flex items-center gap-2">
+          {/* When the range control wraps to its own line (phones), it goes
+              full-width and left-aligned — keeping ml-auto there left it
+              floating right with dead space, reading as misaligned. */}
+          <div className="ml-auto flex items-center gap-2 max-sm:ml-0 max-sm:w-full max-sm:overflow-x-auto">
             {/* range selector — presets + custom date range; refetches /stats */}
             <RangeControl
               days={days}


### PR DESCRIPTION
**Overnight run PR 1/12 — merge this first; the stack builds on it in order.**

Fixes the two layout bugs from the phone screenshots (2026-07-18):

- **Dead gap between the top bar and the page title** (installed PWA): the Stats header renders inside AppShell, below the app bar that already pays `env(safe-area-inset-top)` — its own `safe-top` paid the ~59pt dynamic-island inset a second time. Removed; the header now sits flush.
- **"Versetzt" range picker**: when the timeframe pills wrap below the title on narrow screens, they kept `ml-auto` and floated right with dead space to their left. On `max-sm` the control now takes a full-width, left-aligned row (with horizontal scroll if ever cramped).

**About the scroll indicator behind the header**: with the dead band gone, what remains is the indicator passing under the *translucent* sticky header — which is native iOS behavior (scroll indicators run under translucent bars in system apps too). Judge it on the device with this fix in; if it still reads wrong, the escape hatch is making the header opaque or non-sticky on phones — say the word.

Verified: WebKit iPhone-13 viewport screenshot (gap gone, picker aligned); frontend build/typecheck clean. The safe-area double-inset itself can't be reproduced in emulation (no fake env insets) but the class removal is deterministic.