### PR TITLE
fix(stats): portal chart tooltips out of transformed dashboard tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+- Chart tooltips on Reading Stats no longer detach from the cursor or hide
+  behind neighbouring tiles (#151). The activity heatmap, the hour-by-day
+  heatmap, and the timeline ribbon all rendered their hover tooltip inside
+  the dashboard tile, where the grid's CSS transform re-anchored it and
+  clipped it under adjacent cards; tooltips now render at the document root
+  and follow the mouse everywhere.
+
 ## [2.0.0] - 2026-07-19 - "Omnibus"
 
 ### Added

--- a/frontend/src/components/stats/HourDowHeatmap.tsx
+++ b/frontend/src/components/stats/HourDowHeatmap.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useChartColors } from '@/lib/useChartAccent'
 
 interface HourDowCell {
@@ -109,24 +110,29 @@ export function HourDowHeatmap({ data }: { data: HourDowCell[] }) {
         ))}
       </svg>
 
-      {tooltip && (
-        <div
-          className="fixed z-50 pointer-events-none bg-card border border-border rounded-lg shadow-xl px-3 py-2 text-xs"
-          style={{
-            left: Math.min(tooltip.x + 12, window.innerWidth - 180),
-            top: tooltip.y - 44,
-          }}
-        >
-          <div className="font-medium">
-            {DOW_LABELS[tooltip.dow]} {tooltip.hour}:00
-          </div>
-          <div className="text-muted-foreground">
-            {tooltip.seconds > 0
-              ? `${formatDuration(tooltip.seconds)} · ${tooltip.sessions} session${tooltip.sessions !== 1 ? 's' : ''}`
-              : 'No activity'}
-          </div>
-        </div>
-      )}
+      {tooltip &&
+        createPortal(
+          // Portaled to <body>: inside a dashboard tile an ancestor transform would
+          // re-anchor position:fixed to the tile and trap z-index in its stacking
+          // context, putting the tooltip far from the cursor and behind siblings.
+          <div
+            className="fixed z-50 pointer-events-none bg-card border border-border rounded-lg shadow-xl px-3 py-2 text-xs"
+            style={{
+              left: Math.min(tooltip.x + 12, window.innerWidth - 180),
+              top: tooltip.y - 44,
+            }}
+          >
+            <div className="font-medium">
+              {DOW_LABELS[tooltip.dow]} {tooltip.hour}:00
+            </div>
+            <div className="text-muted-foreground">
+              {tooltip.seconds > 0
+                ? `${formatDuration(tooltip.seconds)} · ${tooltip.sessions} session${tooltip.sessions !== 1 ? 's' : ''}`
+                : 'No activity'}
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   )
 }

--- a/frontend/src/components/stats/TimelineRibbon.tsx
+++ b/frontend/src/components/stats/TimelineRibbon.tsx
@@ -4,6 +4,7 @@
 // that day's minutes as intensity (one hue, sequential). Data is lifetime and
 // reconciled (imported KOReader history included), from GET /stats/timeline.
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useNavigate } from 'react-router-dom'
 import { Minus, Plus } from 'lucide-react'
 import { api } from '@/lib/api'
@@ -375,34 +376,39 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
         </div>
       </div>
 
