### PR TITLE
fix(deps): react-router 7.18.2 + postcss 8.5.25 for security advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Security
+- Updated `react-router` to 7.18.2, clearing four advisories: an unauthenticated
+  route-matching DoS (CVE-2026-55685), an open redirect via backslash in `<Link>`
+  and `useNavigate`, a constructor injection in SSR hydration, and an XSS in the
+  RSC error handler. Only the open redirect is reachable in Tome - the SSR and
+  RSC issues cover render modes Tome does not use, and the DoS is client-side in
+  a static SPA, so it can only affect the tab it runs in. A fifth advisory
+  (GHSA-qwww-vcr4-c8h2, CSRF bypass in RSC mode) has no 7.x fix at all and is
+  equally unreachable from a `BrowserRouter` app; it is left for a future major
+  upgrade rather than pulled into a patch release.
+- Updated `postcss` to 8.5.25, clearing a path-traversal advisory in source-map
+  auto-loading. Build-time only - postcss reaches Tome through Vite and is not
+  part of a deployed instance.
+- Updated `brace-expansion`, a dev-only transitive dependency, to clear a
+  denial-of-service advisory.
+
+### Build
+- Release images now publish a major-version tag as well, so
+  `ghcr.io/bndct-devops/tome:2` follows the newest 2.x release without pinning a
+  minor or patch. The existing `:2.1`, `:2.1.1` and `:latest` tags are unchanged.
+  Thanks to @bl1nk for the contribution. (#163)
+
 ## [2.1.0] - 2026-07-26 - "Palimpsest"
 
 ### Added

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,7 +19,7 @@
         "react-dom": "^19.2.4",
         "react-grid-layout": "^2.2.3",
         "react-is": "^19.2.4",
-        "react-router-dom": "^7.17.0",
+        "react-router-dom": "^7.18.0",
         "recharts": "^3.8.1",
         "tailwind-merge": "^3.5.0",
         "tailwindcss": "^4.2.2",
@@ -3615,16 +3615,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3945,9 +3945,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5026,9 +5026,9 @@
       }
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5324,16 +5324,16 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/glob/node_modules/minimatch": {
@@ -6575,9 +6575,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -6892,9 +6892,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -6912,7 +6912,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7067,9 +7067,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -7089,12 +7089,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,7 @@
     "react-dom": "^19.2.4",
     "react-grid-layout": "^2.2.3",
     "react-is": "^19.2.4",
-    "react-router-dom": "^7.17.0",
+    "react-router-dom": "^7.18.0",
     "recharts": "^3.8.1",
     "tailwind-merge": "^3.5.0",
     "tailwindcss": "^4.2.2",


### PR DESCRIPTION
Clears five of the six open Dependabot alerts on the frontend lockfile, ahead of a v2.1.1 patch release.

## Bumps

| Package | From | To | Alerts cleared |
|---|---|---|---|
| `react-router` / `react-router-dom` | 7.17.0 | 7.18.2 | #43, #44, #45, #46 |
| `postcss` (transitive, via Vite) | 8.5.15 | 8.5.25 | #47 |
| `brace-expansion` (dev-only transitive) | - | patched | audit-only, no alert |

## What actually applies to Tome

Tome is a client-side SPA (`BrowserRouter`, `frontend/src/App.tsx:193`) with no SSR, no RSC and no `react-router.config.*`. Of the four router advisories:

- **Open redirect via backslash in `<Link>` / `useNavigate`** (#45) - genuinely reachable. This is the one worth closing.
- **Route-matching DoS, CVE-2026-55685** (#46) - client-side only here, so the worst case is stalling the tab it runs in, not the server.
- **Constructor injection in SSR hydration** (#43) and **XSS in the RSC error handler** (#44) - cover render modes Tome does not use.

`postcss` (#47) is build-time only; it reaches Tome through Vite and is not part of a deployed instance.

## Deliberately left open: GHSA-qwww-vcr4-c8h2 (#48)

The RSC-mode CSRF bypass has **no fix in the 7.x line** - its only patched version is react-router 8.3.0. It is equally unreachable without RSC mode, so pulling a router major into a patch release would be a considerably larger risk than the one it removes. It stays for a feature release where it can get real testing. Alert to be dismissed as "vulnerable code is not actually used".

## Notes

Installed with `--legacy-peer-deps` to match the Dockerfile, since `vite-plugin-pwa@1.2.0` still declares a pre-vite-8 peer range. That conflict predates this change.

## Verification

- 1043 backend tests pass
- `tsc -b && vite build` clean (2420 modules)
- `npm ci --legacy-peer-deps --dry-run` resolves, so the lockfile installs exactly as the Dockerfile does it
- Router smoke test against the production build: root mounts and redirects to `/login`, the login form renders, deep-linking a guarded route matches and bounces, and client-side navigation does not full-reload. Zero page errors.