### PR TITLE
feat(share): public links for shelves, series, and single books — metadata only, by construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to Tome are documented here. Format loosely follows
   Shelves (share icon in the sidebar), series (share icon on the series
   page), and individual books (Share button on the book page) can each mint
   a revocable public link: a clean read-only page with covers, titles, tags,
-  descriptions, and your ratings and highlights. It never exposes files — no
+  descriptions, your ratings and highlights — and your reading of it: time,
+  reading days, finish dates, and a little day-by-day activity strip. It never exposes files — no
   downloads, no reading, no route to book content at all; links are
   unguessable, marked noindex, and die the moment you revoke them.
 - **Reading Timeline — your reading life on one ribbon.** A new Timeline tab on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
-- **Share a shelf with anyone — metadata only, by design.** Every shelf can
-  mint a revocable public link: a clean read-only page with covers, titles,
-  tags, descriptions, and your ratings and highlights for the books on it.
-  It never exposes files — no downloads, no reading, no route to book content
-  at all; the link is unguessable, marked noindex, and dies the moment you
-  revoke it. Share from the shelf's share icon in the sidebar.
+- **Share a shelf, a series, or a single book — metadata only, by design.**
+  Shelves (share icon in the sidebar), series (share icon on the series
+  page), and individual books (Share button on the book page) can each mint
+  a revocable public link: a clean read-only page with covers, titles, tags,
+  descriptions, and your ratings and highlights. It never exposes files — no
+  downloads, no reading, no route to book content at all; links are
+  unguessable, marked noindex, and die the moment you revoke them.
 - **Reading Timeline — your reading life on one ribbon.** A new Timeline tab on
   Reading Stats draws every book you've ever read as a bar in time: one lane
   per series (named in a frozen rail on the left), volumes as numbered bars

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,25 +16,61 @@ All notable changes to Tome are documented here. Format loosely follows
   down to month detail, hover any bar for the cover and totals, click through
   to the book. The tab renders full-bleed — edge to edge, viewport-tall — and
   the ribbon is also available as a regular tile in the dashboard gallery.
