### PR TITLE
fix(docker): un-ignore CHANGELOG.md for the What's-New panel

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,4 +17,6 @@ docs
 tests
 scripts
 *.md
+# …except the changelog — the What's-New panel serves it at runtime
+!CHANGELOG.md
 !pyproject.toml


### PR DESCRIPTION
One-liner: `*.md` in .dockerignore excluded CHANGELOG.md from the build context, failing the image build on main after #134's `COPY CHANGELOG.md` landed. PR CI skips the docker job, so the stack couldn't surface it. `!CHANGELOG.md` exception added.