### PR TITLE
release: v2.0.0 "Omnibus"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-07-19 - "Omnibus"
+
 ### Added
 - **Share a shelf, a series, or a single book — metadata only, by design.**
   Shelves (share icon in the sidebar), series (share icon on the series

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tome"
-version = "1.8.0"
+version = "2.0.0"
 description = "Self-hosted ebook library"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Version bump to 2.0.0 + changelog section cut (37 entries verified to resolve through the What's-New endpoint). Tag `v2.0.0` follows on the merge commit.