### PR TITLE
feat(stats): imported KOReader history as first-class, deletable sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,29 @@ All notable changes to Tome are documented here. Format loosely follows
 - **Manual sync linking in the UI.** When a KOSync client has synced a
   document that isn't attached to any book, the book page offers a small
   "Link KOReader sync" picker - no more calling the API by hand.
+- **Imported KOReader history shows up as sessions - and single sittings can
+  be deleted.** Reading synced from KOReader's statistics (including history
+  from before Tome existed) used to count toward the totals but never appear
+  in Recent Sessions or the per-book session list, so a book could claim "1
+  session" over an empty list and an accidental open was impossible to remove
+  without wiping the book's whole imported history. The session lists now
+  include imported sittings (marked "imported", grouped the same way KOReader
+  groups sessions), each deletable on its own; the book page's session count
+  matches the sittings that count. Imported sittings can't be trimmed -
+  KOReader's own idle-capping already applies. On books with imported
+  history, the plugin's live device sessions describe the same reading a
+  second time, so they are excluded from the totals - but they stay in the
+  list with a "not counted" label rather than disappearing. An info popover
+  next to the session lists explains all of this in place.
+- **Click a day in the book page's Activity chart to manage that day's
+  sessions.** Each bar opens a popup with the sittings that started on that
+  day - trim or delete right there instead of scrolling the full session
+  log to find the one stray entry.
+- The Habits tab's session timeline now draws imported KOReader sittings
+  too, so device reading on stats-synced books appears in the ribbon
+  instead of leaving those days blank. The superseded live device sessions
+  are left out of the drawing - the same reading would otherwise paint
+  twice.
 
 ### Fixed
 - KOSync progress pushes now follow the same read-status rules as every

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, HTTPException
-from sqlalchemy import func, case
+from sqlalchemy import func, case, or_
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -278,13 +278,23 @@ def get_stats(
         for r in in_progress_rows
     ]
 
