### PR TITLE
feat(meta): What's New panel after upgrades + admin update indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ All notable changes to Tome are documented here. Format loosely follows
   the ribbon is also available as a regular tile in the dashboard gallery.
 
 ### Added
+- **"What's new" after an upgrade.** The first visit after the server moves to
+  a new release shows a one-time panel with that release's notes, straight
+  from the changelog — so features stop shipping invisibly. Dismiss it and it
+  stays gone until the next release; fresh installs never see it.
+- **Update indicator for admins.** Settings → About quietly shows "vX.Y.Z
+  available" (linking to GitHub releases) when a newer release exists, via a
+  daily-cached server-side check. Set `TOME_UPDATE_CHECK=false` to disable
+  the lookup entirely — nothing else phones home.
 - **Timeline: the tooltip now answers at day level.** Hovering a bar resolves
   the exact day under the cursor — "15 May · 22m", or "no reading" on a gap
   day — alongside the book's totals. The day data was always drawn as tick

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN pip install --no-cache-dir .
 COPY backend/ ./backend/
 COPY alembic.ini ./
 COPY alembic/ ./alembic/
+# What's-New panel reads release notes from the changelog at runtime
+COPY CHANGELOG.md ./
 COPY --from=frontend-build /app/frontend/dist ./frontend/dist
 
 ENV TOME_DATA_DIR=/data \

