### PR TITLE
feat(sessions): idle-capped accounting, trim, and runaway-session hygiene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,11 @@ All notable changes to Tome are documented here. Format loosely follows
   with a suggested duration computed from the session's page turns at your
   own median reading pace, so the reading stays and the idle tail goes.
   Suspicious sessions (implausibly long, or minutes per page turn) are
-  marked with a warning icon, the list can sort longest-first, and the
-  per-book time table on the Library tab expands per book to show, trim or
-  delete that book's sessions directly.
+  marked with a warning icon and the list can sort longest-first. The same
+  session list lives in two more places: the per-book time table on the
+  Library stats tab expands per book, and every book page grows a
+  collapsible "Sessions" section under Reading Stats — so sessions stay
+  editable even on a stats dashboard with those tiles removed.
 - **A heads-up when a runaway session syncs.** Sessions arriving from older
   plugin builds still get sanity-checked on the server: an implausibly long
   one raises a bell notification pointing at Reading Stats, so a bad night

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- **Runaway reading sessions are over (KOReader plugin, build 37).** A device
+  that never actually sleeps — a cover that fails to suspend it, or a reader
+  who fell asleep mid-chapter — used to book the whole wall-clock span as
+  reading, turning a 15-minute evening into an 8-hour session (#150). The
+  plugin now counts active reading the way KOReader's own statistics do:
+  each gap between page turns is credited at most an idle cap (10 minutes by
+  default, configurable in TomeSync settings, including off), and the session
+  ends at the last page turn rather than whenever the device finally slept.
+- **Trim a session instead of deleting it.** Sessions that idled — real
+  reading followed by hours of nothing — can now be shortened from the
+  Recent Sessions list: a scissors button opens a small editor, pre-filled
+  with a suggested duration computed from the session's page turns at your
+  own median reading pace, so the reading stays and the idle tail goes.
+  Suspicious sessions (implausibly long, or minutes per page turn) are
+  marked with a warning icon, the list can sort longest-first, and the
+  per-book time table on the Library tab expands per book to show, trim or
+  delete that book's sessions directly.
+- **A heads-up when a runaway session syncs.** Sessions arriving from older
+  plugin builds still get sanity-checked on the server: an implausibly long
+  one raises a bell notification pointing at Reading Stats, so a bad night
+  never silently distorts your numbers.
+
 ## [2.0.0] - 2026-07-19 - "Omnibus"
 
 ### Added

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -23,6 +23,7 @@ from backend.services.streaks import reconciled_user_streaks
 from backend.services.reading_day import ROLLOVER_HOURS, date_modifier, effective_today, epoch_day
 from backend.services import reconciled_reading as rr
 from backend.services.audit import audit
+from backend.services.session_hygiene import is_suspect, median_secs_per_page, suggested_seconds
 
 router = APIRouter(tags=["stats"])
 
@@ -1225,15 +1226,32 @@ def get_reading_timeline(
 def list_sessions(
     offset: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=200),
+    book_id: Optional[int] = Query(None),
+    sort: str = Query("recent", pattern="^(recent|longest)$"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
-    """List individual reading sessions for the current user, newest first."""
+    """List individual reading sessions for the current user.
+
+    ``sort=longest`` and the ``book_id`` filter exist so runaway sessions
+    (#150) are findable without paging through the whole history. Each row
+    carries ``suspect`` and, when computable, ``suggested_seconds`` — the
+    session's page turns re-priced at the user's median pace — feeding the
+    trim dialog's pre-fill.
+    """
     base = (
         db.query(ReadingSession)
         .filter(ReadingSession.user_id == current_user.id)
     )
+    if book_id is not None:
+        base = base.filter(ReadingSession.book_id == book_id)
     total = base.count()
+    order = (
+        ReadingSession.duration_seconds.desc()
+        if sort == "longest"
+        else ReadingSession.started_at.desc()
+    )
+    median_pace = median_secs_per_page(db, current_user.id)
     rows = (
         base
         .outerjoin(Book, Book.id == ReadingSession.book_id)
@@ -1249,7 +1267,7 @@ def list_sessions(
             ReadingSession.progress_start,
             ReadingSession.progress_end,
         )
-        .order_by(ReadingSession.started_at.desc())
+        .order_by(order)
         .offset(offset)
         .limit(limit)
         .all()
@@ -1268,6 +1286,10 @@ def list_sessions(
                 "device": r.device,
                 "progress_start": r.progress_start,
                 "progress_end": r.progress_end,
+                "suspect": is_suspect(r.duration_seconds, r.pages_turned),
+                "suggested_seconds": suggested_seconds(
+                    r.duration_seconds, r.pages_turned, median_pace
+                ),
             }
             for r in rows
         ],
@@ -1295,6 +1317,51 @@ def delete_session(
     audit(db, "session.deleted", user_id=current_user.id, username=current_user.username,
           resource_type="reading_session", resource_id=session_id, details=details)
     return {"ok": True}
+
+
+class TrimSessionRequest(BaseModel):
+    duration_seconds: int
+
+
+@router.patch("/stats/sessions/{session_id}")
+def trim_session(
+    session_id: int,
+    body: TrimSessionRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Shorten a runaway session (#150) without losing the reading it started
+    with — a 15-minute read that idled for 8 hours trims back to 15 minutes.
+
+    Trim only: the new duration must be shorter than the recorded one. This
+    is a cleanup tool for idle time, not a session editor. ``ended_at`` moves
+    back with it so the session's wall span matches the reading."""
+    session = (
+        db.query(ReadingSession)
+        .filter(ReadingSession.id == session_id, ReadingSession.user_id == current_user.id)
+        .first()
+    )
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.duration_seconds is None:
+        raise HTTPException(status_code=400, detail="Session has no duration to trim")
+    if body.duration_seconds < 1:
+        raise HTTPException(status_code=400, detail="Duration must be positive")
+    if body.duration_seconds >= session.duration_seconds:
+        raise HTTPException(status_code=400, detail="Trim can only shorten a session")
+
+    details = {
+        "book_id": session.book_id,
+        "seconds_before": session.duration_seconds,
+        "seconds_after": body.duration_seconds,
+    }
+    session.duration_seconds = body.duration_seconds
+    if session.started_at is not None:
+        session.ended_at = session.started_at + timedelta(seconds=body.duration_seconds)
+    db.commit()
+    audit(db, "session.trimmed", user_id=current_user.id, username=current_user.username,
+          resource_type="reading_session", resource_id=session_id, details=details)
+    return {"ok": True, "duration_seconds": body.duration_seconds}
 
 
 # ── Dashboard persistence ────────────────────────────────────────────────────

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -33,6 +33,7 @@ from backend.models.ko_stats import StatsImport
 from backend.models.send_queue import SendQueueItem
 from backend.services.book_progress import apply_progress_to_status, upsert_position
 from backend.services.hardcover_sync import nudge as hardcover_nudge
+from backend.services.session_hygiene import is_suspect, notify_suspect_session
 from backend.services.audit import audit
 
 router = APIRouter(tags=["tome-sync"])
@@ -74,8 +75,8 @@ logger = logging.getLogger(__name__)
 # bypassing wifi_enable_action so "prompt" never dialogs onto the sleep
 # screen). onNetworkConnected also runs the history backfill now (was
 # launch-only) and no longer requires an open book to flush pending state.
-TOMESYNC_PLUGIN_BUILD = 36
-TOMESYNC_PLUGIN_SEMVER = "1.10.0"
+TOMESYNC_PLUGIN_BUILD = 37
+TOMESYNC_PLUGIN_SEMVER = "1.11.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -461,6 +462,11 @@ def post_session(
         apply_progress_to_status(
             db, user_id=user.id, book_id=body.book_id, pct=body.progress_end,
         )
+
+    # Old plugin builds (< 37) book wall-clock time when a device sits awake
+    # unread — flag implausible sessions so the user can trim them (#150).
+    if is_suspect(body.duration_seconds, body.pages_turned):
+        notify_suspect_session(db, user.id, book.title, body.duration_seconds or 0)
 
     db.commit()
     db.refresh(session)
@@ -1727,6 +1733,10 @@ local SWEEP_EXTS = {{ epub = true, pdf = true, cbz = true, cbr = true, mobi = tr
 -- ── HTTP client ──────────────────────────────────────────────────────────────
 
 local HEARTBEAT_PAGES = 50
+-- Longest credible gap between page turns. Anything beyond it is idle time
+-- (device left awake, reader asleep) and is not booked to the session. The
+-- user can change or disable this in settings; 0 = off.
+local IDLE_CAP_DEFAULT_MINUTES = 10
 local PLUGIN_VERSION  = "{TOMESYNC_PLUGIN_VERSION}"
 local BUILD           = {TOMESYNC_PLUGIN_BUILD}      -- monotonic; the only thing compared
 local SEMVER          = "{TOMESYNC_PLUGIN_SEMVER}"   -- human-facing display only
@@ -1747,6 +1757,13 @@ end
 local function deviceName()
     local ok, name = pcall(function() return Device:getFriendlyDeviceName() end)
     return (ok and name) or "KOReader"
+end
+
+local function idleCapSeconds()
+    local mins = G_reader_settings:readSetting("tomesync_idle_cap_minutes")
+    if mins == nil then mins = IDLE_CAP_DEFAULT_MINUTES end
+    if mins == 0 then return math.huge end
+    return mins * 60
 end
 
 local function apiRequest(method, path, body)
@@ -2050,6 +2067,8 @@ function TomeSync:init()
     self.book_id        = nil
     self.session_start  = nil
     self.page_count     = 0
+    self.active_seconds = 0
+    self.last_activity  = nil
     self.progress_start = nil
     self.last_progress  = nil
     self.enabled        = true
@@ -2327,6 +2346,7 @@ function TomeSync:onPageUpdate(pageno)
         return
     end
 
+    self:_creditActivity(os.time())
     self.page_count = self.page_count + 1
     -- Idle-debounced heartbeat: reaching the page threshold ARMS the push, and
     -- every further turn re-delays it — the HTTP call runs 10s after the LAST
@@ -2337,6 +2357,31 @@ function TomeSync:onPageUpdate(pageno)
         UIManager:unschedule(self._heartbeat_task)
         UIManager:scheduleIn(10, self._heartbeat_task)
     end
+end
+
+-- Credit the time spent on the page just finished, capped at the idle
+-- limit — a gap longer than the cap means the device sat awake unread.
+function TomeSync:_creditActivity(now)
+    if self.last_activity then
+        local gap = now - self.last_activity
+        if gap > 0 then
+            self.active_seconds = (self.active_seconds or 0) + math.min(gap, idleCapSeconds())
+        end
+    end
+    self.last_activity = now
+end
+
+-- Active reading time and honest end for the current session. Every gap
+-- between page turns is credited at most the idle cap, including the tail
+-- after the last turn — a device left awake overnight books the evening's
+-- reading, not the night, and the session ends when the reading did. With
+-- the cap off this degrades to exactly now - session_start / now.
+function TomeSync:_sessionTotals(now)
+    if not self.session_start then return 0, now end
+    local last = self.last_activity or self.session_start
+    local tail = now - last
+    if tail > 0 then tail = math.min(tail, idleCapSeconds()) else tail = 0 end
+    return (self.active_seconds or 0) + tail, last + tail
 end
 
 function TomeSync:_heartbeatNow()
@@ -2363,7 +2408,7 @@ function TomeSync:onSuspend()
         -- Record the reading session (lid close = end of session)
         local pct      = self:_getCurrentPercentage()
         local cfi      = self:_getCurrentProgress()
-        local duration = self.session_start and (os.time() - self.session_start) or 0
+        local duration, session_end = self:_sessionTotals(os.time())
         local dev      = deviceName()
 
         pcall(apiRequest, "PUT", "/tome-sync/position/" .. self.book_id, {{
@@ -2379,7 +2424,7 @@ function TomeSync:onSuspend()
             local session = {{
                 book_id          = self.book_id,
                 started_at       = os.date("!%Y-%m-%dT%H:%M:%SZ", self.session_start),
-                ended_at         = os.date("!%Y-%m-%dT%H:%M:%SZ", os.time()),
+                ended_at         = os.date("!%Y-%m-%dT%H:%M:%SZ", session_end),
                 duration_seconds = duration,
                 progress_start   = self.progress_start,
                 progress_end     = pct,
@@ -2440,6 +2485,8 @@ function TomeSync:onResume()
     -- Start a fresh session (lid open = new session)
     self.session_start  = os.time()
     self.page_count     = 0
+    self.active_seconds = 0
+    self.last_activity  = self.session_start
     self.progress_start = self:_getCurrentPercentage()
     self.last_progress  = self.progress_start
 
@@ -2638,7 +2685,7 @@ function TomeSync:onCloseDocument()
 
     local pct      = self:_getCurrentPercentage()
     local cfi      = self:_getCurrentProgress()
-    local duration = self.session_start and (os.time() - self.session_start) or 0
+    local duration, session_end = self:_sessionTotals(os.time())
     local dev      = deviceName()
 
     pcall(apiRequest, "PUT", "/tome-sync/position/" .. self.book_id, {{
@@ -2655,7 +2702,7 @@ function TomeSync:onCloseDocument()
         pcall(apiRequest, "POST", "/tome-sync/session", {{
             book_id          = self.book_id,
             started_at       = os.date("!%Y-%m-%dT%H:%M:%SZ", self.session_start),
-            ended_at         = os.date("!%Y-%m-%dT%H:%M:%SZ", os.time()),
+            ended_at         = os.date("!%Y-%m-%dT%H:%M:%SZ", session_end),
             duration_seconds = duration,
             progress_start   = self.progress_start,
             progress_end     = pct,
@@ -2668,6 +2715,8 @@ function TomeSync:onCloseDocument()
     self.book_id        = nil
     self.session_start  = nil
     self.page_count     = 0
+    self.active_seconds = 0
+    self.last_activity  = nil
     self.progress_start = nil
     self.last_progress  = nil
     last_session_init.book_id = nil
@@ -2713,8 +2762,10 @@ function TomeSync:_initSession()
     last_session_init.at = os.time()
 
     logger.dbg("TomeSync: book opened, id =", self.book_id)
-    self.session_start = os.time()
-    self.page_count    = 0
+    self.session_start  = os.time()
+    self.page_count     = 0
+    self.active_seconds = 0
+    self.last_activity  = self.session_start
 
     local ok, pos, code = pcall(apiRequest, "GET", "/tome-sync/position/" .. self.book_id)
     if ok and pos and code == 200 then
@@ -4745,6 +4796,46 @@ function TomeSync:_menuItems()
             G_reader_settings:saveSetting("tomesync_suspend_wifi",
                 not G_reader_settings:isTrue("tomesync_suspend_wifi"))
         end,
+    }})
+    -- Idle cap: how long a single page may count before the rest of the gap is
+    -- treated as the device sitting awake unread (fell asleep, cover open).
+    local function idleCapItems()
+        local function current()
+            local m = G_reader_settings:readSetting("tomesync_idle_cap_minutes")
+            if m == nil then m = IDLE_CAP_DEFAULT_MINUTES end
+            return m
+        end
+        local items = {{}}
+        for _, entry in ipairs({{
+            {{ 5,  "5 minutes" }},
+            {{ 10, "10 minutes (default)" }},
+            {{ 15, "15 minutes" }},
+            {{ 30, "30 minutes" }},
+            {{ 0,  "Off - count wall-clock time" }},
+        }}) do
+            local value, label = entry[1], entry[2]
+            table.insert(items, {{
+                text         = label,
+                checked_func = function() return current() == value end,
+                callback     = function()
+                    if value == IDLE_CAP_DEFAULT_MINUTES then
+                        G_reader_settings:delSetting("tomesync_idle_cap_minutes")
+                    else
+                        G_reader_settings:saveSetting("tomesync_idle_cap_minutes", value)
+                    end
+                end,
+            }})
+        end
+        return items
+    end
+    table.insert(settings_items, {{
+        text           = "Idle time cap",
+        help_text      = "Longest gap between page turns that still counts as "
+                       .. "reading. If the device is left awake without turning "
+                       .. "pages - you fell asleep, or the cover did not put it "
+                       .. "to sleep - time beyond the cap is not booked to the "
+                       .. "reading session.",
+        sub_item_table = idleCapItems(),
     }})
 
     -- In-book items

--- a/backend/services/session_hygiene.py
+++ b/backend/services/session_hygiene.py
@@ -1,0 +1,119 @@
+"""Runaway-session detection (issue #150).
+
+A device left awake without turning pages (reader fell asleep, cover failed
+to suspend) books wall-clock time as reading. Plugin build 37 caps idle gaps
+at the source, but sessions from older builds — and the ones already in the
+DB — still need flagging. These rules are shared by the sync ingest path
+(which raises a notification the moment a suspect session arrives) and the
+sessions list (which marks suspect rows and proposes a trimmed duration).
+
+A session is suspect when it is implausibly long for one sitting, or when
+its average time per page turn says the device mostly sat idle. The
+suggested duration re-prices the session's page turns at the user's own
+median pace, so the trim keeps the reading and drops the idle tail.
+"""
+from __future__ import annotations
+
+import logging
+import statistics
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from backend.models.notification import Notification
+from backend.models.tome_sync import ReadingSession
+
+log = logging.getLogger(__name__)
+
+SUSPECT_ABS_SECONDS = 6 * 3600   # a single sitting beyond this is flagged outright
+SUSPECT_SECS_PER_PAGE = 600      # 10+ min average per page turn means idle time
+PACE_MIN, PACE_MAX = 5, 600      # plausible secs/page band for the median
+_MEDIAN_SAMPLE = 500             # most recent sessions considered for the median
+
+
+def is_suspect(duration_seconds: Optional[int], pages_turned: Optional[int]) -> bool:
+    if not duration_seconds:
+        return False
+    if duration_seconds >= SUSPECT_ABS_SECONDS:
+        return True
+    if pages_turned and pages_turned > 0:
+        return duration_seconds / pages_turned > SUSPECT_SECS_PER_PAGE
+    return False
+
+
+def median_secs_per_page(db: Session, user_id: int) -> Optional[float]:
+    """The user's typical dwell time per page turn, from their own history.
+
+    Only sessions whose average falls in a plausible band contribute, so the
+    runaway sessions being diagnosed can't drag their own baseline up.
+    """
+    rows = (
+        db.query(ReadingSession.duration_seconds, ReadingSession.pages_turned)
+        .filter(
+            ReadingSession.user_id == user_id,
+            ReadingSession.duration_seconds.isnot(None),
+            ReadingSession.pages_turned > 0,
+        )
+        .order_by(ReadingSession.started_at.desc())
+        .limit(_MEDIAN_SAMPLE)
+        .all()
+    )
+    paces = [
+        d / p
+        for d, p in rows
+        if d and p and PACE_MIN <= d / p <= PACE_MAX
+    ]
+    if len(paces) < 3:  # too little history for a meaningful baseline
+        return None
+    return statistics.median(paces)
+
+
+def suggested_seconds(
+    duration_seconds: Optional[int],
+    pages_turned: Optional[int],
+    median_pace: Optional[float],
+) -> Optional[int]:
+    """Plausible real duration for a suspect session, or None when there is
+    nothing to base it on. Never suggests more than the recorded duration."""
+    if not duration_seconds or not pages_turned or pages_turned <= 0 or not median_pace:
+        return None
+    estimate = round(pages_turned * median_pace)
+    if estimate >= duration_seconds:
+        return None
+    return max(60, estimate)
+
+
+def notify_suspect_session(
+    db: Session, user_id: int, book_title: str, duration_seconds: int
+) -> None:
+    """Raise a bell notification for a freshly synced suspect session.
+
+    Deduped on unread title so a morning flush of several runaway sessions
+    for the same book doesn't stack identical notices. Caller commits.
+    """
+    hours = duration_seconds / 3600
+    title = f'Unusually long reading session on "{book_title}"'
+    exists = (
+        db.query(Notification.id)
+        .filter(
+            Notification.user_id == user_id,
+            Notification.kind == "session_suspect",
+            Notification.title == title,
+            Notification.read.is_(False),
+        )
+        .first()
+    )
+    if exists:
+        return
+    db.add(
+        Notification(
+            user_id=user_id,
+            kind="session_suspect",
+            title=title,
+            body=(
+                f"A {hours:.1f}-hour session was just synced. If the device sat "
+                "awake unread, you can trim or delete it under Reading Stats."
+            ),
+            link="/stats",
+        )
+    )

--- a/frontend/src/components/InfoHint.tsx
+++ b/frontend/src/components/InfoHint.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from 'react'
+import { Info } from 'lucide-react'
+
+// A small "i" that explains a chart or control on hover or tap. Tap-toggle so
+// it works on touch (native title tooltips don't). Reserved for the non-obvious.
+export function InfoHint({ text }: { text: string }) {
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLSpanElement>(null)
+  // iOS Safari doesn't focus buttons on tap, so onBlur alone never closes the
+  // popover there — close on any tap outside instead.
+  useEffect(() => {
+    if (!open) return
+    const onPointerDown = (e: PointerEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('pointerdown', onPointerDown)
+    return () => document.removeEventListener('pointerdown', onPointerDown)
+  }, [open])
+  return (
+    <span ref={rootRef} className="relative inline-flex leading-none">
+      <button
+        type="button"
+        aria-label="What is this?"
+        onClick={() => setOpen(o => !o)}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onBlur={() => setOpen(false)}
+        className="text-muted-foreground/40 hover:text-muted-foreground transition-colors"
+      >
+        <Info className="w-3 h-3" />
+      </button>
+      {open && (
+        <span
+          role="tooltip"
+          className="absolute left-0 top-5 z-20 w-52 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs leading-snug text-muted-foreground shadow-lg"
+        >
+          {text}
+        </span>
+      )}
+    </span>
+  )
+}

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { Bell, Check, BookOpen, Target } from 'lucide-react'
+import { Bell, Check, BookOpen, Target, Timer } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 import {
@@ -168,7 +168,7 @@ export function NotificationBell() {
                       ? 'bg-success/10 text-success'
                       : 'bg-muted text-muted-foreground'
                   )}>
-                    {n.kind === 'goal_reached' ? <Target className="w-3 h-3" /> : <BookOpen className="w-3 h-3" />}
+                    {n.kind === 'goal_reached' ? <Target className="w-3 h-3" /> : n.kind === 'session_suspect' ? <Timer className="w-3 h-3" /> : <BookOpen className="w-3 h-3" />}
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className={cn(

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -117,6 +117,10 @@ export interface SessionEntry {
   device: string | null
   progress_start: number | null
   progress_end: number | null
+  // Runaway-session hygiene (#150): implausibly long for one sitting, and the
+  // plausible real duration (page turns at the user's median pace) if computable.
+  suspect: boolean
+  suggested_seconds: number | null
 }
 
 // ── Chrome ────────────────────────────────────────────────────────────────────

--- a/frontend/src/components/stats/widgets/library.tsx
+++ b/frontend/src/components/stats/widgets/library.tsx
@@ -1,5 +1,5 @@
 // Library-tab stats widgets — chart/content-only, shared by StatsPage and the Lab.
-import { useState } from 'react'
+import { Fragment, useState } from 'react'
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -18,6 +18,7 @@ import { cn, formatDuration } from '@/lib/utils'
 import { useChartPalette } from '@/lib/useChartPalette'
 import { useChartColors } from '@/lib/useChartAccent'
 import { ChartTooltip, type StatsResponse } from '@/components/stats/shared'
+import { SessionLog } from '@/components/stats/widgets/overview'
 
 export function YearInReview({ summary }: { summary: StatsResponse['year_summary'] }) {
   if (!summary) {
@@ -177,6 +178,9 @@ export function PerBookTimeTable({ data }: { data: StatsResponse['per_book_time'
   const [sortKey, setSortKey] = useState<BookTimeSortKey>('seconds')
   const [sortAsc, setSortAsc] = useState(false)
   const [expanded, setExpanded] = useState(false)
+  // Per-book session drill-down (#150): expand a row to see, trim or delete
+  // that book's individual sessions without paging the global session log.
+  const [openBook, setOpenBook] = useState<number | null>(null)
 
   const handleSort = (key: BookTimeSortKey) => {
     if (sortKey === key) setSortAsc(!sortAsc)
@@ -215,24 +219,43 @@ export function PerBookTimeTable({ data }: { data: StatsResponse['per_book_time'
             <th className="text-right py-2 px-2 cursor-pointer select-none whitespace-nowrap" onClick={() => handleSort('pages_turned')}>
               <span className="inline-flex items-center gap-1">Pages <SortIcon col="pages_turned" /></span>
             </th>
+            <th className="w-8 py-2 px-2" />
           </tr>
         </thead>
         <tbody>
           {visible.map((b, idx) => (
-            <tr key={b.book_id} className={cn('hover:bg-accent/30 transition-colors', idx % 2 === 0 ? 'bg-muted/20' : '')}>
-              <td className="py-1.5 px-2">
-                <div className="w-8 h-12 rounded bg-muted flex items-center justify-center shrink-0 overflow-hidden">
-                  {b.has_cover ? <img src={`/api/books/${b.book_id}/cover`} alt="" className="w-full h-full object-cover" loading="lazy" /> : <FileText className="w-3.5 h-3.5 text-muted-foreground" />}
-                </div>
-              </td>
-              <td className="py-1.5 px-2">
-                <a href={`/books/${b.book_id}`} className="font-medium text-foreground hover:text-primary transition-colors line-clamp-1">{b.title}</a>
-              </td>
-              <td className="py-1.5 px-2 text-muted-foreground hidden sm:table-cell truncate max-w-[160px]">{b.author || '--'}</td>
-              <td className="py-1.5 px-2 text-right text-muted-foreground tabular-nums">{formatDuration(b.seconds)}</td>
-              <td className="py-1.5 px-2 text-right text-muted-foreground tabular-nums">{b.sessions}</td>
-              <td className="py-1.5 px-2 text-right text-muted-foreground tabular-nums">{b.pages_turned}</td>
-            </tr>
+            <Fragment key={b.book_id}>
+              <tr className={cn('hover:bg-accent/30 transition-colors', idx % 2 === 0 ? 'bg-muted/20' : '')}>
+                <td className="py-1.5 px-2">
+                  <div className="w-8 h-12 rounded bg-muted flex items-center justify-center shrink-0 overflow-hidden">
+                    {b.has_cover ? <img src={`/api/books/${b.book_id}/cover`} alt="" className="w-full h-full object-cover" loading="lazy" /> : <FileText className="w-3.5 h-3.5 text-muted-foreground" />}
+                  </div>
+                </td>
+                <td className="py-1.5 px-2">
+                  <a href={`/books/${b.book_id}`} className="font-medium text-foreground hover:text-primary transition-colors line-clamp-1">{b.title}</a>
+                </td>
+                <td className="py-1.5 px-2 text-muted-foreground hidden sm:table-cell truncate max-w-[160px]">{b.author || '--'}</td>
+                <td className="py-1.5 px-2 text-right text-muted-foreground tabular-nums">{formatDuration(b.seconds)}</td>
+                <td className="py-1.5 px-2 text-right text-muted-foreground tabular-nums">{b.sessions}</td>
+                <td className="py-1.5 px-2 text-right text-muted-foreground tabular-nums">{b.pages_turned}</td>
+                <td className="py-1.5 px-2">
+                  <button
+                    onClick={() => setOpenBook(openBook === b.book_id ? null : b.book_id)}
+                    className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                    title={openBook === b.book_id ? 'Hide sessions' : 'Show sessions'}
+                  >
+                    <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', openBook === b.book_id && 'rotate-180')} />
+                  </button>
+                </td>
+              </tr>
+              {openBook === b.book_id && (
+                <tr>
+                  <td colSpan={7} className="px-2 pb-3 pt-1">
+                    <SessionLog bookId={b.book_id} />
+                  </td>
+                </tr>
+              )}
+            </Fragment>
           ))}
         </tbody>
       </table>

--- a/frontend/src/components/stats/widgets/overview.tsx
+++ b/frontend/src/components/stats/widgets/overview.tsx
@@ -15,6 +15,7 @@ import {
 import { FileText, Trash2, Loader2, ChevronDown, BookOpen, ArrowUpDown, Scissors, TriangleAlert } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { api } from '@/lib/api'
+import { InfoHint } from '@/components/InfoHint'
 import { useChartColors } from '@/lib/useChartAccent'
 import { ChartTooltip, HeatmapChart, type StatsResponse, type SessionEntry } from '@/components/stats/shared'
 
@@ -381,6 +382,7 @@ export function SessionLog({ bookId, onChange }: { bookId?: number; onChange?: (
           {trimId === s.id && (
             <div className="flex flex-wrap items-center gap-2 rounded bg-muted/40 px-2 py-2 text-xs">
               <span className="text-muted-foreground">New duration</span>
+              <InfoHint text="Trimming only shortens this session's length and end time — page turns, progress and every other session stay untouched, and the previous duration is kept in the audit log. The suggestion re-prices this session's page turns at your usual reading pace." />
               <input
                 type="number"
                 min={1}

--- a/frontend/src/components/stats/widgets/overview.tsx
+++ b/frontend/src/components/stats/widgets/overview.tsx
@@ -12,7 +12,7 @@ import {
   YAxis,
   Tooltip,
 } from 'recharts'
-import { FileText, Trash2, Loader2, ChevronDown, BookOpen } from 'lucide-react'
+import { FileText, Trash2, Loader2, ChevronDown, BookOpen, ArrowUpDown, Scissors, TriangleAlert } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { api } from '@/lib/api'
 import { useChartColors } from '@/lib/useChartAccent'
@@ -238,18 +238,24 @@ export function BooksFinishedArea({ booksFinished, chartType = 'area' }: { books
 }
 
 // Paginated session log — same rows as the Stats page's "Recent Sessions" card,
-// without the card frame. Self-contained: fetches, paginates and deletes via the
-// API, so it works as a dashboard tile without pushing pagination state upward.
-export function SessionLog() {
+// without the card frame. Self-contained: fetches, paginates, deletes and trims
+// via the API, so it works as a dashboard tile without pushing state upward.
+// With `bookId` it becomes the per-book drill-down inside the time table (#150).
+export function SessionLog({ bookId }: { bookId?: number } = {}) {
   const [sessions, setSessions] = useState<SessionEntry[]>([])
   const [total, setTotal] = useState(0)
   const [loaded, setLoaded] = useState(0)
   const [loading, setLoading] = useState(false)
   const [deleting, setDeleting] = useState<Set<number>>(new Set())
+  const [sort, setSort] = useState<'recent' | 'longest'>('recent')
+  const [trimId, setTrimId] = useState<number | null>(null)
+  const [trimMinutes, setTrimMinutes] = useState('')
+  const [trimBusy, setTrimBusy] = useState(false)
 
   const load = (offset: number, replace: boolean) => {
     setLoading(true)
-    api.get<{ total: number; sessions: SessionEntry[] }>(`/stats/sessions?offset=${offset}&limit=20`)
+    const bookParam = bookId != null ? `&book_id=${bookId}` : ''
+    api.get<{ total: number; sessions: SessionEntry[] }>(`/stats/sessions?offset=${offset}&limit=20&sort=${sort}${bookParam}`)
       .then((res) => {
         setSessions((prev) => (replace ? res.sessions : [...prev, ...res.sessions]))
         setTotal(res.total)
@@ -260,7 +266,33 @@ export function SessionLog() {
   }
   useEffect(() => {
     load(0, true)
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sort, bookId])
+
+  const openTrim = (s: SessionEntry) => {
+    setTrimId(s.id)
+    const preFill = s.suggested_seconds ?? s.duration_seconds ?? 60
+    setTrimMinutes(String(Math.max(1, Math.round(preFill / 60))))
+  }
+
+  const applyTrim = (s: SessionEntry) => {
+    const seconds = Math.round(Number(trimMinutes) * 60)
+    if (!Number.isFinite(seconds) || seconds < 60) return
+    setTrimBusy(true)
+    api.patch(`/stats/sessions/${s.id}`, { duration_seconds: seconds })
+      .then(() => {
+        setSessions((prev) =>
+          prev.map((row) =>
+            row.id === s.id
+              ? { ...row, duration_seconds: seconds, suspect: false, suggested_seconds: null }
+              : row,
+          ),
+        )
+        setTrimId(null)
+      })
+      .catch(() => {})
+      .finally(() => setTrimBusy(false))
+  }
 
   const deleteSession = (id: number) => {
     setDeleting((prev) => new Set(prev).add(id))
@@ -279,7 +311,17 @@ export function SessionLog() {
   }
   return (
     <div className="flex flex-col gap-0">
-      <div className="hidden sm:grid grid-cols-[1fr_120px_80px_80px_40px] gap-2 px-2 pb-2 text-[11px] font-medium text-muted-foreground border-b border-border">
+      <div className="flex justify-end pb-1">
+        <button
+          onClick={() => setSort(sort === 'recent' ? 'longest' : 'recent')}
+          className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+          title="Toggle sort order"
+        >
+          <ArrowUpDown className="w-3 h-3" />
+          {sort === 'recent' ? 'Newest first' : 'Longest first'}
+        </button>
+      </div>
+      <div className="hidden sm:grid grid-cols-[1fr_120px_90px_80px_60px] gap-2 px-2 pb-2 text-[11px] font-medium text-muted-foreground border-b border-border">
         <span>Book</span>
         <span>Date</span>
         <span>Duration</span>
@@ -287,37 +329,88 @@ export function SessionLog() {
         <span />
       </div>
       {sessions.map((s, idx) => (
-        <div
-          key={s.id}
-          className={cn(
-            'grid grid-cols-1 sm:grid-cols-[1fr_120px_80px_80px_40px] gap-1 sm:gap-2 px-2 py-2 items-center hover:bg-accent/30 transition-colors text-xs rounded',
-            idx % 2 === 0 ? 'bg-muted/20' : ''
-          )}
-        >
-          <div className="font-medium text-foreground truncate">
-            {s.book_id ? (
-              <a href={`/books/${s.book_id}`} className="hover:text-primary transition-colors">{s.book_title}</a>
-            ) : (
-              <span className="text-muted-foreground">{s.book_title}</span>
+        <div key={s.id}>
+          <div
+            className={cn(
+              'grid grid-cols-1 sm:grid-cols-[1fr_120px_90px_80px_60px] gap-1 sm:gap-2 px-2 py-2 items-center hover:bg-accent/30 transition-colors text-xs rounded',
+              idx % 2 === 0 ? 'bg-muted/20' : ''
             )}
+          >
+            <div className="font-medium text-foreground truncate">
+              {s.book_id ? (
+                <a href={`/books/${s.book_id}`} className="hover:text-primary transition-colors">{s.book_title}</a>
+              ) : (
+                <span className="text-muted-foreground">{s.book_title}</span>
+              )}
+            </div>
+            <div className="text-muted-foreground">
+              {s.started_at ? new Date(s.started_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '--'}
+            </div>
+            <div className="text-muted-foreground inline-flex items-center gap-1">
+              {s.duration_seconds != null ? formatDuration(s.duration_seconds) : '--'}
+              {s.suspect && (
+                <TriangleAlert
+                  className="w-3 h-3 text-warning shrink-0"
+                  aria-label="Unusually long session"
+                />
+              )}
+            </div>
+            <div className="text-muted-foreground truncate">{s.device || '--'}</div>
+            <div className="flex justify-end gap-0.5">
+              <button
+                onClick={() => (trimId === s.id ? setTrimId(null) : openTrim(s))}
+                className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                title="Trim session"
+              >
+                <Scissors className="w-3.5 h-3.5" />
+              </button>
+              <button
+                onClick={() => deleteSession(s.id)}
+                disabled={deleting.has(s.id)}
+                className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors disabled:opacity-40"
+                title="Delete session"
+              >
+                <Trash2 className="w-3.5 h-3.5" />
+              </button>
+            </div>
           </div>
-          <div className="text-muted-foreground">
-            {s.started_at ? new Date(s.started_at).toLocaleDateString(undefined, { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' }) : '--'}
-          </div>
-          <div className="text-muted-foreground">
-            {s.duration_seconds != null ? formatDuration(s.duration_seconds) : '--'}
-          </div>
-          <div className="text-muted-foreground truncate">{s.device || '--'}</div>
-          <div className="flex justify-end">
-            <button
-              onClick={() => deleteSession(s.id)}
-              disabled={deleting.has(s.id)}
-              className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors disabled:opacity-40"
-              title="Delete session"
-            >
-              <Trash2 className="w-3.5 h-3.5" />
-            </button>
-          </div>
+          {trimId === s.id && (
+            <div className="flex flex-wrap items-center gap-2 rounded bg-muted/40 px-2 py-2 text-xs">
+              <span className="text-muted-foreground">New duration</span>
+              <input
+                type="number"
+                min={1}
+                value={trimMinutes}
+                onChange={(e) => setTrimMinutes(e.target.value)}
+                className="w-16 rounded border border-border bg-background px-1.5 py-0.5 text-right tabular-nums"
+              />
+              <span className="text-muted-foreground">min</span>
+              {s.suggested_seconds != null && (
+                <button
+                  onClick={() => setTrimMinutes(String(Math.max(1, Math.round(s.suggested_seconds! / 60))))}
+                  className="text-primary hover:text-primary/80 transition-colors"
+                  title="Your page turns at your usual reading pace"
+                >
+                  Suggested: {formatDuration(s.suggested_seconds)}
+                </button>
+              )}
+              <div className="ml-auto flex gap-1.5">
+                <button
+                  onClick={() => applyTrim(s)}
+                  disabled={trimBusy}
+                  className="rounded bg-primary px-2 py-0.5 font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+                >
+                  Trim
+                </button>
+                <button
+                  onClick={() => setTrimId(null)}
+                  className="rounded border border-border px-2 py-0.5 text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       ))}
       {loaded < total && (

--- a/frontend/src/components/stats/widgets/overview.tsx
+++ b/frontend/src/components/stats/widgets/overview.tsx
@@ -240,8 +240,10 @@ export function BooksFinishedArea({ booksFinished, chartType = 'area' }: { books
 // Paginated session log — same rows as the Stats page's "Recent Sessions" card,
 // without the card frame. Self-contained: fetches, paginates, deletes and trims
 // via the API, so it works as a dashboard tile without pushing state upward.
-// With `bookId` it becomes the per-book drill-down inside the time table (#150).
-export function SessionLog({ bookId }: { bookId?: number } = {}) {
+// With `bookId` it becomes the per-book drill-down inside the time table and on
+// BookDetailPage (#150); `onChange` lets that host refresh its own aggregates
+// after a trim or delete.
+export function SessionLog({ bookId, onChange }: { bookId?: number; onChange?: () => void } = {}) {
   const [sessions, setSessions] = useState<SessionEntry[]>([])
   const [total, setTotal] = useState(0)
   const [loaded, setLoaded] = useState(0)
@@ -289,6 +291,7 @@ export function SessionLog({ bookId }: { bookId?: number } = {}) {
           ),
         )
         setTrimId(null)
+        onChange?.()
       })
       .catch(() => {})
       .finally(() => setTrimBusy(false))
@@ -301,6 +304,7 @@ export function SessionLog({ bookId }: { bookId?: number } = {}) {
         setSessions((prev) => prev.filter((s) => s.id !== id))
         setTotal((prev) => prev - 1)
         setLoaded((prev) => prev - 1)
+        onChange?.()
       })
       .catch(() => {})
       .finally(() => setDeleting((prev) => { const n = new Set(prev); n.delete(id); return n }))

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -58,6 +58,8 @@ export const api = {
     request<T>(path, { method: "POST", body: JSON.stringify(body) }),
   put: <T>(path: string, body?: unknown) =>
     request<T>(path, { method: "PUT", body: JSON.stringify(body) }),
+  patch: <T>(path: string, body?: unknown) =>
+    request<T>(path, { method: "PATCH", body: JSON.stringify(body) }),
   delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
   upload: <T>(path: string, form: FormData) => {
     const token = localStorage.getItem("tome_token")

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -5,7 +5,7 @@ import {
   Calendar, Globe, Hash, Building2, FileText, Trash2, Loader2,
   Sparkles, Library, Check, BookMarked, ChevronLeft, ChevronRight, Home,
   Tag as TagIcon, StickyNote, ChevronDown, Archive, AlignLeft,
-  Plus, TrendingUp, TrendingDown, Minus, Info, History as HistoryIcon, Share2
+  Plus, TrendingUp, TrendingDown, Minus, History as HistoryIcon, Share2
 } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
@@ -20,6 +20,7 @@ import { StarRating } from '@/components/StarRating'
 import { CoverImage } from '@/components/CoverImage'
 import { AutocompleteInput } from '@/components/AutocompleteInput'
 import { SessionLog } from '@/components/stats/widgets/overview'
+import { InfoHint } from '@/components/InfoHint'
 import { api } from '@/lib/api'
 import type { BookDetail, BookFile, Library as LibraryType, BookStatus, ReadingStatus } from '@/lib/books'
 import { formatBytes } from '@/lib/books'
@@ -1792,46 +1793,6 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
         </form>
       )}
     </div>
-  )
-}
-
-// A small "i" that explains a chart on hover or tap. Tap-toggle so it works on
-// touch (native title tooltips don't). Reserved for the non-obvious charts.
-function InfoHint({ text }: { text: string }) {
-  const [open, setOpen] = useState(false)
-  const rootRef = useRef<HTMLSpanElement>(null)
-  // iOS Safari doesn't focus buttons on tap, so onBlur alone never closes the
-  // popover there — close on any tap outside instead.
-  useEffect(() => {
-    if (!open) return
-    const onPointerDown = (e: PointerEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
-    }
-    document.addEventListener('pointerdown', onPointerDown)
-    return () => document.removeEventListener('pointerdown', onPointerDown)
-  }, [open])
-  return (
-    <span ref={rootRef} className="relative inline-flex leading-none">
-      <button
-        type="button"
-        aria-label="What is this chart?"
-        onClick={() => setOpen(o => !o)}
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-        onBlur={() => setOpen(false)}
-        className="text-muted-foreground/40 hover:text-muted-foreground transition-colors"
-      >
-        <Info className="w-3 h-3" />
-      </button>
-      {open && (
-        <span
-          role="tooltip"
-          className="absolute left-0 top-5 z-20 w-52 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs leading-snug text-muted-foreground shadow-lg"
-        >
-          {text}
-        </span>
-      )}
-    </span>
   )
 }
 

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -19,6 +19,7 @@ import { BookAnimation } from '@/components/BookAnimation'
 import { StarRating } from '@/components/StarRating'
 import { CoverImage } from '@/components/CoverImage'
 import { AutocompleteInput } from '@/components/AutocompleteInput'
+import { SessionLog } from '@/components/stats/widgets/overview'
 import { api } from '@/lib/api'
 import type { BookDetail, BookFile, Library as LibraryType, BookStatus, ReadingStatus } from '@/lib/books'
 import { formatBytes } from '@/lib/books'
@@ -186,6 +187,9 @@ export function BookDetailPage() {
   // intensity + time-per-chapter) has grown tall enough that "keep it closed"
   // is a real preference, not a per-page whim.
   const [statsOpen, setStatsOpen] = useState(() => localStorage.getItem('tome_book_stats_open') !== '0')
+  // Per-book session list (#150) — collapsed by default; the always-available
+  // place to trim/delete a runaway session (the Stats tiles are removable).
+  const [sessionsOpen, setSessionsOpen] = useState(false)
   const [showPositionHistory, setShowPositionHistory] = useState(false)
   const [showShare, setShowShare] = useState(false)
   const [editingNoteId, setEditingNoteId] = useState<number | null>(null)
@@ -781,6 +785,24 @@ export function BookDetailPage() {
             {readingStats.intensity && <IntensityBlock data={readingStats.intensity} />}
             {readingStats.chapters && readingStats.chapters.length > 0 && (
               <ChapterTimesBlock chapters={readingStats.chapters} />
+            )}
+            {readingStats.own.sessions > 0 && (
+              <div className="rounded-xl border border-border bg-card px-5 py-4">
+                <button
+                  type="button"
+                  onClick={() => setSessionsOpen(o => !o)}
+                  aria-expanded={sessionsOpen}
+                  className="flex items-center gap-1.5 text-sm font-medium text-foreground hover:text-primary transition-colors"
+                >
+                  Sessions ({readingStats.own.sessions})
+                  <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', !sessionsOpen && '-rotate-90')} />
+                </button>
+                {sessionsOpen && (
+                  <div className="mt-3">
+                    <SessionLog bookId={Number(id)} onChange={refreshStats} />
+                  </div>
+                )}
+              </div>
             )}
           </div>
         ) : (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,16 @@ from backend.models.reading_goal import ReadingGoal  # noqa: F401 — registers 
 # We raise RuntimeError rather than silently no-op so any accidental attempt
 # fails loudly instead of pretending to send.
 
+# Pin anyio tests to asyncio. anyio's default `anyio_backend` fixture
+# parametrizes over every *installed* backend, so a dev machine with trio in
+# the venv silently doubles every anyio test with a [trio] variant — and the
+# code under test (metadata_fetch's asyncio.gather, FastAPI itself) is
+# asyncio-only by design. CI has no trio, so those variants never ran there.
+@pytest.fixture(scope="module")
+def anyio_backend():
+    return "asyncio"
+
+
 @pytest.fixture(autouse=True, scope="function")
 def _block_smtp():
     """Autouse fixture: replace smtplib.SMTP / SMTP_SSL with a hard block."""

--- a/tests/test_session_hygiene.py
+++ b/tests/test_session_hygiene.py
@@ -1,0 +1,249 @@
+"""Runaway-session hygiene (issue #150).
+
+Covers the shared detection rules (backend/services/session_hygiene.py), the
+suspect-session notification raised at sync ingest, the sessions list's
+book filter / longest-first sort / suspect + suggestion fields, and the
+trim endpoint.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from backend.core.database import get_db
+from backend.core.security import hash_password, create_access_token
+from backend.models.audit_log import AuditLog
+from backend.models.notification import Notification
+from backend.models.tome_sync import ApiKey, ReadingSession
+from backend.models.user import User, UserPermission
+from backend.services.session_hygiene import (
+    SUSPECT_ABS_SECONDS,
+    is_suspect,
+    median_secs_per_page,
+    suggested_seconds,
+)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+def _make_user(db: Session, username: str) -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password=hash_password("pass"),
+        is_active=True,
+        role="member",
+        must_change_password=False,
+    )
+    db.add(user)
+    db.flush()
+    db.add(UserPermission(user_id=user.id, can_use_kosync=True))
+    db.flush()
+    return user, create_access_token(subject=user.id)
+
+
+def _create_api_key(db: Session, user: User) -> str:
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(
+        user_id=user.id,
+        key_hash=ApiKey.hash_key(plaintext),
+        key_prefix=plaintext[:11],
+        label="test",
+    ))
+    db.flush()
+    return plaintext
+
+
+def _add_session(db, user, book, *, start, seconds, pages):
+    row = ReadingSession(
+        user_id=user.id,
+        book_id=book.id,
+        started_at=start,
+        ended_at=start + timedelta(seconds=seconds),
+        duration_seconds=seconds,
+        pages_turned=pages,
+        device="kindle",
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+@pytest.fixture()
+def hygiene_client(db: Session):
+    """(client, db, user, jwt, api_key) — no default auth header."""
+    from backend.main import create_app
+    app = create_app()
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+    user, jwt = _make_user(db, "hygieneuser")
+    api_key = _create_api_key(db, user)
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c, db, user, jwt, api_key
+    app.dependency_overrides.clear()
+
+
+# ── detection rules ───────────────────────────────────────────────────────────
+
+def test_is_suspect_rules():
+    assert is_suspect(SUSPECT_ABS_SECONDS, 500)          # long outright
+    assert is_suspect(3600, 4)                           # 15 min per page turn
+    assert not is_suspect(3600, 60)                      # normal pace
+    assert not is_suspect(None, 60)
+    assert not is_suspect(0, 0)
+    # long-ish but below the absolute bar, and no page data to judge pace by
+    assert not is_suspect(3 * 3600, None)
+
+
+def test_suggested_seconds():
+    # 15 page turns at a 60s median → 900s, far below the recorded 8h
+    assert suggested_seconds(8 * 3600, 15, 60.0) == 900
+    # never suggests >= the recorded duration
+    assert suggested_seconds(900, 15, 60.0) is None
+    assert suggested_seconds(8 * 3600, None, 60.0) is None
+    assert suggested_seconds(8 * 3600, 15, None) is None
+    # floor of one minute
+    assert suggested_seconds(8 * 3600, 1, 6.0) == 60
+
+
+def test_median_ignores_the_runaways_and_needs_history(db, make_book):
+    user, _ = _make_user(db, "medianuser")
+    book = make_book(title="Median Book")
+    start = datetime(2026, 1, 1, 20, 0)
+    # two plausible sessions — not enough history yet
+    _add_session(db, user, book, start=start, seconds=600, pages=10)
+    _add_session(db, user, book, start=start + timedelta(days=1), seconds=1200, pages=20)
+    assert median_secs_per_page(db, user.id) is None
+    # third plausible one unlocks it; a runaway (1000s/page) must not skew it
+    _add_session(db, user, book, start=start + timedelta(days=2), seconds=2400, pages=30)
+    _add_session(db, user, book, start=start + timedelta(days=3), seconds=8 * 3600, pages=28)
+    med = median_secs_per_page(db, user.id)
+    assert med == pytest.approx(60.0, abs=15)
+
+
+# ── ingest notification ───────────────────────────────────────────────────────
+
+def test_suspect_sync_raises_one_notification(hygiene_client, make_book):
+    c, db, user, _jwt, api_key = hygiene_client
+    book = make_book(title="Night Owl")
+    headers = {"Authorization": f"Bearer {api_key}"}
+    payload = {
+        "book_id": book.id,
+        "started_at": "2026-01-01T22:00:00Z",
+        "ended_at": "2026-01-02T06:15:00Z",
+        "duration_seconds": int(8.25 * 3600),
+        "pages_turned": 15,
+        "device": "pocketbook",
+    }
+    r = c.post("/api/tome-sync/session", json=payload, headers=headers)
+    assert r.status_code == 201
+
+    notes = db.query(Notification).filter_by(user_id=user.id, kind="session_suspect").all()
+    assert len(notes) == 1
+    assert "Night Owl" in notes[0].title
+    assert notes[0].link == "/stats"
+
+    # a second runaway for the same book while the first is unread: no stacking
+    payload["started_at"] = "2026-01-03T22:00:00Z"
+    payload["ended_at"] = "2026-01-04T06:15:00Z"
+    payload["session_uuid"] = "other-night"
+    r = c.post("/api/tome-sync/session", json=payload, headers=headers)
+    assert r.status_code == 201
+    notes = db.query(Notification).filter_by(user_id=user.id, kind="session_suspect").all()
+    assert len(notes) == 1
+
+
+def test_normal_sync_raises_no_notification(hygiene_client, make_book):
+    c, db, user, _jwt, api_key = hygiene_client
+    book = make_book(title="Normal Evening")
+    r = c.post("/api/tome-sync/session", json={
+        "book_id": book.id,
+        "started_at": "2026-01-01T20:00:00Z",
+        "ended_at": "2026-01-01T21:00:00Z",
+        "duration_seconds": 3600,
+        "pages_turned": 60,
+        "device": "kindle",
+    }, headers={"Authorization": f"Bearer {api_key}"})
+    assert r.status_code == 201
+    assert db.query(Notification).filter_by(user_id=user.id).count() == 0
+
+
+# ── sessions list: filter, sort, flags ────────────────────────────────────────
+
+def test_sessions_list_filter_sort_and_flags(hygiene_client, make_book):
+    c, db, user, jwt, _key = hygiene_client
+    book_a = make_book(title="Book A")
+    book_b = make_book(title="Book B")
+    start = datetime(2026, 1, 1, 20, 0)
+    # plausible history so the median (60s/page) and suggestions exist
+    for i in range(3):
+        _add_session(db, user, book_a, start=start + timedelta(days=i), seconds=1800, pages=30)
+    runaway = _add_session(
+        db, user, book_b, start=start + timedelta(days=10), seconds=8 * 3600, pages=15
+    )
+    headers = {"Authorization": f"Bearer {jwt}"}
+
+    r = c.get(f"/api/stats/sessions?book_id={book_b.id}", headers=headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 1
+    row = data["sessions"][0]
+    assert row["id"] == runaway.id
+    assert row["suspect"] is True
+    assert row["suggested_seconds"] == pytest.approx(15 * 60, abs=300)
+
+    r = c.get("/api/stats/sessions?sort=longest", headers=headers)
+    rows = r.json()["sessions"]
+    assert rows[0]["id"] == runaway.id
+    assert all(not row["suspect"] for row in rows[1:])
+
+    r = c.get("/api/stats/sessions?sort=bogus", headers=headers)
+    assert r.status_code == 422
+
+
+# ── trim endpoint ─────────────────────────────────────────────────────────────
+
+def test_trim_shortens_and_moves_ended_at(hygiene_client, make_book):
+    c, db, user, jwt, _key = hygiene_client
+    book = make_book(title="Trim Me")
+    start = datetime(2026, 1, 1, 22, 0)
+    row = _add_session(db, user, book, start=start, seconds=8 * 3600, pages=15)
+    headers = {"Authorization": f"Bearer {jwt}"}
+
+    r = c.patch(f"/api/stats/sessions/{row.id}", json={"duration_seconds": 900}, headers=headers)
+    assert r.status_code == 200
+
+    db.expire_all()
+    fresh = db.get(ReadingSession, row.id)
+    assert fresh.duration_seconds == 900
+    assert fresh.ended_at == start + timedelta(seconds=900)
+
+    entry = db.query(AuditLog).filter_by(action="session.trimmed").first()
+    assert entry is not None
+
+
+def test_trim_validation(hygiene_client, make_book):
+    c, db, user, jwt, _key = hygiene_client
+    book = make_book(title="Trim Bounds")
+    row = _add_session(
+        db, user, book, start=datetime(2026, 1, 1, 22, 0), seconds=600, pages=10
+    )
+    headers = {"Authorization": f"Bearer {jwt}"}
+
+    # can only shorten
+    r = c.patch(f"/api/stats/sessions/{row.id}", json={"duration_seconds": 600}, headers=headers)
+    assert r.status_code == 400
+    r = c.patch(f"/api/stats/sessions/{row.id}", json={"duration_seconds": 0}, headers=headers)
+    assert r.status_code == 400
+    # not someone else's session
+    other, other_jwt = _make_user(db, "someoneelse")
+    r = c.patch(
+        f"/api/stats/sessions/{row.id}",
+        json={"duration_seconds": 60},
+        headers={"Authorization": f"Bearer {other_jwt}"},
+    )
+    assert r.status_code == 404

--- a/tests/test_tomesync_idle_cap.py
+++ b/tests/test_tomesync_idle_cap.py
@@ -1,0 +1,192 @@
+"""Idle-capped session accounting in the TomeSync plugin (issue #150).
+
+A device whose cover fails to suspend it books wall-clock time: the plugin
+used ``duration = os.time() - session_start`` and only ended sessions on
+suspend/close, so falling asleep over an open book logged an 8-hour session
+(58h total on a 10h book, per the report). Build 37 accumulates active time
+per page turn instead, crediting each gap at most the idle cap (default
+10 min, configurable, 0 = off), and ends the session at the last activity
+plus the final credit rather than at the moment the device finally slept.
+
+Two layers of tests: regex tripwires on the generated Lua that always run
+(same style as test_tomesync_initsession.py), and an executable harness that
+extracts the real accounting functions and runs them under LuaJIT — the
+engine KOReader itself uses — when one is installed.
+"""
+import re
+import shutil
+import subprocess
+import textwrap
+
+import pytest
+
+from backend.api.tome_sync import TOMESYNC_PLUGIN_BUILD, _main_impl_lua
+
+
+def _impl() -> str:
+    return _main_impl_lua("http://localhost:8080", "tk_test", "tester")
+
+
+def _block(lua: str, header: str) -> str:
+    match = re.search(re.escape(header) + r".*?\nend\n", lua, re.S)
+    assert match, f"{header} not found in generated impl"
+    return match.group(0)
+
+
+# ── Tripwires (always run) ────────────────────────────────────────────────────
+
+def test_build_carries_the_idle_cap():
+    assert TOMESYNC_PLUGIN_BUILD >= 37
+
+
+def test_wall_clock_duration_formula_is_gone():
+    # The old formula must not survive anywhere: every session-end path goes
+    # through _sessionTotals or the runaway-session bug is back.
+    lua = _impl()
+    assert "os.time() - self.session_start" not in lua
+
+
+def test_page_turns_credit_activity():
+    body = _block(_impl(), "function TomeSync:onPageUpdate(pageno)")
+    assert "self:_creditActivity(os.time())" in body
+
+
+def test_both_session_end_paths_use_capped_totals():
+    lua = _impl()
+    for header in ("function TomeSync:onSuspend()",
+                   "function TomeSync:onCloseDocument()"):
+        body = _block(lua, header)
+        assert "self:_sessionTotals(os.time())" in body, header
+        # ended_at must be the honest end (last activity + credit), not the
+        # moment the device finally suspended hours later.
+        assert re.search(r'ended_at\s*=\s*os\.date\("!%Y-%m-%dT%H:%M:%SZ", session_end\)', body), header
+
+
+def test_session_state_resets_everywhere():
+    lua = _impl()
+    for header in ("function TomeSync:_initSession()",
+                   "function TomeSync:onResume()",
+                   "function TomeSync:onCloseDocument()"):
+        body = _block(lua, header)
+        assert "self.active_seconds = 0" in body, header
+
+
+def test_settings_menu_offers_the_cap():
+    lua = _impl()
+    assert "Idle time cap" in lua
+    assert "tomesync_idle_cap_minutes" in lua
+
+
+# ── Executable harness (LuaJIT — the engine KOReader runs on) ─────────────────
+
+LUAJIT = shutil.which("luajit")
+
+
+def _extract(lua: str, pattern: str) -> str:
+    match = re.search(pattern, lua, re.S)
+    assert match, f"pattern not found in impl: {pattern}"
+    return match.group(0)
+
+
+def _harness() -> str:
+    """The real accounting code lifted verbatim from the generated impl,
+    wrapped with a G_reader_settings stub and scenario assertions."""
+    lua = _impl()
+    cap_default = _extract(lua, r"local IDLE_CAP_DEFAULT_MINUTES = \d+")
+    idle_cap = _extract(lua, r"local function idleCapSeconds\(\).*?\nend\n")
+    credit = _extract(lua, r"function TomeSync:_creditActivity\(now\).*?\nend\n")
+    totals = _extract(lua, r"function TomeSync:_sessionTotals\(now\).*?\nend\n")
+    scenarios = textwrap.dedent("""
+        local function newSession(t0)
+            local s = setmetatable({}, {__index = TomeSync})
+            s.session_start  = t0
+            s.page_count     = 0
+            s.active_seconds = 0
+            s.last_activity  = t0
+            return s
+        end
+
+        -- Normal reading: a page a minute for 30 minutes, end 60s after the
+        -- last turn. Nothing hits the cap; duration is the full wall span.
+        local t0 = 1000000
+        local s = newSession(t0)
+        for i = 1, 30 do s:_creditActivity(t0 + i * 60) end
+        local dur, ended = s:_sessionTotals(t0 + 30 * 60 + 60)
+        assert(dur == 30 * 60 + 60, "normal reading: " .. dur)
+        assert(ended == t0 + 30 * 60 + 60, "normal reading end: " .. ended)
+
+        -- The reporter's case: 15 minutes of reading, reader falls asleep,
+        -- device suspends 8 hours later. Books ~15m + one cap of tail, and
+        -- the session ends near the last page turn, not at 6 AM.
+        s = newSession(t0)
+        for i = 1, 15 do s:_creditActivity(t0 + i * 60) end
+        local last_turn = t0 + 15 * 60
+        dur, ended = s:_sessionTotals(last_turn + 8 * 3600)
+        assert(dur == 15 * 60 + 600, "fell asleep: " .. dur)
+        assert(ended == last_turn + 600, "fell asleep end: " .. ended)
+
+        -- Nap in the middle: 10 minutes read, 3 idle hours, 10 more minutes,
+        -- end a minute later. Both reading stretches count; the nap costs
+        -- one cap.
+        s = newSession(t0)
+        for i = 1, 10 do s:_creditActivity(t0 + i * 60) end
+        local resume = t0 + 10 * 60 + 3 * 3600
+        s:_creditActivity(resume)  -- first turn after waking: 3h gap, capped
+        for i = 1, 10 do s:_creditActivity(resume + i * 60) end
+        dur, ended = s:_sessionTotals(resume + 10 * 60 + 60)
+        assert(dur == 10 * 60 + 600 + 10 * 60 + 60, "mid-session nap: " .. dur)
+
+        -- Cap off (0): exact wall-clock behaviour of builds <= 36.
+        G_reader_settings.vals.tomesync_idle_cap_minutes = 0
+        s = newSession(t0)
+        for i = 1, 15 do s:_creditActivity(t0 + i * 60) end
+        dur, ended = s:_sessionTotals(t0 + 15 * 60 + 8 * 3600)
+        assert(dur == 15 * 60 + 8 * 3600, "cap off: " .. dur)
+        assert(ended == t0 + 15 * 60 + 8 * 3600, "cap off end: " .. ended)
+
+        -- Custom 5-minute cap.
+        G_reader_settings.vals.tomesync_idle_cap_minutes = 5
+        s = newSession(t0)
+        s:_creditActivity(t0 + 3600)
+        dur = s:_sessionTotals(t0 + 3600)
+        assert(dur == 300, "5m cap: " .. dur)
+        G_reader_settings.vals.tomesync_idle_cap_minutes = nil
+
+        -- Clock skew: a backwards jump must never go negative or crash.
+        s = newSession(t0)
+        s:_creditActivity(t0 - 500)
+        dur = s:_sessionTotals(t0)
+        assert(dur >= 0, "clock skew: " .. dur)
+
+        print("HARNESS-OK")
+    """)
+    return "\n".join([
+        "G_reader_settings = { vals = {},",
+        "  readSetting = function(self, k) return self.vals[k] end }",
+        cap_default,
+        idle_cap,
+        "TomeSync = {}",
+        credit,
+        totals,
+        scenarios,
+    ])
+
+
+@pytest.mark.skipif(LUAJIT is None, reason="luajit not installed")
+def test_accounting_scenarios_under_luajit(tmp_path):
+    script = tmp_path / "harness.lua"
+    script.write_text(_harness())
+    proc = subprocess.run([LUAJIT, str(script)], capture_output=True, text=True, timeout=30)
+    assert proc.returncode == 0, proc.stderr
+    assert "HARNESS-OK" in proc.stdout
+
+
+@pytest.mark.skipif(LUAJIT is None, reason="luajit not installed")
+def test_generated_impl_parses_under_luajit(tmp_path):
+    script = tmp_path / "main_impl.lua"
+    script.write_text(_impl())
+    proc = subprocess.run(
+        [LUAJIT, "-e", f"assert(loadfile('{script}'))"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert proc.returncode == 0, proc.stderr

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -196,5 +196,10 @@ def test_build_bumped_for_rebake():
     # 1.10.0 / build 36 adds the Shelves browse axis: the device lists the
     # user's shelves and drills into their resolved book lists
     # (GET /tome-sync/{shelves,shelf-books}); mixed lists download per-book.
-    assert TOMESYNC_PLUGIN_BUILD >= 36
-    assert TOMESYNC_PLUGIN_SEMVER == "1.10.0"
+    # 1.11.0 / build 37 adds idle-capped session accounting (issue #150):
+    # active time accumulates per page turn with each gap credited at most
+    # the idle cap (default 10 min, configurable, 0 = off), so a device left
+    # awake unread no longer books wall-clock time; ended_at becomes the last
+    # activity plus the final credit rather than the eventual suspend.
+    assert TOMESYNC_PLUGIN_BUILD >= 37
+    assert TOMESYNC_PLUGIN_SEMVER == "1.11.0"

--- a/website/src/pages/docs/koreader.astro
+++ b/website/src/pages/docs/koreader.astro
@@ -52,6 +52,18 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
     <em>what</em> you did to get there.
   </p>
 
+  <h3>Idle time cap</h3>
+  <p>
+    Session time is counted per page turn, and any single gap is credited at most the
+    <strong>idle time cap</strong> (default 10 minutes, adjustable under
+    <strong>TomeSync → Settings → Idle time cap</strong>, including off). If the device sits
+    awake without a page turn — you fell asleep over the book, or the cover didn't put it to
+    sleep — the time beyond the cap simply isn't booked, and the session ends at your last page
+    turn instead of whenever the device finally suspended. This is the same approach KOReader's
+    own statistics plugin takes, so a 15-minute bedtime read stays 15 minutes even if the
+    device stayed awake all night.
+  </p>
+
   <h3>Bidirectional position sync</h3>
   <p>
     Read on KOReader in bed, pick up on the web reader in the morning, come back to KOReader the

--- a/website/src/pages/docs/stats.astro
+++ b/website/src/pages/docs/stats.astro
@@ -81,6 +81,34 @@ import { withBase } from '../../lib/path'
     statuses, ratings, reviews, and finish dates you already have are never overwritten.
   </p>
 
+  <h2>Fixing a runaway session</h2>
+  <p>
+    A device that never actually went to sleep can sync a session hours longer than the reading
+    it contains — 15 minutes of pages, then a night of idle screen. The
+    <a href={withBase("/docs/koreader")}>TomeSync plugin</a> prevents this at the source with its
+    idle time cap, but sessions from older plugin builds (or other clients) are sanity-checked
+    on arrival: anything implausibly long, or averaging many minutes per page turn, is flagged
+    with a warning icon and raises a bell notification.
+  </p>
+  <p>
+    Any session list lets you fix one: <strong>trim</strong> (the scissors icon) shortens the
+    session to what you actually read, while delete removes it entirely. The trim editor
+    pre-fills a suggestion — the session's own page turns priced at your median seconds-per-page,
+    computed from your recent plausible sessions so the runaways can't skew their own baseline.
+    It's only ever a pre-fill; nothing is changed until you confirm. Session lists live in three
+    places: the <strong>Recent Sessions</strong> tile (sortable longest-first), the per-book
+    time table on the Library board, and a collapsible <strong>Sessions</strong> section under
+    Reading Stats on every book page — so they stay reachable even if you've removed the tiles
+    from your dashboard.
+  </p>
+
+  <Callout variant="info" title="Nothing else is touched">
+    Trimming rewrites exactly two fields on that one session — its duration and end time. Page
+    turns, progress, start time, device, other sessions, and imported KOReader history are all
+    untouched, and the previous duration is recorded in the audit log, so a trim is never a
+    silent loss of data.
+  </Callout>
+
   <h2>Overview board</h2>
   <p>
     The "where am I right now?" board. Designed to be glanceable. Like every section below,


### PR DESCRIPTION
Fixes #150.

A device that never actually suspends — a cover that fails to sleep it, or a reader who fell asleep mid-chapter — booked the whole wall-clock span as reading (58h logged on a 10h book in the report). Three layers:

## Plugin (build 37 / 1.11.0) — root cause
Active reading time now accumulates per page turn, with each gap credited at most an **idle cap** (default 10 min, configurable in TomeSync → Settings → Idle time cap, including off) — the same idea KOReader's own statistics plugin uses. The session's `ended_at` becomes the last page turn plus the final credit rather than whenever the device finally slept. With the cap off, the math degrades to the old wall-clock behaviour exactly. Handles the nastier mid-session case too: fall asleep, wake up, keep reading — both stretches count, the nap costs one cap.

## Server — old plugin builds stay covered
`POST /tome-sync/session` sanity-checks incoming sessions: implausibly long (≥6h) or an absurd pace (>10 min average per page turn) raises a `session_suspect` bell notification (deduped while unread) pointing at Reading Stats.

## Cleanup for damage already in the DB
- `GET /stats/sessions` gains `book_id` filter, `sort=longest`, a per-row `suspect` flag, and `suggested_seconds` — the session's page turns re-priced at the user's own median pace.
- New `PATCH /stats/sessions/{id}`: **trim** (shrink-only, audited; `ended_at` moves with it) so a 15-minute read that idled 8 hours goes back to 15 minutes without deleting the reading.
- UI: warning icon on suspect rows, longest-first sort toggle, scissors → inline trim editor pre-filled with the suggestion, and the per-book time table (Library tab) expands into that book's session list with trim/delete.

## Testing
- **LuaJIT harness** (`tests/test_tomesync_idle_cap.py`): extracts the real accounting functions from the generated impl and runs them under LuaJIT (KOReader's engine) through the fell-asleep, mid-session-nap, cap-off-equivalence, custom-cap, and clock-skew scenarios; plus regex tripwires that run without luajit (CI).
- **Full pytest suite green** (985 passed). New `tests/test_session_hygiene.py` covers detection rules, median robustness against the runaways themselves, ingest notification + dedupe, list filters/flags, trim validation + audit.
- **Emulator round-trip** against showcase: real page turns credit correctly; an injected 15m-read + 2h-idle state synced as a **25m session with an honest end time** (900s active + one 600s cap), and the 2h tail was never booked. Settings menu verified on-device-shape (screenshots in thread).
- Web UI verified with Playwright: suspect badge, longest-first sort, trim flow (8h 15m → 21m via suggestion), per-book drill-down, bell notification.
- Frontend `tsc -b` + build green.

Note for reviewers: `tests/conftest.py` now pins anyio tests to the asyncio backend — with trio installed in a dev venv, anyio's default fixture silently doubled every anyio test with a `[trio]` variant that the asyncio-only code under test can never pass. CI (no trio) is unaffected.