-    # Session timeline — recent sessions with start/end times for timeline view
+    # Session timeline — recent sittings with start/end times for timeline view.
+    # Reconciled like the session log: imported KOReader clusters ARE the device
+    # sittings for covered books, so they're drawn and the superseded live
+    # device sessions are excluded — a ribbon has no way to carry the list's
+    # "not counted" label, and drawing both would paint the same reading twice.
+    tl_base = base.filter(
+        ReadingSession.started_at.isnot(None),
+        ReadingSession.ended_at.isnot(None),
+        ReadingSession.book_id.isnot(None),
+    )
+    if covered:
+        tl_base = tl_base.filter(or_(
+            ReadingSession.book_id.notin_(covered),
+            ReadingSession.device.in_(rr.NON_DEVICE_SOURCES),
+        ))
     timeline_rows = (
-        base.filter(
-            ReadingSession.started_at.isnot(None),
-            ReadingSession.ended_at.isnot(None),
-            ReadingSession.book_id.isnot(None),
-        )
+        tl_base
         .join(Book, Book.id == ReadingSession.book_id)
         .with_entities(
             ReadingSession.id,
@@ -307,6 +317,34 @@ def get_stats(
         }
         for r in timeline_rows
     ]
+    if covered:
+        def _tl_iso(epoch: int) -> str:
+            return datetime.fromtimestamp(epoch, timezone.utc).replace(tzinfo=None).isoformat() + "Z"
+
+        clusters = rr._cluster_rows(db, current_user.id, day_modifier, cutoff, range_end)
+        clusters.sort(key=lambda c: -int(c.start))
+        clusters = clusters[:50]
+        cl_titles = dict(
+            db.query(Book.id, Book.title)
+            .filter(Book.id.in_({c.book_id for c in clusters}))
+            .all()
+        ) if clusters else {}
+        session_timeline.extend(
+            {
+                "id": f"ps-{c.book_id}-{int(c.start)}",
+                "title": cl_titles[c.book_id],
+                "started_at": _tl_iso(int(c.start)),
+                # last page's start — close enough for a ribbon span; the exact
+                # end would need that page's dwell, which the aggregate drops.
+                "ended_at": _tl_iso(int(c.last_start)),
+                "duration_seconds": int(c.secs or 0),
+            }
+            for c in clusters
+            if c.book_id in cl_titles  # deleted books: mirror the join above
+        )
+        # Fixed-width "YYYY-MM-DDTHH:MM:SSZ" strings sort correctly as text.
+        session_timeline.sort(key=lambda e: e["started_at"], reverse=True)
+        session_timeline = session_timeline[:50]
 
     # ── Period comparison ─────────────────────────────────────────────────────
     period_comparison = None
@@ -1228,31 +1266,58 @@ def list_sessions(
     limit: int = Query(50, ge=1, le=200),
     book_id: Optional[int] = Query(None),
     sort: str = Query("recent", pattern="^(recent|longest)$"),
+    tz_offset: int = Query(0),
+    day: Optional[str] = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
-    """List individual reading sessions for the current user.
+    """List the current user's reading sessions, merged with imported KOReader
+    history.
+
+    ``day`` (a reading-day string as emitted in ``session_timeline``, bucketed
+    with ``tz_offset`` + 4h rollover) narrows the list to sittings that
+    *started* on that day — the Activity chart's click-through. A sitting that
+    crosses midnight belongs to the day it began, matching how it was counted.
+
+    The list mirrors what reconciled totals count, so every listed row is
+    deletable and every deletion moves the totals. Two row kinds:
+    - ``session`` — a recorded ReadingSession (live, web, or manual).
+    - ``imported`` — a gap-clustered sitting from imported KOReader page-stats,
+      carrying ``range_start``/``range_end`` (epoch seconds) for
+      ``DELETE /stats/imported-sessions``. Not trimmable (already idle-capped).
+    Every row also carries ``counted``: device-origin live sessions on a book
+    covered by page-stats are ``counted: false`` — reconciliation excludes them
+    from totals (the imported clusters already describe that reading) but they
+    stay listed, labeled, rather than silently hidden.
 
     ``sort=longest`` and the ``book_id`` filter exist so runaway sessions
-    (#150) are findable without paging through the whole history. Each row
-    carries ``suspect`` and, when computable, ``suggested_seconds`` — the
+    (#150) are findable without paging through the whole history. Session rows
+    carry ``suspect`` and, when computable, ``suggested_seconds`` — the
     session's page turns re-priced at the user's median pace — feeding the
     trim dialog's pre-fill.
     """
+    covered = set(rr.covered_book_ids(db, current_user.id))
     base = (
         db.query(ReadingSession)
         .filter(ReadingSession.user_id == current_user.id)
     )
     if book_id is not None:
         base = base.filter(ReadingSession.book_id == book_id)
-    total = base.count()
+    if day is not None:
+        base = base.filter(
+            func.date(ReadingSession.started_at, date_modifier(tz_offset)) == day
+        )
+    total_sessions = base.count()
     order = (
         ReadingSession.duration_seconds.desc()
         if sort == "longest"
         else ReadingSession.started_at.desc()
     )
     median_pace = median_secs_per_page(db, current_user.id)
-    rows = (
+    # k-way merge pagination: the merged page [offset, offset+limit) can only
+    # contain rows from each source's own top (offset+limit).
+    window = offset + limit
+    sess_rows = (
         base
         .outerjoin(Book, Book.id == ReadingSession.book_id)
         .with_entities(
@@ -1268,15 +1333,56 @@ def list_sessions(
             ReadingSession.progress_end,
         )
         .order_by(order)
-        .offset(offset)
-        .limit(limit)
+        .limit(window)
         .all()
     )
-    return {
-        "total": total,
-        "sessions": [
-            {
+    clusters = []
+    if covered and (book_id is None or book_id in covered):
+        clusters = rr._cluster_rows(
+            db, current_user.id, date_modifier(tz_offset), None, None, book_id=book_id
+        )
+        if day is not None:
+            clusters = [c for c in clusters if c.day == day]
+    total = total_sessions + len(clusters)
+
+    def _sess_key(r) -> int:
+        if sort == "longest":
+            return int(r.duration_seconds or 0)
+        return (
+            int(r.started_at.replace(tzinfo=timezone.utc).timestamp())
+            if r.started_at else 0
+        )
+
+    def _cluster_key(c) -> int:
+        return int(c.secs or 0) if sort == "longest" else int(c.start)
+
+    entries = (
+        [(_sess_key(r), "session", r) for r in sess_rows]
+        + [(_cluster_key(c), "imported", c) for c in clusters]
+    )
+    entries.sort(key=lambda t: t[0], reverse=True)
+    page = entries[offset:offset + limit]
+
+    cluster_books = {e[2].book_id for e in page if e[1] == "imported"}
+    cluster_titles: dict[int, str] = (
+        dict(db.query(Book.id, Book.title).filter(Book.id.in_(cluster_books)).all())
+        if cluster_books else {}
+    )
+
+    def _iso(epoch: int) -> str:
+        return datetime.fromtimestamp(epoch, timezone.utc).replace(tzinfo=None).isoformat() + "Z"
+
+    out = []
+    for _, kind, r in page:
+        if kind == "session":
+            superseded = (
+                r.book_id in covered
+                and (r.device or "") not in rr.NON_DEVICE_SOURCES
+            )
+            out.append({
                 "id": r.id,
+                "kind": "session",
+                "counted": not superseded,
                 "book_id": r.book_id,
                 "book_title": r.book_title or "(deleted book)",
                 "started_at": (r.started_at.isoformat() + "Z") if r.started_at else None,
@@ -1290,10 +1396,28 @@ def list_sessions(
                 "suggested_seconds": suggested_seconds(
                     r.duration_seconds, r.pages_turned, median_pace
                 ),
-            }
-            for r in rows
-        ],
-    }
+            })
+        else:
+            start, last_start = int(r.start), int(r.last_start)
+            out.append({
+                "id": f"ps-{r.book_id}-{start}",
+                "kind": "imported",
+                "counted": True,
+                "book_id": r.book_id,
+                "book_title": cluster_titles.get(r.book_id, "(deleted book)"),
+                "started_at": _iso(start),
+                "ended_at": _iso(last_start),
+                "duration_seconds": int(r.secs or 0),
+                "pages_turned": int(r.pages or 0),
+                "device": r.device or "KOReader",
+                "progress_start": None,
+                "progress_end": None,
+                "suspect": False,
+                "suggested_seconds": None,
+                "range_start": start,
+                "range_end": last_start,
+            })
+    return {"total": total, "sessions": out}
 
 
 @router.delete("/stats/sessions/{session_id}")
@@ -1317,6 +1441,48 @@ def delete_session(
     audit(db, "session.deleted", user_id=current_user.id, username=current_user.username,
           resource_type="reading_session", resource_id=session_id, details=details)
     return {"ok": True}
+
+
+@router.delete("/stats/imported-sessions")
+def delete_imported_session(
+    book_id: int = Query(...),
+    start: int = Query(..., description="Cluster range_start (epoch seconds, inclusive)"),
+    end: int = Query(..., description="Cluster range_end (epoch seconds, inclusive)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """Delete one imported-history cluster: the user's own KOReader page-stat
+    rows for a book within [start, end] — the range a `kind: "imported"` row
+    from GET /stats/sessions carries. The accidental-open eraser: removes one
+    sitting without touching the rest of the book's imported history (the
+    per-book purge on BookDetailPage remains the wipe-everything tool).
+
+    Deleting a book's LAST cluster un-covers it, so any device-origin live
+    sessions it has resurface in lists and totals — the fallback source
+    becomes authoritative again, consistent with reconciliation.
+    """
+    from backend.models.ko_stats import PageStat
+
+    if end < start:
+        raise HTTPException(status_code=400, detail="Invalid range")
+    deleted = (
+        db.query(PageStat)
+        .filter(
+            PageStat.user_id == current_user.id,
+            PageStat.book_id == book_id,
+            PageStat.start_time >= start,
+            PageStat.start_time <= end,
+        )
+        .delete(synchronize_session=False)
+    )
+    if not deleted:
+        raise HTTPException(status_code=404, detail="No imported history in that range")
+    db.commit()
+    audit(db, "imported_session.deleted", user_id=current_user.id,
+          username=current_user.username, resource_type="ko_page_stats",
+          resource_id=book_id,
+          details={"book_id": book_id, "start": start, "end": end, "rows": deleted})
+    return {"ok": True, "deleted_rows": deleted}
 
 
 class TrimSessionRequest(BaseModel):

--- a/backend/services/reading_stats.py
+++ b/backend/services/reading_stats.py
@@ -143,7 +143,7 @@ def compute_book_reading_stats(
     # a Kindle-synced book vanish without a trace. Untouched when the book has
     # no page-stats — ps_seconds is 0 and this whole block is skipped.
     from backend.models.ko_stats import PageStat
-    from backend.services.reconciled_reading import NON_DEVICE_SOURCES
+    from backend.services.reconciled_reading import NON_DEVICE_SOURCES, _cluster_rows
 
     ps = (
         db.query(
@@ -214,7 +214,6 @@ def compute_book_reading_stats(
         pages_turned += add_pages
 
         day_map: dict[str, list[int]] = {r.day: [int(r.seconds), int(r.pages)] for r in day_rows}
-        ps_day_count = len(day_map)
         if add_count:
             add_rows = (
                 additive.with_entities(
@@ -233,9 +232,13 @@ def compute_book_reading_stats(
             {"date": d, "seconds": v[0], "pages": v[1]}
             for d, v in sorted(day_map.items())
         ]
-        # Device reading counts one "session" per reading day; additive sessions
-        # keep their real counts.
-        sessions = ps_day_count + add_count
+        # Device reading counts real sittings: gap-clustered page-stats, the
+        # same clusters the session log lists — so "Sessions (N)" on the card
+        # always equals the rows the dropdown can show (plus additive
+        # web/manual sessions, which keep their own counts).
+        sessions = len(
+            _cluster_rows(db, user_id, day_mod, None, None, book_id=book_id)
+        ) + add_count
         avg_session_seconds = round(total_seconds / sessions) if sessions else 0
 
         first_dt = (

--- a/backend/services/reconciled_reading.py
+++ b/backend/services/reconciled_reading.py
@@ -92,8 +92,15 @@ MIN_SESSION_SECONDS = 10
 
 
 def _cluster_rows(db, user_id: int, tzm: str,
-                  cutoff: Optional[datetime], range_end: Optional[datetime]):
-    """Gap-clustered page-stat sessions: (book_id, day, start, secs, pages).
+                  cutoff: Optional[datetime], range_end: Optional[datetime],
+                  book_id: Optional[int] = None):
+    """Gap-clustered page-stat sessions:
+    (book_id, day, start, last_start, secs, pages, device).
+
+    ``last_start`` is the cluster's final row's start_time — the inclusive upper
+    bound for a range delete of exactly this cluster's rows (durations can
+    overshoot past the next cluster's first row, so start+duration is unsafe
+    as a boundary). ``device`` is MAX() over the cluster — display-only.
 
     Pure SQL (SQLite window functions): number the breaks with LAG, run a
     cumulative sum for cluster ids, aggregate. The day is the cluster's START
@@ -110,17 +117,19 @@ def _cluster_rows(db, user_id: int, tzm: str,
         where.append("start_time >= :ce"); params["ce"] = ce
     if ee is not None:
         where.append("start_time < :ee"); params["ee"] = ee
+    if book_id is not None:
+        where.append("book_id = :bid"); params["bid"] = book_id
 
     sql = text(f"""
         WITH ordered AS (
-            SELECT book_id, start_time, duration_seconds,
+            SELECT book_id, start_time, duration_seconds, device,
                    CASE WHEN start_time - LAG(start_time) OVER w > :gap
                         THEN 1 ELSE 0 END AS brk
             FROM ko_page_stats
             WHERE {' AND '.join(where)}
             WINDOW w AS (PARTITION BY book_id ORDER BY start_time)
         ), clustered AS (
-            SELECT book_id, start_time, duration_seconds,
+            SELECT book_id, start_time, duration_seconds, device,
                    SUM(brk) OVER (PARTITION BY book_id ORDER BY start_time
                                   ROWS UNBOUNDED PRECEDING) AS cluster_id
             FROM ordered
@@ -128,8 +137,10 @@ def _cluster_rows(db, user_id: int, tzm: str,
         SELECT book_id,
                date(MIN(start_time), 'unixepoch', :tzm) AS day,
                MIN(start_time) AS start,
+               MAX(start_time) AS last_start,
                SUM(duration_seconds) AS secs,
-               COUNT(*) AS pages
+               COUNT(*) AS pages,
+               MAX(device) AS device
         FROM clustered
         GROUP BY book_id, cluster_id
         HAVING SUM(duration_seconds) >= :min_secs

--- a/frontend/src/components/InfoHint.tsx
+++ b/frontend/src/components/InfoHint.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Info } from 'lucide-react'
 
 // A small "i" that explains a chart or control on hover or tap. Tap-toggle so
 // it works on touch (native title tooltips don't). Reserved for the non-obvious.
-export function InfoHint({ text }: { text: string }) {
+// Pass `text` for a plain sentence, or `children` for structured content (a
+// legend, a definition list); `wide` widens the popover for the latter.
+export function InfoHint({ text, children, wide }: { text?: string; children?: ReactNode; wide?: boolean }) {
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLSpanElement>(null)
   // iOS Safari doesn't focus buttons on tap, so onBlur alone never closes the
@@ -32,9 +34,9 @@ export function InfoHint({ text }: { text: string }) {
       {open && (
         <span
           role="tooltip"
-          className="absolute left-0 top-5 z-20 w-52 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs leading-snug text-muted-foreground shadow-lg"
+          className={`absolute left-0 top-5 z-20 ${wide ? 'w-80' : 'w-52'} rounded-md border border-border bg-background px-2.5 py-1.5 text-xs leading-snug text-muted-foreground shadow-lg`}
         >
-          {text}
+          {children ?? text}
         </span>
       )}
     </span>

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -25,7 +25,8 @@ export interface StatsResponse {
   by_category: { category: string; seconds: number; sessions: number; book_count: number }[]
   reading_pace: { session_id: number; title: string; date: string | null; pages_per_min: number; duration_seconds: number; pages_turned: number }[]
   books_in_progress: { book_id: number; title: string; author: string | null; has_cover: boolean; progress: number; last_read: string | null }[]
-  session_timeline: { id: number; title: string; started_at: string; ended_at: string; duration_seconds: number }[]
+  // id is a string ("ps-<book>-<start>") for imported KOReader sittings.
+  session_timeline: { id: number | string; title: string; started_at: string; ended_at: string; duration_seconds: number }[]
   year_summary?: {
     books_finished: number
     total_hours: number
@@ -108,7 +109,14 @@ export interface CompletionEstimate {
 }
 
 export interface SessionEntry {
-  id: number
+  // Recorded sessions have a numeric DB id; imported KOReader history clusters
+  // get a synthetic string id ("ps-<book>-<start>").
+  id: number | string
+  kind: 'session' | 'imported'
+  // False for a device live session on a book with imported KOReader history:
+  // the imported sittings already describe that reading, so this row is listed
+  // (labeled "not counted") but excluded from totals.
+  counted: boolean
   book_id: number | null
   book_title: string
   started_at: string | null
@@ -122,6 +130,9 @@ export interface SessionEntry {
   // plausible real duration (page turns at the user's median pace) if computable.
   suspect: boolean
   suggested_seconds: number | null
+  // Imported clusters only: the epoch range for DELETE /stats/imported-sessions.
+  range_start?: number
+  range_end?: number
 }
 
 // ── Chrome ────────────────────────────────────────────────────────────────────

--- a/frontend/src/components/stats/widgets/overview.tsx
+++ b/frontend/src/components/stats/widgets/overview.tsx
@@ -238,27 +238,65 @@ export function BooksFinishedArea({ booksFinished, chartType = 'area' }: { books
   )
 }
 
+// Legend for the session log's labels and actions — rendered as an InfoHint
+// beside whatever heads the list (the "Sessions (N)" header on BookDetailPage,
+// the Recent Sessions tile title on Stats). Kept next to SessionLog so the
+// explanation and the rows it explains stay in one file.
+export function SessionLogHint() {
+  return (
+    <InfoHint wide>
+      <span className="flex flex-col gap-1.5 text-left font-normal normal-case">
+        <span>Each row is one reading session.</span>
+        <span>
+          <span className="font-medium text-foreground">Device name</span> (e.g. Kindle) — recorded
+          live by the KOReader plugin. <span className="font-medium text-foreground">web</span> /{' '}
+          <span className="font-medium text-foreground">manual</span> — the web reader, or logged by
+          hand.
+        </span>
+        <span>
+          <span className="font-medium text-foreground">imported</span> — from KOReader&apos;s synced
+          reading history. Delete only: KOReader already caps idle time, so there is nothing to trim.
+        </span>
+        <span>
+          <span className="font-medium text-foreground">not counted</span> — a live device session on
+          a book whose imported history already covers that reading. Listed for completeness,
+          excluded from the totals so nothing is counted twice.
+        </span>
+        <span>
+          The triangle marks an implausibly long session. Scissors shorten a session, the bin
+          deletes it.
+        </span>
+      </span>
+    </InfoHint>
+  )
+}
+
 // Paginated session log — same rows as the Stats page's "Recent Sessions" card,
 // without the card frame. Self-contained: fetches, paginates, deletes and trims
 // via the API, so it works as a dashboard tile without pushing state upward.
 // With `bookId` it becomes the per-book drill-down inside the time table and on
 // BookDetailPage (#150); `onChange` lets that host refresh its own aggregates
-// after a trim or delete.
-export function SessionLog({ bookId, onChange }: { bookId?: number; onChange?: () => void } = {}) {
+// after a trim or delete. `day` (a reading-day string from session_timeline)
+// narrows it to sittings that started that day — the Activity-bar click-through.
+export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: string; onChange?: () => void } = {}) {
   const [sessions, setSessions] = useState<SessionEntry[]>([])
   const [total, setTotal] = useState(0)
   const [loaded, setLoaded] = useState(0)
   const [loading, setLoading] = useState(false)
-  const [deleting, setDeleting] = useState<Set<number>>(new Set())
+  const [deleting, setDeleting] = useState<Set<number | string>>(new Set())
   const [sort, setSort] = useState<'recent' | 'longest'>('recent')
-  const [trimId, setTrimId] = useState<number | null>(null)
+  const [trimId, setTrimId] = useState<number | string | null>(null)
   const [trimMinutes, setTrimMinutes] = useState('')
   const [trimBusy, setTrimBusy] = useState(false)
 
   const load = (offset: number, replace: boolean) => {
     setLoading(true)
     const bookParam = bookId != null ? `&book_id=${bookId}` : ''
-    api.get<{ total: number; sessions: SessionEntry[] }>(`/stats/sessions?offset=${offset}&limit=20&sort=${sort}${bookParam}`)
+    // Reading-day bucketing needs the client timezone; sent always so `day`
+    // filtering and the server's day labels agree.
+    const dayParam = day ? `&day=${day}` : ''
+    const tzParam = `&tz_offset=${new Date().getTimezoneOffset()}`
+    api.get<{ total: number; sessions: SessionEntry[] }>(`/stats/sessions?offset=${offset}&limit=20&sort=${sort}${bookParam}${dayParam}${tzParam}`)
       .then((res) => {
         setSessions((prev) => (replace ? res.sessions : [...prev, ...res.sessions]))
         setTotal(res.total)
@@ -270,7 +308,7 @@ export function SessionLog({ bookId, onChange }: { bookId?: number; onChange?: (
   useEffect(() => {
     load(0, true)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sort, bookId])
+  }, [sort, bookId, day])
 
   const openTrim = (s: SessionEntry) => {
     setTrimId(s.id)
@@ -298,17 +336,21 @@ export function SessionLog({ bookId, onChange }: { bookId?: number; onChange?: (
       .finally(() => setTrimBusy(false))
   }
 
-  const deleteSession = (id: number) => {
-    setDeleting((prev) => new Set(prev).add(id))
-    api.delete(`/stats/sessions/${id}`)
+  const deleteSession = (s: SessionEntry) => {
+    setDeleting((prev) => new Set(prev).add(s.id))
+    const req =
+      s.kind === 'imported'
+        ? api.delete(`/stats/imported-sessions?book_id=${s.book_id}&start=${s.range_start}&end=${s.range_end}`)
+        : api.delete(`/stats/sessions/${s.id}`)
+    req
       .then(() => {
-        setSessions((prev) => prev.filter((s) => s.id !== id))
+        setSessions((prev) => prev.filter((row) => row.id !== s.id))
         setTotal((prev) => prev - 1)
         setLoaded((prev) => prev - 1)
         onChange?.()
       })
       .catch(() => {})
-      .finally(() => setDeleting((prev) => { const n = new Set(prev); n.delete(id); return n }))
+      .finally(() => setDeleting((prev) => { const n = new Set(prev); n.delete(s.id); return n }))
   }
 
   if (sessions.length === 0 && !loading) {
@@ -360,20 +402,38 @@ export function SessionLog({ bookId, onChange }: { bookId?: number; onChange?: (
                 />
               )}
             </div>
-            <div className="text-muted-foreground truncate">{s.device || '--'}</div>
+            <div
+              className="text-muted-foreground truncate"
+              title={
+                s.kind === 'imported'
+                  ? 'Imported from KOReader reading history'
+                  : !s.counted
+                    ? 'Not in totals — this book’s imported KOReader history already covers this reading'
+                    : undefined
+              }
+            >
+              {s.device || '--'}
+              {s.kind === 'imported' ? (
+                <span className="block text-[10px] text-muted-foreground/70">imported</span>
+              ) : !s.counted ? (
+                <span className="block text-[10px] text-muted-foreground/70">not counted</span>
+              ) : null}
+            </div>
             <div className="flex justify-end gap-0.5">
+              {s.kind !== 'imported' && (
+                <button
+                  onClick={() => (trimId === s.id ? setTrimId(null) : openTrim(s))}
+                  className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
+                  title="Trim session"
+                >
+                  <Scissors className="w-3.5 h-3.5" />
+                </button>
+              )}
               <button
-                onClick={() => (trimId === s.id ? setTrimId(null) : openTrim(s))}
-                className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
-                title="Trim session"
-              >
-                <Scissors className="w-3.5 h-3.5" />
-              </button>
-              <button
-                onClick={() => deleteSession(s.id)}
+                onClick={() => deleteSession(s)}
                 disabled={deleting.has(s.id)}
                 className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors disabled:opacity-40"
-                title="Delete session"
+                title={s.kind === 'imported' ? 'Delete this imported sitting' : 'Delete session'}
               >
                 <Trash2 className="w-3.5 h-3.5" />
               </button>

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useParams, useNavigate, Link } from 'react-router-dom'
 import {
   Camera, Download, Edit2, Save, X,
@@ -19,7 +20,7 @@ import { BookAnimation } from '@/components/BookAnimation'
 import { StarRating } from '@/components/StarRating'
 import { CoverImage } from '@/components/CoverImage'
 import { AutocompleteInput } from '@/components/AutocompleteInput'
-import { SessionLog } from '@/components/stats/widgets/overview'
+import { SessionLog, SessionLogHint } from '@/components/stats/widgets/overview'
 import { InfoHint } from '@/components/InfoHint'
 import { api } from '@/lib/api'
 import type { BookDetail, BookFile, Library as LibraryType, BookStatus, ReadingStatus } from '@/lib/books'
@@ -47,6 +48,8 @@ interface Annotation {
 
 interface BookReadingStats {
   total_seconds: number
+  // Reconciled sitting count: recorded web/manual sessions plus gap-clustered
+  // imported KOReader history — exactly the rows the session log lists.
   sessions: number
   pages_turned: number
   avg_session_seconds: number
@@ -879,15 +882,18 @@ export function BookDetailPage() {
             )}
             {readingStats.own.sessions > 0 && (
               <div className="rounded-xl border border-border bg-card px-5 py-4">
-                <button
-                  type="button"
-                  onClick={() => setSessionsOpen(o => !o)}
-                  aria-expanded={sessionsOpen}
-                  className="flex items-center gap-1.5 text-sm font-medium text-foreground hover:text-primary transition-colors"
-                >
-                  Sessions ({readingStats.own.sessions})
-                  <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', !sessionsOpen && '-rotate-90')} />
-                </button>
+                <span className="flex items-center gap-1.5">
+                  <button
+                    type="button"
+                    onClick={() => setSessionsOpen(o => !o)}
+                    aria-expanded={sessionsOpen}
+                    className="flex items-center gap-1.5 text-sm font-medium text-foreground hover:text-primary transition-colors"
+                  >
+                    Sessions ({readingStats.own.sessions})
+                    <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', !sessionsOpen && '-rotate-90')} />
+                  </button>
+                  <SessionLogHint />
+                </span>
                 {sessionsOpen && (
                   <div className="mt-3">
                     <SessionLog bookId={Number(id)} onChange={refreshStats} />
@@ -1480,9 +1486,14 @@ interface StatsLayoutProps {
  *  The progress lane is the per-book "journey" — % complete over calendar time —
  *  drawn whenever the timeline carries 2+ progress points (the backend only
  *  emits progress_pct where a position is actually known). */
-function ActivityChart({ timeline }: {
+function ActivityChart({ timeline, bookId, onChange }: {
   timeline: { date: string; seconds: number; pages: number; progress_pct?: number | null }[]
+  bookId?: number
+  onChange?: () => void
 }) {
+  // Click-through: a bar opens that day's sessions for quick trim/delete —
+  // e.g. an accidentally imported sitting, without scrolling to the full log.
+  const [dayOpen, setDayOpen] = useState<string | null>(null)
   if (timeline.length < 2) return null
   // Real time axis: fill the calendar days between the first and last reading
   // day with zero bars. Active-days-only bars, evenly spaced, misrepresent the
@@ -1528,13 +1539,18 @@ function ActivityChart({ timeline }: {
           {days.map(d => {
             const pct = d.seconds > 0 ? Math.max(d.seconds / max, 0.06) : 0
             const mins = Math.round(d.seconds / 60)
-            const tip = `${fmtDay(d.date)}: ${mins}m${d.pages > 0 ? `, ${d.pages} pages` : ''}${d.progress_pct != null ? ` · ${d.progress_pct}% in` : ''}`
+            const clickable = d.seconds > 0 && bookId != null
+            const tip = `${fmtDay(d.date)}: ${mins}m${d.pages > 0 ? `, ${d.pages} pages` : ''}${d.progress_pct != null ? ` · ${d.progress_pct}% in` : ''}${clickable ? ' — click for sessions' : ''}`
             return (
               <div
                 key={d.date}
-                className="flex-1 min-w-px bg-primary/60 hover:bg-primary transition-colors rounded-t-sm"
+                className={cn(
+                  'flex-1 min-w-px bg-primary/60 hover:bg-primary transition-colors rounded-t-sm',
+                  clickable && 'cursor-pointer',
+                )}
                 style={{ height: pct > 0 ? `${Math.round(pct * 100)}%` : '0%' }}
                 title={d.seconds > 0 ? tip : undefined}
+                onClick={clickable ? () => setDayOpen(d.date) : undefined}
               />
             )
           })}
@@ -1544,6 +1560,35 @@ function ActivityChart({ timeline }: {
         <span>{first?.date ? fmtDay(first.date) : ''}</span>
         <span>{last?.date ? fmtDay(last.date) : ''}</span>
       </div>
+      {dayOpen && bookId != null && createPortal(
+        <>
+          <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" onClick={() => setDayOpen(null)} />
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
+            <div className="pointer-events-auto flex max-h-[70vh] w-full max-w-2xl flex-col rounded-xl border border-border bg-card shadow-xl">
+              <div className="flex shrink-0 items-center justify-between border-b border-border px-5 py-3.5">
+                <span className="flex items-center gap-1.5">
+                  <h2 className="font-display text-sm text-foreground">
+                    Sessions · {new Date(dayOpen + 'T00:00:00').toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' })}
+                  </h2>
+                  <SessionLogHint />
+                </span>
+                <button
+                  type="button"
+                  aria-label="Close"
+                  onClick={() => setDayOpen(null)}
+                  className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                >
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="overflow-y-auto px-5 py-3">
+                <SessionLog bookId={bookId} day={dayOpen} onChange={onChange} />
+              </div>
+            </div>
+          </div>
+        </>,
+        document.body,
+      )}
       {hasJourney && lanePts.length > 1 && (
         <div className="mt-3">
           <div className="flex items-center justify-between mb-1">
@@ -1997,7 +2042,7 @@ function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps)
       </div>
       {own.session_timeline.length > 1 && (
         <div className="mt-4">
-          <ActivityChart timeline={own.session_timeline} />
+          <ActivityChart timeline={own.session_timeline} bookId={bookId} onChange={onChange} />
         </div>
       )}
       {/* Current progress — only when the journey line doesn't actually render

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -28,6 +28,7 @@ import {
   ReadingActivity365,
   BooksFinishedArea,
   SessionLog,
+  SessionLogHint,
   RecentlyFinished,
   StreakCalendar,
 } from '@/components/stats/widgets/overview'
@@ -113,6 +114,9 @@ type WidgetDef = {
   /** Set when the widget ignores the page range picker (e.g. "12 mo") — rendered
       as a small chip so the fixed window is visible, not a surprise. */
   fixedWindow?: string
+  /** Optional info popover rendered beside the tile title (an InfoHint-style
+      component) — for tiles whose rows carry labels that need explaining. */
+  infoHint?: React.ComponentType
   /** List-like content with intrinsic height (not a fill-the-box chart): in view
       mode the tile shrinks to fit what's actually there, so two in-progress books
       don't rattle around a five-row tile. Edit mode shows the true template. */
@@ -285,6 +289,7 @@ const WIDGETS: WidgetDef[] = [
     title: 'Recent Sessions',
     size: { w: 12, h: 6, minW: 5, minH: 2 },
     autoH: true,
+    infoHint: SessionLogHint,
     render: () => <SessionLog />,
   },
   {
@@ -1177,6 +1182,7 @@ function TileShell({
             12px + a 12px icon keeps long labels ("Reading Time") on one line in a
             narrow ~126px stat tile instead of clipping to "Reading Ti…". */}
         <h3 className="min-w-0 truncate font-display text-xs font-medium text-muted-foreground">{def.titleFor?.(config) ?? def.title}</h3>
+        {def.infoHint && <def.infoHint />}
         {def.fixedWindow && (
           <span title="This tile uses a fixed window and ignores the range picker" className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
             {def.fixedWindow}

--- a/tests/test_book_reading_stats.py
+++ b/tests/test_book_reading_stats.py
@@ -293,6 +293,31 @@ def test_aggregate_includes_page_stats(client: TestClient, make_book, admin_user
     assert agg["total_sessions"] == 2          # two distinct reading days, not zero
 
 
+def test_backfill_only_book_counts_gap_clusters(client: TestClient, make_book, admin_user, db: Session):
+    """A backfill-only book counts real sittings (gap-clustered page-stats),
+    matching the rows the session log lists — not one-per-reading-day.
+
+    Two sittings on the same day, two hours apart, are two sessions."""
+    from backend.models.ko_stats import PageStat
+    user, _ = admin_user
+    book = make_book(title="Backfill Only Book")
+    base = 1_700_000_000
+    for start in (base, base + 7200):  # same day, gap > 30 min → two clusters
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=1, total_pages=100,
+                        start_time=start, duration_seconds=300, device="Kindle"))
+    db.flush()
+
+    own = _get_stats(client, book.id)["own"]
+    assert own["sessions"] == 2
+    assert own["total_seconds"] == 600
+
+    # A manual session stays additive on top of the clusters.
+    _make_session(db, user.id, book.id, datetime(2026, 7, 1, 20, 0), device="manual")
+    db.flush()
+    own = _get_stats(client, book.id)["own"]
+    assert own["sessions"] == 3
+
+
 def test_manual_session_completion_is_sticky(client: TestClient, make_book, admin_user, db: Session):
     """A manual session never un-finishes an already-read book."""
     user, _ = admin_user

--- a/tests/test_reading_day.py
+++ b/tests/test_reading_day.py
@@ -65,10 +65,13 @@ def test_rereads_ignore_a_session_crossing_utc_midnight(client, db, admin_user, 
 
 def test_per_book_timeline_one_day_across_midnight(client, db, admin_user, make_book):
     """The per-book reading log buckets a midnight-crossing device read into one
-    reading day (one 'session'), not two."""
+    reading day (one 'session'), not two.
+
+    Page rows 20 minutes apart: within the 30-minute session gap, so the read
+    is one gap-cluster — and one reading day despite crossing midnight."""
     user, _ = admin_user
     book = make_book(title="Night Owl Book")
-    for i, ts in enumerate([_epoch(2026, 6, 1, 23, 30), _epoch(2026, 6, 2, 0, 15)]):
+    for i, ts in enumerate([_epoch(2026, 6, 1, 23, 50), _epoch(2026, 6, 2, 0, 10)]):
         db.add(PageStat(user_id=user.id, book_id=book.id, page=i + 1, total_pages=100,
                         start_time=ts, duration_seconds=600, device="Kindle"))
     db.flush()

--- a/tests/test_session_hygiene.py
+++ b/tests/test_session_hygiene.py
@@ -247,3 +247,160 @@ def test_trim_validation(hygiene_client, make_book):
         headers={"Authorization": f"Bearer {other_jwt}"},
     )
     assert r.status_code == 404
+
+
+# ── imported KOReader history in the session list ─────────────────────────────
+
+def _add_page_stats(db, user, book, *, base, count=5, dur=60, device="Kindle", page0=1):
+    from backend.models.ko_stats import PageStat
+    for i in range(count):
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=page0 + i,
+                        total_pages=100, start_time=base + i * dur,
+                        duration_seconds=dur, device=device))
+    db.flush()
+
+
+def test_imported_clusters_listed_device_sessions_labeled(hygiene_client, make_book):
+    """Imported sittings appear as `kind: "imported"` rows. A covered book's
+    device-origin live session (the same reading, described twice) stays
+    listed but is `counted: false` — labeled, never silently hidden.
+    Web/manual sessions stay counted."""
+    c, db, user, jwt, _key = hygiene_client
+    book = make_book(title="Covered Book")
+    base = 1_700_000_000  # 2023-11-14
+    _add_page_stats(db, user, book, base=base, count=5, dur=60)                 # sitting 1: 300s
+    _add_page_stats(db, user, book, base=base + 7200, count=3, dur=120, page0=10)  # sitting 2: 360s
+    # Device-origin live session on the covered book — listed, but not counted.
+    superseded = _add_session(db, user, book, start=datetime(2023, 11, 14, 23, 0), seconds=600, pages=10)
+    # Manual log — additive, listed and counted.
+    manual = ReadingSession(user_id=user.id, book_id=book.id,
+                            started_at=datetime(2026, 7, 1, 20, 0),
+                            duration_seconds=900, pages_turned=12, device="manual")
+    db.add(manual)
+    db.flush()
+    headers = {"Authorization": f"Bearer {jwt}"}
+
+    r = c.get("/api/stats/sessions", headers=headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["total"] == 4
+    by_id = {row["id"]: row for row in data["sessions"]}
+    assert by_id[manual.id]["counted"] is True
+    assert by_id[superseded.id]["counted"] is False
+    imported = [row for row in data["sessions"] if row["kind"] == "imported"]
+    assert {row["duration_seconds"] for row in imported} == {300, 360}
+    for row in imported:
+        assert row["counted"] is True
+        assert row["range_start"] <= row["range_end"]
+        assert row["device"] == "Kindle"
+        assert row["suggested_seconds"] is None
+
+    # longest-first: manual 900, superseded device 600, sittings 360 / 300
+    r = c.get("/api/stats/sessions?sort=longest", headers=headers)
+    assert [row["duration_seconds"] for row in r.json()["sessions"]] == [900, 600, 360, 300]
+
+    # merged pagination: pages concatenate to the full list without dup or gap
+    r1 = c.get("/api/stats/sessions?limit=2&offset=0", headers=headers).json()
+    r2 = c.get("/api/stats/sessions?limit=2&offset=2", headers=headers).json()
+    ids = [row["id"] for row in r1["sessions"] + r2["sessions"]]
+    assert len(ids) == 4 == len(set(ids))
+
+
+def test_imported_cluster_delete(hygiene_client, make_book):
+    """Deleting an imported row removes exactly that sitting's page-stats;
+    deleting the last one un-covers the book and its live sessions count again."""
+    from backend.models.ko_stats import PageStat
+    c, db, user, jwt, _key = hygiene_client
+    book = make_book(title="Accidental Open")
+    base = 1_700_000_000
+    _add_page_stats(db, user, book, base=base, count=5, dur=60)                 # real sitting
+    _add_page_stats(db, user, book, base=base + 7200, count=2, dur=150, page0=50)  # accidental
+    live = _add_session(db, user, book, start=datetime(2023, 11, 15, 9, 0), seconds=400, pages=7)
+    live_id = live.id  # the instance detaches once the endpoint commits/rolls back
+    headers = {"Authorization": f"Bearer {jwt}"}
+
+    rows = c.get(f"/api/stats/sessions?book_id={book.id}", headers=headers).json()["sessions"]
+    accidental = next(r for r in rows if r["kind"] == "imported" and r["duration_seconds"] == 300)
+
+    r = c.delete(
+        f"/api/stats/imported-sessions?book_id={book.id}"
+        f"&start={accidental['range_start']}&end={accidental['range_end']}",
+        headers=headers,
+    )
+    assert r.status_code == 200
+    assert r.json()["deleted_rows"] == 2
+    assert db.query(PageStat).filter_by(user_id=user.id, book_id=book.id).count() == 5
+    entry = db.query(AuditLog).filter_by(action="imported_session.deleted").first()
+    assert entry is not None
+
+    # same range again: nothing left there
+    r = c.delete(
+        f"/api/stats/imported-sessions?book_id={book.id}"
+        f"&start={accidental['range_start']}&end={accidental['range_end']}",
+        headers=headers,
+    )
+    assert r.status_code == 404
+
+    # one imported sitting remains; the live device session is listed as not counted
+    rows = c.get(f"/api/stats/sessions?book_id={book.id}", headers=headers).json()["sessions"]
+    assert [(r["kind"], r["counted"]) for r in rows] == [("session", False), ("imported", True)]
+    remaining = rows[1]
+
+    # delete the last sitting → book is no longer covered → live session counts again
+    r = c.delete(
+        f"/api/stats/imported-sessions?book_id={book.id}"
+        f"&start={remaining['range_start']}&end={remaining['range_end']}",
+        headers=headers,
+    )
+    assert r.status_code == 200
+    rows = c.get(f"/api/stats/sessions?book_id={book.id}", headers=headers).json()["sessions"]
+    assert [(r["id"], r["counted"]) for r in rows] == [(live_id, True)]
+
+
+def test_imported_delete_scoped_to_own_rows(hygiene_client, make_book):
+    """The range delete never touches another user's page-stats."""
+    from backend.models.ko_stats import PageStat
+    c, db, user, jwt, _key = hygiene_client
+    book = make_book(title="Shared Book")
+    base = 1_700_000_000
+    _add_page_stats(db, user, book, base=base, count=3, dur=60)
+    other, other_jwt = _make_user(db, "otherreader")
+    _add_page_stats(db, other, book, base=base, count=3, dur=60)
+
+    r = c.delete(
+        f"/api/stats/imported-sessions?book_id={book.id}&start={base}&end={base + 600}",
+        headers={"Authorization": f"Bearer {other_jwt}"},
+    )
+    assert r.status_code == 200
+    assert db.query(PageStat).filter_by(user_id=user.id).count() == 3
+    assert db.query(PageStat).filter_by(user_id=other.id).count() == 0
+
+
+def test_sessions_day_filter(hygiene_client, make_book):
+    """`day` narrows the merged list to sittings that started that reading day
+    (Activity-bar click-through)."""
+    c, db, user, jwt, _key = hygiene_client
+    book = make_book(title="Day Filter Book")
+    base = 1_700_000_000  # 2023-11-14 22:13 UTC → reading day 2023-11-14 (4h rollover)
+    _add_page_stats(db, user, book, base=base, count=5, dur=60)
+    _add_page_stats(db, user, book, base=base + 5 * 86_400, count=3, dur=120, page0=10)
+    manual = ReadingSession(user_id=user.id, book_id=book.id,
+                            started_at=datetime(2023, 11, 14, 23, 30),
+                            duration_seconds=600, pages_turned=8, device="manual")
+    db.add(manual)
+    db.flush()
+    headers = {"Authorization": f"Bearer {jwt}"}
+
+    r = c.get(f"/api/stats/sessions?book_id={book.id}&day=2023-11-14&tz_offset=0", headers=headers)
+    data = r.json()
+    assert data["total"] == 2
+    assert {row["kind"] for row in data["sessions"]} == {"session", "imported"}
+
+    r = c.get(f"/api/stats/sessions?book_id={book.id}&day=2023-11-19&tz_offset=0", headers=headers)
+    data = r.json()
+    assert data["total"] == 1
+    assert data["sessions"][0]["kind"] == "imported"
+    assert data["sessions"][0]["duration_seconds"] == 360
+
+    r = c.get(f"/api/stats/sessions?book_id={book.id}&day=14-11-2023", headers=headers)
+    assert r.status_code == 422

--- a/tests/test_stats_reconciliation.py
+++ b/tests/test_stats_reconciliation.py
@@ -142,3 +142,42 @@ def test_per_book_session_counts_are_clustered(db, admin_user, make_book):
     covered = covered_book_ids(db, user.id)
     bs = book_seconds(db, user.id, "+0 hours", covered, None, None)
     assert bs[book.id][1] == 3
+
+
+def test_session_timeline_ribbon_reconciled(client, db, admin_user, make_book):
+    """The Habits session-timeline ribbon draws imported sittings and drops the
+    superseded live device sessions that describe the same reading; web/manual
+    sessions on covered books stay."""
+    user, _ = admin_user
+    covered = make_book(title="Covered Book")
+    webonly = make_book(title="Web Book")
+    # Imported sitting on the covered book + a live device session (same reading)
+    _add_pagestats(db, user, covered, [120, 80], day=(2026, 1, 10))
+    db.add(ReadingSession(user_id=user.id, book_id=covered.id,
+                          started_at=datetime(2026, 1, 10, 12, 0),
+                          ended_at=datetime(2026, 1, 10, 12, 30),
+                          duration_seconds=1800, pages_turned=20, device="Kindle"))
+    # Manual session on the covered book — additive, stays drawn
+    db.add(ReadingSession(user_id=user.id, book_id=covered.id,
+                          started_at=datetime(2026, 1, 11, 20, 0),
+                          ended_at=datetime(2026, 1, 11, 20, 30),
+                          duration_seconds=1800, pages_turned=20, device="manual"))
+    # Session-only book — unaffected
+    db.add(ReadingSession(user_id=user.id, book_id=webonly.id,
+                          started_at=datetime(2026, 1, 12, 9, 0),
+                          ended_at=datetime(2026, 1, 12, 9, 30),
+                          duration_seconds=1800, pages_turned=20, device="web"))
+    db.flush()
+
+    tl = client.get("/api/stats?days=0").json()["session_timeline"]
+    ids = [e["id"] for e in tl]
+    # newest first: web book, manual, imported cluster
+    assert [str(i).startswith("ps-") for i in ids] == [False, False, True]
+    imported = tl[2]
+    assert imported["duration_seconds"] == 200
+    assert imported["title"] == "Covered Book"
+    assert imported["started_at"] < imported["ended_at"]
+    # the superseded 1800s device session is not drawn
+    assert not any(e["duration_seconds"] == 1800 and e["title"] == "Covered Book"
+                   and not str(e["id"]).startswith("ps-") and e["started_at"].startswith("2026-01-10")
+                   for e in tl)

--- a/website/src/pages/docs/koreader.astro
+++ b/website/src/pages/docs/koreader.astro
@@ -205,6 +205,24 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
   </ul>
   <p>Sessions shorter than 10 seconds are filtered out.</p>
 
+  <h3>Reading-history backfill</h3>
+  <p>
+    KOReader's built-in statistics plugin records every page you dwell on — going back to long
+    before Tome existed. TomeSync can push that database to your server:
+    <strong>TomeSync → Settings → Auto-sync reading history on launch</strong>, or run it once
+    via <strong>Sync reading history</strong>. The first sync backfills everything (chunked and
+    resumable — a dropped connection just continues next time); later syncs send only new
+    reading. It carries reading time and pages only, never your read/unread status.
+  </p>
+  <p>
+    Once a book has imported history, that history becomes the source of truth for its device
+    reading: it feeds the per-page <strong>Reading intensity</strong> and
+    <strong>Time per chapter</strong> charts on the book page, and its sittings appear in the
+    <a href={withBase("/docs/stats")}>session lists</a> tagged <em>imported</em>. The plugin's
+    own live sessions for such a book are excluded from the totals so nothing is counted
+    twice.
+  </p>
+
   <h3>Sync on suspend</h3>
   <p>
     Two opt-in settings (TomeSync → Settings) make your morning stats current without ever

--- a/website/src/pages/docs/stats.astro
+++ b/website/src/pages/docs/stats.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro'
 import SectionHero from '../../components/SectionHero.astro'
 import DocsMeta from '../../components/DocsMeta.astro'
 import Callout from '../../components/Callout.astro'
+import UnreleasedNote from '../../components/UnreleasedNote.astro'
 import { ThemedShot } from '../../components/ThemedShot'
 import { withBase } from '../../lib/path'
 ---
@@ -107,6 +108,37 @@ import { withBase } from '../../lib/path'
     turns, progress, start time, device, other sessions, and imported KOReader history are all
     untouched, and the previous duration is recorded in the audit log, so a trim is never a
     silent loss of data.
+  </Callout>
+
+  <h2>Imported KOReader history in the session lists</h2>
+  <UnreleasedNote />
+  <p>
+    Reading synced from KOReader's own statistics database — including everything read before
+    Tome existed, if you enabled the <a href={withBase("/docs/koreader")}>reading-history
+    backfill</a> — appears in the same session lists as everything else. The raw per-page
+    timings are grouped into sittings the way KOReader itself thinks about sessions (a gap of
+    more than 30 minutes starts a new one), and each sitting shows as a row tagged
+    <strong>imported</strong>.
+  </p>
+  <p>
+    Imported sittings can be deleted individually — the fix for a book opened by accident,
+    whose stray minutes used to be removable only by wiping the book's entire imported
+    history. Deleting one removes exactly that sitting's page timings and the totals drop with
+    it. They can't be trimmed: KOReader already caps idle time at the source, so there is
+    nothing to cut. Two labels tell the rest of the story: on a book with imported history,
+    the plugin's live sessions describe the same reading a second time, so they stay listed
+    with a <strong>not counted</strong> tag while the imported rows carry the totals — nothing
+    is ever counted twice, and nothing silently disappears. The small info icon next to every
+    session list explains all labels in place.
+  </p>
+  <p>
+    For getting at one stray day quickly, the <strong>Activity</strong> chart on a book's
+    Reading Stats block is clickable: each bar opens a popup with the sittings that started on
+    that day, with the same trim and delete actions — no scrolling the full log.
+  </p>
+  <Callout variant="info" title="Deleted history stays deleted">
+    The device only ever uploads statistics newer than its last sync, so a deleted sitting is
+    not re-imported on the next connection. New reading syncs and counts as normal.
   </Callout>
 
   <h2>Overview board</h2>


### PR DESCRIPTION
## Why

Reported by a user on the latest release: reading synced from KOReader's statistics (including the pre-Tome backfill) counts toward totals but never appears in Recent Sessions or the per-book session list. A backfill-only book claimed "1 session" over an empty dropdown, and an accidental open could only be removed by wiping the book's entire imported history.

## What

**Imported sittings in the session lists.** `GET /stats/sessions` now merges live sessions with imported KOReader history, gap-clustered into sittings the same way KOReader groups them (30-min gap, sub-10s noise dropped). Imported rows are tagged, deletable per sitting via the new audited `DELETE /stats/imported-sessions` (range delete of that sitting's page-stat rows), and not trimmable — KOReader already idle-caps at the source.

**Label, don't hide.** On a book with imported history, the plugin's live device sessions describe the same reading twice. They are excluded from totals (unchanged) but now stay listed with a "not counted" tag instead of being suppressed. An info legend next to every session list explains all labels in place.

**Counts that match the list.** The per-book card counts real gap-clustered sittings instead of reading-days, so "Sessions (N)" equals the counted rows below it.

**Day drill-down.** Bars in the book page's Activity chart open a popup with the sittings that started on that reading day (new `day` param, same tz + 4h-rollover bucketing as the chart) — trim/delete one stray entry without scrolling the full log.

**Habits ribbon unified.** The session-timeline ribbon draws imported sittings and drops the superseded device sessions that would paint the same reading twice.

**Docs.** New unreleased-marked "Imported KOReader history" section on /docs/stats, plus a previously missing "Reading-history backfill" section on /docs/koreader (that feature shipped in v2.0.0 undocumented).

## Notes

- Deleting a book's last imported sitting un-covers it: its live sessions resurface and count again (fallback source takes over, consistent with reconciliation).
- Deleted history is never re-imported — the per-device watermark only uploads newer rows.
- `InfoHint` gains `children`/`wide` support; stats dashboard tiles gain an `infoHint` slot on the tile definition.

## Testing

- 7 new backend tests: merged list + counted flags + sort + merge pagination, per-sitting delete incl. un-cover fallback and cross-user scoping, day filter (bucketing + 422), cluster-count semantics, ribbon reconciliation.
- 2 existing tests updated to cluster semantics (midnight-crossing read, per-book counts).
- Full suite: 1042 passed. Frontend `tsc -b` + build clean. Website builds.
- Exercised end to end against the dev instance with real backfill data (50k page-stat rows) plus seeded edge cases: backfill-only book, mixed book (imported + web + manual + not-counted device row), day popup delete, runaway trim.