--- a/backend/api/meta.py
+++ b/backend/api/meta.py
@@ -1,0 +1,144 @@
+"""App metadata: What's-New changelog excerpts and the update check.
+
+Both are deliberately small and self-contained:
+- /meta/whats-new parses CHANGELOG.md for the section matching the running
+  version (falling back to [Unreleased] on dev builds) so the frontend can show
+  a one-time "what changed" panel after an upgrade.
+- /meta/update-check compares the running version against the latest GitHub
+  release, cached in memory for a day. Admin-only, and TOME_UPDATE_CHECK=false
+  turns it off entirely — nothing else phones home.
+"""
+import json
+import logging
+import re
+import threading
+import time
+import urllib.request
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from backend import __version__
+from backend.core.config import settings
+from backend.core.security import get_current_user
+from backend.models.user import User
+
+log = logging.getLogger(__name__)
+router = APIRouter(prefix="/meta", tags=["meta"])
+
+GITHUB_RELEASES_API = "https://api.github.com/repos/bndct-devops/tome/releases/latest"
+GITHUB_RELEASES_URL = "https://github.com/bndct-devops/tome/releases"
+
+_CHANGELOG = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
+
+
+def parse_changelog_section(text: str, version: str) -> list[dict]:
+    """Entries of the ``## [version]`` section (or ``## [Unreleased]`` if that
+    version has no section — dev builds). Each ``- **Title.** body`` bullet
+    becomes {kind, title, body}; continuation lines fold into the body."""
+    lines = text.splitlines()
+    section: list[str] = []
+    in_section = False
+    for line in lines:
+        m = re.match(r"^## \[([^\]]+)\]", line)
+        if m:
+            if in_section:
+                break
+            in_section = m.group(1) == version
+            continue
+        if in_section:
+            section.append(line)
+    if not section and version != "Unreleased":
+        return parse_changelog_section(text, "Unreleased")
+
+    entries: list[dict] = []
+    kind = ""
+    for line in section:
+        km = re.match(r"^### (.+)$", line)
+        if km:
+            kind = km.group(1).strip()
+            continue
+        bm = re.match(r"^- (.+)$", line)
+        if bm:
+            entries.append({"kind": kind, "text": bm.group(1).strip()})
+        elif line.startswith("  ") and entries:
+            entries[-1]["text"] += " " + line.strip()
+    # Split the conventional "**Title.** body" lead into title/body.
+    for e in entries:
+        raw = e.pop("text")
+        tm = re.match(r"^\*\*(.+?)\*\*\s*(.*)$", raw)
+        if tm:
+            e["title"], e["body"] = tm.group(1).strip(), tm.group(2).strip()
+        else:
+            e["title"], e["body"] = "", raw
+    return entries
+
+
+@router.get("/whats-new")
+def whats_new(current_user: User = Depends(get_current_user)) -> dict:
+    try:
+        text = _CHANGELOG.read_text(encoding="utf-8")
+    except OSError:
+        return {"version": __version__, "entries": []}
+    return {"version": __version__, "entries": parse_changelog_section(text, __version__)}
+
+
+# ── Update check ──────────────────────────────────────────────────────────────
+
+_cache_lock = threading.Lock()
+_cache: dict = {"at": 0.0, "result": None, "ttl": 0.0}
+_TTL_OK = 24 * 3600.0     # successful lookups: once a day is plenty
+_TTL_FAIL = 3600.0        # failures: retry hourly, don't hammer while offline
+
+
+def _fetch_latest_release() -> str | None:
+    """Latest release tag from GitHub ('1.9.0', no leading v), or None."""
+    req = urllib.request.Request(
+        GITHUB_RELEASES_API,
+        headers={"Accept": "application/vnd.github+json", "User-Agent": "tome-update-check"},
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        tag = json.loads(resp.read().decode()).get("tag_name") or ""
+    return tag.lstrip("v") or None
+
+
+def _ver_tuple(v: str) -> tuple:
+    parts = []
+    for p in re.split(r"[.\-+]", v):
+        parts.append(int(p) if p.isdigit() else 0)
+    return tuple(parts or [0])
+
+
+@router.get("/update-check")
+def update_check(current_user: User = Depends(get_current_user)) -> dict:
+    from backend.core.permissions import is_admin
+
+    if not is_admin(current_user):
+        raise HTTPException(status_code=403, detail="Admin only")
+    if not settings.update_check:
+        return {"enabled": False, "current": __version__,
+                "latest": None, "update_available": False, "url": GITHUB_RELEASES_URL}
+
+    now = time.time()
+    with _cache_lock:
+        if _cache["result"] is not None and now - _cache["at"] < _cache["ttl"]:
+            return _cache["result"]
+
+    latest: str | None = None
+    try:
+        latest = _fetch_latest_release()
+        ttl = _TTL_OK
+    except Exception as exc:  # noqa: BLE001 — network failures are expected offline
+        log.info("update-check: GitHub lookup failed: %s", exc)
+        ttl = _TTL_FAIL
+
+    result = {
+        "enabled": True,
+        "current": __version__,
+        "latest": latest,
+        "update_available": bool(latest) and _ver_tuple(latest) > _ver_tuple(__version__),
+        "url": GITHUB_RELEASES_URL,
+    }
+    with _cache_lock:
+        _cache.update(at=now, result=result, ttl=ttl)
+    return result

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -40,6 +40,11 @@ class Settings(BaseSettings):
     smtp_use_ssl: bool = False
     smtp_daily_limit: int = 50
 
+    # Update awareness (env TOME_UPDATE_CHECK): lets admins see "new version
+    # available" in Settings via a daily-cached GitHub releases lookup. Set
+    # false to never call out (air-gapped installs); nothing else phones home.
+    update_check: bool = True
+
     # Auto-import settings
     auto_import: bool = False
     auto_import_interval: int = 300  # seconds

--- a/backend/main.py
+++ b/backend/main.py
@@ -20,6 +20,7 @@ from backend.api import opds_pins
 from backend.api import kosync
 from backend.api import tome_sync
 from backend.api import stats
+from backend.api import meta as meta_api
 from backend.api import quick_connect
 from backend.api import admin_duplicates
 from backend.api import word_count as word_count_api
@@ -733,6 +734,7 @@ def create_app() -> FastAPI:
     app.include_router(notifications_api.router, prefix="/api")
     app.include_router(oidc_api.router, prefix="/api")
     app.include_router(goals_api.router, prefix="/api")
+    app.include_router(meta_api.router, prefix="/api")
     app.include_router(annotations_api.router, prefix="/api")
 
     # Serve frontend static files in production (SPA fallback)

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -4,6 +4,7 @@ import { useAuth, isMember } from '@/contexts/AuthContext'
 import { TomeMark } from '@/components/TomeMark'
 import { SyncStatusBadge } from '@/components/SyncStatusBadge'
 import { NotificationBell } from '@/components/NotificationBell'
+import { WhatsNewPanel } from '@/components/WhatsNewPanel'
 
 /**
  * The one top navbar — menu button, wordmark, a search slot, and the right-side
@@ -53,6 +54,9 @@ export function AppHeader({ onMenuClick, search, actions, onUploadClick }: {
           )}
         </div>
       </div>
+      {/* Post-upgrade release-notes panel — mounted here because both shell
+          variants (AppShell and DashboardPage) render this header. */}
+      <WhatsNewPanel />
     </header>
   )
 }

