### PR TITLE
fix(stats): list sub-threshold imported blips so accidental opens are deletable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ All notable changes to Tome are documented here. Format loosely follows
   twice.
 
 ### Fixed
+- A seconds-long accidental open synced from KOReader history now shows up
+  in the session lists and the Activity day popup so it can be deleted.
+  Such blips are below the noise floor for session counting (a 7-second
+  page flip is not a sitting) and were filtered out of the lists entirely -
+  but their seconds still drew an Activity bar and set "last read", so the
+  one entry people most want to remove was the one entry that never
+  appeared, and its day popup claimed "No sessions recorded".
 - KOSync progress pushes now follow the same read-status rules as every
   other sync path: finishing requires 99% (was 95%), completion is sticky
   (a re-read no longer drags a finished book back to "reading"), and the

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -1338,8 +1338,13 @@ def list_sessions(
     )
     clusters = []
     if covered and (book_id is None or book_id in covered):
+        # min_secs=0: sub-threshold noise blips (an accidental open of a few
+        # seconds) are exactly what people come here to delete — they hold
+        # seconds in the totals and draw Activity bars, so they must be listed
+        # even though session COUNTS everywhere else keep the noise floor.
         clusters = rr._cluster_rows(
-            db, current_user.id, date_modifier(tz_offset), None, None, book_id=book_id
+            db, current_user.id, date_modifier(tz_offset), None, None,
+            book_id=book_id, min_secs=0,
         )
         if day is not None:
             clusters = [c for c in clusters if c.day == day]

--- a/backend/services/reconciled_reading.py
+++ b/backend/services/reconciled_reading.py
@@ -93,7 +93,8 @@ MIN_SESSION_SECONDS = 10
 
 def _cluster_rows(db, user_id: int, tzm: str,
                   cutoff: Optional[datetime], range_end: Optional[datetime],
-                  book_id: Optional[int] = None):
+                  book_id: Optional[int] = None,
+                  min_secs: int = MIN_SESSION_SECONDS):
     """Gap-clustered page-stat sessions:
     (book_id, day, start, last_start, secs, pages, device).
 
@@ -101,6 +102,12 @@ def _cluster_rows(db, user_id: int, tzm: str,
     bound for a range delete of exactly this cluster's rows (durations can
     overshoot past the next cluster's first row, so start+duration is unsafe
     as a boundary). ``device`` is MAX() over the cluster — display-only.
+
+    ``min_secs`` drops sub-threshold clusters (page-flip noise) — the default
+    for anything that COUNTS sessions. The session list passes 0: a 7-second
+    accidental open still holds page-stat seconds (they're in the totals and
+    draw an Activity bar), so it must be listable and deletable even though it
+    is not a sitting worth counting.
 
     Pure SQL (SQLite window functions): number the breaks with LAG, run a
     cumulative sum for cluster ids, aggregate. The day is the cluster's START
@@ -111,7 +118,7 @@ def _cluster_rows(db, user_id: int, tzm: str,
 
     where, params = ["user_id = :uid"], {"uid": user_id, "tzm": tzm,
                                          "gap": SESSION_GAP_SECONDS,
-                                         "min_secs": MIN_SESSION_SECONDS}
+                                         "min_secs": min_secs}
     ce, ee = _epoch(cutoff), _epoch(range_end)
     if ce is not None:
         where.append("start_time >= :ce"); params["ce"] = ce

--- a/tests/test_session_hygiene.py
+++ b/tests/test_session_hygiene.py
@@ -404,3 +404,43 @@ def test_sessions_day_filter(hygiene_client, make_book):
 
     r = c.get(f"/api/stats/sessions?book_id={book.id}&day=14-11-2023", headers=headers)
     assert r.status_code == 422
+
+
+def test_noise_blip_listed_and_deletable(hygiene_client, make_book):
+    """A sub-10s page-stat blip (accidental open) is not a counted sitting, but
+    it holds seconds in the totals — so the list shows it and it can be
+    deleted. Caught on prod: an Activity bar whose day popup said "No sessions
+    recorded" because the only sitting that day was 7 seconds long."""
+    c, db, user, jwt, _key = hygiene_client
+    book = make_book(title="Blip Book")
+    base = 1_700_000_000
+    _add_page_stats(db, user, book, base=base, count=5, dur=60)          # real sitting
+    _add_page_stats(db, user, book, base=base + 40 * 86_400, count=1, dur=7,
+                    page0=99)                                            # 7s accidental open
+    headers = {"Authorization": f"Bearer {jwt}"}
+
+    rows = c.get(f"/api/stats/sessions?book_id={book.id}&tz_offset=0",
+                 headers=headers).json()["sessions"]
+    assert [r["duration_seconds"] for r in rows] == [7, 300]
+
+    # the blip's reading day resolves like the timeline's: filterable by day
+    blip = rows[0]
+    day = blip["started_at"][:10]
+    rows = c.get(f"/api/stats/sessions?book_id={book.id}&day={day}&tz_offset=0",
+                 headers=headers).json()["sessions"]
+    assert [r["duration_seconds"] for r in rows] == [7]
+
+    # per-book count keeps the noise floor: one sitting, not two
+    r = c.get(f"/api/books/{book.id}/reading-stats", headers=headers)
+    assert r.json()["own"]["sessions"] == 1
+
+    # and it is deletable like any imported sitting
+    r = c.delete(
+        f"/api/stats/imported-sessions?book_id={book.id}"
+        f"&start={blip['range_start']}&end={blip['range_end']}",
+        headers=headers,
+    )
+    assert r.status_code == 200
+    rows = c.get(f"/api/stats/sessions?book_id={book.id}&tz_offset=0",
+                 headers=headers).json()["sessions"]
+    assert [r["duration_seconds"] for r in rows] == [300]


### PR DESCRIPTION
## Why

Found on prod within an hour of testing #160: a book showed an Activity bar on 17 Apr whose day popup said "No sessions recorded". The bar came from a **7-second, 1-page** page-stat blip — an accidental open of a finished book. Clusters under 10 s are noise-filtered out of session counting, and the list reused that floor — so the exact artifact the per-sitting delete exists for was the one row that never appeared (while still holding seconds in the totals, drawing a bar, and setting "last read").

## What

`_cluster_rows` gains a `min_secs` parameter (default = existing 10 s floor). `GET /stats/sessions` passes `min_secs=0`, so every imported cluster — including seconds-long blips — is listed and deletable via `DELETE /stats/imported-sessions`. Session counts, reconciled totals, and the Habits ribbon keep the noise floor unchanged.

## Testing

Regression test reproducing the prod case end to end: blip listed, day-filterable, per-book count still excludes it, delete removes it. 49 tests across the four affected files pass.