### PR TITLE
fix(tomesync): popup menus freeze under full-screen home-screen plugins (build 38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Fixed
+- KOReader plugin (build 38 / 1.11.1): popup menus — the series browser,
+  Authors, Shelves, the Inbox and the TomeSync menu itself — could freeze on
+  their first page when a full-screen home-screen plugin (such as
+  bookshelf.koplugin) covers the file browser: page turns happened internally
+  but the screen never repainted, and stale refreshes could leave blank white
+  rectangles behind. The menus now repaint through their own window instead of
+  the hidden file browser.
+
 ## [2.1.1] - 2026-08-01
 
 ### Security

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -75,8 +75,8 @@ logger = logging.getLogger(__name__)
 # bypassing wifi_enable_action so "prompt" never dialogs onto the sleep
 # screen). onNetworkConnected also runs the history backfill now (was
 # launch-only) and no longer requires an open book to flush pending state.
-TOMESYNC_PLUGIN_BUILD = 37
-TOMESYNC_PLUGIN_SEMVER = "1.11.0"
+TOMESYNC_PLUGIN_BUILD = 38
+TOMESYNC_PLUGIN_SEMVER = "1.11.1"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -3705,7 +3705,6 @@ function TomeSync:_bookListMenu(data)
         item_table  = items,
         width       = Device.screen:getWidth() - 20,
         height      = Device.screen:getHeight() - 20,
-        show_parent = self.ui or UIManager,
     }}
     -- Hold a book row to set its read status (write-back to Tome).
     menu.onMenuHold = function(_, item)
@@ -3835,7 +3834,6 @@ function TomeSync:_authorsMenuImpl()
         item_table = items,
         width = Device.screen:getWidth() - 20,
         height = Device.screen:getHeight() - 20,
-        show_parent = self.ui or UIManager,
     }})
 end
 
@@ -3898,7 +3896,6 @@ function TomeSync:_shelvesMenuImpl()
         item_table = items,
         width = Device.screen:getWidth() - 20,
         height = Device.screen:getHeight() - 20,
-        show_parent = self.ui or UIManager,
     }})
 end
 
@@ -4075,7 +4072,6 @@ function TomeSync:_browseSeriesMenuImpl()
         item_table = items,
         width = Device.screen:getWidth() - 20,
         height = Device.screen:getHeight() - 20,
-        show_parent = self.ui or UIManager,
     }}
     UIManager:show(menu)
 end
@@ -4493,7 +4489,6 @@ function TomeSync:_inboxMenuImpl()
         item_table  = menu_items,
         width       = Device.screen:getWidth() - 20,
         height      = Device.screen:getHeight() - 20,
-        show_parent = self.ui or UIManager,
     }}
     UIManager:show(self._inbox_menu)
 end
@@ -4992,7 +4987,6 @@ function TomeSync:_showPopupMenu(title, raw)
         item_table  = items,
         width       = Device.screen:getWidth() - 20,
         height      = Device.screen:getHeight() - 20,
-        show_parent = self.ui or UIManager,
     }}
     UIManager:show(self._gesture_menu)
 end

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -201,5 +201,11 @@ def test_build_bumped_for_rebake():
     # the idle cap (default 10 min, configurable, 0 = off), so a device left
     # awake unread no longer books wall-clock time; ended_at becomes the last
     # activity plus the final credit rather than the eventual suspend.
-    assert TOMESYNC_PLUGIN_BUILD >= 37
-    assert TOMESYNC_PLUGIN_SEMVER == "1.11.0"
+    # 1.11.1 / build 38 fixes popup menus (series browser, authors, shelves,
+    # inbox, gesture menu) passing show_parent = self.ui: when a full-screen
+    # home-screen plugin (e.g. bookshelf.koplugin) sits above the FileManager,
+    # repaints routed at the hidden FileManager are skipped entirely, so page
+    # flips inside the popup never redraw. Menus now use the Menu default
+    # (show_parent = the menu itself), which is always the visible window.
+    assert TOMESYNC_PLUGIN_BUILD >= 38
+    assert TOMESYNC_PLUGIN_SEMVER == "1.11.1"


### PR DESCRIPTION
## What

KOReader plugin build 38 / 1.11.1. All six TomeSync popup menus (series browser, Authors, Shelves, Inbox, series-books list, and the TomeSync menu itself) stop passing `show_parent = self.ui` and use the `Menu` default (the menu itself) instead.

## Why

Outside a book, `self.ui` is the FileManager. When a home-screen plugin such as bookshelf.koplugin holds a resident full-screen window above it, KOReader's repaint loop - which starts at the topmost full-screen widget - skips the dirty-marked FileManager entirely. Page flips inside the popups happened internally but never redrew, and stale refresh regions could flush as blank white rectangles. Inside a book the same menus paged fine, because ReaderUI is itself the topmost full-screen widget.

This closes the long-open "series list stuck on Page 1 of N" report (2026-07-16), which never reproduced in the emulator because the emulator wasn't running bookshelf.

## Verification

- Reproduced and fixed in the KOReader emulator at v2025.08 (the Kindle's version) and master, with bookshelf + `start_with = "bookshelf"` (page flips now repaint, "Page 2 of 4" renders).
- Stock-shape pass without bookshelf/zen_ui: series browser opens and pages correctly from both the file manager and the reader, so plain-KOReader users are unaffected.
- Manual build-38 impl deploy verified on the Kindle canary.
- `tests/test_tomesync_plugin_url.py` release guard updated (8 passed); full tomesync test selection passes (137).