-      {hover && (
-        <div
-          className="pointer-events-none fixed z-50 flex max-w-[300px] gap-2.5 rounded-lg border border-border bg-card px-3 py-2 text-xs shadow-xl"
-          style={{ left: Math.min(hover.x + 14, window.innerWidth - 320), top: Math.min(hover.y + 16, window.innerHeight - 110) }}
-        >
-          {hover.b.has_cover && (
-            <img src={`/api/books/${hover.b.book_id}/cover`} alt="" className="h-14 w-10 shrink-0 rounded object-cover" />
-          )}
-          <div className="min-w-0">
-            <div className="truncate font-semibold">{hover.b.title}</div>
-            {hover.b.author && <div className="truncate text-muted-foreground">{hover.b.author}</div>}
-            <div className="mt-1 text-muted-foreground">
-              {formatDate(hover.b.first_day)} – {formatDate(hover.b.last_day)} · {hover.b.days.length}{' '}
-              {hover.b.days.length === 1 ? 'day' : 'days'}
-            </div>
-            <div className="text-muted-foreground">
-              {formatDuration(hover.b.total_seconds)}
-              {hover.b.finished_on ? ` · finished ${formatDate(hover.b.finished_on)}` : ''}
-            </div>
-            {hover.day && (
-              <div className="mt-1 border-t border-border/60 pt-1" style={{ color: colors.accent }}>
-                {formatDate(hover.day.date)} ·{' '}
-                {hover.day.seconds > 0 ? formatDuration(hover.day.seconds) : 'no reading'}
-              </div>
+      {hover &&
+        createPortal(
+          // Portaled to <body>: inside a dashboard tile an ancestor transform would
+          // re-anchor position:fixed to the tile and trap z-index in its stacking
+          // context, putting the tooltip far from the cursor and behind siblings.
+          <div
+            className="pointer-events-none fixed z-50 flex max-w-[300px] gap-2.5 rounded-lg border border-border bg-card px-3 py-2 text-xs shadow-xl"
+            style={{ left: Math.min(hover.x + 14, window.innerWidth - 320), top: Math.min(hover.y + 16, window.innerHeight - 110) }}
+          >
+            {hover.b.has_cover && (
+              <img src={`/api/books/${hover.b.book_id}/cover`} alt="" className="h-14 w-10 shrink-0 rounded object-cover" />
             )}
-          </div>
-        </div>
-      )}
+            <div className="min-w-0">
+              <div className="truncate font-semibold">{hover.b.title}</div>
+              {hover.b.author && <div className="truncate text-muted-foreground">{hover.b.author}</div>}
+              <div className="mt-1 text-muted-foreground">
+                {formatDate(hover.b.first_day)} – {formatDate(hover.b.last_day)} · {hover.b.days.length}{' '}
+                {hover.b.days.length === 1 ? 'day' : 'days'}
+              </div>
+              <div className="text-muted-foreground">
+                {formatDuration(hover.b.total_seconds)}
+                {hover.b.finished_on ? ` · finished ${formatDate(hover.b.finished_on)}` : ''}
+              </div>
+              {hover.day && (
+                <div className="mt-1 border-t border-border/60 pt-1" style={{ color: colors.accent }}>
+                  {formatDate(hover.day.date)} ·{' '}
+                  {hover.day.seconds > 0 ? formatDuration(hover.day.seconds) : 'no reading'}
+                </div>
+              )}
+            </div>
+          </div>,
+          document.body,
+        )}
     </div>
   )
 }

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -1,6 +1,7 @@
 // Shared stats types + chrome, used by both the Stats page and the Stats Lab dashboard.
 // Extracted from StatsPage so the two render from a single source of truth (no drift).
 import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { formatDate, formatDuration } from '@/lib/utils'
 import { useChartColors } from '@/lib/useChartAccent'
 
@@ -235,15 +236,20 @@ export function HeatmapChart({ data }: { data: { date: string; seconds: number }
           }),
         )}
       </svg>
-      {tooltip && (
-        <div
-          className="fixed z-50 pointer-events-none bg-card border border-border rounded-lg shadow-xl px-3 py-2 text-xs"
-          style={{ left: Math.min(tooltip.x + 12, window.innerWidth - 180), top: tooltip.y - 44 }}
-        >
-          <div className="font-medium">{formatDate(tooltip.date)}</div>
-          <div className="text-muted-foreground">{formatDuration(tooltip.seconds)}</div>
-        </div>
-      )}
+      {tooltip &&
+        createPortal(
+          // Portaled to <body>: inside a dashboard tile an ancestor transform would
+          // re-anchor position:fixed to the tile and trap z-index in its stacking
+          // context, putting the tooltip far from the cursor and behind siblings.
+          <div
+            className="fixed z-50 pointer-events-none bg-card border border-border rounded-lg shadow-xl px-3 py-2 text-xs"
+            style={{ left: Math.min(tooltip.x + 12, window.innerWidth - 180), top: tooltip.y - 44 }}
+          >
+            <div className="font-medium">{formatDate(tooltip.date)}</div>
+            <div className="text-muted-foreground">{formatDuration(tooltip.seconds)}</div>
+          </div>,
+          document.body,
+        )}
     </div>
   )
 }


### PR DESCRIPTION
Fixes #151.

The stats dashboard tiles are react-grid-layout items, which carry a CSS `transform`. A transformed ancestor becomes the containing block for `position: fixed` descendants and opens its own stacking context, so the mouse-anchored tooltips inside tiles were positioned relative to the tile instead of the viewport (tooltip far from the cursor, first screenshot in the issue) and could not escape the tile's z-order (tooltip behind neighbouring tiles, second screenshot).

Affected all three mouse-anchored chart tooltips:
- 365-day activity heatmap (`shared.tsx`)
- hour-by-day heatmap on Habits (`HourDowHeatmap.tsx`)
- timeline ribbon (`TimelineRibbon.tsx`)

They now render through `createPortal` into `document.body`, restoring viewport-relative positioning and z-index. No visual or behavioural change outside the broken cases.

Verified with Playwright against the showcase: all three tooltips render at the cursor (+12/-44 px offset as designed) and on top of adjacent tiles.