### PR TITLE
feat(library): pre-upload duplicate warning + admin cover audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ All notable changes to Tome are documented here. Format loosely follows
   the ribbon is also available as a regular tile in the dashboard gallery.
 
 ### Added
+- **Upload knows what you already have.** Files added to the upload dialog are
+  hashed in the browser and checked against the library before anything is
+  sent — exact duplicates get an "already in your library" note with a link to
+  the existing book and are skipped, instead of uploading megabytes just for
+  the server to silently discard them.
+- **Admin → Covers: cover-quality audit.** Lists books whose covers are
+  missing, unreadable, or genuinely low-resolution (real thumbnails, not
+  standard-source covers), with sizes shown. Books with no cover at all offer
+  a one-click auto-fix from the cover search (nothing to downgrade); low-res
+  ones deep-link to the book page to pick a better candidate by eye.
 - **"What's new" after an upgrade.** The first visit after the server moves to
   a new release shows a one-time panel with that release's notes, straight
   from the changelog — so features stop shipping invisibly. Dismiss it and it

--- a/backend/api/admin_covers.py
+++ b/backend/api/admin_covers.py
@@ -1,0 +1,78 @@
+"""Admin cover-quality audit: which books have missing or low-resolution covers.
+
+Read-only listing; fixing goes through the existing per-book cover picker (or
+the client-driven auto-fix, which reuses /books/{id}/cover-candidates +
+POST /books/{id}/cover). PIL reads only image headers here, so a full-library
+sweep stays cheap.
+"""
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from backend.core.config import settings
+from backend.core.database import get_db
+from backend.core.permissions import is_admin
+from backend.core.security import get_current_user
+from backend.models.book import Book
+from backend.models.user import User
+
+log = logging.getLogger(__name__)
+router = APIRouter(prefix="/admin/covers", tags=["admin"])
+
+# Below this width a cover renders visibly soft on the dashboard grid. 300 is
+# a deliberate floor: the standard Google Books cover is 329px wide and looks
+# fine in practice — flagging it would drown the real offenders (the 98–128px
+# thumbnails), which is what this audit exists to surface.
+MIN_WIDTH = 300
+
+
+@router.get("/audit")
+def cover_audit(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    if not is_admin(current_user):
+        raise HTTPException(status_code=403, detail="Admin only")
+
+    from PIL import Image
+
+    flagged: list[dict] = []
+    scanned = 0
+    books = (
+        db.query(Book)
+        .filter(Book.status == "active")
+        .order_by(Book.series.isnot(None), Book.series, Book.series_index, Book.title)
+        .all()
+    )
+    for b in books:
+        scanned += 1
+        reason: str | None = None
+        width = height = None
+        if not b.cover_path:
+            reason = "missing"
+        else:
+            path = settings.covers_dir / b.cover_path
+            if not path.is_file():
+                reason = "missing"
+            else:
+                try:
+                    with Image.open(path) as im:  # lazy: header only, no pixel decode
+                        width, height = im.size
+                    if width < MIN_WIDTH:
+                        reason = "low_res"
+                except OSError:
+                    reason = "unreadable"
+        if reason:
+            flagged.append({
+                "book_id": b.id,
+                "title": b.title,
+                "author": b.author,
+                "series": b.series,
+                "series_index": b.series_index,
+                "reason": reason,
+                "width": width,
+                "height": height,
+            })
+
+    return {"scanned": scanned, "min_width": MIN_WIDTH, "books": flagged}

--- a/backend/main.py
+++ b/backend/main.py
@@ -21,6 +21,7 @@ from backend.api import kosync
 from backend.api import tome_sync
 from backend.api import stats
 from backend.api import meta as meta_api
+from backend.api import admin_covers
 from backend.api import quick_connect
 from backend.api import admin_duplicates
 from backend.api import word_count as word_count_api
@@ -735,6 +736,7 @@ def create_app() -> FastAPI:
     app.include_router(oidc_api.router, prefix="/api")
     app.include_router(goals_api.router, prefix="/api")
     app.include_router(meta_api.router, prefix="/api")
+    app.include_router(admin_covers.router, prefix="/api")
     app.include_router(annotations_api.router, prefix="/api")
 
     # Serve frontend static files in production (SPA fallback)

--- a/frontend/src/components/CoverAudit.tsx
+++ b/frontend/src/components/CoverAudit.tsx
@@ -1,0 +1,200 @@
+// Admin → Covers: which books have missing, unreadable, or low-resolution
+// covers (GET /admin/covers/audit). Missing covers offer a one-click auto-fix
+// that applies the first candidate from the existing cover search — safe
+// because there is nothing to downgrade. Low-res covers deep-link to the book
+// page instead, where the cover picker shows candidates to judge by eye.
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ExternalLink, ImageOff, Loader2, RefreshCw, Wand2 } from 'lucide-react'
+import { api } from '@/lib/api'
+import { cn } from '@/lib/utils'
+
+interface FlaggedBook {
+  book_id: number
+  title: string
+  author: string | null
+  series: string | null
+  series_index: number | null
+  reason: 'missing' | 'low_res' | 'unreadable'
+  width: number | null
+  height: number | null
+}
+
+interface AuditResponse {
+  scanned: number
+  min_width: number
+  books: FlaggedBook[]
+}
+
+type FixState = 'fixing' | 'fixed' | 'nocandidate' | 'failed'
+
+const REASON_LABEL: Record<FlaggedBook['reason'], string> = {
+  missing: 'No cover',
+  low_res: 'Low resolution',
+  unreadable: 'Unreadable file',
+}
+
+export function CoverAudit() {
+  const [data, setData] = useState<AuditResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [fix, setFix] = useState<Record<number, FixState>>({})
+  const [bulkRunning, setBulkRunning] = useState(false)
+
+  const load = () => {
+    setLoading(true)
+    api
+      .get<AuditResponse>('/admin/covers/audit')
+      .then(setData)
+      .finally(() => setLoading(false))
+  }
+  useEffect(load, [])
+
+  async function autoFix(b: FlaggedBook): Promise<boolean> {
+    setFix(prev => ({ ...prev, [b.book_id]: 'fixing' }))
+    try {
+      const candidates = await api.get<{ cover_url: string }[]>(`/books/${b.book_id}/cover-candidates`)
+      const first = candidates[0]
+      if (!first) {
+        setFix(prev => ({ ...prev, [b.book_id]: 'nocandidate' }))
+        return false
+      }
+      const form = new FormData()
+      form.append('url', first.cover_url)
+      await api.upload(`/books/${b.book_id}/cover`, form)
+      setFix(prev => ({ ...prev, [b.book_id]: 'fixed' }))
+      return true
+    } catch {
+      setFix(prev => ({ ...prev, [b.book_id]: 'failed' }))
+      return false
+    }
+  }
+
+  async function autoFixAllMissing() {
+    if (!data || bulkRunning) return
+    setBulkRunning(true)
+    for (const b of data.books) {
+      if (b.reason !== 'missing') continue
+      if (fix[b.book_id] === 'fixed') continue
+      await autoFix(b)
+    }
+    setBulkRunning(false)
+  }
+
+  if (!data) {
+    return (
+      <div className="flex items-center gap-2 py-10 justify-center text-sm text-muted-foreground">
+        <Loader2 className="w-4 h-4 animate-spin" /> Scanning covers…
+      </div>
+    )
+  }
+
+  const missingCount = data.books.filter(b => b.reason === 'missing' && fix[b.book_id] !== 'fixed').length
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <p className="text-sm text-muted-foreground">
+          {data.books.length === 0
+            ? `All ${data.scanned} covers look healthy.`
+            : `${data.books.length} of ${data.scanned} books flagged (low-res = narrower than ${data.min_width}px).`}
+        </p>
+        <div className="ml-auto flex items-center gap-2">
+          {missingCount > 0 && (
+            <button
+              onClick={autoFixAllMissing}
+              disabled={bulkRunning}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-all"
+            >
+              {bulkRunning ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Wand2 className="w-3.5 h-3.5" />}
+              Auto-fix {missingCount} missing
+            </button>
+          )}
+          <button
+            onClick={load}
+            disabled={loading}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-card hover:bg-muted disabled:opacity-50 transition-all"
+          >
+            <RefreshCw className={cn('w-3.5 h-3.5', loading && 'animate-spin')} />
+            Rescan
+          </button>
+        </div>
+      </div>
+
+      {data.books.length > 0 && (
+        <div className="rounded-xl border border-border overflow-hidden">
+          <div className="grid grid-cols-[3rem_1fr_8rem_7rem_6rem] items-center gap-2 border-b border-border bg-muted/40 px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            <span />
+            <span>Book</span>
+            <span>Problem</span>
+            <span>Size</span>
+            <span />
+          </div>
+          {data.books.map(b => {
+            const state = fix[b.book_id]
+            return (
+              <div
+                key={b.book_id}
+                className="grid grid-cols-[3rem_1fr_8rem_7rem_6rem] items-center gap-2 border-b border-border/60 px-3 py-2 last:border-b-0"
+              >
+                <span className="flex h-12 w-8 items-center justify-center overflow-hidden rounded bg-muted">
+                  {b.reason === 'missing' || state === 'fixed' ? (
+                    state === 'fixed' ? (
+                      <img src={`/api/books/${b.book_id}/cover?ts=${Date.now() % 100000}`} alt="" className="h-full w-full object-cover" />
+                    ) : (
+                      <ImageOff className="h-3.5 w-3.5 text-muted-foreground" />
+                    )
+                  ) : (
+                    <img src={`/api/books/${b.book_id}/cover`} alt="" className="h-full w-full object-cover" />
+                  )}
+                </span>
+                <span className="min-w-0">
+                  <span className="block truncate text-sm text-foreground">
+                    {b.series ? `${b.series} ${b.series_index != null ? `#${b.series_index}` : ''} — ` : ''}
+                    {b.title}
+                  </span>
+                  {b.author && <span className="block truncate text-xs text-muted-foreground">{b.author}</span>}
+                </span>
+                <span
+                  className={cn(
+                    'text-xs font-medium',
+                    b.reason === 'missing' ? 'text-destructive' : 'text-warning',
+                    state === 'fixed' && 'text-success',
+                  )}
+                >
+                  {state === 'fixed' ? 'Fixed' : REASON_LABEL[b.reason]}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {b.width != null ? `${b.width}×${b.height}px` : '—'}
+                </span>
+                <span className="flex items-center justify-end gap-1.5">
+                  {b.reason === 'missing' && state !== 'fixed' && (
+                    <button
+                      onClick={() => autoFix(b)}
+                      disabled={state === 'fixing' || bulkRunning}
+                      title="Apply the first cover-search candidate"
+                      className="rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+                    >
+                      {state === 'fixing' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Wand2 className="h-3.5 w-3.5" />}
+                    </button>
+                  )}
+                  <Link
+                    to={`/books/${b.book_id}`}
+                    title="Open book (pick a cover by eye)"
+                    className="rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </Link>
+                </span>
+              </div>
+            )
+          })}
+        </div>
+      )}
+      {Object.values(fix).some(s => s === 'nocandidate' || s === 'failed') && (
+        <p className="text-xs text-muted-foreground">
+          Some books had no usable candidate or failed to apply — open them and use the cover picker.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -9,8 +9,23 @@ interface UploadItem {
   id: string
   file: File
   bookTypeId: string
-  status: 'pending' | 'uploading' | 'done' | 'error'
+  status: 'pending' | 'uploading' | 'done' | 'error' | 'duplicate'
   errorMsg?: string
+  /** Book already holding these exact bytes (pre-upload hash check). */
+  dupBookId?: number
+}
+
+// Hash in the browser and ask the server before uploading — the server would
+// detect the duplicate anyway (upload attaches nothing for identical bytes),
+// but only after the whole file crossed the wire.
+async function sha256Hex(file: File): Promise<string | null> {
+  if (file.size > 512 * 1024 * 1024) return null // don't buffer >512MB in RAM
+  try {
+    const digest = await crypto.subtle.digest('SHA-256', await file.arrayBuffer())
+    return [...new Uint8Array(digest)].map(b => b.toString(16).padStart(2, '0')).join('')
+  } catch {
+    return null
+  }
 }
 
 function formatIcon(file: File) {
@@ -52,6 +67,32 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
     }))
     setItems(prev => [...prev, ...newItems])
     setSummary(null)
+    void flagDuplicates(newItems)
+  }
+
+  async function flagDuplicates(newItems: UploadItem[]) {
+    // Sequential hashing keeps peak memory at one file's buffer.
+    const hashed: { id: string; hash: string }[] = []
+    for (const it of newItems) {
+      const hash = await sha256Hex(it.file)
+      if (hash) hashed.push({ id: it.id, hash })
+    }
+    if (!hashed.length) return
+    try {
+      const resp = await api.post<{ existing: Record<string, number> }>(
+        '/books/check-hashes',
+        { hashes: hashed.map(h => h.hash) },
+      )
+      setItems(prev => prev.map(p => {
+        const h = hashed.find(x => x.id === p.id)
+        const bookId = h ? resp.existing[h.hash] : undefined
+        return bookId && p.status === 'pending'
+          ? { ...p, status: 'duplicate', dupBookId: bookId }
+          : p
+      }))
+    } catch {
+      // Offline / older server: uploads proceed, the server still dedupes.
+    }
   }
 
   function handleFileInput(e: React.ChangeEvent<HTMLInputElement>) {
@@ -90,7 +131,12 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
     const allMatchedWishIds: number[] = []
     const matchedBookIds: number[] = []
 
+    let skipped = 0
     for (const item of items) {
+      if (item.status === 'duplicate') {
+        skipped++
+        continue
+      }
       setItems(prev => prev.map(it => it.id === item.id ? { ...it, status: 'uploading' } : it))
       const form = new FormData()
       form.append('file', item.file)
@@ -124,13 +170,16 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
     }
     if (success > 0) {
       onDone()
+      const skipNote = skipped > 0 ? `, ${skipped} already in library` : ''
       if (failed === 0) {
-        toast.success(`${success} book${success !== 1 ? 's' : ''} uploaded`)
+        toast.success(`${success} book${success !== 1 ? 's' : ''} uploaded${skipNote}`)
       } else {
-        toast.info(`${success} uploaded, ${failed} failed`)
+        toast.info(`${success} uploaded, ${failed} failed${skipNote}`)
       }
     } else if (failed > 0) {
       toast.error(`Upload failed for ${failed} file${failed !== 1 ? 's' : ''}`)
+    } else if (skipped > 0) {
+      toast.info(`Nothing to upload — ${skipped} file${skipped !== 1 ? 's are' : ' is'} already in your library`)
     }
   }
 
@@ -258,7 +307,7 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
                   </select>
                   {/* Status */}
                   <span className="shrink-0 w-5 flex items-center justify-center">
-                    {item.status === 'pending' && (
+                    {(item.status === 'pending' || item.status === 'duplicate') && (
                       <button
                         onClick={() => removeItem(item.id)}
                         className="text-muted-foreground hover:text-destructive transition-colors"
@@ -280,6 +329,19 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
                   </div>
                   {item.status === 'error' && item.errorMsg && (
                     <p className="px-2.5 pb-2 text-xs text-destructive">{item.errorMsg}</p>
+                  )}
+                  {item.status === 'duplicate' && (
+                    <p className="px-2.5 pb-2 text-xs text-warning">
+                      Already in your library — will be skipped.{' '}
+                      <a
+                        href={`/books/${item.dupBookId}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:no-underline"
+                      >
+                        View book
+                      </a>
+                    </p>
                   )}
                 </div>
               ))}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -11,6 +11,7 @@ import {
 import { DOCS, docsLink } from '@/lib/docs'
 import { MetadataManager } from '@/components/MetadataManager'
 import { LibraryHealthTab } from '@/components/LibraryHealth'
+import { CoverAudit } from '@/components/CoverAudit'
 import { WordCountTab } from '@/components/WordCount'
 import { SeriesCoverageStrip } from '@/components/SeriesCoverageStrip'
 import { useAuth, isAdmin } from '@/contexts/AuthContext'
@@ -2004,7 +2005,7 @@ function WishlistTab() {
 
 // ── AdminPage ─────────────────────────────────────────────────────────────
 
-type Tab = 'users' | 'scanner' | 'server' | 'types' | 'audit' | 'metadata' | 'library' | 'wordcount' | 'sync' | 'duplicates' | 'email' | 'wishlist'
+type Tab = 'users' | 'scanner' | 'server' | 'types' | 'audit' | 'metadata' | 'library' | 'wordcount' | 'sync' | 'duplicates' | 'covers' | 'email' | 'wishlist'
 
 export function AdminPage() {
   const { user } = useAuth()
@@ -2031,6 +2032,7 @@ export function AdminPage() {
     { id: 'wordcount', label: 'Word Counts' },
     { id: 'sync', label: 'Sync Status' },
     { id: 'duplicates', label: 'Duplicates' },
+    { id: 'covers', label: 'Covers' },
     { id: 'email', label: 'Email' },
     { id: 'wishlist', label: 'Wishlist' },
   ]
@@ -2075,6 +2077,7 @@ export function AdminPage() {
         {tab === 'wordcount' && <WordCountTab />}
         {tab === 'sync' && <SyncStatusTab />}
         {tab === 'duplicates' && <DuplicatesTab />}
+        {tab === 'covers' && <CoverAudit />}
         {tab === 'email' && <EmailTab />}
         {tab === 'wishlist' && <WishlistTab />}
       </main>

--- a/tests/test_admin_covers.py
+++ b/tests/test_admin_covers.py
@@ -1,0 +1,51 @@
+"""Tests for GET /api/admin/covers/audit."""
+from PIL import Image
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from backend.core.config import settings
+from backend.core.security import create_access_token, hash_password
+from backend.models.user import User, UserPermission
+
+
+def _write_cover(name: str, width: int, height: int) -> str:
+    settings.covers_dir.mkdir(parents=True, exist_ok=True)
+    path = settings.covers_dir / name
+    Image.new("RGB", (width, height), "white").save(path, "JPEG")
+    return name
+
+
+def test_audit_flags_missing_and_low_res(client: TestClient, db: Session, make_book):
+    good = make_book(title="Good Cover")
+    good.cover_path = _write_cover("good.jpg", 600, 900)
+    small = make_book(title="Tiny Cover")
+    small.cover_path = _write_cover("small.jpg", 128, 190)
+    bare = make_book(title="No Cover")
+    bare.cover_path = None
+    ghost = make_book(title="Ghost Cover")
+    ghost.cover_path = "does-not-exist.jpg"
+    db.flush()
+
+    r = client.get("/api/admin/covers/audit")
+    assert r.status_code == 200
+    data = r.json()
+    flagged = {b["title"]: b for b in data["books"]}
+    assert "Good Cover" not in flagged
+    assert flagged["Tiny Cover"]["reason"] == "low_res"
+    assert flagged["Tiny Cover"]["width"] == 128
+    assert flagged["No Cover"]["reason"] == "missing"
+    assert flagged["Ghost Cover"]["reason"] == "missing"
+    assert data["scanned"] >= 4
+
+
+def test_audit_admin_only(client: TestClient, db: Session):
+    member = User(username="cov_member", email="cov_member@example.com",
+                  hashed_password=hash_password("pass1234"), is_active=True,
+                  is_admin=False, role="member", must_change_password=False)
+    db.add(member)
+    db.flush()
+    db.add(UserPermission(user_id=member.id))
+    db.flush()
+    token = create_access_token(subject=member.id)
+    r = client.get("/api/admin/covers/audit", headers={"Authorization": f"Bearer {token}"})
+    assert r.status_code == 403


### PR DESCRIPTION
**Overnight run PR 4/12 — stacked on #134; merge in order.**

## What

- **Upload dedupe warning**: the upload dialog hashes files in the browser (WebCrypto sha256, sequential so peak memory is one file's buffer, >512MB skipped) and checks `POST /books/check-hashes` before sending. Byte-identical files get an amber "Already in your library — will be skipped" note with a link to the existing book. The server already deduped silently on upload; this saves the transfer and tells the user. If the check fails (offline), everything proceeds as before.
- **Admin → Covers**: `GET /api/admin/covers/audit` (admin-only) lists books with missing/unreadable/low-res covers, with dimensions. Threshold 300px — chosen after running against the real dev library: the standard Google Books cover is 329px and looks fine; the audit's real targets are the 98–128px thumbnails it found. Missing covers have a one-click auto-fix that applies the first cover-search candidate (safe: nothing to downgrade); low-res rows deliberately don't auto-fix (a blind refetch could downgrade) and deep-link to the book's cover picker instead.

## Verification

- Backend tests: flags low-res (real 128px JPEG via PIL) + missing + dangling cover path, passes healthy covers, admin-only 403.
- End-to-end: Covers tab against the dev library found 16/270 real offenders (Berserk 128px, Gantz 98px thumbnails) before threshold tuning; upload dialog with an existing library EPUB shows the duplicate badge (screenshot-verified both).
- Frontend build/typecheck clean.