### PR TITLE
fix(stats): volume-guarded history matching, startup repair, per-book purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Fixed
+- Imported KOReader reading history can no longer land on the wrong volume of
+  a series (#152). When a volume read on the device was missing from the Tome
+  library, the history importer's title matching could confidently attribute
+  its entire reading log to a sibling volume — hours of sessions and page
+  data on a book never opened. The matcher now treats a parsed volume number
+  as authoritative: a candidate claiming a different volume is never matched,
+  half-volumes (2.5) resolve exactly instead of truncating, and French-style
+  "T2" tome numbering is understood. History for a volume Tome doesn't own is
+  parked until the book exists rather than guessed onto a lookalike.
+- On update, previously mis-imported history heals itself: stored matches are
+  re-verified against the fixed rules on startup, ghost page data whose book
+  has no other import source is removed, the device re-syncs its history on
+  the next connection, and a notification explains what happened. Books where
+  wrong and genuine history are mixed are left untouched and flagged instead.
+
 - Chart tooltips on Reading Stats no longer detach from the cursor or hide
   behind neighbouring tiles (#151). The activity heatmap, the hour-by-day
   heatmap, and the timeline ribbon all rendered their hover tooltip inside
@@ -15,6 +30,11 @@ All notable changes to Tome are documented here. Format loosely follows
   and follow the mouse everywhere.
 
 ### Added
+- **Clear imported history per book.** The Reading intensity panel on a book
+  page grows a small trash action that removes the current user's imported
+  KOReader page data for that book — the manual escape hatch for mixed cases
+  the automatic repair deliberately leaves alone. Web and manual sessions are
+  unaffected, and reading the book on a device again re-imports from there on.
 - **Runaway reading sessions are over (KOReader plugin, build 37).** A device
   that never actually sleeps — a cover that fails to suspend it, or a reader
   who fell asleep mid-chapter — used to book the whole wall-clock span as

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1412,6 +1412,60 @@ def add_manual_reading_session(
     return {"own": compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset)}
 
 
+@router.delete("/{book_id}/imported-history")
+def clear_imported_history(
+    book_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Delete the current user's imported KOReader page-stats for one book.
+
+    The escape hatch for history the statistics import attributed to the wrong
+    book (issue #152) — cases the automatic repair refuses to touch because the
+    book mixes ghost and genuine rows. Scope is deliberately narrow: only
+    imported page-stats (the "Reading intensity" data), never live or manual
+    ReadingSessions, positions, or read-status — those have their own tooling.
+
+    Fuzzy match rows pointing at the book are reset to unmatched so future
+    syncs re-decide them under the volume-guarded matcher instead of re-filing
+    onto the same book. Hash/filename matches are left alone: their identity is
+    deterministic, so future reading of the book re-imports correctly — this
+    clears history, it does not disable tracking.
+    """
+    from backend.models.ko_stats import KoStatsBookMatch, PageStat
+
+    book = db.get(Book, book_id)
+    if not book or book.status != "active":
+        raise HTTPException(status_code=404, detail="Book not found")
+    if not user_can_see_book(db, current_user, book):
+        raise HTTPException(status_code=404, detail="Book not found")
+
+    deleted = (
+        db.query(PageStat)
+        .filter(PageStat.user_id == current_user.id, PageStat.book_id == book_id)
+        .delete(synchronize_session=False)
+    )
+    matches_reset = 0
+    fuzzy_matches = (
+        db.query(KoStatsBookMatch)
+        .filter(
+            KoStatsBookMatch.user_id == current_user.id,
+            KoStatsBookMatch.book_id == book_id,
+            KoStatsBookMatch.method == "fuzzy",
+        )
+        .all()
+    )
+    for m in fuzzy_matches:
+        m.book_id = None
+        m.status = "unmatched"
+        m.method = "none"
+        m.confidence = 0.0
+        matches_reset += 1
+
+    db.commit()
+    return {"pages_deleted": deleted, "matches_reset": matches_reset}
+
+
 # ── Single book ───────────────────────────────────────────────────────────────
 
 @router.get("/{book_id}", response_model=BookDetailOut)

--- a/backend/main.py
+++ b/backend/main.py
@@ -341,6 +341,13 @@ async def lifespan(app: FastAPI):
     threading.Thread(target=backfill_missing_raw_hashes, daemon=True,
                      name="ko-hash-backfill").start()
 
+    # One-shot repair of KOReader-history matches the pre-volume-guard fuzzy
+    # matcher attributed to the wrong sibling volume (issue #152). Idempotent:
+    # corrected rows no longer qualify, so later startups are no-ops.
+    from backend.services.ko_stats_import import repair_fuzzy_matches_startup
+    threading.Thread(target=repair_fuzzy_matches_startup, daemon=True,
+                     name="ko-stats-repair").start()
+
     release_task: asyncio.Task | None = None
     if settings.release_detection:
         logger.info("Release detection enabled — checking follows every %d seconds",

--- a/backend/services/ko_stats_import.py
+++ b/backend/services/ko_stats_import.py
@@ -13,6 +13,7 @@ onto one book.
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 from dataclasses import dataclass
@@ -28,6 +29,8 @@ from backend.models.book import Book, BookFile
 from backend.services.ko_hash import lookup_book_ids
 from backend.models.ko_stats import KoStatsBookMatch, PageStat, StatsImport
 
+logger = logging.getLogger(__name__)
+
 # NOTE: the import deliberately does NOT write Tome read-status (read/reading/finished).
 # Status is user-curation, not telemetry — a fuzzy match plus possibly-incomplete history
 # must not flip a hard, library-wide flag. KOReader data feeds *time & pages* only; status
@@ -35,7 +38,12 @@ from backend.models.ko_stats import KoStatsBookMatch, PageStat, StatsImport
 
 # ── Title parsing / normalization ─────────────────────────────────────────────
 
-_VOL_RE = re.compile(r"\b(?:vol(?:ume)?\.?|book|tome|part)\s*0*(\d+)\b", re.I)
+# Decimal capture so "Vol. 2.5" stays 2.5 instead of truncating to 2 (the
+# resolve endpoint made the same call) — a half-volume is a different book.
+_VOL_RE = re.compile(r"\b(?:vol(?:ume)?\.?|book|tome|part)\s*0*(\d+(?:\.\d+)?)\b", re.I)
+# French-style tome abbreviation ("Série T2" / "Série T.2"). Bounded to 1-3
+# digits so a standalone "T 1927" year can't be misread as a volume.
+_VOL_T_RE = re.compile(r"\bt\.?\s*0*(\d{1,3})\b", re.I)
 _MID_RE = re.compile(r"(.*?)\s+0*(\d{1,3})\s*[-–]\s+\S")   # "Series 01 - Subtitle"
 _TRAIL_RE = re.compile(r"(.*?)[\s,:–-]+0*(\d{1,3})\s*$")    # "Series 05" / "Series - 02"
 
@@ -63,18 +71,23 @@ def _author_key(a: str) -> str:
     return re.sub(r"[^a-z ]", " ", a).strip()
 
 
-def parse_ko_title(title: str) -> tuple[str, Optional[int]]:
-    """-> (normalized base, volume:int|None)."""
+def parse_ko_title(title: str) -> tuple[str, Optional[float]]:
+    """-> (normalized base, volume:float|None). Volumes are floats so 2.5
+    (half-volumes) survive; integer volumes compare equal to their int form."""
     t = _strip_paren(title or "")
-    vol: Optional[int] = None
+    vol: Optional[float] = None
     m = _VOL_RE.search(t)
+    mt = _VOL_T_RE.search(t)
     if m:
-        vol = int(m.group(1))
+        vol = float(m.group(1))
         base = _VOL_RE.sub(" ", t)
+    elif mt:
+        vol = float(mt.group(1))
+        base = _VOL_T_RE.sub(" ", t)
     elif _MID_RE.match(t):
-        m3 = _MID_RE.match(t); base, vol = m3.group(1), int(m3.group(2))
+        m3 = _MID_RE.match(t); base, vol = m3.group(1), float(m3.group(2))
     elif _TRAIL_RE.match(t):
-        m2 = _TRAIL_RE.match(t); base, vol = m2.group(1), int(m2.group(2))
+        m2 = _TRAIL_RE.match(t); base, vol = m2.group(1), float(m2.group(2))
     else:
         base = t
     return _norm(_desub(base)), vol
@@ -108,6 +121,19 @@ def _basename(p: str) -> str:
     return os.path.basename((p or "").replace("\\", "/")).strip().lower()
 
 
+def _candidate_volumes(c: BookCandidate) -> set[float]:
+    """Every volume number a candidate credibly claims: its ``series_index``
+    and any volume parsed out of its own title. Empty set = no volume signal
+    (standalones, distinct-title volumes)."""
+    vols: set[float] = set()
+    if c.series_index is not None:
+        vols.add(float(c.series_index))
+    title_vol = parse_ko_title(c.title or "")[1]
+    if title_vol is not None:
+        vols.add(title_vol)
+    return vols
+
+
 def match_book(
     candidates: list[BookCandidate],
     ko_title: str,
@@ -127,12 +153,13 @@ def match_book(
     kauth = _author_key(ko_authors or "")
     knt = _norm(_desub(ko_title or ""))
 
-    # Pre-index candidates by (norm series, int index) and norm title.
-    series_vol: dict[tuple[str, int], list[BookCandidate]] = {}
+    # Pre-index candidates by (norm series, float index) and norm title.
+    # Float keys so half-volumes (2.5) are exact-matchable like integers.
+    series_vol: dict[tuple[str, float], list[BookCandidate]] = {}
     series_names: set[str] = set()
     for c in candidates:
-        if c.series and c.series_index is not None and float(c.series_index).is_integer():
-            key = (_norm(c.series), int(c.series_index))
+        if c.series and c.series_index is not None:
+            key = (_norm(c.series), float(c.series_index))
             series_vol.setdefault(key, []).append(c)
             series_names.add(_norm(c.series))
 
@@ -160,7 +187,19 @@ def match_book(
             parsed_vol_candidate = True
 
     # Layer 3: plain title fuzzy (distinct-title volumes like "Dungeon Mauling").
+    # A parsed KO volume is authoritative here too (issue #152): sibling volumes
+    # whose titles differ only in the digit ("… Book 2" vs "… Book 5") score
+    # 0.95+, and same-titled series volumes score 1.0 after de-subtitling — so a
+    # volume Tome doesn't own would strong-match a sibling and silently import
+    # a whole book's reading history onto it. A candidate claiming a different
+    # volume (via series_index or its own title) is excluded; candidates with no
+    # volume signal stay eligible so standalones and distinct-title volumes
+    # still match. Better parked-unmatched than confidently wrong.
     for c in candidates:
+        if kvol is not None:
+            cvols = _candidate_volumes(c)
+            if cvols and kvol not in cvols:
+                continue
         r = SequenceMatcher(None, knt, _norm(_desub(c.title or ""))).ratio()
         if r > best:
             best, best_c = r, c
@@ -353,3 +392,166 @@ def import_batch(
         "page_rows_skipped": len(rows) - imported,
         "watermark": max_start,
     }
+
+
+# ── Startup repair: re-verify stored fuzzy matches (issue #152) ───────────────
+
+def repair_fuzzy_matches(db: Session) -> dict:
+    """Re-run the (volume-guarded) matcher over every stored fuzzy match and
+    clean up the fallout of matches the old matcher got wrong.
+
+    Before the Layer-3 volume guard, a volume Tome doesn't own could
+    strong-match a sibling volume and import a whole book's page-stats onto it
+    (issue #152: vol 2's 20 h landed on the never-opened vol 5). The wrong
+    verdicts are recoverable because every fuzzy match row stores the KO title
+    and authors it was decided from.
+
+    For each non-confirmed ``method='fuzzy', status='matched'`` row, resolve it
+    again — hash first (deterministic, mirrors ``import_batch``), then the
+    fixed matcher. When the verdict changes, the row is updated and the
+    previously-matched book's page-stats are handled conservatively:
+
+    - If no other match row (for that user) still points at the old book, all
+      of its rows came from the bad match → delete them, reset the user's
+      device watermarks so the next sync re-uploads history under the fixed
+      rules, and notify the user.
+    - Otherwise the book mixes ghost and genuine rows, which cannot be told
+      apart (``total_pages`` shifts with device re-renders, so it can't
+      partition them) → keep everything and notify the user to use
+      "Clear imported history" on the book page if it looks wrong.
+
+    Idempotent: repaired rows no longer satisfy the filter, so the next
+    startup is a no-op. Never raises — callers run it fire-and-forget.
+    """
+    from backend.models.book import Book as _Book
+    from backend.models.notification import Notification
+    from backend.models.user import User
+
+    rows = (
+        db.query(KoStatsBookMatch)
+        .filter(
+            KoStatsBookMatch.method == "fuzzy",
+            KoStatsBookMatch.status == "matched",
+            KoStatsBookMatch.confirmed.is_(False),
+            KoStatsBookMatch.book_id.isnot(None),
+        )
+        .all()
+    )
+    result = {"checked": len(rows), "changed": 0, "pages_deleted": 0, "kept_mixed": 0}
+    if not rows:
+        return result
+
+    cand_cache: dict[int, tuple[list[BookCandidate], dict[str, int]]] = {}
+    # (user_id, old_book_id) pairs whose attribution was revoked — cleanup runs
+    # after every row is re-verdicted so "does anything else point at this
+    # book" sees the final state, not a half-updated one.
+    revoked: set[tuple[int, int]] = set()
+
+    for row in rows:
+        user = db.get(User, row.user_id)
+        if user is None:
+            continue
+        if user.id not in cand_cache:
+            cand_cache[user.id] = _load_candidates(db, user)
+        candidates, _path_index = cand_cache[user.id]
+
+        old_book_id = row.book_id
+        hash_hit = lookup_book_ids(db, [row.ko_md5]).get(row.ko_md5) if row.ko_md5 else None
+        if hash_hit is not None:
+            new_book_id, confidence, method, status = hash_hit, 1.0, "ko_hash", "matched"
+        else:
+            res = match_book(candidates, row.ko_title or "", row.ko_authors)
+            new_book_id = res.book_id if res.status == "matched" else None
+            confidence, method, status = res.confidence, res.method, res.status
+
+        if new_book_id == old_book_id and status == "matched":
+            continue  # the match still stands under the fixed rules
+
+        row.book_id = new_book_id
+        row.confidence = confidence
+        row.method = method
+        row.status = status
+        result["changed"] += 1
+        revoked.add((row.user_id, old_book_id))
+
+    db.flush()
+
+    for user_id, book_id in sorted(revoked):
+        pages = (
+            db.query(PageStat)
+            .filter(PageStat.user_id == user_id, PageStat.book_id == book_id)
+            .count()
+        )
+        if pages == 0:
+            continue
+        book = db.get(_Book, book_id)
+        title = book.title if book else "a deleted book"
+        # Only 'matched' rows ever imported pages — a parked review row also
+        # carries a book_id but contributed nothing, so it must not block cleanup.
+        other_sources = (
+            db.query(KoStatsBookMatch.id)
+            .filter(
+                KoStatsBookMatch.user_id == user_id,
+                KoStatsBookMatch.book_id == book_id,
+                KoStatsBookMatch.status == "matched",
+            )
+            .first()
+        )
+        if other_sources is None:
+            # The bad match was this book's only import source — every row is ghost.
+            db.query(PageStat).filter(
+                PageStat.user_id == user_id, PageStat.book_id == book_id
+            ).delete(synchronize_session=False)
+            # Full re-upload on next sync rebuilds anything the bad match starved
+            # (rows behind the watermark that now resolve elsewhere). Idempotent
+            # ingest makes the re-send a no-op for everything already correct.
+            db.query(StatsImport).filter(StatsImport.user_id == user_id).update(
+                {StatsImport.last_start_time_synced: 0}, synchronize_session=False
+            )
+            result["pages_deleted"] += pages
+            db.add(Notification(
+                user_id=user_id,
+                kind="stats_repair",
+                title=f'Removed misattributed reading history from "{title}"',
+                body=(
+                    "An earlier import matched another book's KOReader history to "
+                    "this book. The wrong entries were removed; your device will "
+                    "re-sync its history on the next connection."
+                ),
+                link=f"/books/{book_id}" if book else None,
+            ))
+        else:
+            result["kept_mixed"] += 1
+            db.add(Notification(
+                user_id=user_id,
+                kind="stats_repair",
+                title=f'Reading history on "{title}" may include another book\'s sessions',
+                body=(
+                    "An earlier import matched another book's KOReader history to "
+                    "this book, which also has correctly imported history. The two "
+                    "cannot be told apart automatically. If the numbers look wrong, "
+                    "use \"Clear imported history\" in the book's Reading Stats."
+                ),
+                link=f"/books/{book_id}" if book else None,
+            ))
+
+    db.commit()
+    return result
+
+
+def repair_fuzzy_matches_startup() -> None:
+    """Daemon-thread entry point: run the repair against a fresh session and
+    swallow everything — bookkeeping must never take the server down."""
+    from backend.core.database import SessionLocal
+
+    try:
+        with SessionLocal() as db:
+            result = repair_fuzzy_matches(db)
+        if result["changed"]:
+            logger.info(
+                "ko-stats repair: %(checked)d fuzzy matches checked, "
+                "%(changed)d corrected, %(pages_deleted)d ghost page-stats deleted, "
+                "%(kept_mixed)d mixed books kept for manual review", result,
+            )
+    except Exception:
+        logger.exception("ko-stats fuzzy-match repair failed")

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -783,7 +783,9 @@ export function BookDetailPage() {
                 onChange={refreshStats}
               />
             )}
-            {readingStats.intensity && <IntensityBlock data={readingStats.intensity} />}
+            {readingStats.intensity && (
+              <IntensityBlock data={readingStats.intensity} bookId={Number(id)} onChange={refreshStats} />
+            )}
             {readingStats.chapters && readingStats.chapters.length > 0 && (
               <ChapterTimesBlock chapters={readingStats.chapters} />
             )}
@@ -1522,9 +1524,18 @@ function SourceSplit({ sources }: { sources: { device: string; seconds: number; 
 
 // ── Reading intensity: per-page dwell across the book, from imported KOReader page-stats ─────
 
-function IntensityBlock({ data }: { data: BookIntensity }) {
+function IntensityBlock({ data, bookId, onChange }: { data: BookIntensity; bookId: number; onChange?: () => void }) {
   const max = Math.max(...data.curve, 1)
   const finished = data.pct_read >= 99
+  const [confirmClear, setConfirmClear] = useState(false)
+  const [clearing, setClearing] = useState(false)
+  const clearImported = () => {
+    setClearing(true)
+    api.delete(`/books/${bookId}/imported-history`)
+      .then(() => { setConfirmClear(false); onChange?.() })
+      .catch(() => {})
+      .finally(() => setClearing(false))
+  }
   return (
     <div className="rounded-xl border border-border bg-card px-5 py-4">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
@@ -1532,13 +1543,45 @@ function IntensityBlock({ data }: { data: BookIntensity }) {
           <p className="font-display text-sm text-foreground">Reading intensity</p>
           <InfoHint text="Where in the book your time went — taller means more time spent on those pages." />
         </span>
-        <p className="text-xs text-muted-foreground">
-          <span className="font-medium tabular-nums text-foreground">{data.pages_read.toLocaleString()}</span>
-          {' '}of {data.total_pages.toLocaleString()} pages
-          {!finished && <span className="tabular-nums"> · {data.pct_read}%</span>}
-          {' · '}{formatDuration(data.total_seconds)} on device
-        </p>
+        <span className="flex items-center gap-2">
+          <p className="text-xs text-muted-foreground">
+            <span className="font-medium tabular-nums text-foreground">{data.pages_read.toLocaleString()}</span>
+            {' '}of {data.total_pages.toLocaleString()} pages
+            {!finished && <span className="tabular-nums"> · {data.pct_read}%</span>}
+            {' · '}{formatDuration(data.total_seconds)} on device
+          </p>
+          <button
+            type="button"
+            onClick={() => setConfirmClear(o => !o)}
+            className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
+            title="Clear imported history — remove this book's KOReader page data"
+          >
+            <Trash2 className="w-3.5 h-3.5" />
+          </button>
+        </span>
       </div>
+      {confirmClear && (
+        <div className="mt-3 flex flex-wrap items-center gap-2 rounded bg-muted/40 px-3 py-2 text-xs">
+          <span className="text-muted-foreground">
+            Remove all of this book&apos;s imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on.
+          </span>
+          <button
+            type="button"
+            onClick={clearImported}
+            disabled={clearing}
+            className="rounded border border-destructive/40 px-2 py-0.5 text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40"
+          >
+            {clearing ? 'Clearing…' : 'Clear'}
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirmClear(false)}
+            className="rounded border border-border px-2 py-0.5 text-muted-foreground hover:bg-muted transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
       {/* Dwell across the book, 0% → 100%. Taller bar = more time spent there. */}
       <div className="mt-3 relative h-16">
         <div className="absolute bottom-0 left-0 right-0 h-px bg-border/40" />

--- a/tests/test_ko_stats_import.py
+++ b/tests/test_ko_stats_import.py
@@ -165,3 +165,336 @@ def test_unmatched_book_parks_its_pages(db, admin_user, make_book):
     assert r["page_rows_imported"] == 0          # parked, not attributed to a wrong book
     m = db.query(KoStatsBookMatch).filter(KoStatsBookMatch.ko_md5 == "zzz").one()
     assert m.book_id is None and m.status == "unmatched"
+
+
+# ── Layer-3 volume guard (issue #152) ─────────────────────────────────────────
+# A volume Tome doesn't own must never strong-match a sibling volume: numbered
+# titles differ by one digit (ratio 0.95+) and same-titled series volumes are
+# identical after de-subtitling (ratio 1.0), so without the guard a whole
+# book's reading history imports onto the wrong book.
+
+def _dcc(n: int, titled: bool = True) -> BookCandidate:
+    """Dungeon Crawler Carl shaped candidate: numbered title or clean title."""
+    title = f"Dungeon Crawler Carl {n}" if titled else "Dungeon Crawler Carl"
+    return BookCandidate(id=200 + n, title=title, author="Matt Dinniman",
+                         series="Dungeon Crawler Carl", series_index=float(n))
+
+
+def test_missing_volume_does_not_match_numbered_sibling():
+    # The reporter's exact shape: vol 2 absent from Tome, siblings 1/3/5/6 present.
+    cands = [_dcc(n) for n in (1, 3, 5, 6)]
+    for ko_title in ("Dungeon Crawler Carl 2", "Dungeon Crawler Carl Book 2",
+                     "Dungeon Crawler Carl, Book 2", "Dungeon Crawler Carl T2"):
+        r = match_book(cands, ko_title, "Matt Dinniman")
+        assert r.book_id is None, f"{ko_title!r} wrongly matched book {r.book_id}"
+        assert r.status == "unmatched"
+
+
+def test_missing_volume_does_not_match_same_titled_sibling():
+    # Same-titled series volumes ("Black Summoner" x15): the de-subtitled KO
+    # title is identical to every sibling's title (ratio 1.0). Without the
+    # guard, a missing volume matched the first sibling in the list.
+    cands = [_summoner(n) for n in (1, 3, 5)]
+    r = match_book(cands, "Black Summoner: Volume 2", "Doufu Mayoi")
+    assert r.book_id is None and r.status == "unmatched"
+
+
+def test_present_volume_still_matches_exactly():
+    # Control: when the volume IS in the library, both title shapes resolve to it.
+    cands = [_dcc(n) for n in (1, 2, 3, 5)]
+    r = match_book(cands, "Dungeon Crawler Carl 2", "Matt Dinniman")
+    assert r.book_id == 202 and r.status == "matched"
+    cands2 = [_summoner(n) for n in range(1, 16)]
+    r2 = match_book(cands2, "Black Summoner: Volume 2", "Doufu Mayoi")
+    assert r2.book_id == 102 and r2.status == "matched"
+
+
+def test_distinct_title_with_volume_suffix_matches_by_title():
+    # Publisher long-form KO title, clean distinct titles in Tome: the candidate
+    # at the SAME index stays eligible and wins on title ratio.
+    cands = [
+        BookCandidate(1, "Dungeon Crawler Carl", "Matt Dinniman", "Dungeon Crawler Carl", 1.0),
+        BookCandidate(5, "The Butcher's Masquerade", "Matt Dinniman", "Dungeon Crawler Carl", 5.0),
+    ]
+    r = match_book(cands, "The Butcher's Masquerade: Dungeon Crawler Carl Book 5", "Matt Dinniman")
+    assert r.book_id == 5 and r.status == "matched"
+
+
+def test_half_volume_resolves_exactly():
+    # "Vol. 2.5" must parse as 2.5 (not truncate to 2) and hit the 2.5 book;
+    # "Vol. 2" with only 1 and 2.5 in the library must park, not land on either.
+    cands = [
+        BookCandidate(1, "Black Summoner", "Doufu Mayoi", "Black Summoner", 1.0),
+        BookCandidate(25, "Black Summoner", "Doufu Mayoi", "Black Summoner", 2.5),
+    ]
+    r = match_book(cands, "Black Summoner: Volume 2.5", "Doufu Mayoi")
+    assert r.book_id == 25 and r.status == "matched"
+    r2 = match_book(cands, "Black Summoner: Volume 2", "Doufu Mayoi")
+    assert r2.book_id is None and r2.status == "unmatched"
+
+
+def test_french_tome_abbreviation_parses():
+    assert parse_ko_title("La Horde du Contrevent T2")[1] == 2
+    # ... and a missing T-volume parks instead of matching a sibling.
+    cands = [BookCandidate(1, "La Horde du Contrevent T1", "Alain Damasio",
+                           "La Horde du Contrevent", 1.0)]
+    r = match_book(cands, "La Horde du Contrevent T2", "Alain Damasio")
+    assert r.book_id is None and r.status == "unmatched"
+
+
+def test_title_number_standalone_still_matches():
+    # "Fahrenheit 451" parses as volume 451; a standalone candidate has no
+    # volume signal and stays eligible.
+    cands = [BookCandidate(1, "Fahrenheit 451", "Ray Bradbury", None, None)]
+    r = match_book(cands, "Fahrenheit 451", "Ray Bradbury")
+    assert r.book_id == 1 and r.status == "matched"
+    # Even shelved as index 1 of its own series, the title's own 451 keeps it
+    # eligible (either volume signal may agree).
+    cands2 = [BookCandidate(1, "Fahrenheit 451", "Ray Bradbury", "Fahrenheit 451", 1.0)]
+    r2 = match_book(cands2, "Fahrenheit 451", "Ray Bradbury")
+    assert r2.book_id == 1 and r2.status == "matched"
+
+
+def test_import_batch_parks_missing_volume(db, admin_user, make_book):
+    # End-to-end: the ghost scenario from issue #152 imports zero rows.
+    user, _ = admin_user
+    for n in (1, 3, 5):
+        make_book(title=f"Dungeon Crawler Carl {n}", author="Matt Dinniman",
+                  series="Dungeon Crawler Carl", series_index=float(n))
+    r = import_batch(
+        db, user, device="Kindle",
+        books=[{"ko_id": 1, "md5": "vol2md5", "title": "Dungeon Crawler Carl 2",
+                "authors": "Matt Dinniman"}],
+        page_stats=[{"ko_id": 1, "page": p, "start_time": 1700000000 + p * 60,
+                     "duration": 50, "total_pages": 811} for p in range(1, 30)],
+    )
+    assert r["unmatched"] == 1 and r["page_rows_imported"] == 0
+    assert db.query(PageStat).filter(PageStat.user_id == user.id).count() == 0
+
+
+# ── Startup repair of pre-guard wrong matches (issue #152) ────────────────────
+
+from backend.services.ko_stats_import import repair_fuzzy_matches  # noqa: E402
+from backend.models.notification import Notification  # noqa: E402
+
+
+def _seed_ghost(db, user, make_book, *, md5="ghostmd5"):
+    """Library 1/3/5, a wrong fuzzy match (KO vol 2 -> book 5) and its imported
+    ghost pages + advanced watermark. Returns the wrongly-credited book."""
+    books = {n: make_book(title=f"Dungeon Crawler Carl {n}", author="Matt Dinniman",
+                          series="Dungeon Crawler Carl", series_index=float(n))
+             for n in (1, 3, 5)}
+    ghost_target = books[5]
+    db.add(KoStatsBookMatch(
+        user_id=user.id, ko_md5=md5,
+        ko_title="Dungeon Crawler Carl 2", ko_authors="Matt Dinniman",
+        book_id=ghost_target.id, confidence=0.9545, method="fuzzy", status="matched",
+    ))
+    for p in range(1, 30):
+        db.add(PageStat(user_id=user.id, book_id=ghost_target.id, page=p,
+                        total_pages=811, start_time=1700000000 + p * 60,
+                        duration_seconds=50, device="Kindle"))
+    db.add(StatsImport(user_id=user.id, device="Kindle",
+                       last_start_time_synced=1700010000, rows_imported=29))
+    db.flush()
+    return ghost_target
+
+
+def test_repair_reverts_wrong_match_and_deletes_ghost_pages(db, admin_user, make_book):
+    user, _ = admin_user
+    ghost = _seed_ghost(db, user, make_book)
+
+    result = repair_fuzzy_matches(db)
+
+    assert result["changed"] == 1
+    assert result["pages_deleted"] == 29
+    m = db.query(KoStatsBookMatch).filter_by(ko_md5="ghostmd5").one()
+    assert m.book_id is None and m.status == "unmatched"
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=ghost.id).count() == 0
+    # Watermark reset so the device re-uploads history under the fixed rules.
+    wm = db.query(StatsImport).filter_by(user_id=user.id, device="Kindle").one()
+    assert wm.last_start_time_synced == 0
+    notes = db.query(Notification).filter_by(user_id=user.id, kind="stats_repair").all()
+    assert len(notes) == 1 and "Removed misattributed" in notes[0].title
+
+
+def test_repair_keeps_mixed_book_and_notifies(db, admin_user, make_book):
+    # The wrongly-credited book ALSO has a legitimate import source: rows can't
+    # be told apart, so nothing is deleted and the user is pointed at the
+    # manual "Clear imported history" action.
+    user, _ = admin_user
+    ghost = _seed_ghost(db, user, make_book)
+    db.add(KoStatsBookMatch(
+        user_id=user.id, ko_md5="legitmd5",
+        ko_title="Dungeon Crawler Carl 5", ko_authors="Matt Dinniman",
+        book_id=ghost.id, confidence=1.0, method="ko_hash", status="matched",
+    ))
+    db.flush()
+
+    result = repair_fuzzy_matches(db)
+
+    assert result["changed"] == 1 and result["kept_mixed"] == 1
+    assert result["pages_deleted"] == 0
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=ghost.id).count() == 29
+    # No rebuild needed -> watermark untouched.
+    wm = db.query(StatsImport).filter_by(user_id=user.id, device="Kindle").one()
+    assert wm.last_start_time_synced == 1700010000
+    notes = db.query(Notification).filter_by(user_id=user.id, kind="stats_repair").all()
+    assert len(notes) == 1 and "may include another book" in notes[0].title
+
+
+def test_repair_is_idempotent(db, admin_user, make_book):
+    user, _ = admin_user
+    _seed_ghost(db, user, make_book)
+    first = repair_fuzzy_matches(db)
+    second = repair_fuzzy_matches(db)
+    assert first["changed"] == 1
+    assert second["changed"] == 0 and second["pages_deleted"] == 0
+    assert db.query(Notification).filter_by(user_id=user.id, kind="stats_repair").count() == 1
+
+
+def test_repair_skips_confirmed_rows(db, admin_user, make_book):
+    user, _ = admin_user
+    ghost = _seed_ghost(db, user, make_book)
+    db.query(KoStatsBookMatch).filter_by(ko_md5="ghostmd5").update({"confirmed": True})
+    db.flush()
+    result = repair_fuzzy_matches(db)
+    assert result["checked"] == 0 and result["changed"] == 0
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=ghost.id).count() == 29
+
+
+def test_repair_rematches_via_hash_when_available(db, admin_user, make_book):
+    # If Tome has since recorded the device file's partial-MD5 (the book was
+    # added/served), the repair resolves deterministically to the right book.
+    from backend.models.ko_stats import KoHash
+    user, _ = admin_user
+    ghost = _seed_ghost(db, user, make_book)
+    real_vol2 = make_book(title="Dungeon Crawler Carl 2", author="Matt Dinniman",
+                          series="Dungeon Crawler Carl", series_index=2.0)
+    db.add(KoHash(book_id=real_vol2.id, ko_partial_md5="ghostmd5", kind="raw"))
+    db.flush()
+
+    result = repair_fuzzy_matches(db)
+
+    assert result["changed"] == 1
+    m = db.query(KoStatsBookMatch).filter_by(ko_md5="ghostmd5").one()
+    assert m.book_id == real_vol2.id and m.method == "ko_hash" and m.status == "matched"
+    # Ghost pages on the old book still cleaned up; re-sync refills the right book.
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=ghost.id).count() == 0
+
+
+def test_repair_leaves_valid_matches_alone(db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Black Summoner", author="Doufu Mayoi",
+                     series="Black Summoner", series_index=1.0)
+    db.add(KoStatsBookMatch(
+        user_id=user.id, ko_md5="finemd5",
+        ko_title="Black Summoner: Volume 1", ko_authors="Doufu Mayoi",
+        book_id=book.id, confidence=1.0, method="fuzzy", status="matched",
+    ))
+    db.add(PageStat(user_id=user.id, book_id=book.id, page=1, total_pages=200,
+                    start_time=1700000000, duration_seconds=30, device="Kindle"))
+    db.add(StatsImport(user_id=user.id, device="Kindle",
+                       last_start_time_synced=1700000000, rows_imported=1))
+    db.flush()
+
+    result = repair_fuzzy_matches(db)
+
+    assert result["changed"] == 0
+    m = db.query(KoStatsBookMatch).filter_by(ko_md5="finemd5").one()
+    assert m.book_id == book.id and m.status == "matched"
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=book.id).count() == 1
+    wm = db.query(StatsImport).filter_by(user_id=user.id, device="Kindle").one()
+    assert wm.last_start_time_synced == 1700000000
+    assert db.query(Notification).filter_by(user_id=user.id).count() == 0
+
+
+def test_repair_two_bad_rows_same_book_single_cleanup(db, admin_user, make_book):
+    # Two wrong matches piled onto the same book: one cleanup, one notification.
+    user, _ = admin_user
+    ghost = _seed_ghost(db, user, make_book)
+    db.add(KoStatsBookMatch(
+        user_id=user.id, ko_md5="ghostmd5b",
+        ko_title="Dungeon Crawler Carl 4", ko_authors="Matt Dinniman",
+        book_id=ghost.id, confidence=0.9545, method="fuzzy", status="matched",
+    ))
+    db.flush()
+
+    result = repair_fuzzy_matches(db)
+
+    assert result["changed"] == 2
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=ghost.id).count() == 0
+    assert db.query(Notification).filter_by(user_id=user.id, kind="stats_repair").count() == 1
+
+
+def test_repair_scopes_cleanup_per_user(db, admin_user, make_book):
+    # Another user's genuine history on the same book must survive user A's cleanup.
+    from backend.models.user import User as UserModel
+    from backend.core.security import hash_password
+    user, _ = admin_user
+    ghost = _seed_ghost(db, user, make_book)
+    other = UserModel(username="reader2", email="r2@example.com",
+                      hashed_password=hash_password("pw12345678"), is_active=True)
+    db.add(other)
+    db.flush()
+    db.add(KoStatsBookMatch(
+        user_id=other.id, ko_md5="othermd5",
+        ko_title="Dungeon Crawler Carl 5", ko_authors="Matt Dinniman",
+        book_id=ghost.id, confidence=1.0, method="ko_hash", status="matched",
+    ))
+    db.add(PageStat(user_id=other.id, book_id=ghost.id, page=1, total_pages=811,
+                    start_time=1700000000, duration_seconds=30, device="Boox"))
+    db.add(StatsImport(user_id=other.id, device="Boox",
+                       last_start_time_synced=1700000000, rows_imported=1))
+    db.flush()
+
+    repair_fuzzy_matches(db)
+
+    # User A cleaned up; user B untouched (pages, watermark, no notification).
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=ghost.id).count() == 0
+    assert db.query(PageStat).filter_by(user_id=other.id, book_id=ghost.id).count() == 1
+    wm_b = db.query(StatsImport).filter_by(user_id=other.id, device="Boox").one()
+    assert wm_b.last_start_time_synced == 1700000000
+    assert db.query(Notification).filter_by(user_id=other.id).count() == 0
+
+
+# ── Clear-imported-history endpoint ───────────────────────────────────────────
+
+def test_clear_imported_history_endpoint(db, client, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Dungeon Crawler Carl 5", author="Matt Dinniman",
+                     series="Dungeon Crawler Carl", series_index=5.0)
+    from backend.models.user import User as UserModel
+    from backend.core.security import hash_password
+    other = UserModel(username="someoneelse", email="e@example.com",
+                      hashed_password=hash_password("pw12345678"), is_active=True)
+    db.add(other)
+    db.flush()
+    for p in (1, 2):
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=p, total_pages=811,
+                        start_time=1700000000 + p, duration_seconds=30, device="Kindle"))
+    db.add(PageStat(user_id=other.id, book_id=book.id, page=1, total_pages=811,
+                    start_time=1700000000, duration_seconds=30, device="Kindle"))
+    db.add(KoStatsBookMatch(user_id=user.id, ko_md5="m1", ko_title="Dungeon Crawler Carl 2",
+                            book_id=book.id, confidence=0.95, method="fuzzy", status="matched"))
+    db.add(KoStatsBookMatch(user_id=user.id, ko_md5="m2", ko_title="Dungeon Crawler Carl 5",
+                            book_id=book.id, confidence=1.0, method="ko_hash", status="matched"))
+    db.flush()
+
+    resp = client.delete(f"/api/books/{book.id}/imported-history")
+    assert resp.status_code == 200
+    assert resp.json() == {"pages_deleted": 2, "matches_reset": 1}
+
+    # Own rows gone, the other user's row untouched.
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=book.id).count() == 0
+    assert db.query(PageStat).filter_by(user_id=other.id, book_id=book.id).count() == 1
+    # Fuzzy match reset for re-decision; deterministic hash match left alone.
+    m1 = db.query(KoStatsBookMatch).filter_by(ko_md5="m1").one()
+    assert m1.book_id is None and m1.status == "unmatched" and m1.method == "none"
+    m2 = db.query(KoStatsBookMatch).filter_by(ko_md5="m2").one()
+    assert m2.book_id == book.id and m2.status == "matched"
+
+
+def test_clear_imported_history_unknown_book_404(client):
+    resp = client.delete("/api/books/999999/imported-history")
+    assert resp.status_code == 404


### PR DESCRIPTION
Fixes #152.

## Problem

The KOReader statistics importer's Layer-3 title fuzzy ignored the volume number it had already parsed. A volume read on the device but missing from the Tome library could strong-match a sibling volume ("Dungeon Crawler Carl 2" vs "... 5" scores 0.95, same-titled series volumes score 1.0 after de-subtitling) and import a whole book's reading history onto a book never opened. That produced #152's exact symptoms: parallel-but-different sessions, page progression, and an untouched Unread status (the import never writes status by design).

## Changes

- **Matcher volume guard** (`ko_stats_import.match_book`): a parsed KO volume is authoritative in Layer 3. Candidates claiming a different volume (via `series_index` or a number in their own title) are excluded; candidates with no volume signal stay eligible, so standalones ("Fahrenheit 451") and distinct-title volumes ("Dungeon Mauling") keep matching. Volumes parse as floats so half-volumes (2.5) resolve exactly instead of truncating, and French "T2" tome numbering is now understood.
- **Startup self-repair** (`repair_fuzzy_matches`, daemon thread): re-verifies every stored non-confirmed fuzzy match under the fixed rules. When a verdict flips and the wrongly-credited book has no other import source, its page-stats are deleted, the user's device watermarks are reset (next sync re-uploads history under the fixed matcher), and the user is notified. Books mixing ghost and genuine rows cannot be split apart, so they are kept and flagged instead. Idempotent: later startups are no-ops.
- **Per-book purge**: `DELETE /books/{id}/imported-history` plus a confirm-gated trash action on the Reading intensity panel. Removes only the current user's imported page data for that book; live/manual sessions, positions, and status are untouched. The manual escape hatch for the mixed cases the repair refuses to touch.

## Testing

- Full backend suite: 1023 passed. The importer test file grew from 8 to 29 tests (guard shapes, half-volumes, T-form, repair clean/mixed/idempotent/hash-rematch/multi-user/confirmed-skip, purge endpoint incl. cross-user isolation).
- A/B corpus sweep of old vs new matcher over 25 realistic cases: all legitimate matches unchanged, all ghost shapes parked, two half-volume misattributions additionally fixed, zero regressions.
- Live smoke on a real server: seeded the reporter's scenario, restarted, verified automatic cleanup + notification + idempotent second restart; purge exercised over HTTP.
- Real UI click-through with Playwright; frontend production build clean.

Server-side only: no plugin update and no migration required.