### PR TITLE
feat(sync): position history + one-click restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ All notable changes to Tome are documented here. Format loosely follows
   the ribbon is also available as a regular tile in the dashboard gallery.
 
 ### Added
+- **Position history — undo a bad sync.** Tome now keeps a short log of every
+  meaningful reading-position change per book (device, web, manual — the
+  idle heartbeat doesn't spam it). A history button on the book page's
+  Reading Stats header lists them, and any entry can be restored as the live
+  position with one click — including explicitly un-finishing a book that a
+  device falsely jumped to 100%. Devices pick the restored position up on
+  their next sync. The classic sync horror story is no longer unrecoverable.
 - **Command palette.** Press Cmd+K (Ctrl+K) anywhere to jump straight to a
   book, series, author, or page — full-text book search with covers, ranked
   series/author matches, and quick navigation, all keyboard-driven. Listed

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1107,6 +1107,110 @@ def get_book_annotations(
     ]
 
 
+# ── Position history (restore a bad sync) ─────────────────────────────────────
+
+def _visible_book_or_404(db: Session, current_user: User, book_id: int) -> Book:
+    book = db.get(Book, book_id)
+    if not book or book.status != "active" or not user_can_see_book(db, current_user, book):
+        raise HTTPException(status_code=404, detail="Book not found")
+    return book
+
+
+@router.get("/{book_id}/position-history")
+def get_position_history(
+    book_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """The user's recent position log for this book, newest first, plus the
+    live position — the recovery UI for a bad sync (a device jumping a book
+    to 100% is otherwise unrecoverable)."""
+    from backend.models.tome_sync import PositionHistory, TomeSyncPosition
+
+    _visible_book_or_404(db, current_user, book_id)
+    current = (
+        db.query(TomeSyncPosition)
+        .filter(TomeSyncPosition.user_id == current_user.id,
+                TomeSyncPosition.book_id == book_id)
+        .first()
+    )
+    rows = (
+        db.query(PositionHistory)
+        .filter(PositionHistory.user_id == current_user.id,
+                PositionHistory.book_id == book_id)
+        .order_by(PositionHistory.id.desc())
+        .all()
+    )
+    return {
+        "current": {
+            "percentage": current.percentage,
+            "device": current.device,
+            "updated_at": current.updated_at.isoformat() + "Z",
+        } if current else None,
+        "history": [
+            {
+                "id": r.id,
+                "percentage": r.percentage,
+                "device": r.device,
+                "created_at": r.created_at.isoformat() + "Z",
+            }
+            for r in rows
+        ],
+    }
+
+
+@router.post("/{book_id}/position-history/{history_id}/restore")
+def restore_position(
+    book_id: int,
+    history_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Set the live position back to a logged entry. Devices pick it up on
+    their next pull (per their pull-conflict strategy); the restore itself is
+    logged too, so it can be undone the same way.
+
+    Unlike normal progress writes, a restore is an explicit override of the
+    sticky-completion rule: recovering from a device that falsely jumped a
+    book to 100% must also un-finish it, or the position comes back but the
+    book stays "read"."""
+    from datetime import datetime
+    from backend.models.tome_sync import PositionHistory
+    from backend.models.user_book_status import UserBookStatus
+    from backend.services.book_progress import upsert_position
+
+    _visible_book_or_404(db, current_user, book_id)
+    entry = db.get(PositionHistory, history_id)
+    if not entry or entry.user_id != current_user.id or entry.book_id != book_id:
+        raise HTTPException(status_code=404, detail="History entry not found")
+
+    upsert_position(
+        db, user_id=current_user.id, book_id=book_id,
+        percentage=entry.percentage, progress=entry.progress, device="restore",
+    )
+    status_row = (
+        db.query(UserBookStatus)
+        .filter(UserBookStatus.user_id == current_user.id,
+                UserBookStatus.book_id == book_id)
+        .first()
+    )
+    if status_row is None:
+        status_row = UserBookStatus(user_id=current_user.id, book_id=book_id)
+        db.add(status_row)
+    status_row.progress_pct = entry.percentage
+    status_row.cfi = entry.progress
+    if entry.percentage >= 0.99:
+        status_row.status = "read"
+        if status_row.finished_at is None:
+            status_row.finished_at = datetime.utcnow()
+    else:
+        if status_row.status == "read":
+            status_row.finished_at = None
+        status_row.status = "reading" if entry.percentage > 0 else "unread"
+    db.commit()
+    return {"ok": True, "percentage": entry.percentage, "status": status_row.status}
+
+
 # ── Per-book reading stats ────────────────────────────────────────────────────
 
 @router.get("/{book_id}/reading-stats")

--- a/backend/models/tome_sync.py
+++ b/backend/models/tome_sync.py
@@ -90,6 +90,35 @@ class TomeSyncPosition(Base):
     book: Mapped["Book"] = relationship("Book")  # type: ignore[name-defined]
 
 
+class PositionHistory(Base):
+    """Append-only log of meaningful position changes per user+book.
+
+    The safety net under position sync: one bad write (a device jumping a book
+    to 100%, a mis-tapped chapter skip that propagated) is otherwise
+    unrecoverable because TomeSyncPosition is a single overwritten row. Written
+    by upsert_position only when the position moved meaningfully (so the
+    ten-page heartbeat doesn't spam near-duplicates), pruned to the newest
+    HISTORY_KEEP entries per (user, book)."""
+    __tablename__ = "position_history"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    book_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    progress: Mapped[Optional[str]] = mapped_column(Text, nullable=True)  # CFI or page ref
+    percentage: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    device: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False, index=True
+    )
+
+    user: Mapped["User"] = relationship("User")  # type: ignore[name-defined]
+    book: Mapped["Book"] = relationship("Book")  # type: ignore[name-defined]
+
+
 class Annotation(Base):
     """A highlight (and optional note) synced from KOReader, per user+book.
 

--- a/backend/services/book_progress.py
+++ b/backend/services/book_progress.py
@@ -22,8 +22,37 @@ from typing import Optional
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from backend.models.tome_sync import TomeSyncPosition
+from backend.models.tome_sync import PositionHistory, TomeSyncPosition
 from backend.models.user_book_status import UserBookStatus
+
+# Position history: record a new entry only when the position moved at least
+# this much (or the locator string changed) — the device heartbeat re-PUTs
+# every few pages and would otherwise fill the log with near-duplicates.
+HISTORY_MIN_DELTA = 0.002
+# Newest entries kept per (user, book); pruned on insert.
+HISTORY_KEEP = 40
+
+
+def _record_history(
+    db: Session, *, user_id: int, book_id: int,
+    percentage: float, progress: Optional[str], device: Optional[str],
+) -> None:
+    db.add(PositionHistory(
+        user_id=user_id, book_id=book_id,
+        percentage=percentage, progress=progress, device=device,
+    ))
+    # Prune beyond the cap — ids beat created_at for same-second inserts.
+    stale = (
+        db.query(PositionHistory.id)
+        .filter(PositionHistory.user_id == user_id, PositionHistory.book_id == book_id)
+        .order_by(PositionHistory.id.desc())
+        .offset(HISTORY_KEEP)
+        .all()
+    )
+    if stale:
+        db.query(PositionHistory).filter(
+            PositionHistory.id.in_([s.id for s in stale])
+        ).delete(synchronize_session=False)
 
 
 def upsert_position(
@@ -58,6 +87,8 @@ def upsert_position(
             with db.begin_nested():
                 db.add(row)
                 db.flush()
+            _record_history(db, user_id=user_id, book_id=book_id,
+                            percentage=percentage, progress=progress, device=device)
             return row
         except IntegrityError:
             # Another writer created the row between our SELECT and INSERT.
@@ -70,10 +101,17 @@ def upsert_position(
             if row is None:
                 raise
 
+    moved = (
+        abs(percentage - (row.percentage or 0.0)) >= HISTORY_MIN_DELTA
+        or (progress or "") != (row.progress or "")
+    )
     row.percentage = percentage
     row.progress = progress
     row.device = device
     row.updated_at = datetime.utcnow()
+    if moved:
+        _record_history(db, user_id=user_id, book_id=book_id,
+                        percentage=percentage, progress=progress, device=device)
     return row
 
 

--- a/frontend/src/components/PositionHistoryModal.tsx
+++ b/frontend/src/components/PositionHistoryModal.tsx
@@ -1,0 +1,134 @@
+// Position history + restore: the recovery UI for a bad sync. Lists the
+// recent position log for one book (GET /books/{id}/position-history) and
+// restores any entry as the live position — explicitly un-finishing the book
+// when recovering from a false 100%.
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { History, Loader2, RotateCcw, X } from 'lucide-react'
+import { api } from '@/lib/api'
+import { cn } from '@/lib/utils'
+
+interface HistoryEntry {
+  id: number
+  percentage: number
+  device: string | null
+  created_at: string
+}
+
+interface HistoryResponse {
+  current: { percentage: number; device: string | null; updated_at: string } | null
+  history: HistoryEntry[]
+}
+
+function fmtWhen(iso: string): string {
+  const d = new Date(iso)
+  const diff = Date.now() - d.getTime()
+  if (diff < 3600_000) return `${Math.max(1, Math.floor(diff / 60_000))} min ago`
+  if (diff < 86400_000) return `${Math.floor(diff / 3600_000)}h ago`
+  return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short' }) +
+    ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
+
+export function PositionHistoryModal({ bookId, onClose, onRestored }: {
+  bookId: number
+  onClose: () => void
+  onRestored: () => void
+}) {
+  const [data, setData] = useState<HistoryResponse | null>(null)
+  const [restoring, setRestoring] = useState<number | null>(null)
+
+  const load = () => {
+    api.get<HistoryResponse>(`/books/${bookId}/position-history`).then(setData).catch(() => {})
+  }
+  useEffect(load, [bookId])
+
+  async function restore(entry: HistoryEntry) {
+    if (restoring != null) return
+    setRestoring(entry.id)
+    try {
+      await api.post(`/books/${bookId}/position-history/${entry.id}/restore`)
+      load()
+      onRestored()
+    } finally {
+      setRestoring(null)
+    }
+  }
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
+        <div className="pointer-events-auto flex max-h-[70vh] w-full max-w-md flex-col rounded-xl border border-border bg-card shadow-xl">
+          <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
+            <History className="h-4 w-4 text-primary" />
+            <h2 className="font-display text-base text-foreground">Position history</h2>
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="ml-auto rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="min-h-0 overflow-y-auto overscroll-contain px-5 py-3">
+            {!data ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+              </div>
+            ) : data.history.length === 0 ? (
+              <p className="py-6 text-center text-sm text-muted-foreground">
+                No position changes recorded yet — history starts with the next sync.
+              </p>
+            ) : (
+              <ul className="flex flex-col">
+                {data.history.map((h, i) => {
+                  const isCurrent =
+                    i === 0 && data.current != null &&
+                    Math.abs(h.percentage - data.current.percentage) < 0.0005
+                  return (
+                    <li
+                      key={h.id}
+                      className={cn(
+                        'flex items-center gap-3 border-b border-border/50 py-2.5 last:border-b-0',
+                      )}
+                    >
+                      <span className="w-12 text-sm font-semibold tabular-nums text-foreground">
+                        {Math.round(h.percentage * 1000) / 10}%
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                        {h.device || 'unknown device'} · {fmtWhen(h.created_at)}
+                        {isCurrent && (
+                          <span className="ml-1.5 rounded bg-muted px-1.5 py-0.5 text-[10px] text-foreground">
+                            current
+                          </span>
+                        )}
+                      </span>
+                      {!isCurrent && (
+                        <button
+                          onClick={() => restore(h)}
+                          disabled={restoring != null}
+                          className="flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
+                        >
+                          {restoring === h.id
+                            ? <Loader2 className="h-3 w-3 animate-spin" />
+                            : <RotateCcw className="h-3 w-3" />}
+                          Restore
+                        </button>
+                      )}
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+            <p className="pb-1 pt-3 text-[11px] leading-relaxed text-muted-foreground">
+              Restoring sets the live position (and read status) back to that
+              point; devices pick it up on their next sync. Restoring below
+              100% un-finishes a falsely completed book.
+            </p>
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  )
+}

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -5,13 +5,14 @@ import {
   Calendar, Globe, Hash, Building2, FileText, Trash2, Loader2,
   Sparkles, Library, Check, BookMarked, ChevronLeft, ChevronRight, Home,
   Tag as TagIcon, StickyNote, ChevronDown, Archive, AlignLeft,
-  Plus, TrendingUp, TrendingDown, Minus, Info
+  Plus, TrendingUp, TrendingDown, Minus, Info, History as HistoryIcon
 } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { MetadataFetchModal } from '@/components/MetadataFetchModal'
 import { CoverPickerModal } from '@/components/CoverPickerModal'
+import { PositionHistoryModal } from '@/components/PositionHistoryModal'
 import { SendButton } from '@/components/SendButton'
 import { BookAnimation } from '@/components/BookAnimation'
 import { StarRating } from '@/components/StarRating'
@@ -184,6 +185,7 @@ export function BookDetailPage() {
   // intensity + time-per-chapter) has grown tall enough that "keep it closed"
   // is a real preference, not a per-page whim.
   const [statsOpen, setStatsOpen] = useState(() => localStorage.getItem('tome_book_stats_open') !== '0')
+  const [showPositionHistory, setShowPositionHistory] = useState(false)
   const [descExpanded, setDescExpanded] = useState(false)
   const [facets, setFacets] = useState<Facets>({ authors: [], series: [], tags: [], formats: [] })
   const [draftTags, setDraftTags] = useState<string[]>([])
@@ -752,6 +754,14 @@ export function BookDetailPage() {
           Reading Stats
           <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', !statsOpen && '-rotate-90')} />
         </button>
+        <button
+          type="button"
+          onClick={() => setShowPositionHistory(true)}
+          title="Position history — restore a bad sync"
+          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <HistoryIcon className="w-3.5 h-3.5" />
+        </button>
       </div>
       {statsOpen && (
         hasReadingData ? (
@@ -1262,6 +1272,18 @@ export function BookDetailPage() {
           open={coverPickerOpen}
           onClose={() => setCoverPickerOpen(false)}
           onApplied={updated => { setBook(updated); setDraft(updated) }}
+        />
+      )}
+      {showPositionHistory && (
+        <PositionHistoryModal
+          bookId={Number(id)}
+          onClose={() => setShowPositionHistory(false)}
+          onRestored={() => {
+            refreshStats()
+            api.get<BookStatus>(`/books/${id}/status`)
+              .then(s => { setBookStatus(s.status); setProgressPct(s.progress_pct); setCfi(s.cfi ?? null) })
+              .catch(() => {})
+          }}
         />
       )}
     </div>

--- a/tests/test_position_history.py
+++ b/tests/test_position_history.py
@@ -1,0 +1,107 @@
+"""Position history + restore — the safety net under position sync."""
+from datetime import datetime
+
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from backend.models.tome_sync import PositionHistory
+from backend.models.user_book_status import UserBookStatus
+from backend.services.book_progress import HISTORY_KEEP, upsert_position
+
+
+def _entries(db: Session, user_id: int, book_id: int) -> list[PositionHistory]:
+    return (
+        db.query(PositionHistory)
+        .filter(PositionHistory.user_id == user_id, PositionHistory.book_id == book_id)
+        .order_by(PositionHistory.id)
+        .all()
+    )
+
+
+def test_heartbeat_noise_not_recorded(db: Session, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Heartbeat Book")
+    upsert_position(db, user_id=user.id, book_id=book.id,
+                    percentage=0.42, progress="cfi(a)", device="Kindle")
+    # Same position re-PUT (idle heartbeat) — no new entry.
+    upsert_position(db, user_id=user.id, book_id=book.id,
+                    percentage=0.42, progress="cfi(a)", device="Kindle")
+    upsert_position(db, user_id=user.id, book_id=book.id,
+                    percentage=0.4205, progress="cfi(a)", device="Kindle")  # sub-threshold
+    db.flush()
+    assert len(_entries(db, user.id, book.id)) == 1
+
+
+def test_movement_recorded_and_pruned(db: Session, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Mover Book")
+    for i in range(HISTORY_KEEP + 15):
+        upsert_position(db, user_id=user.id, book_id=book.id,
+                        percentage=i / 100.0, progress=f"cfi({i})", device="Kindle")
+    db.flush()
+    rows = _entries(db, user.id, book.id)
+    assert len(rows) == HISTORY_KEEP
+    # Newest survive the prune.
+    assert rows[-1].percentage == (HISTORY_KEEP + 14) / 100.0
+
+
+def test_history_endpoint_lists_newest_first(client: TestClient, db: Session, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Listed Book")
+    for pct in (0.1, 0.5, 0.9):
+        upsert_position(db, user_id=user.id, book_id=book.id,
+                        percentage=pct, progress=f"cfi({pct})", device="Kindle")
+    db.flush()
+    r = client.get(f"/api/books/{book.id}/position-history")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["current"]["percentage"] == 0.9
+    assert [h["percentage"] for h in data["history"]] == [0.9, 0.5, 0.1]
+
+
+def test_restore_reverts_false_completion(client: TestClient, db: Session, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Jumped Book")
+    upsert_position(db, user_id=user.id, book_id=book.id,
+                    percentage=0.45, progress="cfi(mid)", device="Kindle")
+    # The bad sync: device reports 100%, book gets finished.
+    upsert_position(db, user_id=user.id, book_id=book.id,
+                    percentage=1.0, progress="cfi(end)", device="Kindle")
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="read",
+                          progress_pct=1.0, finished_at=datetime(2026, 7, 1)))
+    db.flush()
+
+    hid = next(h["id"] for h in client.get(f"/api/books/{book.id}/position-history").json()["history"]
+               if h["percentage"] == 0.45)
+    r = client.post(f"/api/books/{book.id}/position-history/{hid}/restore")
+    assert r.status_code == 200
+    assert r.json()["status"] == "reading"
+
+    data = client.get(f"/api/books/{book.id}/position-history").json()
+    assert data["current"]["percentage"] == 0.45
+    assert data["current"]["device"] == "restore"
+    status = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
+    db.refresh(status)
+    assert status.status == "reading"
+    assert status.finished_at is None
+    assert status.progress_pct == 0.45
+
+
+def test_restore_rejects_foreign_entry(client: TestClient, db: Session, admin_user, make_book):
+    from backend.core.security import hash_password
+    from backend.models.user import User, UserPermission
+
+    other = User(username="ph_other", email="ph_other@example.com",
+                 hashed_password=hash_password("pass1234"), is_active=True,
+                 is_admin=False, role="member", must_change_password=False)
+    db.add(other)
+    db.flush()
+    db.add(UserPermission(user_id=other.id))
+    book = make_book(title="Foreign Book")
+    upsert_position(db, user_id=other.id, book_id=book.id,
+                    percentage=0.3, progress="cfi(x)", device="Kindle")
+    db.flush()
+    foreign_id = _entries(db, other.id, book.id)[0].id
+    # Admin (the client's default auth) must not restore another user's entry.
+    r = client.post(f"/api/books/{book.id}/position-history/{foreign_id}/restore")
+    assert r.status_code == 404


### PR DESCRIPTION
**Overnight run PR 6/12 — stacked on #136; merge in order. The one DB change in the stack (additive table).**

## What

The safety net under position sync: `TomeSyncPosition` is a single overwritten row, so one bad write — a device falsely jumping a book to 100%, a mis-tap that propagated — was unrecoverable. Now:

- **`position_history` table** (additive; created on startup by `create_all`, same as every other table — no Alembic migration needed, nothing destructive). Written inside `upsert_position`, the one choke point every position writer already goes through (device PUT, web autosave, admin flows), only when the position moves ≥0.2% or the locator changes — the ten-page idle heartbeat can't spam it. Pruned to the newest 40 per user+book.
- **`GET /books/{id}/position-history`** — the log plus the live position; **`POST /books/{id}/position-history/{hid}/restore`** — sets the live position back to that entry.
- **Restore deliberately overrides sticky completion**: restoring below 100% un-finishes the book (status → reading, `finished_at` cleared). Without this the position would come back but the book would stay "read" — the exact scenario the feature exists for. Restores are themselves logged, so a restore can be undone.
- **UI**: history-clock button on the book page's Reading Stats header → modal with the log ("45% · Kindle · 2h ago"), per-entry Restore, current entry marked. Stats + status pill refresh after restore.

## Verification

- 5 backend tests: heartbeat/sub-threshold noise not recorded, movement recorded + prune cap honored, endpoint ordering, **false-completion recovery round-trip** (jump to 100% + finished → restore 45% → status reading, finished_at cleared, device "restore"), foreign-user entry 404s.
- Browser round-trip on dev: seeded 31→45→52→100% writes through the real service path, restored the 45% entry from the modal — new "restore · current" row appears, status pill flips to Reading (screenshots in run log).
- Full position-related suite + build/typecheck clean.