### PR TITLE
Push major version container image tags for releases

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,6 +65,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=sha,prefix=
             # :latest tracks the newest RELEASE (vX.Y.Z tag), not main HEAD.
             # main keeps publishing the rolling :main tag (type=ref,event=branch


### PR DESCRIPTION
Hey there! I would like to track the major version tag on the container images you publish. Right now you only push major-minor and major-minor-patch version tags.

I did not create an issue beforehand since this is a one-line change and I thought I can just ask in the PR instead. Feel free to reject this if it is not desired! :)

## Summary

<!-- What and why in 2-3 bullets. Link the issue if there is one ("Fixes #123"). -->

Adds a major-only semver tag to the container image release pipeline. This lets users of the container image track major versions without having to specify minor or patch versions.

For example, a release tagged `v1.2.3` will now publish:
- `:1`
- `:1.2`
- `:1.2.3`

where it before would only have published `:1.2` and `:1.2.3`.

## Changes

**CI**

`.github/workflows/docker.yml`: Tags releases with `major`, in addition to the existing `major-minor` and `version` tags

No changes in other parts of the source.

## Checklist

- [x] `pytest` passes
- [x] `npm run build` clean (frontend typecheck)
- [ ] ~~Manually tested the happy path~~
- [ ] ~~Docs updated (if user-facing)~~ I don't think docs exist about the tags.
- [ ] ~~#In-app "Learn more →" link points to the new/updated docs (if docs added)~~
- [ ] ~~Screenshots added (if UI change)~~
- [x] No secrets or credentials committed

## Notes

<!-- Anything tricky, intentionally skipped, or deferred. Delete if N/A. -->

I don't think so!

---

By submitting this PR, I confirm my contributions are licensed under AGPL-3.0.