--- a/frontend/src/components/WhatsNewPanel.tsx
+++ b/frontend/src/components/WhatsNewPanel.tsx
@@ -1,0 +1,112 @@
+// One-time "What's new" panel after a server upgrade. The server reports its
+// version with the release-notes entries for it (GET /meta/whats-new, parsed
+// from the changelog); we remember the last version this browser saw and show
+// the panel once when it changes. Fresh browsers/installs store silently — a
+// first login should not open with a modal.
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Sparkles, X } from 'lucide-react'
+import { api } from '@/lib/api'
+
+interface WhatsNewEntry {
+  kind: string
+  title: string
+  body: string
+}
+interface WhatsNewResponse {
+  version: string
+  entries: WhatsNewEntry[]
+}
+
+const SEEN_KEY = 'tome_seen_version'
+// Once per SPA session is enough — remounts (route changes) must not refetch.
+let checkedThisSession = false
+
+const KIND_ORDER = ['Added', 'Changed', 'Fixed', 'Removed']
+
+export function WhatsNewPanel() {
+  const [data, setData] = useState<WhatsNewResponse | null>(null)
+
+  useEffect(() => {
+    if (checkedThisSession) return
+    checkedThisSession = true
+    api
+      .get<WhatsNewResponse>('/meta/whats-new')
+      .then((d) => {
+        if (!d.version || d.version === 'dev') return
+        const seen = localStorage.getItem(SEEN_KEY)
+        if (seen === null) {
+          // First visit from this browser: nothing to announce, just baseline.
+          localStorage.setItem(SEEN_KEY, d.version)
+          return
+        }
+        if (seen !== d.version && d.entries.length > 0) setData(d)
+      })
+      .catch(() => {})
+  }, [])
+
+  if (!data) return null
+
+  const dismiss = () => {
+    localStorage.setItem(SEEN_KEY, data.version)
+    setData(null)
+  }
+
+  const groups = KIND_ORDER.filter((k) => data.entries.some((e) => e.kind === k)).concat(
+    [...new Set(data.entries.map((e) => e.kind))].filter((k) => !KIND_ORDER.includes(k)),
+  )
+
+  // Portal to <body>: the header that mounts this has backdrop-blur, which
+  // makes it the containing block for fixed descendants — the overlay would
+  // center on the header bar instead of the viewport.
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" onClick={dismiss} />
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
+        <div className="pointer-events-auto flex max-h-[80vh] w-full max-w-lg flex-col rounded-xl border border-border bg-card shadow-xl">
+          <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
+            <Sparkles className="h-4 w-4 text-primary" />
+            <h2 className="font-display text-base text-foreground">
+              What&apos;s new in Tome {data.version}
+            </h2>
+            <button
+              onClick={dismiss}
+              aria-label="Dismiss"
+              className="ml-auto rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="min-h-0 overflow-y-auto overscroll-contain px-5 py-4">
+            {groups.map((kind) => (
+              <div key={kind} className="mb-4 last:mb-0">
+                <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  {kind}
+                </h3>
+                <ul className="flex flex-col gap-2.5">
+                  {data.entries
+                    .filter((e) => e.kind === kind)
+                    .map((e, i) => (
+                      <li key={i} className="text-sm leading-relaxed">
+                        {e.title && <span className="font-semibold text-foreground">{e.title} </span>}
+                        <span className="text-muted-foreground">{e.body}</span>
+                      </li>
+                    ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+          <div className="border-t border-border px-5 py-3 text-right">
+            <button
+              onClick={dismiss}
+              className="rounded-lg bg-primary px-3.5 py-1.5 text-xs font-semibold text-primary-foreground transition-all hover:bg-primary/90"
+            >
+              Got it
+            </button>
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  )
+}

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import {
-  ArrowLeft, Eye, EyeOff, Download, Check, RefreshCw, Loader2,
+  ArrowLeft, ArrowUpCircle, Eye, EyeOff, Download, Check, RefreshCw, Loader2,
   Copy, Trash2, Plus, Key, Smartphone, CheckCircle, Info, X, ChevronDown, ChevronUp,
   AlertTriangle, ExternalLink, Send,
 } from 'lucide-react'
@@ -44,6 +44,19 @@ export function SettingsPage() {
   useEffect(() => {
     api.get<{ version: string }>('/health').then(r => setTomeVersion(r.version)).catch(() => {})
   }, [])
+
+  // Quiet update indicator (admins): daily-cached server-side check against
+  // GitHub releases; renders a link in About only when something is newer.
+  const [updateInfo, setUpdateInfo] = useState<{ latest: string; url: string } | null>(null)
+  useEffect(() => {
+    if (!user?.is_admin) return
+    api
+      .get<{ update_available: boolean; latest: string | null; url: string }>('/meta/update-check')
+      .then(r => {
+        if (r.update_available && r.latest) setUpdateInfo({ latest: r.latest, url: r.url })
+      })
+      .catch(() => {})
+  }, [user?.is_admin])
 
   // ── SSO linking ────────────────────────────────────────────────────────────
   const [ssoEnabled, setSsoEnabled] = useState(false)
@@ -1528,6 +1541,20 @@ export function SettingsPage() {
             >
               GitHub
             </a>
+            {updateInfo && (
+              <>
+                <span>&middot;</span>
+                <a
+                  href={updateInfo.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-primary hover:underline"
+                >
+                  <ArrowUpCircle className="w-3.5 h-3.5" />
+                  v{updateInfo.latest} available
+                </a>
+              </>
+            )}
           </div>
         </section>
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,130 @@
+"""Tests for /api/meta — What's-New changelog parsing and the update check."""
+from starlette.testclient import TestClient
+from sqlalchemy.orm import Session
+
+import backend.api.meta as meta
+from backend.core.config import settings
+from backend.core.security import create_access_token, hash_password
+from backend.models.user import User, UserPermission
+
+
+SAMPLE = """# Changelog
+
+## [Unreleased]
+
+### Added
+- **Unreleased thing.** Not shipped yet.
+
+## [1.8.0]
+
+### Added
+- **Sync closed books.** Walks the device for books the plugin never synced,
+  adopting status and rating from the sidecar.
+- Plain bullet without a bold lead.
+
+### Fixed
+- **Chapter maps extract from EPUB2 books.** NCX fallback.
+
+## [1.7.0]
+
+### Added
+- **Older thing.** Should never appear for 1.8.0.
+"""
+
+
+def test_parse_matches_version_section():
+    entries = meta.parse_changelog_section(SAMPLE, "1.8.0")
+    assert len(entries) == 3
+    assert entries[0]["kind"] == "Added"
+    assert entries[0]["title"] == "Sync closed books."
+    assert "adopting status and rating" in entries[0]["body"]  # continuation folded
+    assert entries[1]["title"] == ""
+    assert entries[1]["body"] == "Plain bullet without a bold lead."
+    assert entries[2]["kind"] == "Fixed"
+    assert all("Older thing" not in (e["title"] + e["body"]) for e in entries)
+
+
+def test_parse_falls_back_to_unreleased():
+    entries = meta.parse_changelog_section(SAMPLE, "9.9.9")
+    assert len(entries) == 1
+    assert entries[0]["title"] == "Unreleased thing."
+
+
+def test_whats_new_endpoint_shape(client: TestClient):
+    r = client.get("/api/meta/whats-new")
+    assert r.status_code == 200
+    data = r.json()
+    assert "version" in data
+    assert isinstance(data["entries"], list)
+
+
+def _reset_cache():
+    meta._cache.update(at=0.0, result=None, ttl=0.0)
+
+
+def test_update_check_available(client: TestClient, monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(meta, "_fetch_latest_release", lambda: "99.0.0")
+    r = client.get("/api/meta/update-check")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["enabled"] is True
+    assert data["latest"] == "99.0.0"
+    assert data["update_available"] is True
+    assert data["url"].startswith("https://github.com/")
+
+
+def test_update_check_current_is_latest(client: TestClient, monkeypatch):
+    _reset_cache()
+    from backend import __version__
+    monkeypatch.setattr(meta, "_fetch_latest_release", lambda: __version__)
+    data = client.get("/api/meta/update-check").json()
+    assert data["update_available"] is False
+
+
+def test_update_check_cached(client: TestClient, monkeypatch):
+    _reset_cache()
+    calls = {"n": 0}
+
+    def fetch():
+        calls["n"] += 1
+        return "99.0.0"
+
+    monkeypatch.setattr(meta, "_fetch_latest_release", fetch)
+    client.get("/api/meta/update-check")
+    client.get("/api/meta/update-check")
+    assert calls["n"] == 1
+
+
+def test_update_check_network_failure_is_graceful(client: TestClient, monkeypatch):
+    _reset_cache()
+
+    def boom():
+        raise OSError("offline")
+
+    monkeypatch.setattr(meta, "_fetch_latest_release", boom)
+    data = client.get("/api/meta/update-check").json()
+    assert data["update_available"] is False
+    assert data["latest"] is None
+
+
+def test_update_check_disabled_by_env(client: TestClient, monkeypatch):
+    _reset_cache()
+    monkeypatch.setattr(settings, "update_check", False)
+    data = client.get("/api/meta/update-check").json()
+    assert data["enabled"] is False
+    assert data["update_available"] is False
+
+
+def test_update_check_admin_only(client: TestClient, db: Session, monkeypatch):
+    _reset_cache()
+    member = User(username="meta_member", email="meta_member@example.com",
+                  hashed_password=hash_password("pass1234"), is_active=True,
+                  is_admin=False, role="member", must_change_password=False)
+    db.add(member)
+    db.flush()
+    db.add(UserPermission(user_id=member.id))
+    db.flush()
+    token = create_access_token(subject=member.id)
+    r = client.get("/api/meta/update-check", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 403


### PR DESCRIPTION
**Overnight run PR 3/12 — stacked on #133; merge in order.**

## What

- **What's New panel**: `GET /api/meta/whats-new` parses `CHANGELOG.md` for the section matching the running version (`[Unreleased]` fallback on dev builds). The frontend shows a one-time dismissible overlay when the server's version differs from the last version this browser saw (`tome_seen_version`). Fresh browsers baseline silently — a first login never opens with a modal. `CHANGELOG.md` is now copied into the Docker image.
- **Update indicator**: `GET /api/meta/update-check` (admin-only) compares the running version to the latest GitHub release — in-memory cache, 24h TTL (1h after network failures), 5s timeout. Settings → About renders a quiet "vX.Y.Z available" link only when something is newer; nothing pops up. `TOME_UPDATE_CHECK=false` disables the outbound lookup entirely (air-gapped installs); nothing else phones home.

## Notes

- The panel portals to `document.body` — it's mounted from the app header, whose `backdrop-blur` makes it a containing block for `fixed` elements; without the portal the overlay centered on the header bar (caught during visual verification, geometry re-measured after: panel exactly centered).
- Versioning: `backend.__version__` reads package metadata, which tracks `pyproject.toml`'s version — bumped at release, so the panel fires exactly on release upgrades. Dev quirk: a stale editable-install can report an old version locally; irrelevant in Docker where `pip install .` runs at build.

## Verification

- 9 new backend tests: changelog parsing (version match, Unreleased fallback, bold-lead split, continuation folding), update-check availability/parity/caching/network-failure/env-gate/admin-only.
- End-to-end in the browser: seeded an old `tome_seen_version` → panel appears with release entries; "Got it" stores the version; measured centered geometry post-portal-fix.
- Frontend build/typecheck clean.