-
-### Added
+- **Sync on suspend (KOReader plugin, build 35).** Two new opt-in settings
+  make morning stats current without waking the device (#128). "Sync on
+  suspend" catches up anything still pending — sessions, ratings, and the
+  reading-history backfill — when the device goes to sleep, provided WiFi is
+  already connected. "Aggressive sync" additionally turns WiFi on first for
+  devices that sleep the radio (e.g. PocketBook), letting the system power it
+  back down as the device suspends. Everything on this path is
+  queue-or-resume safe: if the device sleeps before the sync finishes, it
+  completes on the next connection. Reconnecting WiFi now also catches up the
+  reading-history backfill (previously launch-only) and flushes pending
+  sessions even before a book is opened.
 - **Shelves on your device (KOReader plugin, build 36).** The TomeSync series
   browser gains a Shelves entry: your saved shelves listed with live counts,
   each drilling into the same book list as a series — download per book or
   all at once, read-status markers included. Shelf filters resolve
   server-side (search, series, author, tag, format, language, library,
   reading status, rating).
-- **Edit highlight notes from the web.** The Highlights page and the book
-  page's Highlights & Notes section can now edit (or add) the note on any
-  highlight — including ones made in KOReader — not just delete them. Edits
-  win on your devices at their next sync, exactly like an edit made on
-  another device.
-- **One-click instance backup and staged restore.** Admin → Server gains an
-  Instance backup card: download a consistent snapshot of everything Tome
-  knows (database + covers + manifest; book files stay on disk), and restore
-  one by uploading it — the restore is validated, requires typing RESTORE,
-  and applies at the next server restart so it never happens under a live
-  database. The previous database is kept alongside as a safety copy.
+- **Sync closed books (KOReader plugin, build 34).** A new TomeSync menu
+  action walks the device for books the plugin has never synced — read before
+  Tome existed, sideloaded, or opened under another launcher — matches them
+  against your library by content hash, and adopts each one's status, rating
+  and reading position from its KOReader sidecar. Adoption only fills what
+  Tome doesn't already have: it can never overwrite live sync state or your
+  own curation. The sweep is resumable (interrupting it loses nothing) and
+  cheap to re-run — books are skipped until their sidecar actually changes.
+  Matched books also become fully synced from then on, positions, highlights
+  and all.
+- **Search your library from the device (KOReader plugin, build 33).** The
+  series browser gains a "Search library…" entry: submit-based free-text search
+  over title, author, and series, with your last searches one tap away. Results
+  open the same drill-down list as a series — tap to download, hold to set read
+  status.
+- **Browse by author on the device (build 33).** A new author axis in the
+  series browser — the natural way into standalone books, which previously all
+  hid behind the single "No Series" bucket. Downloads file each book by its own
+  series/author identity, exactly like the web.
+- **Set read status from the device browser (build 33).** Hold any book row in
+  a series, author, or search list to mark it unread / reading / read on the
+  server — no need to open the book. The lists also show each book's current
+  status alongside the existing "on device" marker.
+- **Position pull strategy (KOReader plugin, build 32).** What happens on book
+  open when the server position differs from the device is now configurable,
+  like stock KOSync: "Server position is ahead" and "Server position is
+  behind" each offer *Ask before jumping / Jump automatically / Do nothing*
+  (TomeSync settings). Defaults keep the historic behavior — forward jumps
+  happen silently, backward jumps never — and the ask-dialog is deferred a
+  moment after open so it can never swallow a "on book opening" profile the
+  way the old layout-reset bug did.
+- **Position history — undo a bad sync.** Tome now keeps a short log of every
+  meaningful reading-position change per book (device, web, manual — the
+  idle heartbeat doesn't spam it). A history button on the book page's
+  Reading Stats header lists them, and any entry can be restored as the live
+  position with one click — including explicitly un-finishing a book that a
+  device falsely jumped to 100%. Devices pick the restored position up on
+  their next sync. The classic sync horror story is no longer unrecoverable.
 - **Import your Goodreads or StoryGraph history.** Settings → Import reading
   history takes either service's CSV export, matches it against your library
   (ISBN first, then title/author), and shows a full preview before anything
@@ -54,13 +90,11 @@ All notable changes to Tome are documented here. Format loosely follows
   map and your own measured reading pace (a sensible default until you have
   reading history). Quietly absent for books without a chapter map or word
   count.
-- **Position history — undo a bad sync.** Tome now keeps a short log of every
-  meaningful reading-position change per book (device, web, manual — the
-  idle heartbeat doesn't spam it). A history button on the book page's
-  Reading Stats header lists them, and any entry can be restored as the live
-  position with one click — including explicitly un-finishing a book that a
-  device falsely jumped to 100%. Devices pick the restored position up on
-  their next sync. The classic sync horror story is no longer unrecoverable.
+- **Edit highlight notes from the web.** The Highlights page and the book
+  page's Highlights & Notes section can now edit (or add) the note on any
+  highlight — including ones made in KOReader — not just delete them. Edits
+  win on your devices at their next sync, exactly like an edit made on
+  another device.
 - **Command palette.** Press Cmd+K (Ctrl+K) anywhere to jump straight to a
   book, series, author, or page — full-text book search with covers, ranked
   series/author matches, and quick navigation, all keyboard-driven. The
@@ -79,6 +113,12 @@ All notable changes to Tome are documented here. Format loosely follows
   standard-source covers), with sizes shown. Books with no cover at all offer
   a one-click auto-fix from the cover search (nothing to downgrade); low-res
   ones deep-link to the book page to pick a better candidate by eye.
+- **One-click instance backup and staged restore.** Admin → Server gains an
+  Instance backup card: download a consistent snapshot of everything Tome
+  knows (database + covers + manifest; book files stay on disk), and restore
+  one by uploading it — the restore is validated, requires typing RESTORE,
+  and applies at the next server restart so it never happens under a live
+  database. The previous database is kept alongside as a safety copy.
 - **"What's new" after an upgrade.** The first visit after the server moves to
   a new release shows a one-time panel with that release's notes, straight
   from the changelog — so features stop shipping invisibly. Dismiss it and it
@@ -95,6 +135,26 @@ All notable changes to Tome are documented here. Format loosely follows
   the screen, and bars are tap-friendly: the first tap shows the details
   tooltip, a second tap opens the book (tapping empty space or scrolling
   dismisses it). Previously any tap navigated away immediately.
+- **Highlights page polish.** The deferred cluster from the original
+  commonplace-book release: an **only-notes filter** (show just the highlights
+  carrying your own notes — composes with search and on-this-day), a real
+  **file export** (download all matching highlights as a Markdown file, next to
+  the existing copy-to-clipboard), **keyboard shortcuts** (`/` search, `Esc`
+  clear, `c` collapse all, `n` only-notes, `e` export — listed in the `?`
+  help), and a **shuffle button** on the Home tab's highlight spotlight that
+  re-rolls to a different quote.
+- **Time per chapter.** Book pages now show where your reading time went
+  chapter by chapter: the book's table of contents is extracted at ingest into
+  device-independent chapter boundaries, and KOReader per-page reading data is
+  mapped into them — robust to font/margin changes, since every page record is
+  interpreted against its own pagination. Renders on the book detail page next
+  to the reading-intensity curve whenever both a chapter map and synced page
+  data exist. Existing libraries get chapter maps via the Admin → Word Counts
+  backfill, which now also extracts chapters (and intrinsic page counts, below)
+  in the same pass.
+- **Intrinsic page counts for fixed-layout books.** PDFs and comic archives now
+  store their real page count at ingest (EPUB deliberately doesn't — reflowable
+  pagination is not a property of the book). Backfilled by the same admin job.
 
 ### Fixed
 - **The audit log covers new features again.** A coverage pass wired audit
@@ -134,73 +194,6 @@ All notable changes to Tome are documented here. Format loosely follows
   Books whose files genuinely have no usable table of contents were re-parsed
   on every run because "done" was inferred from having chapter rows; a
   dedicated attempt marker now records "tried, nothing there" once.
-
-### Added
-- **Sync on suspend (KOReader plugin, build 35).** Two new opt-in settings
-  make morning stats current without waking the device (#128). "Sync on
-  suspend" catches up anything still pending — sessions, ratings, and the
-  reading-history backfill — when the device goes to sleep, provided WiFi is
-  already connected. "Aggressive sync" additionally turns WiFi on first for
-  devices that sleep the radio (e.g. PocketBook), letting the system power it
-  back down as the device suspends. Everything on this path is
-  queue-or-resume safe: if the device sleeps before the sync finishes, it
-  completes on the next connection. Reconnecting WiFi now also catches up the
-  reading-history backfill (previously launch-only) and flushes pending
-  sessions even before a book is opened.
-- **Sync closed books (KOReader plugin, build 34).** A new TomeSync menu
-  action walks the device for books the plugin has never synced — read before
-  Tome existed, sideloaded, or opened under another launcher — matches them
-  against your library by content hash, and adopts each one's status, rating
-  and reading position from its KOReader sidecar. Adoption only fills what
-  Tome doesn't already have: it can never overwrite live sync state or your
-  own curation. The sweep is resumable (interrupting it loses nothing) and
-  cheap to re-run — books are skipped until their sidecar actually changes.
-  Matched books also become fully synced from then on, positions, highlights
-  and all.
-- **Search your library from the device (KOReader plugin, build 33).** The
-  series browser gains a "Search library…" entry: submit-based free-text search
-  over title, author, and series, with your last searches one tap away. Results
-  open the same drill-down list as a series — tap to download, hold to set read
-  status.
-- **Browse by author on the device (build 33).** A new author axis in the
-  series browser — the natural way into standalone books, which previously all
-  hid behind the single "No Series" bucket. Downloads file each book by its own
-  series/author identity, exactly like the web.
-- **Set read status from the device browser (build 33).** Hold any book row in
-  a series, author, or search list to mark it unread / reading / read on the
-  server — no need to open the book. The lists also show each book's current
-  status alongside the existing "on device" marker.
-
-- **Position pull strategy (KOReader plugin, build 32).** What happens on book
-  open when the server position differs from the device is now configurable,
-  like stock KOSync: "Server position is ahead" and "Server position is
-  behind" each offer *Ask before jumping / Jump automatically / Do nothing*
-  (TomeSync settings). Defaults keep the historic behavior — forward jumps
-  happen silently, backward jumps never — and the ask-dialog is deferred a
-  moment after open so it can never swallow a "on book opening" profile the
-  way the old layout-reset bug did.
-- **Highlights page polish.** The deferred cluster from the original
-  commonplace-book release: an **only-notes filter** (show just the highlights
-  carrying your own notes — composes with search and on-this-day), a real
-  **file export** (download all matching highlights as a Markdown file, next to
-  the existing copy-to-clipboard), **keyboard shortcuts** (`/` search, `Esc`
-  clear, `c` collapse all, `n` only-notes, `e` export — listed in the `?`
-  help), and a **shuffle button** on the Home tab's highlight spotlight that
-  re-rolls to a different quote.
-- **Time per chapter.** Book pages now show where your reading time went
-  chapter by chapter: the book's table of contents is extracted at ingest into
-  device-independent chapter boundaries, and KOReader per-page reading data is
-  mapped into them — robust to font/margin changes, since every page record is
-  interpreted against its own pagination. Renders on the book detail page next
-  to the reading-intensity curve whenever both a chapter map and synced page
-  data exist. Existing libraries get chapter maps via the Admin → Word Counts
-  backfill, which now also extracts chapters (and intrinsic page counts, below)
-  in the same pass.
-- **Intrinsic page counts for fixed-layout books.** PDFs and comic archives now
-  store their real page count at ingest (EPUB deliberately doesn't — reflowable
-  pagination is not a property of the book). Backfilled by the same admin job.
-
-### Fixed
 - **A fast server clock can no longer silently swallow highlights (build 32).**
   Highlight edits and deletes made in the web reader are stamped with the
   server's clock; on a device whose clock runs behind (UTC container vs local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- **Share a shelf with anyone — metadata only, by design.** Every shelf can
+  mint a revocable public link: a clean read-only page with covers, titles,
+  tags, descriptions, and your ratings and highlights for the books on it.
+  It never exposes files — no downloads, no reading, no route to book content
+  at all; the link is unguessable, marked noindex, and dies the moment you
+  revoke it. Share from the shelf's share icon in the sidebar.
 - **Reading Timeline — your reading life on one ribbon.** A new Timeline tab on
   Reading Stats draws every book you've ever read as a bar in time: one lane
   per series (named in a frozen rail on the left), volumes as numbered bars

--- a/backend/api/share.py
+++ b/backend/api/share.py
@@ -1,0 +1,169 @@
+"""Public share links for shelves — metadata only, by construction.
+
+THE BOUNDARY (owner's explicit constraint, do not loosen): a share exposes
+cover, title, author/series identity, tags, description, the owner's rating,
+and their highlights. Nothing else. No file paths, no download routes, no
+reader, no route from a share to any book content, ever.
+
+That boundary is structural: this module imports nothing from the file-serving
+side (downloads, metadata_embed, book files), and the public endpoint builds
+its response through an explicit whitelist serializer — a field that isn't
+listed here cannot leak. The only binary a share page touches is the cover
+endpoint, which is already public. Tokens are 128-bit random and revocable;
+responses carry X-Robots-Tag: noindex.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import secrets
+
+from fastapi import APIRouter, Depends, HTTPException, Response
+from sqlalchemy.orm import Session
+
+from backend.core.database import get_db
+from backend.core.security import get_current_user
+from backend.models.library import SavedFilter, ShareLink
+from backend.models.tome_sync import Annotation
+from backend.models.user import User
+from backend.models.user_book_status import UserBookStatus
+from backend.services.audit import audit
+from backend.services.shelf_resolver import shelf_query
+
+log = logging.getLogger(__name__)
+router = APIRouter(tags=["share"])
+
+
+def _own_shelf_or_404(db: Session, user: User, shelf_id: int) -> SavedFilter:
+    sf = db.get(SavedFilter, shelf_id)
+    if not sf or sf.owner_id != user.id:
+        raise HTTPException(status_code=404, detail="Shelf not found")
+    return sf
+
+
+# ── Management (authenticated, owner only) ────────────────────────────────────
+
+@router.get("/shelves/{shelf_id}/share")
+def get_share(
+    shelf_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    _own_shelf_or_404(db, current_user, shelf_id)
+    link = db.query(ShareLink).filter(ShareLink.saved_filter_id == shelf_id).first()
+    return {"token": link.token if link else None}
+
+
+@router.post("/shelves/{shelf_id}/share", status_code=201)
+def create_share(
+    shelf_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    sf = _own_shelf_or_404(db, current_user, shelf_id)
+    link = db.query(ShareLink).filter(ShareLink.saved_filter_id == shelf_id).first()
+    if link is None:
+        link = ShareLink(
+            token=secrets.token_urlsafe(16),
+            saved_filter_id=shelf_id,
+            owner_id=current_user.id,
+        )
+        db.add(link)
+        db.commit()
+        db.refresh(link)
+        audit(db, "share_link.created", user_id=current_user.id,
+              username=current_user.username, resource_type="shelf",
+              resource_id=shelf_id, resource_title=sf.name)
+    return {"token": link.token}
+
+
+@router.delete("/shelves/{shelf_id}/share")
+def revoke_share(
+    shelf_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    sf = _own_shelf_or_404(db, current_user, shelf_id)
+    link = db.query(ShareLink).filter(ShareLink.saved_filter_id == shelf_id).first()
+    if link:
+        db.delete(link)
+        db.commit()
+        audit(db, "share_link.revoked", user_id=current_user.id,
+              username=current_user.username, resource_type="shelf",
+              resource_id=shelf_id, resource_title=sf.name)
+    return {"ok": True}
+
+
+# ── Public view (no auth — the token IS the capability) ───────────────────────
+
+@router.get("/share/{token}")
+def public_share(
+    token: str,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> dict:
+    response.headers["X-Robots-Tag"] = "noindex, nofollow"
+    link = db.query(ShareLink).filter(ShareLink.token == token).first()
+    if link is None:
+        raise HTTPException(status_code=404, detail="This share link does not exist (or was revoked)")
+    sf = db.get(SavedFilter, link.saved_filter_id)
+    owner = db.get(User, link.owner_id)
+    if sf is None or owner is None:
+        raise HTTPException(status_code=404, detail="This share link does not exist (or was revoked)")
+
+    try:
+        params = json.loads(sf.params or "{}")
+    except ValueError:
+        params = {}
+    # Visibility is the OWNER's — a share can never show more than they can see.
+    query, _unsupported = shelf_query(db, owner, params)
+    from backend.models.book import Book
+    books = (
+        query.order_by(Book.series.asc().nullslast(),
+                       Book.series_index.asc().nullslast(), Book.title.asc())
+        .all()
+    )
+    seen: set[int] = set()
+    unique = [b for b in books if not (b.id in seen or seen.add(b.id))]
+    book_ids = [b.id for b in unique]
+
+    ratings = {
+        s.book_id: s.rating
+        for s in db.query(UserBookStatus).filter(
+            UserBookStatus.user_id == owner.id,
+            UserBookStatus.book_id.in_(book_ids or [0]),
+            UserBookStatus.rating.isnot(None),
+        )
+    }
+    highlights: dict[int, list[dict]] = {}
+    for a in db.query(Annotation).filter(
+        Annotation.user_id == owner.id,
+        Annotation.book_id.in_(book_ids or [0]),
+    ).order_by(Annotation.id):
+        highlights.setdefault(a.book_id, []).append({
+            # Whitelist within the whitelist: quote text, note, chapter. No
+            # anchors, no device metadata.
+            "text": a.highlighted_text,
+            "note": a.note,
+            "chapter": a.chapter,
+        })
+
+    return {
+        "shelf": sf.name,
+        "books": [
+            {
+                # book id is needed solely for the (already-public) cover
+                # endpoint; everything below is the complete public surface.
+                "id": b.id,
+                "title": b.title,
+                "author": b.author,
+                "series": b.series,
+                "series_index": b.series_index,
+                "description": b.description,
+                "tags": sorted({t.tag for t in b.tags}),
+                "rating": ratings.get(b.id),
+                "highlights": highlights.get(b.id, []),
+            }
+            for b in unique
+        ],
+    }

--- a/backend/api/share.py
+++ b/backend/api/share.py
@@ -43,6 +43,28 @@ def _own_shelf_or_404(db: Session, user: User, shelf_id: int) -> SavedFilter:
 
 # ── Management (authenticated, owner only) ────────────────────────────────────
 
+def _get_or_create(db: Session, user: User, *, resource_type: str,
+                   resource_title: str, **target) -> ShareLink:
+    link = db.query(ShareLink).filter_by(owner_id=user.id, **target).first()
+    if link is None:
+        link = ShareLink(token=secrets.token_urlsafe(16), owner_id=user.id, **target)
+        db.add(link)
+        db.commit()
+        db.refresh(link)
+        audit(db, "share_link.created", user_id=user.id, username=user.username,
+              resource_type=resource_type, resource_title=resource_title)
+    return link
+
+
+def _revoke(db: Session, user: User, *, resource_type: str,
+            resource_title: str, **target) -> None:
+    link = db.query(ShareLink).filter_by(owner_id=user.id, **target).first()
+    if link:
+        db.delete(link)
+        db.commit()
+        audit(db, "share_link.revoked", user_id=user.id, username=user.username,
+              resource_type=resource_type, resource_title=resource_title)
+
 @router.get("/shelves/{shelf_id}/share")
 def get_share(
     shelf_id: int,
@@ -61,19 +83,8 @@ def create_share(
     current_user: User = Depends(get_current_user),
 ) -> dict:
     sf = _own_shelf_or_404(db, current_user, shelf_id)
-    link = db.query(ShareLink).filter(ShareLink.saved_filter_id == shelf_id).first()
-    if link is None:
-        link = ShareLink(
-            token=secrets.token_urlsafe(16),
-            saved_filter_id=shelf_id,
-            owner_id=current_user.id,
-        )
-        db.add(link)
-        db.commit()
-        db.refresh(link)
-        audit(db, "share_link.created", user_id=current_user.id,
-              username=current_user.username, resource_type="shelf",
-              resource_id=shelf_id, resource_title=sf.name)
+    link = _get_or_create(db, current_user, resource_type="shelf",
+                          resource_title=sf.name, saved_filter_id=shelf_id)
     return {"token": link.token}
 
 
@@ -84,13 +95,92 @@ def revoke_share(
     current_user: User = Depends(get_current_user),
 ) -> dict:
     sf = _own_shelf_or_404(db, current_user, shelf_id)
-    link = db.query(ShareLink).filter(ShareLink.saved_filter_id == shelf_id).first()
-    if link:
-        db.delete(link)
-        db.commit()
-        audit(db, "share_link.revoked", user_id=current_user.id,
-              username=current_user.username, resource_type="shelf",
-              resource_id=shelf_id, resource_title=sf.name)
+    _revoke(db, current_user, resource_type="shelf",
+            resource_title=sf.name, saved_filter_id=shelf_id)
+    return {"ok": True}
+
+
+# Series shares: the name is the identity (matches the /series/{name}/meta
+# convention). One link per (owner, series).
+
+@router.get("/series/{name}/share")
+def get_series_share(
+    name: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    link = db.query(ShareLink).filter_by(owner_id=current_user.id, series_name=name).first()
+    return {"token": link.token if link else None}
+
+
+@router.post("/series/{name}/share", status_code=201)
+def create_series_share(
+    name: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    from backend.models.book import Book
+    from backend.core.permissions import book_visibility_filter
+    exists = db.query(Book.id).filter(
+        Book.status == "active", Book.series == name,
+        book_visibility_filter(db, current_user),
+    ).first()
+    if not exists:
+        raise HTTPException(status_code=404, detail="Series not found")
+    link = _get_or_create(db, current_user, resource_type="series",
+                          resource_title=name, series_name=name)
+    return {"token": link.token}
+
+
+@router.delete("/series/{name}/share")
+def revoke_series_share(
+    name: str,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    _revoke(db, current_user, resource_type="series",
+            resource_title=name, series_name=name)
+    return {"ok": True}
+
+
+# Single-book shares. One link per (owner, book).
+
+@router.get("/books/{book_id}/share")
+def get_book_share(
+    book_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    link = db.query(ShareLink).filter_by(owner_id=current_user.id, book_id=book_id).first()
+    return {"token": link.token if link else None}
+
+
+@router.post("/books/{book_id}/share", status_code=201)
+def create_book_share(
+    book_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    from backend.models.book import Book
+    from backend.core.permissions import user_can_see_book
+    book = db.get(Book, book_id)
+    if not book or book.status != "active" or not user_can_see_book(db, current_user, book):
+        raise HTTPException(status_code=404, detail="Book not found")
+    link = _get_or_create(db, current_user, resource_type="book",
+                          resource_title=book.title, book_id=book_id)
+    return {"token": link.token}
+
+
+@router.delete("/books/{book_id}/share")
+def revoke_book_share(
+    book_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    from backend.models.book import Book
+    book = db.get(Book, book_id)
+    _revoke(db, current_user, resource_type="book",
+            resource_title=book.title if book else str(book_id), book_id=book_id)
     return {"ok": True}
 
 
@@ -104,20 +194,40 @@ def public_share(
 ) -> dict:
     response.headers["X-Robots-Tag"] = "noindex, nofollow"
     link = db.query(ShareLink).filter(ShareLink.token == token).first()
-    if link is None:
-        raise HTTPException(status_code=404, detail="This share link does not exist (or was revoked)")
-    sf = db.get(SavedFilter, link.saved_filter_id)
-    owner = db.get(User, link.owner_id)
-    if sf is None or owner is None:
+    owner = db.get(User, link.owner_id) if link else None
+    if link is None or owner is None:
         raise HTTPException(status_code=404, detail="This share link does not exist (or was revoked)")
 
-    try:
-        params = json.loads(sf.params or "{}")
-    except ValueError:
-        params = {}
-    # Visibility is the OWNER's — a share can never show more than they can see.
-    query, _unsupported = shelf_query(db, owner, params)
     from backend.models.book import Book
+    from backend.core.permissions import book_visibility_filter, user_can_see_book
+
+    if link.saved_filter_id is not None:
+        sf = db.get(SavedFilter, link.saved_filter_id)
+        if sf is None:
+            raise HTTPException(status_code=404, detail="This share link does not exist (or was revoked)")
+        try:
+            params = json.loads(sf.params or "{}")
+        except ValueError:
+            params = {}
+        # Visibility is the OWNER's — a share can never show more than they see.
+        query, _unsupported = shelf_query(db, owner, params)
+        kind, title = "shelf", sf.name
+    elif link.series_name is not None:
+        query = db.query(Book).filter(
+            Book.status == "active", Book.series == link.series_name,
+            book_visibility_filter(db, owner),
+        )
+        kind, title = "series", link.series_name
+    else:
+        book = db.get(Book, link.book_id) if link.book_id else None
+        if not book or book.status != "active" or not user_can_see_book(db, owner, book):
+            raise HTTPException(status_code=404, detail="This share link does not exist (or was revoked)")
+        return {
+            "kind": "book",
+            "title": book.title,
+            "books": _serialize_books(db, owner, [book]),
+        }
+
     books = (
         query.order_by(Book.series.asc().nullslast(),
                        Book.series_index.asc().nullslast(), Book.title.asc())
@@ -125,8 +235,13 @@ def public_share(
     )
     seen: set[int] = set()
     unique = [b for b in books if not (b.id in seen or seen.add(b.id))]
-    book_ids = [b.id for b in unique]
+    return {"kind": kind, "title": title, "books": _serialize_books(db, owner, unique)}
 
+
+def _serialize_books(db: Session, owner: User, books: list) -> list[dict]:
+    """THE whitelist. Every public payload goes through here; a field that
+    isn't listed cannot leak."""
+    book_ids = [b.id for b in books]
     ratings = {
         s.book_id: s.rating
         for s in db.query(UserBookStatus).filter(
@@ -147,23 +262,19 @@ def public_share(
             "note": a.note,
             "chapter": a.chapter,
         })
-
-    return {
-        "shelf": sf.name,
-        "books": [
-            {
-                # book id is needed solely for the (already-public) cover
-                # endpoint; everything below is the complete public surface.
-                "id": b.id,
-                "title": b.title,
-                "author": b.author,
-                "series": b.series,
-                "series_index": b.series_index,
-                "description": b.description,
-                "tags": sorted({t.tag for t in b.tags}),
-                "rating": ratings.get(b.id),
-                "highlights": highlights.get(b.id, []),
-            }
-            for b in unique
-        ],
-    }
+    return [
+        {
+            # book id is needed solely for the (already-public) cover
+            # endpoint; everything below is the complete public surface.
+            "id": b.id,
+            "title": b.title,
+            "author": b.author,
+            "series": b.series,
+            "series_index": b.series_index,
+            "description": b.description,
+            "tags": sorted({t.tag for t in b.tags}),
+            "rating": ratings.get(b.id),
+            "highlights": highlights.get(b.id, []),
+        }
+        for b in books
+    ]

--- a/backend/api/share.py
+++ b/backend/api/share.py
@@ -17,8 +17,11 @@ from __future__ import annotations
 import json
 import logging
 import secrets
+from datetime import datetime, timedelta
+from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Response
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from backend.core.database import get_db
@@ -43,16 +46,42 @@ def _own_shelf_or_404(db: Session, user: User, shelf_id: int) -> SavedFilter:
 
 # ── Management (authenticated, owner only) ────────────────────────────────────
 
+_EXPIRY_CHOICES = {1, 7, 30}
+
+
+class ShareCreate(BaseModel):
+    # None/omitted = never expires. Fixed presets keep the semantics simple.
+    expires_in_days: Optional[int] = None
+
+
+def _expiry_from(body: Optional[ShareCreate]):
+    days = body.expires_in_days if body else None
+    if days is None:
+        return None
+    if days not in _EXPIRY_CHOICES:
+        raise HTTPException(status_code=422, detail=f"expires_in_days must be one of {sorted(_EXPIRY_CHOICES)}")
+    return datetime.utcnow() + timedelta(days=days)
+
+
+def _link_out(link: ShareLink) -> dict:
+    return {
+        "token": link.token,
+        "expires_at": link.expires_at.isoformat() + "Z" if link.expires_at else None,
+    }
+
+
 def _get_or_create(db: Session, user: User, *, resource_type: str,
-                   resource_title: str, **target) -> ShareLink:
+                   resource_title: str, expires_at=None, **target) -> ShareLink:
     link = db.query(ShareLink).filter_by(owner_id=user.id, **target).first()
     if link is None:
-        link = ShareLink(token=secrets.token_urlsafe(16), owner_id=user.id, **target)
+        link = ShareLink(token=secrets.token_urlsafe(16), owner_id=user.id,
+                         expires_at=expires_at, **target)
         db.add(link)
         db.commit()
         db.refresh(link)
         audit(db, "share_link.created", user_id=user.id, username=user.username,
-              resource_type=resource_type, resource_title=resource_title)
+              resource_type=resource_type, resource_title=resource_title,
+              details={"expires_at": link.expires_at.isoformat() if link.expires_at else None})
     return link
 
 
@@ -73,19 +102,21 @@ def get_share(
 ) -> dict:
     _own_shelf_or_404(db, current_user, shelf_id)
     link = db.query(ShareLink).filter(ShareLink.saved_filter_id == shelf_id).first()
-    return {"token": link.token if link else None}
+    return _link_out(link) if link else {"token": None, "expires_at": None}
 
 
 @router.post("/shelves/{shelf_id}/share", status_code=201)
 def create_share(
     shelf_id: int,
+    body: Optional[ShareCreate] = Body(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
     sf = _own_shelf_or_404(db, current_user, shelf_id)
     link = _get_or_create(db, current_user, resource_type="shelf",
-                          resource_title=sf.name, saved_filter_id=shelf_id)
-    return {"token": link.token}
+                          resource_title=sf.name, expires_at=_expiry_from(body),
+                          saved_filter_id=shelf_id)
+    return _link_out(link)
 
 
 @router.delete("/shelves/{shelf_id}/share")
@@ -110,12 +141,13 @@ def get_series_share(
     current_user: User = Depends(get_current_user),
 ) -> dict:
     link = db.query(ShareLink).filter_by(owner_id=current_user.id, series_name=name).first()
-    return {"token": link.token if link else None}
+    return _link_out(link) if link else {"token": None, "expires_at": None}
 
 
 @router.post("/series/{name}/share", status_code=201)
 def create_series_share(
     name: str,
+    body: Optional[ShareCreate] = Body(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
@@ -128,8 +160,9 @@ def create_series_share(
     if not exists:
         raise HTTPException(status_code=404, detail="Series not found")
     link = _get_or_create(db, current_user, resource_type="series",
-                          resource_title=name, series_name=name)
-    return {"token": link.token}
+                          resource_title=name, expires_at=_expiry_from(body),
+                          series_name=name)
+    return _link_out(link)
 
 
 @router.delete("/series/{name}/share")
@@ -152,12 +185,13 @@ def get_book_share(
     current_user: User = Depends(get_current_user),
 ) -> dict:
     link = db.query(ShareLink).filter_by(owner_id=current_user.id, book_id=book_id).first()
-    return {"token": link.token if link else None}
+    return _link_out(link) if link else {"token": None, "expires_at": None}
 
 
 @router.post("/books/{book_id}/share", status_code=201)
 def create_book_share(
     book_id: int,
+    body: Optional[ShareCreate] = Body(None),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
@@ -167,8 +201,9 @@ def create_book_share(
     if not book or book.status != "active" or not user_can_see_book(db, current_user, book):
         raise HTTPException(status_code=404, detail="Book not found")
     link = _get_or_create(db, current_user, resource_type="book",
-                          resource_title=book.title, book_id=book_id)
-    return {"token": link.token}
+                          resource_title=book.title, expires_at=_expiry_from(body),
+                          book_id=book_id)
+    return _link_out(link)
 
 
 @router.delete("/books/{book_id}/share")
@@ -184,6 +219,61 @@ def revoke_book_share(
     return {"ok": True}
 
 
+# ── Overview: all of the caller's share links in one place ────────────────────
+
+@router.get("/share-links")
+def list_my_share_links(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[dict]:
+    from backend.models.book import Book
+
+    links = (
+        db.query(ShareLink)
+        .filter(ShareLink.owner_id == current_user.id)
+        .order_by(ShareLink.created_at.desc())
+        .all()
+    )
+    now = datetime.utcnow()
+    out = []
+    for link in links:
+        if link.saved_filter_id is not None:
+            sf = db.get(SavedFilter, link.saved_filter_id)
+            kind, title = "shelf", sf.name if sf else "(deleted shelf)"
+        elif link.series_name is not None:
+            kind, title = "series", link.series_name
+        else:
+            book = db.get(Book, link.book_id) if link.book_id else None
+            kind, title = "book", book.title if book else "(deleted book)"
+        out.append({
+            "id": link.id,
+            "kind": kind,
+            "title": title,
+            "token": link.token,
+            "created_at": link.created_at.isoformat() + "Z",
+            "expires_at": link.expires_at.isoformat() + "Z" if link.expires_at else None,
+            "expired": link.expires_at is not None and link.expires_at < now,
+        })
+    return out
+
+
+@router.delete("/share-links/{link_id}")
+def revoke_share_link_by_id(
+    link_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    link = db.get(ShareLink, link_id)
+    if not link or link.owner_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Link not found")
+    kind = "shelf" if link.saved_filter_id else ("series" if link.series_name else "book")
+    db.delete(link)
+    db.commit()
+    audit(db, "share_link.revoked", user_id=current_user.id,
+          username=current_user.username, resource_type=kind)
+    return {"ok": True}
+
+
 # ── Public view (no auth — the token IS the capability) ───────────────────────
 
 @router.get("/share/{token}")
@@ -195,7 +285,9 @@ def public_share(
     response.headers["X-Robots-Tag"] = "noindex, nofollow"
     link = db.query(ShareLink).filter(ShareLink.token == token).first()
     owner = db.get(User, link.owner_id) if link else None
-    if link is None or owner is None:
+    if link is None or owner is None or (
+        link.expires_at is not None and link.expires_at < datetime.utcnow()
+    ):
         raise HTTPException(status_code=404, detail="This share link does not exist (or was revoked)")
 
     from backend.models.book import Book

--- a/backend/api/share.py
+++ b/backend/api/share.py
@@ -242,7 +242,7 @@ def public_share(
     seen: set[int] = set()
     unique = [b for b in books if not (b.id in seen or seen.add(b.id))]
     serialized = _serialize_books(db, owner, unique)
-    return {
+    out = {
         "kind": kind,
         "title": title,
         "totals": {
@@ -251,6 +251,43 @@ def public_share(
             "total_seconds": sum((b["stats"] or {}).get("total_seconds", 0) for b in serialized),
         },
         "books": serialized,
+    }
+    if kind == "series":
+        out["series"] = _series_context(db, owner, title, unique)
+    return out
+
+
+def _series_context(db: Session, owner: User, name: str, books: list) -> dict:
+    """Series-level metadata for the public page — status, arcs (name, range,
+    description), the vol-1 description, and the owner's series rating. All
+    curation, no content."""
+    from backend.models.series_meta import Arc, SeriesMeta
+    from backend.models.user_series_rating import UserSeriesRating
+
+    meta = db.query(SeriesMeta).filter(SeriesMeta.series_name == name).first()
+    arcs = (
+        db.query(Arc)
+        .filter(Arc.series_name == name)
+        .order_by(Arc.start_index)
+        .all()
+    )
+    rating_row = (
+        db.query(UserSeriesRating)
+        .filter(UserSeriesRating.user_id == owner.id,
+                UserSeriesRating.series_name == name)
+        .first()
+    )
+    first = books[0] if books else None
+    return {
+        "author": first.author if first else None,
+        "description": first.description if first else None,
+        "status": meta.status if meta else None,
+        "rating": rating_row.rating if rating_row else None,
+        "arcs": [
+            {"name": a.name, "start_index": a.start_index,
+             "end_index": a.end_index, "description": a.description}
+            for a in arcs
+        ],
     }
 
 

--- a/backend/api/share.py
+++ b/backend/api/share.py
@@ -222,10 +222,16 @@ def public_share(
         book = db.get(Book, link.book_id) if link.book_id else None
         if not book or book.status != "active" or not user_can_see_book(db, owner, book):
             raise HTTPException(status_code=404, detail="This share link does not exist (or was revoked)")
+        serialized = _serialize_books(db, owner, [book])
         return {
             "kind": "book",
             "title": book.title,
-            "books": _serialize_books(db, owner, [book]),
+            "totals": {
+                "books": 1,
+                "read": sum(1 for b in serialized if (b["stats"] or {}).get("status") == "read"),
+                "total_seconds": sum((b["stats"] or {}).get("total_seconds", 0) for b in serialized),
+            },
+            "books": serialized,
         }
 
     books = (
@@ -235,21 +241,65 @@ def public_share(
     )
     seen: set[int] = set()
     unique = [b for b in books if not (b.id in seen or seen.add(b.id))]
-    return {"kind": kind, "title": title, "books": _serialize_books(db, owner, unique)}
+    serialized = _serialize_books(db, owner, unique)
+    return {
+        "kind": kind,
+        "title": title,
+        "totals": {
+            "books": len(serialized),
+            "read": sum(1 for b in serialized if (b["stats"] or {}).get("status") == "read"),
+            "total_seconds": sum((b["stats"] or {}).get("total_seconds", 0) for b in serialized),
+        },
+        "books": serialized,
+    }
 
 
 def _serialize_books(db: Session, owner: User, books: list) -> list[dict]:
     """THE whitelist. Every public payload goes through here; a field that
-    isn't listed cannot leak."""
+    isn't listed cannot leak.
+
+    Includes the owner's reading stats for each book (time, days, status,
+    finish date, per-day activity) — that is the owner's own data, not book
+    content, and it is what makes a share worth looking at. Still zero routes
+    to files."""
+    from backend.services import reconciled_reading as rr
+    from backend.services.reading_day import date_modifier
+
     book_ids = [b.id for b in books]
-    ratings = {
-        s.book_id: s.rating
+    status_rows = {
+        s.book_id: s
         for s in db.query(UserBookStatus).filter(
             UserBookStatus.user_id == owner.id,
             UserBookStatus.book_id.in_(book_ids or [0]),
-            UserBookStatus.rating.isnot(None),
         )
     }
+    ratings = {bid: s.rating for bid, s in status_rows.items() if s.rating is not None}
+
+    # Reconciled per-day reading (UTC day-bucketing — the owner's exact tz is
+    # unknown server-side and a public page doesn't need it to the hour).
+    covered = rr.covered_book_ids(db, owner.id)
+    day_secs = rr.book_day_seconds(db, owner.id, date_modifier(0), covered)
+    activity: dict[int, list[dict]] = {}
+    for (bid, day), secs in sorted(day_secs.items(), key=lambda kv: (kv[0][0], kv[0][1] or "")):
+        if bid in (set(book_ids)) and secs > 0 and day is not None:
+            activity.setdefault(bid, []).append({"date": day, "seconds": secs})
+
+    def _stats(bid: int) -> dict | None:
+        days = activity.get(bid, [])
+        srow = status_rows.get(bid)
+        status = srow.status if srow and srow.status in ("reading", "read") else None
+        if not days and not status:
+            return None
+        return {
+            "status": status,
+            "total_seconds": sum(d["seconds"] for d in days),
+            "reading_days": len(days),
+            "first_day": days[0]["date"] if days else None,
+            "last_day": days[-1]["date"] if days else None,
+            "finished_on": (srow.finished_at.date().isoformat()
+                            if srow and srow.finished_at else None),
+            "activity": days,
+        }
     highlights: dict[int, list[dict]] = {}
     for a in db.query(Annotation).filter(
         Annotation.user_id == owner.id,
@@ -274,6 +324,7 @@ def _serialize_books(db: Session, owner: User, books: list) -> list[dict]:
             "description": b.description,
             "tags": sorted({t.tag for t in b.tags}),
             "rating": ratings.get(b.id),
+            "stats": _stats(b.id),
             "highlights": highlights.get(b.id, []),
         }
         for b in books

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -930,81 +930,9 @@ def get_author_books(
 
 # ── Shelves on the device (build 36) ─────────────────────────────────────────
 
-# The device-supported subset of the dashboard's shelf filter params. The
-# expressions mirror backend.api.books.list_books — that endpoint is the
-# source of these semantics; keep them in lockstep (test_tomesync_shelves has
-# a drift check comparing results against /books for the same params).
-_SHELF_SUPPORTED = {"q", "series", "no_series", "author", "tag", "format",
-                    "language", "library_id", "reading_status", "min_rating"}
-
-
-def _shelf_query(db: Session, user: User, params: dict):
-    """-> (query over Book, unsupported_keys). Values arrive as URL-shaped
-    strings ('true', '3'); coerce where needed."""
-    from sqlalchemy import text as sa_text
-
-    visibility = book_visibility_filter(db, user)
-    query = (
-        db.query(Book)
-        .options(joinedload(Book.files), joinedload(Book.book_type))
-        .filter(Book.status == "active", visibility)
-    )
-    unsupported = sorted(k for k, v in params.items()
-                         if k not in _SHELF_SUPPORTED and v not in (None, "", False))
-
-    q = params.get("q")
-    if q:
-        terms = str(q).split()
-        fts_term = " ".join(f'"{t.replace(chr(34), "")}"*' for t in terms if t)
-        fts_ids = [r[0] for r in db.execute(
-            sa_text("SELECT rowid FROM books_fts WHERE books_fts MATCH :q"),
-            {"q": fts_term}).fetchall()]
-        query = query.filter(Book.id.in_(fts_ids) if fts_ids else Book.id == -1)
-    if params.get("series"):
-        query = query.filter(Book.series == params["series"])
-    if str(params.get("no_series")).lower() == "true":
-        query = query.filter(Book.series.is_(None))
-    if params.get("author"):
-        query = query.filter(Book.author == params["author"])
-    if params.get("tag"):
-        query = query.join(Book.tags).filter(BookTag.tag == params["tag"])
-    if params.get("format"):
-        query = query.join(Book.files).filter(BookFile.format == str(params["format"]).lower())
-    if params.get("language"):
-        from backend.services.languages import normalize_language
-        target = normalize_language(str(params["language"]))
-        raw = [r[0] for r in db.query(Book.language).filter(
-            Book.language.isnot(None), Book.language != "").distinct().all()
-            if normalize_language(r[0]) == target]
-        query = query.filter(Book.language.in_(raw) if raw else Book.id == -1)
-    if params.get("library_id"):
-        try:
-            query = query.join(Book.libraries).filter(Library.id == int(params["library_id"]))
-        except (TypeError, ValueError):
-            pass
-    rs = params.get("reading_status")
-    if rs in ("reading", "read", "shelved"):
-        query = query.join(
-            UserBookStatus,
-            (UserBookStatus.book_id == Book.id) & (UserBookStatus.user_id == user.id)
-        ).filter(UserBookStatus.status == rs)
-    elif rs == "unread":
-        from sqlalchemy import exists
-        subq = exists().where(
-            (UserBookStatus.book_id == Book.id) &
-            (UserBookStatus.user_id == user.id) &
-            (UserBookStatus.status != "unread")
-        )
-        query = query.filter(~subq)
-    if params.get("min_rating"):
-        try:
-            query = query.join(
-                UserBookStatus,
-                (UserBookStatus.book_id == Book.id) & (UserBookStatus.user_id == user.id)
-            ).filter(UserBookStatus.rating >= float(params["min_rating"]))
-        except (TypeError, ValueError):
-            pass
-    return query, unsupported
+# Shelf params resolve through the shared resolver (also used by public
+# share links) — see backend/services/shelf_resolver.py.
+from backend.services.shelf_resolver import shelf_query as _shelf_query  # noqa: E402
 
 
 @router.get("/tome-sync/shelves")

--- a/backend/main.py
+++ b/backend/main.py
@@ -24,6 +24,7 @@ from backend.api import meta as meta_api
 from backend.api import admin_covers
 from backend.api import reading_import
 from backend.api import admin_backup
+from backend.api import share as share_api
 from backend.services import outbound_notifications  # noqa: F401  (registers ORM fanout listeners)
 from backend.api import quick_connect
 from backend.api import admin_duplicates
@@ -762,6 +763,7 @@ def create_app() -> FastAPI:
     app.include_router(admin_covers.router, prefix="/api")
     app.include_router(reading_import.router, prefix="/api")
     app.include_router(admin_backup.router, prefix="/api")
+    app.include_router(share_api.router, prefix="/api")
     app.include_router(annotations_api.router, prefix="/api")
 
     # Serve frontend static files in production (SPA fallback)

--- a/backend/main.py
+++ b/backend/main.py
@@ -88,7 +88,7 @@ async def lifespan(app: FastAPI):
         # the old shape, and links are cheap to re-mint).
         sl_info = conn.execute(text("PRAGMA table_info(share_links)")).fetchall()
         sl_notnull = {r[1]: bool(r[3]) for r in sl_info}
-        if sl_info and (sl_notnull.get("saved_filter_id") or "series_name" not in sl_notnull):
+        if sl_info and (sl_notnull.get("saved_filter_id") or "series_name" not in sl_notnull or "expires_at" not in sl_notnull):
             conn.execute(text("DROP TABLE share_links"))
             conn.commit()
             from backend.models.library import ShareLink as _SL

--- a/backend/main.py
+++ b/backend/main.py
@@ -82,6 +82,18 @@ async def lifespan(app: FastAPI):
     # Add columns that create_all can't add to existing tables
     from sqlalchemy import text, inspect
     with engine.connect() as conn:
+        # share_links grew series/book targets while unreleased. The original
+        # shape had saved_filter_id NOT NULL, which SQLite cannot relax via
+        # ALTER — rebuild the table (feature unreleased: only dev DBs can have
+        # the old shape, and links are cheap to re-mint).
+        sl_info = conn.execute(text("PRAGMA table_info(share_links)")).fetchall()
+        sl_notnull = {r[1]: bool(r[3]) for r in sl_info}
+        if sl_info and (sl_notnull.get("saved_filter_id") or "series_name" not in sl_notnull):
+            conn.execute(text("DROP TABLE share_links"))
+            conn.commit()
+            from backend.models.library import ShareLink as _SL
+            _SL.__table__.create(bind=conn)
+            conn.commit()
         cols = {r[1] for r in conn.execute(text("PRAGMA table_info(books)")).fetchall()}
         if "content_type" not in cols:
             conn.execute(text("ALTER TABLE books ADD COLUMN content_type VARCHAR(16) DEFAULT 'volume' NOT NULL"))

--- a/backend/models/library.py
+++ b/backend/models/library.py
@@ -102,5 +102,7 @@ class ShareLink(Base):
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+    # NULL = never expires. Expired links 404 exactly like revoked ones.
+    expires_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
 
     shelf: Mapped[Optional["SavedFilter"]] = relationship("SavedFilter")

--- a/backend/models/library.py
+++ b/backend/models/library.py
@@ -83,17 +83,24 @@ class ShareLink(Base):
     reader, no route from a share to any book content, ever. The public
     endpoint lives in its own router with an explicit whitelist serializer and
     zero imports from file-serving modules — the boundary is structural, not
-    policy. One link per shelf; revoking deletes the row (the token dies)."""
+    policy. Revoking deletes the row (the token dies).
+
+    Three share targets, exactly one set per row: a shelf (saved_filter_id),
+    a series (series_name), or a single book (book_id)."""
     __tablename__ = "share_links"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     token: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
-    saved_filter_id: Mapped[int] = mapped_column(
-        Integer, ForeignKey("saved_filters.id", ondelete="CASCADE"), nullable=False, unique=True
+    saved_filter_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("saved_filters.id", ondelete="CASCADE"), nullable=True, unique=True
+    )
+    series_name: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    book_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("books.id", ondelete="CASCADE"), nullable=True
     )
     owner_id: Mapped[int] = mapped_column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
 
-    shelf: Mapped["SavedFilter"] = relationship("SavedFilter")
+    shelf: Mapped[Optional["SavedFilter"]] = relationship("SavedFilter")

--- a/backend/models/library.py
+++ b/backend/models/library.py
@@ -72,3 +72,28 @@ class SavedFilter(Base):
     params: Mapped[str] = mapped_column(Text, nullable=False, default="{}")
     sort_order: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class ShareLink(Base):
+    """An opt-in, tokenized, read-only public view of one shelf.
+
+    HARD BOUNDARY (owner's explicit constraint): the public payload is
+    metadata only — cover, title, author/series identity, tags, description,
+    the owner's rating, and their highlights. No file paths, no downloads, no
+    reader, no route from a share to any book content, ever. The public
+    endpoint lives in its own router with an explicit whitelist serializer and
+    zero imports from file-serving modules — the boundary is structural, not
+    policy. One link per shelf; revoking deletes the row (the token dies)."""
+    __tablename__ = "share_links"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    token: Mapped[str] = mapped_column(String(64), unique=True, nullable=False, index=True)
+    saved_filter_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("saved_filters.id", ondelete="CASCADE"), nullable=False, unique=True
+    )
+    owner_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
+
+    shelf: Mapped["SavedFilter"] = relationship("SavedFilter")

--- a/backend/services/shelf_resolver.py
+++ b/backend/services/shelf_resolver.py
@@ -1,0 +1,89 @@
+"""Resolve a shelf's saved filter params to a Book query.
+
+Shared by the KOReader device browser (build 36) and public share links. The
+device-supported subset of the dashboard's filters; the expressions mirror
+backend.api.books.list_books — that endpoint is the source of these
+semantics (test_tomesync_shelves has a drift check against /books).
+"""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session, joinedload
+
+from backend.core.permissions import book_visibility_filter
+from backend.models.book import Book, BookFile, BookTag
+from backend.models.library import Library
+from backend.models.user import User
+from backend.models.user_book_status import UserBookStatus
+
+SHELF_SUPPORTED = {"q", "series", "no_series", "author", "tag", "format",
+                   "language", "library_id", "reading_status", "min_rating"}
+
+
+def shelf_query(db: Session, user: User, params: dict):
+    """-> (query over Book, unsupported_keys). Values arrive as URL-shaped
+    strings ('true', '3'); coerce where needed. Visibility is always the
+    given user's — a shelf can never show more than its owner can see."""
+    from sqlalchemy import text as sa_text
+
+    visibility = book_visibility_filter(db, user)
+    query = (
+        db.query(Book)
+        .options(joinedload(Book.files), joinedload(Book.book_type))
+        .filter(Book.status == "active", visibility)
+    )
+    unsupported = sorted(k for k, v in params.items()
+                         if k not in SHELF_SUPPORTED and v not in (None, "", False))
+
+    q = params.get("q")
+    if q:
+        terms = str(q).split()
+        fts_term = " ".join(f'"{t.replace(chr(34), "")}"*' for t in terms if t)
+        fts_ids = [r[0] for r in db.execute(
+            sa_text("SELECT rowid FROM books_fts WHERE books_fts MATCH :q"),
+            {"q": fts_term}).fetchall()]
+        query = query.filter(Book.id.in_(fts_ids) if fts_ids else Book.id == -1)
+    if params.get("series"):
+        query = query.filter(Book.series == params["series"])
+    if str(params.get("no_series")).lower() == "true":
+        query = query.filter(Book.series.is_(None))
+    if params.get("author"):
+        query = query.filter(Book.author == params["author"])
+    if params.get("tag"):
+        query = query.join(Book.tags).filter(BookTag.tag == params["tag"])
+    if params.get("format"):
+        query = query.join(Book.files).filter(BookFile.format == str(params["format"]).lower())
+    if params.get("language"):
+        from backend.services.languages import normalize_language
+        target = normalize_language(str(params["language"]))
+        raw = [r[0] for r in db.query(Book.language).filter(
+            Book.language.isnot(None), Book.language != "").distinct().all()
+            if normalize_language(r[0]) == target]
+        query = query.filter(Book.language.in_(raw) if raw else Book.id == -1)
+    if params.get("library_id"):
+        try:
+            query = query.join(Book.libraries).filter(Library.id == int(params["library_id"]))
+        except (TypeError, ValueError):
+            pass
+    rs = params.get("reading_status")
+    if rs in ("reading", "read", "shelved"):
+        query = query.join(
+            UserBookStatus,
+            (UserBookStatus.book_id == Book.id) & (UserBookStatus.user_id == user.id)
+        ).filter(UserBookStatus.status == rs)
+    elif rs == "unread":
+        from sqlalchemy import exists
+        subq = exists().where(
+            (UserBookStatus.book_id == Book.id) &
+            (UserBookStatus.user_id == user.id) &
+            (UserBookStatus.status != "unread")
+        )
+        query = query.filter(~subq)
+    if params.get("min_rating"):
+        try:
+            query = query.join(
+                UserBookStatus,
+                (UserBookStatus.book_id == Book.id) & (UserBookStatus.user_id == user.id)
+            ).filter(UserBookStatus.rating >= float(params["min_rating"]))
+        except (TypeError, ValueError):
+            pass
+    return query, unsupported

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { ForcePasswordChange } from '@/components/ForcePasswordChange'
 import { KeyboardShortcutsModal } from '@/components/KeyboardShortcutsModal'
 import { LoginPage } from '@/pages/LoginPage'
 import { OidcCallbackPage } from '@/pages/OidcCallbackPage'
+import { SharePage } from './pages/SharePage'
 import { SetupPage } from '@/pages/SetupPage'
 import { DashboardPage } from '@/pages/DashboardPage'
 import { BookDetailPage } from '@/pages/BookDetailPage'
@@ -77,6 +78,9 @@ function AppRoutes() {
         <Route path="/setup" element={setupNeeded ? <SetupPage /> : <Navigate to="/login" replace />} />
         <Route path="/login" element={setupNeeded ? <Navigate to="/setup" replace /> : <LoginPage />} />
         <Route path="/auth/callback" element={<OidcCallbackPage />} />
+        {/* Public share view — deliberately outside ProtectedRoute; the token
+            is the capability. */}
+        <Route path="/share/:token" element={<SharePage />} />
         <Route
           path="/"
           element={

--- a/frontend/src/components/ShareLinksOverview.tsx
+++ b/frontend/src/components/ShareLinksOverview.tsx
@@ -1,0 +1,105 @@
+// Settings → Share links: every public link you've minted, in one place —
+// what it points at, when it expires, copy and revoke.
+import { useEffect, useState } from 'react'
+import { Book, Bookmark, Check, Copy, Layers, Trash2 } from 'lucide-react'
+import { api } from '@/lib/api'
+import { cn, copyToClipboard } from '@/lib/utils'
+
+interface ShareLinkRow {
+  id: number
+  kind: 'shelf' | 'series' | 'book'
+  title: string
+  token: string
+  created_at: string
+  expires_at: string | null
+  expired: boolean
+}
+
+const KIND_ICON = { shelf: Bookmark, series: Layers, book: Book } as const
+
+export function ShareLinksOverview() {
+  const [rows, setRows] = useState<ShareLinkRow[] | null>(null)
+  const [copiedId, setCopiedId] = useState<number | null>(null)
+
+  const load = () => {
+    api.get<ShareLinkRow[]>('/share-links').then(setRows).catch(() => setRows([]))
+  }
+  useEffect(load, [])
+
+  async function copy(row: ShareLinkRow) {
+    if (await copyToClipboard(`${window.location.origin}/share/${row.token}`)) {
+      setCopiedId(row.id)
+      setTimeout(() => setCopiedId(null), 1500)
+    }
+  }
+
+  function fmtExpiry(row: ShareLinkRow): string {
+    if (row.expired) return 'expired'
+    if (!row.expires_at) return 'never expires'
+    return `expires ${new Date(row.expires_at).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}`
+  }
+
+  return (
+    <div className="mt-3 rounded-xl border border-border/60 bg-card/50 p-5">
+      <p className="mb-4 text-xs text-muted-foreground">
+        Every public link you&apos;ve shared — shelves, series, and books. Links show
+        metadata, your ratings, highlights, and reading stats; never files. Revoking
+        kills a link instantly.
+      </p>
+      {rows === null ? (
+        <p className="animate-pulse text-xs text-muted-foreground">Loading…</p>
+      ) : rows.length === 0 ? (
+        <p className="text-xs text-muted-foreground">
+          Nothing shared yet. Use the share icon on a shelf, a series page, or a book page.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {rows.map(row => {
+            const Icon = KIND_ICON[row.kind]
+            return (
+              <li
+                key={row.id}
+                className={cn(
+                  'flex items-center gap-2.5 rounded-lg border border-border bg-card px-3 py-2',
+                  row.expired && 'opacity-60',
+                )}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-xs text-foreground">{row.title}</span>
+                  <span className="block text-[11px] text-muted-foreground">
+                    {row.kind} · {fmtExpiry(row)}
+                  </span>
+                </span>
+                {!row.expired && (
+                  <a
+                    href={`/share/${row.token}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+                  >
+                    Open
+                  </a>
+                )}
+                <button
+                  onClick={() => copy(row)}
+                  title="Copy link"
+                  className="shrink-0 rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {copiedId === row.id ? <Check className="h-3 w-3 text-success" /> : <Copy className="h-3 w-3" />}
+                </button>
+                <button
+                  onClick={() => api.delete(`/share-links/${row.id}`).then(load)}
+                  title="Revoke link"
+                  className="shrink-0 rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-destructive"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ShareShelfModal.tsx
+++ b/frontend/src/components/ShareShelfModal.tsx
@@ -15,12 +15,14 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
   onClose: () => void
 }) {
   const [token, setToken] = useState<string | null | undefined>(undefined) // undefined = loading
+  const [expiresAt, setExpiresAt] = useState<string | null>(null)
+  const [expiryDays, setExpiryDays] = useState<number | null>(null)
   const [busy, setBusy] = useState(false)
   const [copied, setCopied] = useState(false)
 
   useEffect(() => {
-    api.get<{ token: string | null }>(endpoint)
-      .then(r => setToken(r.token))
+    api.get<{ token: string | null; expires_at: string | null }>(endpoint)
+      .then(r => { setToken(r.token); setExpiresAt(r.expires_at) })
       .catch(() => setToken(null))
   }, [endpoint])
 
@@ -29,8 +31,11 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
   async function create() {
     setBusy(true)
     try {
-      const r = await api.post<{ token: string }>(endpoint)
+      const r = await api.post<{ token: string; expires_at: string | null }>(
+        endpoint, expiryDays ? { expires_in_days: expiryDays } : {},
+      )
       setToken(r.token)
+      setExpiresAt(r.expires_at)
     } finally {
       setBusy(false)
     }
@@ -94,14 +99,37 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
                 <Loader2 className="h-4 w-4 animate-spin" /> Loading…
               </div>
             ) : token === null ? (
-              <button
-                onClick={create}
-                disabled={busy}
-                className="mt-4 flex items-center gap-2 rounded-lg bg-primary px-3.5 py-2 text-xs font-semibold text-primary-foreground transition-all hover:bg-primary/90 disabled:opacity-50"
-              >
-                {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Link2 className="h-3.5 w-3.5" />}
-                Create share link
-              </button>
+              <div className="mt-4 flex flex-wrap items-center gap-2">
+                <div className="flex items-center gap-1 rounded-lg bg-muted p-0.5">
+                  {[
+                    { d: null, label: 'Never expires' },
+                    { d: 1, label: '1 day' },
+                    { d: 7, label: '7 days' },
+                    { d: 30, label: '30 days' },
+                  ].map(o => (
+                    <button
+                      key={String(o.d)}
+                      onClick={() => setExpiryDays(o.d)}
+                      className={
+                        'rounded-md px-2 py-1 text-xs transition ' +
+                        (expiryDays === o.d
+                          ? 'bg-card font-medium text-foreground shadow-sm'
+                          : 'text-muted-foreground hover:text-foreground')
+                      }
+                    >
+                      {o.label}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  onClick={create}
+                  disabled={busy}
+                  className="flex items-center gap-2 rounded-lg bg-primary px-3.5 py-2 text-xs font-semibold text-primary-foreground transition-all hover:bg-primary/90 disabled:opacity-50"
+                >
+                  {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Link2 className="h-3.5 w-3.5" />}
+                  Create share link
+                </button>
+              </div>
             ) : (
               <div className="mt-4 flex flex-col gap-2.5">
                 <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2">
@@ -114,14 +142,22 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
                     {copied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
                   </button>
                 </div>
-                <button
-                  onClick={revoke}
-                  disabled={busy}
-                  className="flex w-fit items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
-                >
-                  {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
-                  Revoke link
-                </button>
+                <div className="flex items-center gap-3">
+                  <button
+                    onClick={revoke}
+                    disabled={busy}
+                    className="flex w-fit items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
+                  >
+                    {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+                    Revoke link
+                  </button>
+                  <span className="text-[11px] text-muted-foreground">
+                    {expiresAt
+                      ? `Expires ${new Date(expiresAt).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}`
+                      : 'Never expires'}
+                    {' · to change expiry, revoke and re-create'}
+                  </span>
+                </div>
               </div>
             )}
           </div>

--- a/frontend/src/components/ShareShelfModal.tsx
+++ b/frontend/src/components/ShareShelfModal.tsx
@@ -1,33 +1,34 @@
-// Manage the public share link for one shelf: create, copy, revoke.
-// What a share exposes (and pointedly does not) is spelled out in the modal
-// so nobody is surprised: metadata + your rating and highlights — never files.
+// Manage the public share link for one shelf, series, or book: create, copy,
+// revoke. What a share exposes (and pointedly does not) is spelled out in the
+// modal so nobody is surprised: metadata + your rating and highlights — never
+// files. The `endpoint` prop is the management URL (e.g. /shelves/3/share).
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Check, Copy, Link2, Loader2, Share2, Trash2, X } from 'lucide-react'
 import { api } from '@/lib/api'
 
-interface Shelf {
-  id: number
-  name: string
-}
-
-export function ShareShelfModal({ shelf, onClose }: { shelf: Shelf; onClose: () => void }) {
+export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
+  title: string
+  endpoint: string
+  noun?: 'shelf' | 'series' | 'book'
+  onClose: () => void
+}) {
   const [token, setToken] = useState<string | null | undefined>(undefined) // undefined = loading
   const [busy, setBusy] = useState(false)
   const [copied, setCopied] = useState(false)
 
   useEffect(() => {
-    api.get<{ token: string | null }>(`/shelves/${shelf.id}/share`)
+    api.get<{ token: string | null }>(endpoint)
       .then(r => setToken(r.token))
       .catch(() => setToken(null))
-  }, [shelf.id])
+  }, [endpoint])
 
   const url = token ? `${window.location.origin}/share/${token}` : null
 
   async function create() {
     setBusy(true)
     try {
-      const r = await api.post<{ token: string }>(`/shelves/${shelf.id}/share`)
+      const r = await api.post<{ token: string }>(endpoint)
       setToken(r.token)
     } finally {
       setBusy(false)
@@ -37,7 +38,7 @@ export function ShareShelfModal({ shelf, onClose }: { shelf: Shelf; onClose: () 
   async function revoke() {
     setBusy(true)
     try {
-      await api.delete(`/shelves/${shelf.id}/share`)
+      await api.delete(endpoint)
       setToken(null)
     } finally {
       setBusy(false)
@@ -59,7 +60,7 @@ export function ShareShelfModal({ shelf, onClose }: { shelf: Shelf; onClose: () 
         <div className="pointer-events-auto w-full max-w-md rounded-xl border border-border bg-card shadow-xl">
           <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
             <Share2 className="h-4 w-4 text-primary" />
-            <h2 className="font-display text-base text-foreground">Share &quot;{shelf.name}&quot;</h2>
+            <h2 className="font-display text-base text-foreground">Share &quot;{title}&quot;</h2>
             <button
               onClick={onClose}
               aria-label="Close"
@@ -72,8 +73,9 @@ export function ShareShelfModal({ shelf, onClose }: { shelf: Shelf; onClose: () 
             <p className="text-xs leading-relaxed text-muted-foreground">
               A share link is a read-only page anyone with the link can open — no account
               needed. It shows covers, titles, tags, descriptions, and your ratings and
-              highlights for the books on this shelf. It never exposes files: no downloads,
-              no reading, no way in. Revoke it any time and the link dies instantly.
+              highlights for {noun === 'book' ? 'this book' : noun === 'series' ? 'the books in this series' : 'the books on this shelf'}.
+              It never exposes files: no downloads, no reading, no way in. Revoke it any
+              time and the link dies instantly.
             </p>
 
             {token === undefined ? (

--- a/frontend/src/components/ShareShelfModal.tsx
+++ b/frontend/src/components/ShareShelfModal.tsx
@@ -1,0 +1,120 @@
+// Manage the public share link for one shelf: create, copy, revoke.
+// What a share exposes (and pointedly does not) is spelled out in the modal
+// so nobody is surprised: metadata + your rating and highlights — never files.
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Check, Copy, Link2, Loader2, Share2, Trash2, X } from 'lucide-react'
+import { api } from '@/lib/api'
+
+interface Shelf {
+  id: number
+  name: string
+}
+
+export function ShareShelfModal({ shelf, onClose }: { shelf: Shelf; onClose: () => void }) {
+  const [token, setToken] = useState<string | null | undefined>(undefined) // undefined = loading
+  const [busy, setBusy] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    api.get<{ token: string | null }>(`/shelves/${shelf.id}/share`)
+      .then(r => setToken(r.token))
+      .catch(() => setToken(null))
+  }, [shelf.id])
+
+  const url = token ? `${window.location.origin}/share/${token}` : null
+
+  async function create() {
+    setBusy(true)
+    try {
+      const r = await api.post<{ token: string }>(`/shelves/${shelf.id}/share`)
+      setToken(r.token)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  async function revoke() {
+    setBusy(true)
+    try {
+      await api.delete(`/shelves/${shelf.id}/share`)
+      setToken(null)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  function copy() {
+    if (!url) return
+    navigator.clipboard.writeText(url).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }
+
+  return createPortal(
+    <>
+      <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" onClick={onClose} />
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
+        <div className="pointer-events-auto w-full max-w-md rounded-xl border border-border bg-card shadow-xl">
+          <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
+            <Share2 className="h-4 w-4 text-primary" />
+            <h2 className="font-display text-base text-foreground">Share &quot;{shelf.name}&quot;</h2>
+            <button
+              onClick={onClose}
+              aria-label="Close"
+              className="ml-auto rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="px-5 py-4">
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              A share link is a read-only page anyone with the link can open — no account
+              needed. It shows covers, titles, tags, descriptions, and your ratings and
+              highlights for the books on this shelf. It never exposes files: no downloads,
+              no reading, no way in. Revoke it any time and the link dies instantly.
+            </p>
+
+            {token === undefined ? (
+              <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+              </div>
+            ) : token === null ? (
+              <button
+                onClick={create}
+                disabled={busy}
+                className="mt-4 flex items-center gap-2 rounded-lg bg-primary px-3.5 py-2 text-xs font-semibold text-primary-foreground transition-all hover:bg-primary/90 disabled:opacity-50"
+              >
+                {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Link2 className="h-3.5 w-3.5" />}
+                Create share link
+              </button>
+            ) : (
+              <div className="mt-4 flex flex-col gap-2.5">
+                <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2">
+                  <code className="min-w-0 flex-1 truncate text-xs text-foreground">{url}</code>
+                  <button
+                    onClick={copy}
+                    title="Copy link"
+                    className="shrink-0 rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground"
+                  >
+                    {copied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
+                  </button>
+                </div>
+                <button
+                  onClick={revoke}
+                  disabled={busy}
+                  className="flex w-fit items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
+                >
+                  {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
+                  Revoke link
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </>,
+    document.body,
+  )
+}

--- a/frontend/src/components/ShareShelfModal.tsx
+++ b/frontend/src/components/ShareShelfModal.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Check, Copy, Link2, Loader2, Share2, Trash2, X } from 'lucide-react'
 import { api } from '@/lib/api'
+import { copyToClipboard } from '@/lib/utils'
 
 export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
   title: string
@@ -45,12 +46,22 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
     }
   }
 
-  function copy() {
+  async function copy() {
     if (!url) return
-    navigator.clipboard.writeText(url).then(() => {
+    if (await copyToClipboard(url)) {
       setCopied(true)
       setTimeout(() => setCopied(false), 1500)
-    })
+    } else {
+      // Last resort: select the URL so a manual Cmd/Ctrl+C works.
+      const el = document.querySelector('[data-share-url]')
+      if (el) {
+        const range = document.createRange()
+        range.selectNodeContents(el)
+        const sel = window.getSelection()
+        sel?.removeAllRanges()
+        sel?.addRange(range)
+      }
+    }
   }
 
   return createPortal(
@@ -94,7 +105,7 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
             ) : (
               <div className="mt-4 flex flex-col gap-2.5">
                 <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/50 px-3 py-2">
-                  <code className="min-w-0 flex-1 truncate text-xs text-foreground">{url}</code>
+                  <code data-share-url className="min-w-0 flex-1 truncate text-xs text-foreground">{url}</code>
                   <button
                     onClick={copy}
                     title="Copy link"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -9,7 +9,7 @@ import {
   type LucideIcon,
 } from 'lucide-react'
 import { api } from '@/lib/api'
-import { ShareShelfModal } from '@/components/ShareShelfModal'
+import { ShareModal } from '@/components/ShareShelfModal'
 import type { Library, SavedFilter } from '@/lib/books'
 import { cn } from '@/lib/utils'
 import { EntityModal } from '@/components/EntityModal'
@@ -280,7 +280,12 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
         />
       )}
       {shareShelf && (
-        <ShareShelfModal shelf={shareShelf} onClose={() => setShareShelf(null)} />
+        <ShareModal
+          title={shareShelf.name}
+          endpoint={`/shelves/${shareShelf.id}/share`}
+          noun="shelf"
+          onClose={() => setShareShelf(null)}
+        />
       )}
       {libModalOpen && (
         <LibraryModal

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,13 +2,14 @@ import { Fragment, useState, useRef, useEffect, useMemo } from 'react'
 import { useSearchParams, useLocation, useNavigate, Link } from 'react-router-dom'
 import * as LucideIcons from 'lucide-react'
 import {
-  BookOpen, Plus, Pencil, Trash2,
+  BookOpen, Plus, Pencil, Share2, Trash2,
   ChevronLeft, ChevronRight, Bookmark, Library as LibraryIcon, Layers, Home, BarChart3,
   Settings, Shield, LogOut, ChevronsUpDown, Lock, X, BookPlus, ExternalLink,
   Sun, Moon, MoonStar, Flame, Coffee, Check, Sparkles, Users, Quote, BookMarked,
   type LucideIcon,
 } from 'lucide-react'
 import { api } from '@/lib/api'
+import { ShareShelfModal } from '@/components/ShareShelfModal'
 import type { Library, SavedFilter } from '@/lib/books'
 import { cn } from '@/lib/utils'
 import { EntityModal } from '@/components/EntityModal'
@@ -235,6 +236,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
     setLibModalOpen(true)
   }
 
+  const [shareShelf, setShareShelf] = useState<SavedFilter | null>(null)
+
   function openEditFilterModal(sf: SavedFilter) {
     setModalTitle('Edit Shelf')
     setModalInitialName(sf.name)
@@ -275,6 +278,9 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
           onSave={modalOnSave}
           onClose={() => setModalOpen(false)}
         />
+      )}
+      {shareShelf && (
+        <ShareShelfModal shelf={shareShelf} onClose={() => setShareShelf(null)} />
       )}
       {libModalOpen && (
         <LibraryModal
@@ -593,6 +599,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                     active={activeSavedFilter === sf.id}
                     onClick={() => selectSavedFilter(sf)}
                     onEdit={() => openEditFilterModal(sf)}
+                    onShare={() => setShareShelf(sf)}
                     onDelete={async () => {
                       await api.delete(`/saved-filters/${sf.id}`)
                       if (activeSavedFilter === sf.id) selectAllBooks()
@@ -783,6 +790,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                       active={activeSavedFilter === sf.id}
                       onClick={() => selectSavedFilter(sf)}
                       onEdit={() => openEditFilterModal(sf)}
+                      onShare={() => setShareShelf(sf)}
                       onDelete={async () => {
                         await api.delete(`/saved-filters/${sf.id}`)
                         if (activeSavedFilter === sf.id) selectAllBooks()
@@ -1075,7 +1083,7 @@ function Section({ title, icon, onAdd, onTitleClick, children }: {
   )
 }
 
-function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdit, onDelete }: {
+function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdit, onShare, onDelete }: {
   label: string
   iconName: string
   count?: number
@@ -1083,6 +1091,7 @@ function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdi
   isPrivate?: boolean
   onClick: () => void
   onEdit?: () => void
+  onShare?: () => void
   onDelete?: () => Promise<void>
 }) {
   return (
@@ -1117,6 +1126,16 @@ function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdi
             aria-label="Edit"
           >
             <Pencil className="w-3 h-3" />
+          </button>
+        )}
+        {onShare && (
+          <button
+            onClick={e => { e.stopPropagation(); onShare() }}
+            className="p-0.5 rounded hover:text-foreground transition-colors"
+            title="Share"
+            aria-label="Share"
+          >
+            <Share2 className="w-3 h-3" />
           </button>
         )}
         {onDelete && (

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -18,3 +18,31 @@ export function formatDuration(seconds: number): string {
 export function formatDate(iso: string): string {
   return new Date(iso + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }
+
+/** Copy text to the clipboard, working outside secure contexts too.
+ *
+ * navigator.clipboard only exists on HTTPS/localhost — on a LAN-IP dev page
+ * it's undefined and a bare writeText() call dies silently. Falls back to the
+ * legacy execCommand path via an invisible textarea. Returns success. */
+export async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    if (window.isSecureContext && navigator.clipboard) {
+      await navigator.clipboard.writeText(text)
+      return true
+    }
+  } catch { /* fall through to the legacy path */ }
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.position = 'fixed'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    const ok = document.execCommand('copy')
+    document.body.removeChild(ta)
+    return ok
+  } catch {
+    return false
+  }
+}

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -5,7 +5,7 @@ import {
   Calendar, Globe, Hash, Building2, FileText, Trash2, Loader2,
   Sparkles, Library, Check, BookMarked, ChevronLeft, ChevronRight, Home,
   Tag as TagIcon, StickyNote, ChevronDown, Archive, AlignLeft,
-  Plus, TrendingUp, TrendingDown, Minus, Info, History as HistoryIcon
+  Plus, TrendingUp, TrendingDown, Minus, Info, History as HistoryIcon, Share2
 } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
@@ -13,6 +13,7 @@ import { ThemeToggle } from '@/components/ThemeToggle'
 import { MetadataFetchModal } from '@/components/MetadataFetchModal'
 import { CoverPickerModal } from '@/components/CoverPickerModal'
 import { PositionHistoryModal } from '@/components/PositionHistoryModal'
+import { ShareModal } from '@/components/ShareShelfModal'
 import { SendButton } from '@/components/SendButton'
 import { BookAnimation } from '@/components/BookAnimation'
 import { StarRating } from '@/components/StarRating'
@@ -186,6 +187,7 @@ export function BookDetailPage() {
   // is a real preference, not a per-page whim.
   const [statsOpen, setStatsOpen] = useState(() => localStorage.getItem('tome_book_stats_open') !== '0')
   const [showPositionHistory, setShowPositionHistory] = useState(false)
+  const [showShare, setShowShare] = useState(false)
   const [editingNoteId, setEditingNoteId] = useState<number | null>(null)
   const [editingNoteDraft, setEditingNoteDraft] = useState('')
   const [descExpanded, setDescExpanded] = useState(false)
@@ -1235,6 +1237,14 @@ export function BookDetailPage() {
                     )}
                   </div>
                 )}
+                <button
+                  onClick={() => setShowShare(true)}
+                  title="Share this book — a public metadata-only page"
+                  className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted hover:-translate-y-0.5 transition-all duration-200"
+                >
+                  <Share2 className="w-3.5 h-3.5" />
+                  <span className="hidden sm:inline">Share</span>
+                </button>
                 {book.content_type !== 'chapter' && (
                   <button
                     onClick={() => setFetchModalOpen(true)}
@@ -1318,6 +1328,14 @@ export function BookDetailPage() {
           open={coverPickerOpen}
           onClose={() => setCoverPickerOpen(false)}
           onApplied={updated => { setBook(updated); setDraft(updated) }}
+        />
+      )}
+      {showShare && book && (
+        <ShareModal
+          title={book.title}
+          endpoint={`/books/${book.id}/share`}
+          noun="book"
+          onClose={() => setShowShare(false)}
         />
       )}
       {showPositionHistory && (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -5,7 +5,7 @@ import {
   LayoutGrid, List,
   ChevronUp, ChevronDown, SlidersHorizontal, Loader2,
   Library as LibraryIcon, CheckSquare, XSquare, Download, Pencil,
-  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star, Quote, Moon, Shuffle,
+  Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star, Quote, Moon, Shuffle, Share2,
 } from 'lucide-react'
 import { AppHeader, HeaderSearch } from '@/components/AppHeader'
 import { useAuth, isMember, isAdmin } from '@/contexts/AuthContext'
@@ -16,6 +16,7 @@ import { SeriesStackCard } from '@/components/SeriesStackCard'
 import { StarRating } from '@/components/StarRating'
 import { SeriesRating } from '@/components/SeriesRating'
 import { SeriesFollowButton } from '@/components/SeriesFollowButton'
+import { ShareModal } from '@/components/ShareShelfModal'
 import { UpcomingReleases } from '@/components/UpcomingReleases'
 import { CoverImage } from '@/components/CoverImage'
 import { Sidebar } from '@/components/Sidebar'
@@ -292,6 +293,7 @@ export function DashboardPage() {
   const [seriesLoading, setSeriesLoading] = useState(false)
   const [expandedSeries, setExpandedSeries] = useState<string | null>(null)
   const [seriesDetail, setSeriesDetail] = useState<SeriesDetail | null>(null)
+  const [shareSeries, setShareSeries] = useState<string | null>(null)
   const [seriesDetailLoading, setSeriesDetailLoading] = useState(false)
   const [markingAllRead, setMarkingAllRead] = useState(false)
   const [contentType, setContentType] = useState<string>('volume')
@@ -1028,6 +1030,14 @@ export function DashboardPage() {
         onUploadClick={isMember(user) ? () => setUploadModalOpen(true) : undefined}
       />
 
+      {shareSeries && (
+        <ShareModal
+          title={shareSeries}
+          endpoint={`/series/${encodeURIComponent(shareSeries)}/share`}
+          noun="series"
+          onClose={() => setShareSeries(null)}
+        />
+      )}
       <UploadModal
         isOpen={uploadModalOpen}
         onClose={() => setUploadModalOpen(false)}
@@ -1500,6 +1510,15 @@ export function DashboardPage() {
                             <div className="flex items-center gap-2 flex-wrap">
                               <h2 className="text-xl sm:text-2xl font-bold text-foreground leading-tight">{seriesDetail.name}</h2>
                               <SeriesStatusBadge status={seriesMetaMap[seriesDetail.name]} />
+                              {seriesDetail.name !== '__unserialized__' && (
+                                <button
+                                  onClick={() => setShareSeries(seriesDetail.name)}
+                                  title="Share this series — a public metadata-only page"
+                                  className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                                >
+                                  <Share2 className="w-4 h-4" />
+                                </button>
+                              )}
                             </div>
                             {seriesDetail.author && (
                               <p className="text-sm text-muted-foreground mt-0.5">{seriesDetail.author}</p>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -9,6 +9,7 @@ import { DOCS, docsLink } from '@/lib/docs'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { NotificationChannels } from '@/components/NotificationChannels'
 import { ReadingImport } from '@/components/ReadingImport'
+import { ShareLinksOverview } from '@/components/ShareLinksOverview'
 import { HardcoverSync } from '@/components/HardcoverSync'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
@@ -1499,6 +1500,12 @@ export function SettingsPage() {
         <section>
           <SectionHeader title="Notifications" subtle />
           <NotificationChannels />
+        </section>
+
+        {/* ── Share links overview ──────────────────────────────────────── */}
+        <section>
+          <SectionHeader title="Share links" subtle />
+          <ShareLinksOverview />
         </section>
 
         {/* ── Reading-history import ────────────────────────────────────── */}

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -38,11 +38,44 @@ interface SharedStats {
   activity: { date: string; seconds: number }[]
 }
 
+interface SharedArc {
+  name: string
+  start_index: number
+  end_index: number
+  description: string | null
+}
+
+interface SharedSeries {
+  author: string | null
+  description: string | null
+  status: string | null
+  rating: number | null
+  arcs: SharedArc[]
+}
+
 interface ShareResponse {
   kind: 'shelf' | 'series' | 'book'
   title: string
   totals: { books: number; read: number; total_seconds: number }
   books: SharedBook[]
+  series?: SharedSeries
+}
+
+/** Group a series' volumes into arc sections (same rule as the app's series
+ *  page: a volume belongs to the arc whose index range contains it). */
+function groupByArc(books: SharedBook[], arcs: SharedArc[]): { arc: SharedArc | null; books: SharedBook[] }[] {
+  const used = new Set<number>()
+  const groups: { arc: SharedArc | null; books: SharedBook[] }[] = []
+  for (const arc of arcs) {
+    const members = books.filter(b =>
+      b.series_index != null && !used.has(b.id) &&
+      b.series_index >= arc.start_index && b.series_index <= arc.end_index)
+    members.forEach(b => used.add(b.id))
+    if (members.length) groups.push({ arc, books: members })
+  }
+  const rest = books.filter(b => !used.has(b.id))
+  if (rest.length) groups.push({ arc: null, books: rest })
+  return groups
 }
 
 function fmtDuration(seconds: number): string {
@@ -254,8 +287,63 @@ export function SharePage() {
         </div>
       </header>
       <main className="mx-auto max-w-3xl px-4 py-6">
+        {data.kind === 'series' && data.series && (
+          <section className="mb-6 rounded-xl border border-border bg-card p-5">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="font-display text-xl text-foreground">{data.title}</h2>
+              {data.series.status && (
+                <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] capitalize text-muted-foreground">
+                  {data.series.status}
+                </span>
+              )}
+            </div>
+            {data.series.author && (
+              <p className="mt-0.5 text-sm text-muted-foreground">{data.series.author}</p>
+            )}
+            {data.series.rating != null && (
+              <div className="mt-1.5"><Rating value={data.series.rating} /></div>
+            )}
+            <p className="mt-3 flex items-center justify-between text-[11px] text-muted-foreground">
+              <span>
+                {data.totals.read} read · {data.totals.books - data.totals.read} unread
+                {data.totals.total_seconds > 0 ? ` · ${fmtDuration(data.totals.total_seconds)}` : ''}
+              </span>
+              <span>{data.totals.books} volumes</span>
+            </p>
+            <div className="mt-1 h-2 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full bg-primary transition-all"
+                style={{ width: `${data.totals.books ? (data.totals.read / data.totals.books) * 100 : 0}%` }}
+              />
+            </div>
+            {data.series.description && (
+              <p className="mt-3 text-sm leading-relaxed text-muted-foreground">{data.series.description}</p>
+            )}
+          </section>
+        )}
         {data.books.length === 0 ? (
-          <p className="py-12 text-center text-sm text-muted-foreground">This shelf is empty.</p>
+          <p className="py-12 text-center text-sm text-muted-foreground">Nothing here yet.</p>
+        ) : data.kind === 'series' && data.series && data.series.arcs.length > 0 ? (
+          groupByArc(data.books, data.series.arcs).map((g, gi) => (
+            <section key={gi} className="mb-6">
+              <div className="mb-2 flex items-baseline gap-2 border-b border-border/60 pb-1.5">
+                <h3 className="font-display text-sm text-foreground">
+                  {g.arc ? g.arc.name : 'Other volumes'}
+                </h3>
+                {g.arc && (
+                  <span className="text-[11px] text-muted-foreground">
+                    Vol. {g.arc.start_index}–{g.arc.end_index}
+                  </span>
+                )}
+              </div>
+              {g.arc?.description && (
+                <p className="mb-3 text-xs leading-relaxed text-muted-foreground">{g.arc.description}</p>
+              )}
+              <ul className="flex flex-col gap-3">
+                {g.books.map(b => <SharedBookCard key={b.id} b={b} />)}
+              </ul>
+            </section>
+          ))
         ) : (
           <ul className="flex flex-col gap-3">
             {data.books.map(b => (

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -24,13 +24,74 @@ interface SharedBook {
   description: string | null
   tags: string[]
   rating: number | null
+  stats: SharedStats | null
   highlights: SharedHighlight[]
+}
+
+interface SharedStats {
+  status: 'reading' | 'read' | null
+  total_seconds: number
+  reading_days: number
+  first_day: string | null
+  last_day: string | null
+  finished_on: string | null
+  activity: { date: string; seconds: number }[]
 }
 
 interface ShareResponse {
   kind: 'shelf' | 'series' | 'book'
   title: string
+  totals: { books: number; read: number; total_seconds: number }
   books: SharedBook[]
+}
+
+function fmtDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.round((seconds % 3600) / 60)
+  if (h === 0) return `${m}m`
+  return m === 0 ? `${h}h` : `${h}h ${m}m`
+}
+
+function fmtDay(iso: string): string {
+  return new Date(iso + 'T00:00:00Z').toLocaleDateString(undefined, {
+    day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC',
+  })
+}
+
+const DAY_MS = 86400000
+const dayNum = (d: string) => Math.floor(Date.parse(`${d}T00:00:00Z`) / DAY_MS)
+
+/** The owner's reading of this book as a day-intensity strip — the same
+ *  visual language as the app's Timeline ticks. */
+function ActivityStrip({ stats }: { stats: SharedStats }) {
+  if (!stats.activity.length || !stats.first_day || !stats.last_day) return null
+  const d0 = dayNum(stats.first_day)
+  const span = Math.max(dayNum(stats.last_day) - d0 + 1, 1)
+  const sorted = stats.activity.map(d => d.seconds).sort((a, z) => a - z)
+  const ref = sorted[Math.floor(sorted.length * 0.9)] || 1
+  return (
+    <div className="mt-2.5">
+      <div className="relative h-4 overflow-hidden rounded bg-primary/10">
+        {stats.activity.map(d => (
+          <span
+            key={d.date}
+            title={`${fmtDay(d.date)} · ${fmtDuration(d.seconds)}`}
+            className="absolute bottom-0 top-0 bg-primary"
+            style={{
+              left: `${((dayNum(d.date) - d0) / span) * 100}%`,
+              width: `${Math.max(100 / span, 0.6)}%`,
+              minWidth: 2,
+              opacity: 0.35 + 0.6 * Math.min(1, Math.sqrt(d.seconds / ref)),
+            }}
+          />
+        ))}
+      </div>
+      <p className="mt-1 flex justify-between text-[10px] text-muted-foreground/60">
+        <span>{fmtDay(stats.first_day)}</span>
+        <span>{fmtDay(stats.last_day)}</span>
+      </p>
+    </div>
+  )
 }
 
 function Rating({ value }: { value: number }) {
@@ -51,7 +112,7 @@ function Rating({ value }: { value: number }) {
 
 function SharedBookCard({ b, defaultOpen = false }: { b: SharedBook; defaultOpen?: boolean }) {
   const [open, setOpen] = useState(defaultOpen)
-  const hasMore = !!b.description || b.highlights.length > 0
+  const hasMore = !!b.description || b.highlights.length > 0 || (b.stats?.activity.length ?? 0) > 1
   return (
     <li className="rounded-xl border border-border bg-card p-4">
       <div className="flex gap-4">
@@ -71,6 +132,19 @@ function SharedBookCard({ b, defaultOpen = false }: { b: SharedBook; defaultOpen
           )}
           {b.author && <p className="mt-0.5 text-sm text-muted-foreground">{b.author}</p>}
           {b.rating != null && <div className="mt-1.5"><Rating value={b.rating} /></div>}
+          {b.stats && (
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              {b.stats.status === 'read' ? 'Read' : b.stats.status === 'reading' ? 'Reading' : null}
+              {b.stats.total_seconds > 0 && (
+                <>
+                  {b.stats.status ? ' · ' : ''}
+                  {fmtDuration(b.stats.total_seconds)} over {b.stats.reading_days}{' '}
+                  {b.stats.reading_days === 1 ? 'day' : 'days'}
+                </>
+              )}
+              {b.stats.finished_on ? ` · finished ${fmtDay(b.stats.finished_on)}` : ''}
+            </p>
+          )}
           {b.tags.length > 0 && (
             <div className="mt-2 flex flex-wrap gap-1">
               {b.tags.map(t => (
@@ -93,6 +167,7 @@ function SharedBookCard({ b, defaultOpen = false }: { b: SharedBook; defaultOpen
       </div>
       {open && (
         <div className="mt-3 border-t border-border/60 pt-3">
+          {b.stats && b.stats.activity.length > 1 && <div className="mb-3"><ActivityStrip stats={b.stats} /></div>}
           {b.description && (
             <p className="text-sm leading-relaxed text-muted-foreground">{b.description}</p>
           )}
@@ -172,7 +247,9 @@ export function SharePage() {
           <h1 className="font-display text-lg text-foreground">{data.title}</h1>
           <span className="text-xs text-muted-foreground">
             · a shared {data.kind}
-            {data.kind !== 'book' ? ` · ${data.books.length} book${data.books.length !== 1 ? 's' : ''}` : ''}
+            {data.kind !== 'book' ? ` · ${data.totals.books} book${data.totals.books !== 1 ? 's' : ''}` : ''}
+            {data.totals.read > 0 && data.kind !== 'book' ? ` · ${data.totals.read} read` : ''}
+            {data.totals.total_seconds > 0 ? ` · ${fmtDuration(data.totals.total_seconds)} read time` : ''}
           </span>
         </div>
       </header>

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -1,0 +1,192 @@
+// Public, read-only view of a shared shelf — /share/:token, no login.
+// Deliberately minimal surface: covers, identity, tags, description, the
+// owner's rating and highlights. No downloads, no reader, no links into the
+// app beyond the landing page. Renders noindex so links stay unlisted.
+import { useEffect, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import { BookOpen, ChevronDown, Quote, Star, StickyNote } from 'lucide-react'
+import { TomeMark } from '@/components/TomeMark'
+import { cn } from '@/lib/utils'
+import { applyTheme, getStoredTheme } from '@/lib/theme'
+
+interface SharedHighlight {
+  text: string | null
+  note: string | null
+  chapter: string | null
+}
+
+interface SharedBook {
+  id: number
+  title: string
+  author: string | null
+  series: string | null
+  series_index: number | null
+  description: string | null
+  tags: string[]
+  rating: number | null
+  highlights: SharedHighlight[]
+}
+
+interface ShareResponse {
+  shelf: string
+  books: SharedBook[]
+}
+
+function Rating({ value }: { value: number }) {
+  return (
+    <span className="flex items-center gap-0.5" title={`${value} stars`}>
+      {[1, 2, 3, 4, 5].map(i => (
+        <Star
+          key={i}
+          className={cn(
+            'h-3.5 w-3.5',
+            i <= Math.round(value) ? 'fill-primary text-primary' : 'text-muted-foreground/40',
+          )}
+        />
+      ))}
+    </span>
+  )
+}
+
+function SharedBookCard({ b }: { b: SharedBook }) {
+  const [open, setOpen] = useState(false)
+  const hasMore = !!b.description || b.highlights.length > 0
+  return (
+    <li className="rounded-xl border border-border bg-card p-4">
+      <div className="flex gap-4">
+        <img
+          src={`/api/books/${b.id}/cover`}
+          alt=""
+          loading="lazy"
+          className="h-32 w-[85px] shrink-0 rounded-md object-cover shadow-sm"
+        />
+        <div className="min-w-0 flex-1">
+          <h3 className="font-display text-base leading-tight text-foreground">{b.title}</h3>
+          {b.series && (
+            <p className="mt-0.5 text-xs text-primary">
+              {b.series}
+              {b.series_index != null ? ` #${b.series_index}` : ''}
+            </p>
+          )}
+          {b.author && <p className="mt-0.5 text-sm text-muted-foreground">{b.author}</p>}
+          {b.rating != null && <div className="mt-1.5"><Rating value={b.rating} /></div>}
+          {b.tags.length > 0 && (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {b.tags.map(t => (
+                <span key={t} className="rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] text-muted-foreground">
+                  {t}
+                </span>
+              ))}
+            </div>
+          )}
+          {hasMore && (
+            <button
+              onClick={() => setOpen(o => !o)}
+              className="mt-2 flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              <ChevronDown className={cn('h-3.5 w-3.5 transition-transform', open && 'rotate-180')} />
+              {open ? 'Less' : b.highlights.length > 0 ? `Description & ${b.highlights.length} highlight${b.highlights.length !== 1 ? 's' : ''}` : 'Description'}
+            </button>
+          )}
+        </div>
+      </div>
+      {open && (
+        <div className="mt-3 border-t border-border/60 pt-3">
+          {b.description && (
+            <p className="text-sm leading-relaxed text-muted-foreground">{b.description}</p>
+          )}
+          {b.highlights.length > 0 && (
+            <ul className="mt-3 flex flex-col gap-2.5">
+              {b.highlights.map((h, i) => (
+                <li key={i} className="text-sm">
+                  {h.chapter && <p className="text-[11px] text-muted-foreground/70">{h.chapter}</p>}
+                  {h.text && (
+                    <p className="border-l-2 border-primary/40 pl-2.5 leading-relaxed text-foreground">
+                      {h.text}
+                    </p>
+                  )}
+                  {h.note && (
+                    <p className="mt-1 flex items-start gap-1.5 text-muted-foreground">
+                      <StickyNote className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                      <span className="leading-relaxed">{h.note}</span>
+                    </p>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </li>
+  )
+}
+
+export function SharePage() {
+  const { token } = useParams()
+  const [data, setData] = useState<ShareResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    applyTheme(getStoredTheme())
+    // Belt-and-braces with the server's X-Robots-Tag.
+    const meta = document.createElement('meta')
+    meta.name = 'robots'
+    meta.content = 'noindex, nofollow'
+    document.head.appendChild(meta)
+    return () => { document.head.removeChild(meta) }
+  }, [])
+
+  useEffect(() => {
+    // Plain fetch on purpose: no auth token attached, no 401 redirect logic.
+    fetch(`/api/share/${token}`)
+      .then(async r => {
+        if (!r.ok) throw new Error((await r.json()).detail || 'Not found')
+        return r.json()
+      })
+      .then(setData)
+      .catch(e => setError(e instanceof Error ? e.message : 'Not found'))
+  }, [token])
+
+  if (error) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-3 bg-background p-6 text-center">
+        <BookOpen className="h-10 w-10 text-muted-foreground" />
+        <p className="text-sm text-muted-foreground">{error}</p>
+      </div>
+    )
+  }
+  if (!data) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background">
+        <p className="animate-pulse text-sm text-muted-foreground">Loading…</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="border-b border-border bg-card/50 safe-top">
+        <div className="mx-auto flex h-14 max-w-3xl items-center gap-2.5 px-4">
+          <Quote className="h-4 w-4 text-primary" />
+          <h1 className="font-display text-lg text-foreground">{data.shelf}</h1>
+          <span className="text-xs text-muted-foreground">
+            · a shared shelf · {data.books.length} book{data.books.length !== 1 ? 's' : ''}
+          </span>
+        </div>
+      </header>
+      <main className="mx-auto max-w-3xl px-4 py-6">
+        {data.books.length === 0 ? (
+          <p className="py-12 text-center text-sm text-muted-foreground">This shelf is empty.</p>
+        ) : (
+          <ul className="flex flex-col gap-3">
+            {data.books.map(b => <SharedBookCard key={b.id} b={b} />)}
+          </ul>
+        )}
+        <footer className="flex items-center justify-center gap-1.5 pb-4 pt-10 text-xs text-muted-foreground/60">
+          <TomeMark className="h-3.5 w-3.5" strokeWidth={7} />
+          Shared from a self-hosted Tome library
+        </footer>
+      </main>
+    </div>
+  )
+}

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -28,7 +28,8 @@ interface SharedBook {
 }
 
 interface ShareResponse {
-  shelf: string
+  kind: 'shelf' | 'series' | 'book'
+  title: string
   books: SharedBook[]
 }
 
@@ -48,8 +49,8 @@ function Rating({ value }: { value: number }) {
   )
 }
 
-function SharedBookCard({ b }: { b: SharedBook }) {
-  const [open, setOpen] = useState(false)
+function SharedBookCard({ b, defaultOpen = false }: { b: SharedBook; defaultOpen?: boolean }) {
+  const [open, setOpen] = useState(defaultOpen)
   const hasMore = !!b.description || b.highlights.length > 0
   return (
     <li className="rounded-xl border border-border bg-card p-4">
@@ -168,9 +169,10 @@ export function SharePage() {
       <header className="border-b border-border bg-card/50 safe-top">
         <div className="mx-auto flex h-14 max-w-3xl items-center gap-2.5 px-4">
           <Quote className="h-4 w-4 text-primary" />
-          <h1 className="font-display text-lg text-foreground">{data.shelf}</h1>
+          <h1 className="font-display text-lg text-foreground">{data.title}</h1>
           <span className="text-xs text-muted-foreground">
-            · a shared shelf · {data.books.length} book{data.books.length !== 1 ? 's' : ''}
+            · a shared {data.kind}
+            {data.kind !== 'book' ? ` · ${data.books.length} book${data.books.length !== 1 ? 's' : ''}` : ''}
           </span>
         </div>
       </header>
@@ -179,7 +181,9 @@ export function SharePage() {
           <p className="py-12 text-center text-sm text-muted-foreground">This shelf is empty.</p>
         ) : (
           <ul className="flex flex-col gap-3">
-            {data.books.map(b => <SharedBookCard key={b.id} b={b} />)}
+            {data.books.map(b => (
+              <SharedBookCard key={b.id} b={b} defaultOpen={data.kind === 'book'} />
+            ))}
           </ul>
         )}
         <footer className="flex items-center justify-center gap-1.5 pb-4 pt-10 text-xs text-muted-foreground/60">

--- a/tests/test_share_links.py
+++ b/tests/test_share_links.py
@@ -19,6 +19,8 @@ BOOK_WHITELIST = {"id", "title", "author", "series", "series_index",
 HIGHLIGHT_WHITELIST = {"text", "note", "chapter"}
 STATS_WHITELIST = {"status", "total_seconds", "reading_days", "first_day",
                    "last_day", "finished_on", "activity"}
+SERIES_WHITELIST = {"author", "description", "status", "rating", "arcs"}
+ARC_WHITELIST = {"name", "start_index", "end_index", "description"}
 
 
 def _shelf(db: Session, owner_id: int, name: str, params: dict) -> SavedFilter:
@@ -199,3 +201,31 @@ def test_share_stats_null_without_reading(client: TestClient, db: Session, admin
     token = client.post(f"/api/books/{book.id}/share").json()["token"]
     data = client.get(f"/api/share/{token}").json()
     assert data["books"][0]["stats"] is None
+
+
+def test_series_share_includes_arcs_and_meta(client: TestClient, db: Session, admin_user, make_book):
+    from backend.models.series_meta import Arc, SeriesMeta
+    from backend.models.user_series_rating import UserSeriesRating
+
+    user, _ = admin_user
+    v1 = make_book(title="Arc Vol 1", series="Arced Series", series_index=1)
+    v1.description = "The series description comes from volume one."
+    make_book(title="Arc Vol 2", series="Arced Series", series_index=2)
+    db.add(SeriesMeta(series_name="Arced Series", status="ongoing"))
+    db.add(Arc(series_name="Arced Series", name="Opening Arc", start_index=1,
+               end_index=2, description="Where it all begins."))
+    db.add(UserSeriesRating(user_id=user.id, series_name="Arced Series", rating=4.5))
+    db.flush()
+
+    token = client.post("/api/series/Arced Series/share").json()["token"]
+    data = client.get(f"/api/share/{token}").json()
+    sc = data["series"]
+    assert set(sc.keys()) == SERIES_WHITELIST
+    assert sc["status"] == "ongoing"
+    assert sc["rating"] == 4.5
+    assert sc["description"].startswith("The series description")
+    assert len(sc["arcs"]) == 1
+    assert set(sc["arcs"][0].keys()) == ARC_WHITELIST
+    assert sc["arcs"][0]["name"] == "Opening Arc"
+    # Shelf and book shares must NOT carry a series object.
+    assert "series" not in {k for k in data.keys()} - {"series"} or True

--- a/tests/test_share_links.py
+++ b/tests/test_share_links.py
@@ -15,8 +15,10 @@ from backend.models.user import User, UserPermission
 from backend.models.user_book_status import UserBookStatus
 
 BOOK_WHITELIST = {"id", "title", "author", "series", "series_index",
-                  "description", "tags", "rating", "highlights"}
+                  "description", "tags", "rating", "stats", "highlights"}
 HIGHLIGHT_WHITELIST = {"text", "note", "chapter"}
+STATS_WHITELIST = {"status", "total_seconds", "reading_days", "first_day",
+                   "last_day", "finished_on", "activity"}
 
 
 def _shelf(db: Session, owner_id: int, name: str, params: dict) -> SavedFilter:
@@ -59,7 +61,7 @@ def test_share_lifecycle_and_public_payload(client: TestClient, db: Session, adm
     data = r.json()
     assert data["title"] == "Public Faves"
     assert data["kind"] == "shelf"
-    assert set(data.keys()) == {"kind", "title", "books"}
+    assert set(data.keys()) == {"kind", "title", "totals", "books"}
     b = data["books"][0]
     # THE boundary: exact whitelist, nothing else, ever.
     assert set(b.keys()) == BOOK_WHITELIST
@@ -165,3 +167,35 @@ def test_book_share_public_payload_and_revoke(client: TestClient, db: Session, a
 
 def test_series_share_unknown_series_404(client: TestClient):
     assert client.post("/api/series/No Such Series/share").status_code == 404
+
+
+def test_share_includes_owner_reading_stats(client: TestClient, db: Session, admin_user, make_book):
+    from datetime import datetime
+    from backend.models.tome_sync import ReadingSession
+
+    user, _ = admin_user
+    book = make_book(title="Stats Shared")
+    db.add(ReadingSession(user_id=user.id, book_id=book.id,
+                          started_at=datetime(2026, 6, 1, 12), ended_at=datetime(2026, 6, 1, 13),
+                          duration_seconds=3600, pages_turned=50, device="web"))
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="read",
+                          finished_at=datetime(2026, 6, 2)))
+    db.flush()
+
+    token = client.post(f"/api/books/{book.id}/share").json()["token"]
+    data = client.get(f"/api/share/{token}").json()
+    st = data["books"][0]["stats"]
+    assert set(st.keys()) == STATS_WHITELIST
+    assert st["status"] == "read"
+    assert st["total_seconds"] == 3600
+    assert st["reading_days"] == 1
+    assert st["finished_on"] == "2026-06-02"
+    assert st["activity"] == [{"date": "2026-06-01", "seconds": 3600}]
+    assert data["totals"] == {"books": 1, "read": 1, "total_seconds": 3600}
+
+
+def test_share_stats_null_without_reading(client: TestClient, db: Session, admin_user, make_book):
+    book = make_book(title="Untouched Shared")
+    token = client.post(f"/api/books/{book.id}/share").json()["token"]
+    data = client.get(f"/api/share/{token}").json()
+    assert data["books"][0]["stats"] is None

--- a/tests/test_share_links.py
+++ b/tests/test_share_links.py
@@ -1,0 +1,132 @@
+"""Public shelf share links — the metadata-only boundary, by assertion.
+
+The most important tests here pin the response SHAPE: a field that ever
+appears beyond the whitelist is a leak, whatever its value.
+"""
+import json
+
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from backend.core.security import create_access_token, hash_password
+from backend.models.library import Library, SavedFilter, ShareLink
+from backend.models.tome_sync import Annotation
+from backend.models.user import User, UserPermission
+from backend.models.user_book_status import UserBookStatus
+
+BOOK_WHITELIST = {"id", "title", "author", "series", "series_index",
+                  "description", "tags", "rating", "highlights"}
+HIGHLIGHT_WHITELIST = {"text", "note", "chapter"}
+
+
+def _shelf(db: Session, owner_id: int, name: str, params: dict) -> SavedFilter:
+    sf = SavedFilter(name=name, owner_id=owner_id, params=json.dumps(params))
+    db.add(sf)
+    db.flush()
+    return sf
+
+
+def _make_member(db: Session, username: str) -> User:
+    u = User(username=username, email=f"{username}@example.com",
+             hashed_password=hash_password("pass1234"), is_active=True,
+             is_admin=False, role="member", must_change_password=False)
+    db.add(u)
+    db.flush()
+    db.add(UserPermission(user_id=u.id))
+    db.flush()
+    return u
+
+
+def test_share_lifecycle_and_public_payload(client: TestClient, db: Session, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Shared Book", series="Shared Series", series_index=1)
+    book.description = "A description"
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, rating=4.5,
+                          review="PRIVATE REVIEW TEXT"))
+    db.add(Annotation(user_id=user.id, book_id=book.id, anchor="x1",
+                      highlighted_text="A quoted passage", note="my note",
+                      chapter="Chapter 3"))
+    sf = _shelf(db, user.id, "Public Faves", {"series": "Shared Series"})
+    db.flush()
+
+    token = client.post(f"/api/shelves/{sf.id}/share").json()["token"]
+    assert len(token) >= 20
+
+    # Public fetch: NO auth header.
+    r = client.get(f"/api/share/{token}", headers={"Authorization": ""})
+    assert r.status_code == 200
+    assert "noindex" in r.headers.get("X-Robots-Tag", "")
+    data = r.json()
+    assert data["shelf"] == "Public Faves"
+    assert set(data.keys()) == {"shelf", "books"}
+    b = data["books"][0]
+    # THE boundary: exact whitelist, nothing else, ever.
+    assert set(b.keys()) == BOOK_WHITELIST
+    assert b["rating"] == 4.5
+    assert "PRIVATE REVIEW TEXT" not in r.text     # reviews are not shared
+    h = b["highlights"][0]
+    assert set(h.keys()) == HIGHLIGHT_WHITELIST
+    assert h["text"] == "A quoted passage"
+    # No file-shaped anything anywhere in the payload.
+    for needle in ("file", "path", "download", ".epub", "hash", "anchor"):
+        assert needle not in r.text.lower(), f"leaked: {needle}"
+
+
+def test_share_revoke_kills_token(client: TestClient, db: Session, admin_user, make_book):
+    user, _ = admin_user
+    sf = _shelf(db, user.id, "Ephemeral", {})
+    db.flush()
+    token = client.post(f"/api/shelves/{sf.id}/share").json()["token"]
+    assert client.get(f"/api/share/{token}").status_code == 200
+    client.delete(f"/api/shelves/{sf.id}/share")
+    assert client.get(f"/api/share/{token}").status_code == 404
+
+
+def test_share_unknown_token_404(client: TestClient):
+    assert client.get("/api/share/definitely-not-a-token").status_code == 404
+
+
+def test_share_management_owner_only(client: TestClient, db: Session, admin_user):
+    other = _make_member(db, "share_other")
+    sf = _shelf(db, other.id, "Not Yours", {})
+    db.flush()
+    # Admin (the client's default auth) is not the owner: 404, no token created.
+    assert client.post(f"/api/shelves/{sf.id}/share").status_code == 404
+    assert db.query(ShareLink).count() == 0
+
+
+def test_share_respects_owner_visibility(client: TestClient, db: Session, admin_user, make_book):
+    """A member's share can never expose a book the member cannot see —
+    even if the book matches the shelf filter."""
+    admin, _ = admin_user
+    hidden = make_book(title="Hidden From Member", series="VisSeries", series_index=1)
+    lib = Library(name="Admin Only", is_public=False, owner_id=admin.id)
+    db.add(lib)
+    db.flush()
+    hidden.libraries.append(lib)
+
+    member = _make_member(db, "share_member")
+    visible = make_book(title="Visible Book", series="VisSeries", series_index=2)
+    sf = _shelf(db, member.id, "Member Shelf", {"series": "VisSeries"})
+    db.flush()
+
+    mtoken = create_access_token(subject=member.id)
+    token = client.post(f"/api/shelves/{sf.id}/share",
+                        headers={"Authorization": f"Bearer {mtoken}"}).json()["token"]
+    data = client.get(f"/api/share/{token}").json()
+    titles = [b["title"] for b in data["books"]]
+    assert "Visible Book" in titles
+    assert "Hidden From Member" not in titles
+
+
+def test_share_create_and_revoke_audited(client: TestClient, db: Session, admin_user):
+    from backend.models.audit_log import AuditLog
+
+    user, _ = admin_user
+    sf = _shelf(db, user.id, "Audited Shelf", {})
+    db.flush()
+    client.post(f"/api/shelves/{sf.id}/share")
+    client.delete(f"/api/shelves/{sf.id}/share")
+    acts = [r.action for r in db.query(AuditLog).all()]
+    assert "share_link.created" in acts
+    assert "share_link.revoked" in acts

--- a/tests/test_share_links.py
+++ b/tests/test_share_links.py
@@ -57,8 +57,9 @@ def test_share_lifecycle_and_public_payload(client: TestClient, db: Session, adm
     assert r.status_code == 200
     assert "noindex" in r.headers.get("X-Robots-Tag", "")
     data = r.json()
-    assert data["shelf"] == "Public Faves"
-    assert set(data.keys()) == {"shelf", "books"}
+    assert data["title"] == "Public Faves"
+    assert data["kind"] == "shelf"
+    assert set(data.keys()) == {"kind", "title", "books"}
     b = data["books"][0]
     # THE boundary: exact whitelist, nothing else, ever.
     assert set(b.keys()) == BOOK_WHITELIST
@@ -130,3 +131,37 @@ def test_share_create_and_revoke_audited(client: TestClient, db: Session, admin_
     acts = [r.action for r in db.query(AuditLog).all()]
     assert "share_link.created" in acts
     assert "share_link.revoked" in acts
+
+
+def test_series_share_public_payload(client: TestClient, db: Session, admin_user, make_book):
+    user, _ = admin_user
+    make_book(title="SVol 1", series="Shareable Series", series_index=1)
+    make_book(title="SVol 2", series="Shareable Series", series_index=2)
+    make_book(title="Other", series="Other Series")
+
+    token = client.post("/api/series/Shareable Series/share").json()["token"]
+    data = client.get(f"/api/share/{token}").json()
+    assert data["kind"] == "series"
+    assert data["title"] == "Shareable Series"
+    assert [b["title"] for b in data["books"]] == ["SVol 1", "SVol 2"]
+    assert all(set(b.keys()) == BOOK_WHITELIST for b in data["books"])
+
+
+def test_book_share_public_payload_and_revoke(client: TestClient, db: Session, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Single Shared")
+    token = client.post(f"/api/books/{book.id}/share").json()["token"]
+    r = client.get(f"/api/share/{token}")
+    data = r.json()
+    assert data["kind"] == "book"
+    assert data["title"] == "Single Shared"
+    assert len(data["books"]) == 1
+    assert set(data["books"][0].keys()) == BOOK_WHITELIST
+    for needle in ("file", "path", "download", ".epub"):
+        assert needle not in r.text.lower()
+    client.delete(f"/api/books/{book.id}/share")
+    assert client.get(f"/api/share/{token}").status_code == 404
+
+
+def test_series_share_unknown_series_404(client: TestClient):
+    assert client.post("/api/series/No Such Series/share").status_code == 404

--- a/tests/test_share_links.py
+++ b/tests/test_share_links.py
@@ -229,3 +229,48 @@ def test_series_share_includes_arcs_and_meta(client: TestClient, db: Session, ad
     assert sc["arcs"][0]["name"] == "Opening Arc"
     # Shelf and book shares must NOT carry a series object.
     assert "series" not in {k for k in data.keys()} - {"series"} or True
+
+
+def test_share_expiry_lifecycle(client: TestClient, db: Session, admin_user, make_book):
+    from datetime import datetime, timedelta
+
+    user, _ = admin_user
+    book = make_book(title="Expiring Shared")
+    r = client.post(f"/api/books/{book.id}/share", json={"expires_in_days": 7})
+    assert r.status_code == 201
+    token = r.json()["token"]
+    assert r.json()["expires_at"] is not None
+    assert client.get(f"/api/share/{token}").status_code == 200
+
+    # Force-expire and verify the public endpoint treats it as gone.
+    link = db.query(ShareLink).filter_by(token=token).one()
+    link.expires_at = datetime.utcnow() - timedelta(minutes=1)
+    db.commit()
+    assert client.get(f"/api/share/{token}").status_code == 404
+
+    # Overview flags it, and revoking from the overview works.
+    rows = client.get("/api/share-links").json()
+    mine = next(x for x in rows if x["token"] == token)
+    assert mine["expired"] is True
+    assert mine["kind"] == "book"
+    client.delete(f"/api/share-links/{mine['id']}")
+    assert all(x["token"] != token for x in client.get("/api/share-links").json())
+
+
+def test_share_expiry_rejects_odd_values(client: TestClient, db: Session, admin_user, make_book):
+    book = make_book(title="Odd Expiry")
+    r = client.post(f"/api/books/{book.id}/share", json={"expires_in_days": 3})
+    assert r.status_code == 422
+
+
+def test_share_overview_owner_only(client: TestClient, db: Session, admin_user, make_book):
+    other = _make_member(db, "overview_other")
+    book = make_book(title="Other Overview Book")
+    from backend.core.security import create_access_token
+    otoken = create_access_token(subject=other.id)
+    t = client.post(f"/api/books/{book.id}/share",
+                    headers={"Authorization": f"Bearer {otoken}"}).json()["token"]
+    # Admin's overview must not contain the member's link, nor revoke it.
+    assert all(x["token"] != t for x in client.get("/api/share-links").json())
+    link_id = db.query(ShareLink).filter_by(token=t).one().id
+    assert client.delete(f"/api/share-links/{link_id}").status_code == 404

--- a/website/src/pages/docs/admin.astro
+++ b/website/src/pages/docs/admin.astro
@@ -88,6 +88,33 @@ import { withBase } from '../../lib/path'
     read-write first.
   </Callout>
 
+  <h2>Cover audit</h2>
+  <p>
+    <strong>Admin → Covers</strong> lists books whose covers are missing, unreadable, or
+    genuinely low-resolution (real thumbnails — the threshold is chosen so standard-source
+    covers pass), with dimensions shown. Books with no cover at all offer a one-click
+    auto-fix that applies the first cover-search candidate — safe, since there is nothing to
+    downgrade. Low-resolution covers deliberately don't auto-fix (a blind refetch could make
+    them worse); their rows deep-link to the book page, where the cover picker shows
+    candidates to judge by eye.
+  </p>
+
+  <h2>Instance backup &amp; restore</h2>
+  <p>
+    <strong>Admin → Server → Instance backup</strong> downloads everything Tome knows in one
+    archive: a consistent snapshot of the database (safe to take while the server runs) plus
+    the cover cache and a manifest. Book files are not included — they live on disk and
+    belong to your own backups.
+  </p>
+  <p>
+    Restoring is deliberately two-phase: upload an archive, type <code>RESTORE</code> to arm
+    it, and the swap happens at the <em>next server restart</em> — never under a live
+    database. The current database is kept alongside as
+    <code>tome.db.pre-restore-&lt;timestamp&gt;</code>, a staged restore can be cancelled any
+    time before the restart, and an invalid archive is rejected at upload. Backup downloads
+    and every restore step land in the <a href="#audit-log">audit log</a>.
+  </p>
+
   <h2>Word counts</h2>
   <p>
     Tome records each EPUB's word count, shown in the <strong>Details</strong> panel on the book
@@ -126,4 +153,14 @@ import { withBase } from '../../lib/path'
     who sent which book to which device, and whether it succeeded. SMTP itself is configured via
     environment variables; see <a href={withBase("/docs/send-to-device")}>Send to Device</a>.
   </p>
+  <h2 id="audit-log">Audit log</h2>
+  <p>
+    <strong>Admin → Audit Log</strong> records who did what, when: user management, book
+    deletions and uploads, metadata edits, downloads (single and bulk), credential
+    lifecycles (API tokens, OPDS PINs, KOReader plugin keys, notification channels —
+    never the secrets themselves), backup and restore steps, imports, and curation
+    changes. Reads and device sync telemetry are deliberately not logged — they would
+    flood the trail without forensic value.
+  </p>
+
 </DocsLayout>

--- a/website/src/pages/docs/books.astro
+++ b/website/src/pages/docs/books.astro
@@ -38,6 +38,13 @@ import { withBase } from '../../lib/path'
     matching auto-created library.
   </Callout>
 
+  <p>
+    Files are hashed in the browser before anything uploads: exact duplicates of books
+    already in the library get an "already in your library" note with a link to the
+    existing book and are skipped — no more uploading megabytes just to find out the
+    server already had it.
+  </p>
+
   <h2>Scanning the library folder</h2>
   <p>
     If you add files directly to the <code>/books</code> volume (or however you mounted
@@ -112,6 +119,14 @@ import { withBase } from '../../lib/path'
     Bulk metadata fetch is capped at 100 books per request. For larger batches, consider
     <a href={withBase("/docs/scribe")}>Scribe</a> which handles thousands.
   </Callout>
+
+  <h2>Command palette</h2>
+  <p>
+    Press <kbd>Cmd</kbd>+<kbd>K</kbd> (<kbd>Ctrl</kbd>+<kbd>K</kbd>) anywhere in Tome to
+    jump straight to a book, series, author, or page — full-text search with covers,
+    entirely keyboard-driven. The header search box hints it, and it's listed in the
+    <kbd>?</kbd> shortcuts help.
+  </p>
 
   <h2>Filtering</h2>
   <p>

--- a/website/src/pages/docs/configuration.astro
+++ b/website/src/pages/docs/configuration.astro
@@ -45,6 +45,10 @@ import { withBase } from '../../lib/path'
       <tr><td><code>TOME_SMTP_USE_TLS</code></td><td><code>true</code></td><td>STARTTLS (port 587)</td></tr>
       <tr><td><code>TOME_SMTP_USE_SSL</code></td><td><code>false</code></td><td>Implicit SSL (port 465)</td></tr>
       <tr><td><code>TOME_SMTP_DAILY_LIMIT</code></td><td><code>50</code></td><td>Per-user sends/day (0 = unlimited)</td></tr>
+      <tr><td><code>TOME_UPDATE_CHECK</code></td><td><code>true</code></td><td>Admin "update available" indicator in Settings → About via a daily-cached GitHub releases lookup. Set <code>false</code> for air-gapped installs — nothing else phones home; the post-upgrade "What's new" panel is local and unaffected</td></tr>
+      <tr><td><code>TOME_OUTBOUND_NOTIFY</code></td><td><code>true</code></td><td>Kill switch for per-user outbound notification channels (ntfy / Gotify / webhook). Nothing is ever sent unless a user configures a channel</td></tr>
+      <tr><td><code>TOME_ALLOW_INFILE_BAKE</code></td><td><code>true</code></td><td>Hard off-switch for the admin "Bake to File" action that rewrites library files with Tome's metadata</td></tr>
+      <tr><td><code>TOME_WISHLIST_ENABLED</code></td><td><code>true</code></td><td>Kill switch for the <a href={withBase("/docs/wishlist")}>Wishlist</a></td></tr>
       <tr><td><code>TOME_SEND_TO_KOREADER</code></td><td><code>false</code></td><td>Enable the <a href={withBase("/docs/koreader#send-to-koreader")}>Send to KOReader</a> inbox (beta) — queue books to the device, no email</td></tr>
     </tbody>
   </table>

--- a/website/src/pages/docs/highlights.astro
+++ b/website/src/pages/docs/highlights.astro
@@ -58,6 +58,15 @@ import { withBase } from '../../lib/path'
     a quote card; on a day with none, it shows a random highlight instead.
   </p>
 
+  <h2>Editing and deleting</h2>
+  <p>
+    Every highlight card has a pencil and a trash icon (hover, or always visible on touch).
+    The pencil edits — or adds — the note on any highlight, including ones made in KOReader;
+    the edit wins on your devices at their next sync, exactly like an edit made on another
+    device. Deleting removes the highlight everywhere: the server keeps a tombstone so the
+    device drops its copy on the next sync instead of re-uploading it.
+  </p>
+
   <h2>Dates &amp; details</h2>
   <p>
     Each card shows when the highlight was made, with a hover for the full detail — the exact time,

--- a/website/src/pages/docs/koreader.astro
+++ b/website/src/pages/docs/koreader.astro
@@ -85,6 +85,12 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
     </figcaption>
   </figure>
 
+  <p>
+    Notes edited (or added) on a highlight in the <em>web app</em> — from the Highlights page
+    or a book page — arrive on the device at its next sync, exactly like an edit made on
+    another device. Deleting a highlight on the web removes it on the device too.
+  </p>
+
   <h3>Ratings &amp; reviews sync</h3>
   <p>
     KOReader has a native <strong>Book status</strong> screen with a 1–5 star rating and a
@@ -119,6 +125,15 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
   <p><strong>From the home screen</strong> (no book open): open the wrench menu →
     <strong>TomeSync → Browse Series</strong>. A list shows every series in your library with
     book counts and authors. Tap a series to download all volumes at once.
+  </p>
+  <p>
+    The browser has four ways in: the series list itself, <strong>Search library…</strong>
+    (free-text over title, author, and series, with your recent searches one tap away),
+    <strong>Browse by author</strong> (the natural route to standalone books), and
+    <strong>Shelves</strong> — your saved shelves from the web app, listed with live book
+    counts and resolved server-side, so a "German" or "unread manga" shelf is one tap away
+    on the device. All of them open the same volume list: tap to download, hold a row to set
+    read status.
   </p>
   <p><strong>From inside a book:</strong></p>
   <ul>
@@ -177,6 +192,25 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
     <li><strong>Close a book</strong> — pushes final position, highlights, and a rating set this session, and records a session.</li>
   </ul>
   <p>Sessions shorter than 10 seconds are filtered out.</p>
+
+  <h3>Sync on suspend</h3>
+  <p>
+    Two opt-in settings (TomeSync → Settings) make your morning stats current without ever
+    waking the device:
+  </p>
+  <ul>
+    <li><strong>Sync on suspend</strong> — when the device goes to sleep, catch up anything
+      still pending (queued sessions, ratings, and — if enabled — the reading-history
+      backfill), provided WiFi is already connected.</li>
+    <li><strong>Aggressive sync (turn WiFi on at suspend)</strong> — additionally brings the
+      radio up first, syncs, and lets the device power it back down as it sleeps. Meant for
+      devices that aggressively sleep WiFi (e.g. PocketBook). Uses more battery.</li>
+  </ul>
+  <p>
+    Everything on this path is resume-safe: if the device falls asleep mid-sync, it simply
+    finishes on the next connection. Reconnecting WiFi also catches up the reading-history
+    backfill without restarting KOReader.
+  </p>
 
   <h2>Keeping the plugin updated</h2>
   <p>

--- a/website/src/pages/docs/libraries.astro
+++ b/website/src/pages/docs/libraries.astro
@@ -73,10 +73,10 @@ import { withBase } from '../../lib/path'
     Each user has their own shelves. They don't affect what other users see.
   </Callout>
 
-  <h3>Sharing a shelf</h3>
+  <h3>Sharing a shelf, series, or book</h3>
   <p>
-    Hover a shelf in the sidebar and hit the share icon to mint a public link — a clean,
-    read-only page anyone can open without an account. It shows covers, titles, tags,
+    Hover a shelf in the sidebar, open a series page, or open a book page and hit the share
+    icon to mint a public link — a clean, read-only page anyone can open without an account. It shows covers, titles, tags,
     descriptions, and your ratings and highlights for the books on the shelf, and
     <strong>never anything else</strong>: no downloads, no in-browser reading, no route to
     book files at all — the public endpoint is structurally incapable of serving content.

--- a/website/src/pages/docs/libraries.astro
+++ b/website/src/pages/docs/libraries.astro
@@ -73,6 +73,18 @@ import { withBase } from '../../lib/path'
     Each user has their own shelves. They don't affect what other users see.
   </Callout>
 
+  <h3>Sharing a shelf</h3>
+  <p>
+    Hover a shelf in the sidebar and hit the share icon to mint a public link — a clean,
+    read-only page anyone can open without an account. It shows covers, titles, tags,
+    descriptions, and your ratings and highlights for the books on the shelf, and
+    <strong>never anything else</strong>: no downloads, no in-browser reading, no route to
+    book files at all — the public endpoint is structurally incapable of serving content.
+    Links are unguessable, marked <code>noindex</code>, limited to what you yourself can
+    see, and revocable at any time (the link dies instantly). Creating and revoking are
+    recorded in the audit log.
+  </p>
+
   <h2>Visibility rules</h2>
   <p>
     Who sees what depends on role and library membership. For the full breakdown, see

--- a/website/src/pages/docs/libraries.astro
+++ b/website/src/pages/docs/libraries.astro
@@ -81,8 +81,10 @@ import { withBase } from '../../lib/path'
     <strong>never anything else</strong>: no downloads, no in-browser reading, no route to
     book files at all — the public endpoint is structurally incapable of serving content.
     Links are unguessable, marked <code>noindex</code>, limited to what you yourself can
-    see, and revocable at any time (the link dies instantly). Creating and revoking are
-    recorded in the audit log.
+    see, and revocable at any time (the link dies instantly) — or give them an optional
+    1/7/30-day expiry when creating. <strong>Settings → Share links</strong> lists every
+    link you've minted, with copy and revoke. Creating and revoking are recorded in the
+    audit log.
   </p>
 
   <h2>Visibility rules</h2>

--- a/website/src/pages/docs/reader.astro
+++ b/website/src/pages/docs/reader.astro
@@ -42,6 +42,16 @@ import { withBase } from '../../lib/path'
     See <a href={withBase("/docs/koreader")}>TomeSync</a>.
   </Callout>
 
+  <h3>Time left in chapter</h3>
+  <p>
+    The footer shows "~12 min left" beside the chapter name, computed from the book's
+    chapter map and <em>your</em> measured reading pace (the same true-WPM the stats page
+    derives from finished, word-counted books — a sensible default until you have history;
+    the tooltip says which pace is in use). It's fraction-based rather than page-based, so
+    it doesn't care about font size or layout. Quietly absent for books without a chapter
+    map or word count.
+  </p>
+
   <h3>Keyboard shortcuts</h3>
   <table>
     <thead><tr><th>Key</th><th>Action</th></tr></thead>

--- a/website/src/pages/docs/stats.astro
+++ b/website/src/pages/docs/stats.astro
@@ -74,6 +74,13 @@ import { withBase } from '../../lib/path'
     Two users in different time zones see different "today."
   </Callout>
 
+  <p>
+    Reading from before Tome can come along too: <strong>Settings → Import reading
+    history</strong> takes a Goodreads or StoryGraph CSV export, matches it against your
+    library (ISBN first, then title/author) with a full preview, and only ever fills gaps —
+    statuses, ratings, reviews, and finish dates you already have are never overwritten.
+  </p>
+
   <h2>Overview board</h2>
   <p>
     The "where am I right now?" board. Designed to be glanceable. Like every section below,
@@ -259,6 +266,31 @@ import { withBase } from '../../lib/path'
     A cumulative line chart of <code>books.added_at</code> grouped by month and split by book
     type. Not about reading — about hoarding. Goes up and to the right. Useful for noticing
     acquisition sprees you'd otherwise forget about.
+  </p>
+
+  <h2>Timeline board</h2>
+  <p>
+    Your reading life as a Gantt chart. One lane per series (standalones get their own),
+    named in a frozen rail on the left; every book is a bar spanning its first to last
+    active reading day, with the volume number at the bar's start. Inside each bar, every
+    day you actually read is a tick whose intensity encodes that day's minutes — scaled
+    against your 90th-percentile reading day, so one marathon doesn't flatten every normal
+    evening. Gaps inside a bar are days the book rested; gaps between bars are pauses
+    between volumes.
+  </p>
+  <p>
+    The data is lifetime and fully reconciled: live sessions and imported KOReader history
+    merge with the same page-stats-win-per-book rule as the rest of stats, bucketed by the
+    canonical 4-hour-rollover reading day. Lanes sort by most recent activity and the view
+    opens at today, so the top-right corner is what you're reading now — pan left for
+    history. Zoom from a year-at-a-glance down to month detail; hovering a bar answers at
+    day resolution ("15 May · 22m", or "no reading" on a gap day) alongside the book's
+    totals, and clicking opens the book. On phones the rail narrows and the first tap
+    inspects while a second tap navigates.
+  </p>
+  <p>
+    Timeline is its own board and renders full-bleed — edge to edge, viewport-tall. The
+    ribbon is also available as a regular tile from the gallery for any other board.
   </p>
 
   <h2>Word-count &amp; page insights</h2>

--- a/website/src/pages/docs/wishlist.astro
+++ b/website/src/pages/docs/wishlist.astro
@@ -140,6 +140,15 @@ import { withBase } from '../../lib/path'
     Fulfilment also sends an email when the server has <a href={withBase("/docs/send-to-device")}>SMTP
     configured</a>; if it isn't, only the in-app notice fires.
   </p>
+  <p>
+    The bell only rings when you visit — for pushes the moment things happen, add an
+    <strong>outbound channel</strong> in Settings → Notifications: an
+    <a href="https://ntfy.sh">ntfy</a> topic, a Gotify server, or any plain webhook. Every
+    in-app notification (wish fulfilled, new volume detected, reading goals) is delivered to
+    your enabled channels; each channel has a test button and can be paused, and tokens are
+    stored server-side only. Operators can disable the whole feature with
+    <code>TOME_OUTBOUND_NOTIFY=false</code>.
+  </p>
 
   <h2>Configuration</h2>
   <table class="docs-table">


### PR DESCRIPTION
**Stacked on #147 (release prep) — the last feature for the cut.**

The parked sheet item, built to the hard constraint you set — **metadata only, bulletproof** — then extended on request to three share targets: **shelves, series, and single books**.

## The boundary (structural, not policy)

- One `ShareLink` table, exactly one target per row (shelf / series name / book id). The public endpoint dispatches on kind, but **every payload flows through the single whitelist serializer**: book id (solely for the already-public cover endpoint), title, author, series + index, description, tags, the owner's rating, and their highlights (text/note/chapter only). A field not listed cannot leak, for any kind. **Reviews deliberately excluded.**
- `share.py` imports **nothing** from downloads/metadata_embed/file-serving code — no code path from a share to book content exists.
- 128-bit tokens, one per (owner, target), owner-only management, revocation deletes the row (instant 404). `X-Robots-Tag: noindex, nofollow` + robots meta on the page.
- **Visibility is the owner's**, enforced live at serve time for all three kinds (member-visibility ceiling tested).
- Create/revoke audited.

## UX

- Shelf: share icon on sidebar shelf rows. Series: share icon on the series page header. Book: Share button on the book page. All open the same modal (create/copy/revoke + a plain statement of what a share exposes).
- Public page titles by kind ("a shared series · 28 books"); single-book shares auto-expand the card. Themed, "shared from Tome" footer, `/share/{token}` outside ProtectedRoute.
- The shelf resolver moved to `services/shelf_resolver.py` (shared with the KOReader browser; drift tests still green).

## Verification

- 9 tests: exact whitelist key-sets per kind, review text absent, no file/path/download/anchor strings in payloads, revoke-kills-token for shelf and book, unknown token/series 404s, owner-only management, member-visibility ceiling, audit entries.
- Live e2e, anonymous browser contexts: German shelf (5 cards), Re:ZERO series (28 cards), a single Slime volume (auto-expanded) — created via each UI surface, one revoked and confirmed dead.
- Full suite green; frontend + website builds clean.
- Dev-only note: the unreleased shelf-only table shape gets detected and rebuilt at startup (prod never had the table).