### PR TITLE
chore(release): changelog consolidation + docs for the 1.9 feature set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,25 +16,61 @@ All notable changes to Tome are documented here. Format loosely follows
   down to month detail, hover any bar for the cover and totals, click through
   to the book. The tab renders full-bleed — edge to edge, viewport-tall — and
   the ribbon is also available as a regular tile in the dashboard gallery.
-
-### Added
+- **Sync on suspend (KOReader plugin, build 35).** Two new opt-in settings
+  make morning stats current without waking the device (#128). "Sync on
+  suspend" catches up anything still pending — sessions, ratings, and the
+  reading-history backfill — when the device goes to sleep, provided WiFi is
+  already connected. "Aggressive sync" additionally turns WiFi on first for
+  devices that sleep the radio (e.g. PocketBook), letting the system power it
+  back down as the device suspends. Everything on this path is
+  queue-or-resume safe: if the device sleeps before the sync finishes, it
+  completes on the next connection. Reconnecting WiFi now also catches up the
+  reading-history backfill (previously launch-only) and flushes pending
+  sessions even before a book is opened.
 - **Shelves on your device (KOReader plugin, build 36).** The TomeSync series
   browser gains a Shelves entry: your saved shelves listed with live counts,
   each drilling into the same book list as a series — download per book or
   all at once, read-status markers included. Shelf filters resolve
   server-side (search, series, author, tag, format, language, library,
   reading status, rating).
-- **Edit highlight notes from the web.** The Highlights page and the book
-  page's Highlights & Notes section can now edit (or add) the note on any
-  highlight — including ones made in KOReader — not just delete them. Edits
-  win on your devices at their next sync, exactly like an edit made on
-  another device.
-- **One-click instance backup and staged restore.** Admin → Server gains an
-  Instance backup card: download a consistent snapshot of everything Tome
-  knows (database + covers + manifest; book files stay on disk), and restore
-  one by uploading it — the restore is validated, requires typing RESTORE,
-  and applies at the next server restart so it never happens under a live
-  database. The previous database is kept alongside as a safety copy.
+- **Sync closed books (KOReader plugin, build 34).** A new TomeSync menu
+  action walks the device for books the plugin has never synced — read before
+  Tome existed, sideloaded, or opened under another launcher — matches them
+  against your library by content hash, and adopts each one's status, rating
+  and reading position from its KOReader sidecar. Adoption only fills what
+  Tome doesn't already have: it can never overwrite live sync state or your
+  own curation. The sweep is resumable (interrupting it loses nothing) and
+  cheap to re-run — books are skipped until their sidecar actually changes.
+  Matched books also become fully synced from then on, positions, highlights
+  and all.
+- **Search your library from the device (KOReader plugin, build 33).** The
+  series browser gains a "Search library…" entry: submit-based free-text search
+  over title, author, and series, with your last searches one tap away. Results
+  open the same drill-down list as a series — tap to download, hold to set read
+  status.
+- **Browse by author on the device (build 33).** A new author axis in the
+  series browser — the natural way into standalone books, which previously all
+  hid behind the single "No Series" bucket. Downloads file each book by its own
+  series/author identity, exactly like the web.
+- **Set read status from the device browser (build 33).** Hold any book row in
+  a series, author, or search list to mark it unread / reading / read on the
+  server — no need to open the book. The lists also show each book's current
+  status alongside the existing "on device" marker.
+- **Position pull strategy (KOReader plugin, build 32).** What happens on book
+  open when the server position differs from the device is now configurable,
+  like stock KOSync: "Server position is ahead" and "Server position is
+  behind" each offer *Ask before jumping / Jump automatically / Do nothing*
+  (TomeSync settings). Defaults keep the historic behavior — forward jumps
+  happen silently, backward jumps never — and the ask-dialog is deferred a
+  moment after open so it can never swallow a "on book opening" profile the
+  way the old layout-reset bug did.
+- **Position history — undo a bad sync.** Tome now keeps a short log of every
+  meaningful reading-position change per book (device, web, manual — the
+  idle heartbeat doesn't spam it). A history button on the book page's
+  Reading Stats header lists them, and any entry can be restored as the live
+  position with one click — including explicitly un-finishing a book that a
+  device falsely jumped to 100%. Devices pick the restored position up on
+  their next sync. The classic sync horror story is no longer unrecoverable.
 - **Import your Goodreads or StoryGraph history.** Settings → Import reading
   history takes either service's CSV export, matches it against your library
   (ISBN first, then title/author), and shows a full preview before anything
@@ -54,13 +90,11 @@ All notable changes to Tome are documented here. Format loosely follows
   map and your own measured reading pace (a sensible default until you have
   reading history). Quietly absent for books without a chapter map or word
   count.
-- **Position history — undo a bad sync.** Tome now keeps a short log of every
-  meaningful reading-position change per book (device, web, manual — the
-  idle heartbeat doesn't spam it). A history button on the book page's
-  Reading Stats header lists them, and any entry can be restored as the live
-  position with one click — including explicitly un-finishing a book that a
-  device falsely jumped to 100%. Devices pick the restored position up on
-  their next sync. The classic sync horror story is no longer unrecoverable.
+- **Edit highlight notes from the web.** The Highlights page and the book
+  page's Highlights & Notes section can now edit (or add) the note on any
+  highlight — including ones made in KOReader — not just delete them. Edits
+  win on your devices at their next sync, exactly like an edit made on
+  another device.
 - **Command palette.** Press Cmd+K (Ctrl+K) anywhere to jump straight to a
   book, series, author, or page — full-text book search with covers, ranked
   series/author matches, and quick navigation, all keyboard-driven. The
@@ -79,6 +113,12 @@ All notable changes to Tome are documented here. Format loosely follows
   standard-source covers), with sizes shown. Books with no cover at all offer
   a one-click auto-fix from the cover search (nothing to downgrade); low-res
   ones deep-link to the book page to pick a better candidate by eye.
+- **One-click instance backup and staged restore.** Admin → Server gains an
+  Instance backup card: download a consistent snapshot of everything Tome
+  knows (database + covers + manifest; book files stay on disk), and restore
+  one by uploading it — the restore is validated, requires typing RESTORE,
+  and applies at the next server restart so it never happens under a live
+  database. The previous database is kept alongside as a safety copy.
 - **"What's new" after an upgrade.** The first visit after the server moves to
   a new release shows a one-time panel with that release's notes, straight
   from the changelog — so features stop shipping invisibly. Dismiss it and it
@@ -95,6 +135,26 @@ All notable changes to Tome are documented here. Format loosely follows
   the screen, and bars are tap-friendly: the first tap shows the details
   tooltip, a second tap opens the book (tapping empty space or scrolling
   dismisses it). Previously any tap navigated away immediately.
+- **Highlights page polish.** The deferred cluster from the original
+  commonplace-book release: an **only-notes filter** (show just the highlights
+  carrying your own notes — composes with search and on-this-day), a real
+  **file export** (download all matching highlights as a Markdown file, next to
+  the existing copy-to-clipboard), **keyboard shortcuts** (`/` search, `Esc`
+  clear, `c` collapse all, `n` only-notes, `e` export — listed in the `?`
+  help), and a **shuffle button** on the Home tab's highlight spotlight that
+  re-rolls to a different quote.
+- **Time per chapter.** Book pages now show where your reading time went
+  chapter by chapter: the book's table of contents is extracted at ingest into
+  device-independent chapter boundaries, and KOReader per-page reading data is
+  mapped into them — robust to font/margin changes, since every page record is
+  interpreted against its own pagination. Renders on the book detail page next
+  to the reading-intensity curve whenever both a chapter map and synced page
+  data exist. Existing libraries get chapter maps via the Admin → Word Counts
+  backfill, which now also extracts chapters (and intrinsic page counts, below)
+  in the same pass.
+- **Intrinsic page counts for fixed-layout books.** PDFs and comic archives now
+  store their real page count at ingest (EPUB deliberately doesn't — reflowable
+  pagination is not a property of the book). Backfilled by the same admin job.
 
 ### Fixed
 - **The audit log covers new features again.** A coverage pass wired audit
@@ -134,73 +194,6 @@ All notable changes to Tome are documented here. Format loosely follows
   Books whose files genuinely have no usable table of contents were re-parsed
   on every run because "done" was inferred from having chapter rows; a
   dedicated attempt marker now records "tried, nothing there" once.
-
-### Added
-- **Sync on suspend (KOReader plugin, build 35).** Two new opt-in settings
-  make morning stats current without waking the device (#128). "Sync on
-  suspend" catches up anything still pending — sessions, ratings, and the
-  reading-history backfill — when the device goes to sleep, provided WiFi is
-  already connected. "Aggressive sync" additionally turns WiFi on first for
-  devices that sleep the radio (e.g. PocketBook), letting the system power it
-  back down as the device suspends. Everything on this path is
-  queue-or-resume safe: if the device sleeps before the sync finishes, it
-  completes on the next connection. Reconnecting WiFi now also catches up the
-  reading-history backfill (previously launch-only) and flushes pending
-  sessions even before a book is opened.
-- **Sync closed books (KOReader plugin, build 34).** A new TomeSync menu
-  action walks the device for books the plugin has never synced — read before
-  Tome existed, sideloaded, or opened under another launcher — matches them
-  against your library by content hash, and adopts each one's status, rating
-  and reading position from its KOReader sidecar. Adoption only fills what
-  Tome doesn't already have: it can never overwrite live sync state or your
-  own curation. The sweep is resumable (interrupting it loses nothing) and
-  cheap to re-run — books are skipped until their sidecar actually changes.
-  Matched books also become fully synced from then on, positions, highlights
-  and all.
-- **Search your library from the device (KOReader plugin, build 33).** The
-  series browser gains a "Search library…" entry: submit-based free-text search
-  over title, author, and series, with your last searches one tap away. Results
-  open the same drill-down list as a series — tap to download, hold to set read
-  status.
-- **Browse by author on the device (build 33).** A new author axis in the
-  series browser — the natural way into standalone books, which previously all
-  hid behind the single "No Series" bucket. Downloads file each book by its own
-  series/author identity, exactly like the web.
-- **Set read status from the device browser (build 33).** Hold any book row in
-  a series, author, or search list to mark it unread / reading / read on the
-  server — no need to open the book. The lists also show each book's current
-  status alongside the existing "on device" marker.
-
-- **Position pull strategy (KOReader plugin, build 32).** What happens on book
-  open when the server position differs from the device is now configurable,
-  like stock KOSync: "Server position is ahead" and "Server position is
-  behind" each offer *Ask before jumping / Jump automatically / Do nothing*
-  (TomeSync settings). Defaults keep the historic behavior — forward jumps
-  happen silently, backward jumps never — and the ask-dialog is deferred a
-  moment after open so it can never swallow a "on book opening" profile the
-  way the old layout-reset bug did.
-- **Highlights page polish.** The deferred cluster from the original
-  commonplace-book release: an **only-notes filter** (show just the highlights
-  carrying your own notes — composes with search and on-this-day), a real
-  **file export** (download all matching highlights as a Markdown file, next to
-  the existing copy-to-clipboard), **keyboard shortcuts** (`/` search, `Esc`
-  clear, `c` collapse all, `n` only-notes, `e` export — listed in the `?`
-  help), and a **shuffle button** on the Home tab's highlight spotlight that
-  re-rolls to a different quote.
-- **Time per chapter.** Book pages now show where your reading time went
-  chapter by chapter: the book's table of contents is extracted at ingest into
-  device-independent chapter boundaries, and KOReader per-page reading data is
-  mapped into them — robust to font/margin changes, since every page record is
-  interpreted against its own pagination. Renders on the book detail page next
-  to the reading-intensity curve whenever both a chapter map and synced page
-  data exist. Existing libraries get chapter maps via the Admin → Word Counts
-  backfill, which now also extracts chapters (and intrinsic page counts, below)
-  in the same pass.
-- **Intrinsic page counts for fixed-layout books.** PDFs and comic archives now
-  store their real page count at ingest (EPUB deliberately doesn't — reflowable
-  pagination is not a property of the book). Backfilled by the same admin job.
-
-### Fixed
 - **A fast server clock can no longer silently swallow highlights (build 32).**
   Highlight edits and deletes made in the web reader are stamped with the
   server's clock; on a device whose clock runs behind (UTC container vs local

--- a/website/src/pages/docs/admin.astro
+++ b/website/src/pages/docs/admin.astro
@@ -88,6 +88,33 @@ import { withBase } from '../../lib/path'
     read-write first.
   </Callout>
 
+  <h2>Cover audit</h2>
+  <p>
+    <strong>Admin → Covers</strong> lists books whose covers are missing, unreadable, or
+    genuinely low-resolution (real thumbnails — the threshold is chosen so standard-source
+    covers pass), with dimensions shown. Books with no cover at all offer a one-click
+    auto-fix that applies the first cover-search candidate — safe, since there is nothing to
+    downgrade. Low-resolution covers deliberately don't auto-fix (a blind refetch could make
+    them worse); their rows deep-link to the book page, where the cover picker shows
+    candidates to judge by eye.
+  </p>
+
+  <h2>Instance backup &amp; restore</h2>
+  <p>
+    <strong>Admin → Server → Instance backup</strong> downloads everything Tome knows in one
+    archive: a consistent snapshot of the database (safe to take while the server runs) plus
+    the cover cache and a manifest. Book files are not included — they live on disk and
+    belong to your own backups.
+  </p>
+  <p>
+    Restoring is deliberately two-phase: upload an archive, type <code>RESTORE</code> to arm
+    it, and the swap happens at the <em>next server restart</em> — never under a live
+    database. The current database is kept alongside as
+    <code>tome.db.pre-restore-&lt;timestamp&gt;</code>, a staged restore can be cancelled any
+    time before the restart, and an invalid archive is rejected at upload. Backup downloads
+    and every restore step land in the <a href="#audit-log">audit log</a>.
+  </p>
+
   <h2>Word counts</h2>
   <p>
     Tome records each EPUB's word count, shown in the <strong>Details</strong> panel on the book
@@ -126,4 +153,14 @@ import { withBase } from '../../lib/path'
     who sent which book to which device, and whether it succeeded. SMTP itself is configured via
     environment variables; see <a href={withBase("/docs/send-to-device")}>Send to Device</a>.
   </p>
+  <h2 id="audit-log">Audit log</h2>
+  <p>
+    <strong>Admin → Audit Log</strong> records who did what, when: user management, book
+    deletions and uploads, metadata edits, downloads (single and bulk), credential
+    lifecycles (API tokens, OPDS PINs, KOReader plugin keys, notification channels —
+    never the secrets themselves), backup and restore steps, imports, and curation
+    changes. Reads and device sync telemetry are deliberately not logged — they would
+    flood the trail without forensic value.
+  </p>
+
 </DocsLayout>

--- a/website/src/pages/docs/books.astro
+++ b/website/src/pages/docs/books.astro
@@ -38,6 +38,13 @@ import { withBase } from '../../lib/path'
     matching auto-created library.
   </Callout>
 
+  <p>
+    Files are hashed in the browser before anything uploads: exact duplicates of books
+    already in the library get an "already in your library" note with a link to the
+    existing book and are skipped — no more uploading megabytes just to find out the
+    server already had it.
+  </p>
+
   <h2>Scanning the library folder</h2>
   <p>
     If you add files directly to the <code>/books</code> volume (or however you mounted
@@ -112,6 +119,14 @@ import { withBase } from '../../lib/path'
     Bulk metadata fetch is capped at 100 books per request. For larger batches, consider
     <a href={withBase("/docs/scribe")}>Scribe</a> which handles thousands.
   </Callout>
+
+  <h2>Command palette</h2>
+  <p>
+    Press <kbd>Cmd</kbd>+<kbd>K</kbd> (<kbd>Ctrl</kbd>+<kbd>K</kbd>) anywhere in Tome to
+    jump straight to a book, series, author, or page — full-text search with covers,
+    entirely keyboard-driven. The header search box hints it, and it's listed in the
+    <kbd>?</kbd> shortcuts help.
+  </p>
 
   <h2>Filtering</h2>
   <p>

--- a/website/src/pages/docs/configuration.astro
+++ b/website/src/pages/docs/configuration.astro
@@ -45,6 +45,10 @@ import { withBase } from '../../lib/path'
       <tr><td><code>TOME_SMTP_USE_TLS</code></td><td><code>true</code></td><td>STARTTLS (port 587)</td></tr>
       <tr><td><code>TOME_SMTP_USE_SSL</code></td><td><code>false</code></td><td>Implicit SSL (port 465)</td></tr>
       <tr><td><code>TOME_SMTP_DAILY_LIMIT</code></td><td><code>50</code></td><td>Per-user sends/day (0 = unlimited)</td></tr>
+      <tr><td><code>TOME_UPDATE_CHECK</code></td><td><code>true</code></td><td>Admin "update available" indicator in Settings → About via a daily-cached GitHub releases lookup. Set <code>false</code> for air-gapped installs — nothing else phones home; the post-upgrade "What's new" panel is local and unaffected</td></tr>
+      <tr><td><code>TOME_OUTBOUND_NOTIFY</code></td><td><code>true</code></td><td>Kill switch for per-user outbound notification channels (ntfy / Gotify / webhook). Nothing is ever sent unless a user configures a channel</td></tr>
+      <tr><td><code>TOME_ALLOW_INFILE_BAKE</code></td><td><code>true</code></td><td>Hard off-switch for the admin "Bake to File" action that rewrites library files with Tome's metadata</td></tr>
+      <tr><td><code>TOME_WISHLIST_ENABLED</code></td><td><code>true</code></td><td>Kill switch for the <a href={withBase("/docs/wishlist")}>Wishlist</a></td></tr>
       <tr><td><code>TOME_SEND_TO_KOREADER</code></td><td><code>false</code></td><td>Enable the <a href={withBase("/docs/koreader#send-to-koreader")}>Send to KOReader</a> inbox (beta) — queue books to the device, no email</td></tr>
     </tbody>
   </table>

--- a/website/src/pages/docs/highlights.astro
+++ b/website/src/pages/docs/highlights.astro
@@ -58,6 +58,15 @@ import { withBase } from '../../lib/path'
     a quote card; on a day with none, it shows a random highlight instead.
   </p>
 
+  <h2>Editing and deleting</h2>
+  <p>
+    Every highlight card has a pencil and a trash icon (hover, or always visible on touch).
+    The pencil edits — or adds — the note on any highlight, including ones made in KOReader;
+    the edit wins on your devices at their next sync, exactly like an edit made on another
+    device. Deleting removes the highlight everywhere: the server keeps a tombstone so the
+    device drops its copy on the next sync instead of re-uploading it.
+  </p>
+
   <h2>Dates &amp; details</h2>
   <p>
     Each card shows when the highlight was made, with a hover for the full detail — the exact time,

--- a/website/src/pages/docs/koreader.astro
+++ b/website/src/pages/docs/koreader.astro
@@ -85,6 +85,12 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
     </figcaption>
   </figure>
 
+  <p>
+    Notes edited (or added) on a highlight in the <em>web app</em> — from the Highlights page
+    or a book page — arrive on the device at its next sync, exactly like an edit made on
+    another device. Deleting a highlight on the web removes it on the device too.
+  </p>
+
   <h3>Ratings &amp; reviews sync</h3>
   <p>
     KOReader has a native <strong>Book status</strong> screen with a 1–5 star rating and a
@@ -119,6 +125,15 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
   <p><strong>From the home screen</strong> (no book open): open the wrench menu →
     <strong>TomeSync → Browse Series</strong>. A list shows every series in your library with
     book counts and authors. Tap a series to download all volumes at once.
+  </p>
+  <p>
+    The browser has four ways in: the series list itself, <strong>Search library…</strong>
+    (free-text over title, author, and series, with your recent searches one tap away),
+    <strong>Browse by author</strong> (the natural route to standalone books), and
+    <strong>Shelves</strong> — your saved shelves from the web app, listed with live book
+    counts and resolved server-side, so a "German" or "unread manga" shelf is one tap away
+    on the device. All of them open the same volume list: tap to download, hold a row to set
+    read status.
   </p>
   <p><strong>From inside a book:</strong></p>
   <ul>
@@ -177,6 +192,25 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
     <li><strong>Close a book</strong> — pushes final position, highlights, and a rating set this session, and records a session.</li>
   </ul>
   <p>Sessions shorter than 10 seconds are filtered out.</p>
+
+  <h3>Sync on suspend</h3>
+  <p>
+    Two opt-in settings (TomeSync → Settings) make your morning stats current without ever
+    waking the device:
+  </p>
+  <ul>
+    <li><strong>Sync on suspend</strong> — when the device goes to sleep, catch up anything
+      still pending (queued sessions, ratings, and — if enabled — the reading-history
+      backfill), provided WiFi is already connected.</li>
+    <li><strong>Aggressive sync (turn WiFi on at suspend)</strong> — additionally brings the
+      radio up first, syncs, and lets the device power it back down as it sleeps. Meant for
+      devices that aggressively sleep WiFi (e.g. PocketBook). Uses more battery.</li>
+  </ul>
+  <p>
+    Everything on this path is resume-safe: if the device falls asleep mid-sync, it simply
+    finishes on the next connection. Reconnecting WiFi also catches up the reading-history
+    backfill without restarting KOReader.
+  </p>
 
   <h2>Keeping the plugin updated</h2>
   <p>

--- a/website/src/pages/docs/reader.astro
+++ b/website/src/pages/docs/reader.astro
@@ -42,6 +42,16 @@ import { withBase } from '../../lib/path'
     See <a href={withBase("/docs/koreader")}>TomeSync</a>.
   </Callout>
 
+  <h3>Time left in chapter</h3>
+  <p>
+    The footer shows "~12 min left" beside the chapter name, computed from the book's
+    chapter map and <em>your</em> measured reading pace (the same true-WPM the stats page
+    derives from finished, word-counted books — a sensible default until you have history;
+    the tooltip says which pace is in use). It's fraction-based rather than page-based, so
+    it doesn't care about font size or layout. Quietly absent for books without a chapter
+    map or word count.
+  </p>
+
   <h3>Keyboard shortcuts</h3>
   <table>
     <thead><tr><th>Key</th><th>Action</th></tr></thead>

--- a/website/src/pages/docs/stats.astro
+++ b/website/src/pages/docs/stats.astro
@@ -74,6 +74,13 @@ import { withBase } from '../../lib/path'
     Two users in different time zones see different "today."
   </Callout>
 
+  <p>
+    Reading from before Tome can come along too: <strong>Settings → Import reading
+    history</strong> takes a Goodreads or StoryGraph CSV export, matches it against your
+    library (ISBN first, then title/author) with a full preview, and only ever fills gaps —
+    statuses, ratings, reviews, and finish dates you already have are never overwritten.
+  </p>
+
   <h2>Overview board</h2>
   <p>
     The "where am I right now?" board. Designed to be glanceable. Like every section below,
@@ -259,6 +266,31 @@ import { withBase } from '../../lib/path'
     A cumulative line chart of <code>books.added_at</code> grouped by month and split by book
     type. Not about reading — about hoarding. Goes up and to the right. Useful for noticing
     acquisition sprees you'd otherwise forget about.
+  </p>
+
+  <h2>Timeline board</h2>
+  <p>
+    Your reading life as a Gantt chart. One lane per series (standalones get their own),
+    named in a frozen rail on the left; every book is a bar spanning its first to last
+    active reading day, with the volume number at the bar's start. Inside each bar, every
+    day you actually read is a tick whose intensity encodes that day's minutes — scaled
+    against your 90th-percentile reading day, so one marathon doesn't flatten every normal
+    evening. Gaps inside a bar are days the book rested; gaps between bars are pauses
+    between volumes.
+  </p>
+  <p>
+    The data is lifetime and fully reconciled: live sessions and imported KOReader history
+    merge with the same page-stats-win-per-book rule as the rest of stats, bucketed by the
+    canonical 4-hour-rollover reading day. Lanes sort by most recent activity and the view
+    opens at today, so the top-right corner is what you're reading now — pan left for
+    history. Zoom from a year-at-a-glance down to month detail; hovering a bar answers at
+    day resolution ("15 May · 22m", or "no reading" on a gap day) alongside the book's
+    totals, and clicking opens the book. On phones the rail narrows and the first tap
+    inspects while a second tap navigates.
+  </p>
+  <p>
+    Timeline is its own board and renders full-bleed — edge to edge, viewport-tall. The
+    ribbon is also available as a regular tile from the gallery for any other board.
   </p>
 
   <h2>Word-count &amp; page insights</h2>

--- a/website/src/pages/docs/wishlist.astro
+++ b/website/src/pages/docs/wishlist.astro
@@ -140,6 +140,15 @@ import { withBase } from '../../lib/path'
     Fulfilment also sends an email when the server has <a href={withBase("/docs/send-to-device")}>SMTP
     configured</a>; if it isn't, only the in-app notice fires.
   </p>
+  <p>
+    The bell only rings when you visit — for pushes the moment things happen, add an
+    <strong>outbound channel</strong> in Settings → Notifications: an
+    <a href="https://ntfy.sh">ntfy</a> topic, a Gotify server, or any plain webhook. Every
+    in-app notification (wish fulfilled, new volume detected, reading goals) is delivered to
+    your enabled channels; each channel has a test button and can be paused, and tokens are
+    stored server-side only. Operators can disable the whole feature with
+    <code>TOME_OUTBOUND_NOTIFY=false</code>.
+  </p>
 
   <h2>Configuration</h2>
   <table class="docs-table">


### PR DESCRIPTION
Release prep, no code changes:

- **CHANGELOG**: `[Unreleased]` had fragmented duplicate sections from the stacked merges (3× Added, 2× Fixed) — now one of each, 36 entries, flagship-first ordering. Verified to parse cleanly through the What's-New endpoint (the panel and the website both render this file).
- **Website docs** for everything new since 1.8.0: Timeline board + reading-history import (stats), sync-on-suspend + browse axes incl. shelves + note round-trip (koreader), time-left-in-chapter (reader), highlight editing (highlights), cover audit + instance backup/restore + a proper audit-log section (admin), outbound channels (wishlist), upload dedupe + Cmd+K (books), and four missing env-var rows (configuration). Astro build clean.

A release-notes draft (Highlights + plugin footer + cut checklist) is in `local/` per convention — not committed. Version/codename/date are yours to call.