### PR TITLE
Library integrity: orphan cleanup, duplicates Apply All, real bulk delete (#165)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,8 +31,53 @@ jobs:
       - name: Run tests
         run: pytest tests/ -q
 
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install backend dependencies
+        run: pip install '.[dev]'
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci --legacy-peer-deps
+        working-directory: frontend
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: Run E2E tests
+        run: npx playwright test
+        working-directory: frontend
+        env:
+          E2E_PYTHON: python
+          CI: "true"
+
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: frontend/test-results/
+          retention-days: 7
+
   build:
-    needs: test
+    needs: [test, e2e]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,50 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- Library Health now detects orphaned entries — books whose files no longer
+  exist on disk (for example after files were deleted or moved outside of
+  Tome). A new section lists them and a one-click "Remove Dead Entries" action
+  cleans them up: dead file entries are removed and books left with no files
+  at all are deleted entirely. Entries whose file still exists are never
+  touched. (#165)
+- Duplicates (Admin) gained a "Delete Others" action: keep the selected book
+  and delete the other copies in the group, including their files on disk,
+  with an inline confirmation step. Files that are missing from disk are now
+  badged as such on each duplicate, so dead copies are easy to spot. (#165)
+- New `POST /api/books/bulk-delete` endpoint deletes several books in one
+  request with per-book permission checks and error reporting. The dashboard's
+  multi-select delete now uses it instead of issuing one request per book,
+  and failures are reported instead of silently skipped. (#165)
+- The Duplicates tab now works in one pass: pick the book to keep and an
+  action (Merge, Delete Others, Dismiss) per group, then hit a single "Apply
+  All" — instead of the screen refreshing and resetting your selections after
+  every individual merge or dismiss. A summary reports what was applied and
+  any failures. (#165)
+
+### Fixed
+- KOReader plugin (build 38 / 1.11.1): popup menus — the series browser,
+  Authors, Shelves, the Inbox and the TomeSync menu itself — could freeze on
+  their first page when a full-screen home-screen plugin (such as
+  bookshelf.koplugin) covers the file browser: page turns happened internally
+  but the screen never repainted, and stale refreshes could leave blank white
+  rectangles behind. The menus now repaint through their own window instead of
+  the hidden file browser.
+- "Select all" on the dashboard now selects every book matching the current
+  filters, not just the ones the infinite scroll had already loaded — so bulk
+  actions on large libraries no longer silently miss the books further down.
+  (#165)
+- Toggling "Group series" no longer occasionally shows duplicate books in the
+  grid: an in-flight page request from the previous view could land after the
+  toggle and append stale results onto the fresh list. Page requests are now
+  cancelled when the view changes, and appends are deduplicated. (#165)
+- Merging duplicates now actually transfers the removed book's files to the
+  kept book. Previously the transferred file entries were silently deleted
+  together with the removed book, leaving the files on disk untracked.
+- Merging duplicates no longer carries dead file references over to the kept
+  book: entries whose file is missing from disk are dropped during the merge
+  instead of leaving the kept book with a file that errors on open. (#165)
+
 ## [2.1.1] - 2026-08-01
 
 ### Security

--- a/backend/api/admin_duplicates.py
+++ b/backend/api/admin_duplicates.py
@@ -12,6 +12,7 @@ from subsequent GET results.
 import difflib
 import itertools
 import uuid
+from pathlib import Path
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -37,6 +38,7 @@ class BookFileOut(BaseModel):
     id: int
     format: str
     file_size: Optional[int]
+    path_exists: bool = True
 
     model_config = {"from_attributes": True}
 
@@ -95,7 +97,15 @@ def _book_to_out(book: Book) -> DuplicateBookOut:
         series=book.series,
         series_index=book.series_index,
         year=book.year,
-        files=[BookFileOut(id=f.id, format=f.format, file_size=f.file_size) for f in book.files],
+        files=[
+            BookFileOut(
+                id=f.id,
+                format=f.format,
+                file_size=f.file_size,
+                path_exists=Path(f.file_path).exists(),
+            )
+            for f in book.files
+        ],
         tags=[t.tag for t in book.tags],
         library_ids=book.library_ids,
     )
@@ -301,15 +311,27 @@ def merge_duplicates(
         raise HTTPException(status_code=400, detail="keep_id must not appear in remove_ids")
 
     merged_count = 0
+    dropped_missing_files = 0
 
     for remove_id in body.remove_ids:
         remove = db.get(Book, remove_id)
         if not remove:
             continue
 
-        # Move BookFile rows to keep
+        # Move BookFile rows to keep — but never carry over a dead reference:
+        # a row whose file is gone from disk would leave the kept book with a
+        # phantom file that 404s on open (issue #165). Drop those instead.
         for bf in list(remove.files):
-            bf.book_id = keep.id
+            if Path(bf.file_path).exists():
+                # Reassign via the relationship, not the raw FK: a row still
+                # sitting in remove.files gets swept by the delete-orphan
+                # cascade when `remove` is deleted below.
+                bf.book = keep
+            else:
+                # Detach so the delete-orphan cascade drops the row — a direct
+                # db.delete would collide with the cascade when `remove` goes.
+                remove.files.remove(bf)
+                dropped_missing_files += 1
         db.flush()
 
         # Copy tags not already present on keep
@@ -365,10 +387,18 @@ def merge_duplicates(
         resource_type="book",
         resource_id=keep.id,
         resource_title=keep.title,
-        details={"kept_id": body.keep_id, "removed_ids": body.remove_ids},
+        details={
+            "kept_id": body.keep_id,
+            "removed_ids": body.remove_ids,
+            "dropped_missing_files": dropped_missing_files,
+        },
     )
 
-    return {"merged": merged_count, "kept_id": body.keep_id}
+    return {
+        "merged": merged_count,
+        "kept_id": body.keep_id,
+        "dropped_missing_files": dropped_missing_files,
+    }
 
 
 # ── POST /admin/duplicates/dismiss ────────────────────────────────────────────

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -108,31 +108,33 @@ SORT_FIELDS = {
     "added_at": Book.added_at,
 }
 
-@router.get("", response_model=list[BookOut])
-def list_books(
-    response: Response,
-    q: Optional[str] = Query(None, description="Full-text search across title/author/series/tags"),
-    skip: int = Query(0, ge=0),
-    limit: int = Query(200, ge=1, le=500),
-    sort: str = Query("title", pattern="^(title|author|year|added_at|status_updated|rating)$"),
-    order: str = Query("asc", pattern="^(asc|desc)$"),
-    min_rating: Optional[int] = Query(None, ge=1, le=5, description="Filter to books the current user rated at least this many stars"),
-    series: Optional[str] = Query(None, description="Exact series name filter"),
-    no_series: Optional[bool] = Query(None, description="Filter to books with no series"),
-    author: Optional[str] = Query(None, description="Exact author filter"),
-    tag: Optional[str] = Query(None, description="Tag name filter"),
-    format: Optional[str] = Query(None, description="File format filter (epub, pdf, …)"),
-    language: Optional[str] = Query(None, description="Language filter — canonical code (en, de, …); matches messy stored variants"),
-    library_id: Optional[int] = Query(None, description="Filter to books in this library"),
-    reading_status: Optional[str] = Query(None, description="Filter by reading status: unread, reading, read"),
-    missing: Optional[str] = Query(None, description="Filter books missing a field: cover, description, author, series, any"),
-    content_type: Optional[str] = Query(None, description="Filter by content type: volume, chapter"),
-    added_by: Optional[int] = Query(None, description="Filter by uploader user ID (admin only)"),
-    ownership: Optional[str] = Query(None, description="Ownership filter: 'mine' or 'shared' (member only)"),
-    group_by_series: Optional[bool] = Query(None, description="Collapse series into one representative book each, annotated with series_count"),
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
+def _filtered_books_query(
+    db: Session,
+    current_user: User,
+    *,
+    q: Optional[str] = None,
+    series: Optional[str] = None,
+    no_series: Optional[bool] = None,
+    author: Optional[str] = None,
+    tag: Optional[str] = None,
+    format: Optional[str] = None,
+    language: Optional[str] = None,
+    library_id: Optional[int] = None,
+    reading_status: Optional[str] = None,
+    min_rating: Optional[int] = None,
+    missing: Optional[str] = None,
+    content_type: Optional[str] = None,
+    added_by: Optional[int] = None,
+    ownership: Optional[str] = None,
+    with_rating_join: bool = False,
 ):
+    """Build the filtered books query shared by the list and ids endpoints.
+
+    Returns (query, join_effective_rating, eff_rating). eff_rating is None
+    unless min_rating or with_rating_join forced the rating outer-joins;
+    join_effective_rating lets the caller re-apply those joins after a
+    group-by rebuild (which drops them).
+    """
     from backend.core.permissions import is_admin as _is_admin
 
     query = db.query(Book).filter(Book.status == "active")
@@ -201,22 +203,22 @@ def list_books(
     # ── Rating filter / sort prep ────────────────────────────────────────────
     # Effective rating = the user's own volume rating, else the inherited series
     # rating (COALESCE). Two aliased outer-joins (current user only) carry both
-    # without colliding with the reading_status join above. _join_effective_rating
+    # without colliding with the reading_status join above. join_effective_rating
     # is re-applied after the group_by rebuild (which drops joins) so grouped sort
     # works too. min_rating is applied before group_by so it flows into id_sq.
     from sqlalchemy.orm import aliased as _aliased
     from sqlalchemy import func as _rfunc
     from backend.models.user_series_rating import UserSeriesRating
 
-    def _join_effective_rating(q):
+    def _join_effective_rating(inner):
         ubs = _aliased(UserBookStatus)
         usr = _aliased(UserSeriesRating)
-        q = q.outerjoin(ubs, (ubs.book_id == Book.id) & (ubs.user_id == current_user.id))
-        q = q.outerjoin(usr, (usr.series_name == Book.series) & (usr.user_id == current_user.id))
-        return q, _rfunc.coalesce(ubs.rating, usr.rating)
+        inner = inner.outerjoin(ubs, (ubs.book_id == Book.id) & (ubs.user_id == current_user.id))
+        inner = inner.outerjoin(usr, (usr.series_name == Book.series) & (usr.user_id == current_user.id))
+        return inner, _rfunc.coalesce(ubs.rating, usr.rating)
 
-    rating_active = min_rating is not None or sort == "rating"
-    if rating_active:
+    eff_rating = None
+    if min_rating is not None or with_rating_join:
         query, eff_rating = _join_effective_rating(query)
         if min_rating is not None:
             query = query.filter(eff_rating >= min_rating)
@@ -226,7 +228,7 @@ def list_books(
         no_cover = Book.cover_path.is_(None)
         no_description = sa_or_(Book.description.is_(None), Book.description == "")
         no_author = sa_or_(Book.author.is_(None), Book.author == "")
-        no_series = sa_or_(Book.series.is_(None), Book.series == "")
+        no_series_f = sa_or_(Book.series.is_(None), Book.series == "")
         if missing == "cover":
             query = query.filter(no_cover)
         elif missing == "description":
@@ -234,16 +236,15 @@ def list_books(
         elif missing == "author":
             query = query.filter(no_author)
         elif missing == "series":
-            query = query.filter(no_series)
+            query = query.filter(no_series_f)
         elif missing == "any":
-            query = query.filter(sa_or_(no_cover, no_description, no_author, no_series))
+            query = query.filter(sa_or_(no_cover, no_description, no_author, no_series_f))
 
     if content_type:
         query = query.filter(Book.content_type == content_type)
 
     # ── Ownership / uploader filters ─────────────────────────────────────────
-    from backend.core.permissions import is_admin as _is_admin_check
-    if added_by is not None and _is_admin_check(current_user):
+    if added_by is not None and _is_admin(current_user):
         query = query.filter(Book.added_by == added_by)
     if ownership == "mine":
         query = query.filter(Book.added_by == current_user.id)
@@ -260,6 +261,79 @@ def list_books(
                 Book.added_by.is_(None),
             )
         )
+
+    return query, _join_effective_rating, eff_rating
+
+
+@router.get("/ids")
+def list_book_ids(
+    q: Optional[str] = Query(None),
+    series: Optional[str] = Query(None),
+    no_series: Optional[bool] = Query(None),
+    author: Optional[str] = Query(None),
+    tag: Optional[str] = Query(None),
+    format: Optional[str] = Query(None),
+    language: Optional[str] = Query(None),
+    library_id: Optional[int] = Query(None),
+    reading_status: Optional[str] = Query(None),
+    min_rating: Optional[int] = Query(None, ge=1, le=5),
+    missing: Optional[str] = Query(None),
+    content_type: Optional[str] = Query(None),
+    added_by: Optional[int] = Query(None),
+    ownership: Optional[str] = Query(None),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """IDs of every book matching the given filters.
+
+    Powers dashboard select-all so it covers the whole filtered set, not just
+    the pages the infinite scroll has loaded. Same filters and visibility
+    rules as the list endpoint.
+    """
+    query, _jr, _er = _filtered_books_query(
+        db, current_user,
+        q=q, series=series, no_series=no_series, author=author, tag=tag,
+        format=format, language=language, library_id=library_id,
+        reading_status=reading_status, min_rating=min_rating, missing=missing,
+        content_type=content_type, added_by=added_by, ownership=ownership,
+    )
+    ids = [row[0] for row in query.with_entities(Book.id).distinct().all()]
+    return {"ids": ids}
+
+
+@router.get("", response_model=list[BookOut])
+def list_books(
+    response: Response,
+    q: Optional[str] = Query(None, description="Full-text search across title/author/series/tags"),
+    skip: int = Query(0, ge=0),
+    limit: int = Query(200, ge=1, le=500),
+    sort: str = Query("title", pattern="^(title|author|year|added_at|status_updated|rating)$"),
+    order: str = Query("asc", pattern="^(asc|desc)$"),
+    min_rating: Optional[int] = Query(None, ge=1, le=5, description="Filter to books the current user rated at least this many stars"),
+    series: Optional[str] = Query(None, description="Exact series name filter"),
+    no_series: Optional[bool] = Query(None, description="Filter to books with no series"),
+    author: Optional[str] = Query(None, description="Exact author filter"),
+    tag: Optional[str] = Query(None, description="Tag name filter"),
+    format: Optional[str] = Query(None, description="File format filter (epub, pdf, …)"),
+    language: Optional[str] = Query(None, description="Language filter — canonical code (en, de, …); matches messy stored variants"),
+    library_id: Optional[int] = Query(None, description="Filter to books in this library"),
+    reading_status: Optional[str] = Query(None, description="Filter by reading status: unread, reading, read"),
+    missing: Optional[str] = Query(None, description="Filter books missing a field: cover, description, author, series, any"),
+    content_type: Optional[str] = Query(None, description="Filter by content type: volume, chapter"),
+    added_by: Optional[int] = Query(None, description="Filter by uploader user ID (admin only)"),
+    ownership: Optional[str] = Query(None, description="Ownership filter: 'mine' or 'shared' (member only)"),
+    group_by_series: Optional[bool] = Query(None, description="Collapse series into one representative book each, annotated with series_count"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    query, _join_effective_rating, eff_rating = _filtered_books_query(
+        db, current_user,
+        q=q, series=series, no_series=no_series, author=author, tag=tag,
+        format=format, language=language, library_id=library_id,
+        reading_status=reading_status, min_rating=min_rating, missing=missing,
+        content_type=content_type, added_by=added_by, ownership=ownership,
+        with_rating_join=(sort == "rating"),
+    )
 
     # ── Group by series ──────────────────────────────────────────────────────
     # Collapse each series to one representative volume (lowest series_index)
@@ -846,6 +920,7 @@ def library_health(
     )
 
     issues = []
+    missing = []
     for book in books:
         meta = {
             "title": book.title,
@@ -856,6 +931,22 @@ def library_health(
         }
         for bf in book.files:
             actual_path = Path(bf.file_path)
+
+            # A file that is gone from disk is an orphaned entry, not a
+            # misplaced one — report it separately and skip the layout check.
+            if not actual_path.exists():
+                missing.append({
+                    "book_id": book.id,
+                    "file_id": bf.id,
+                    "title": book.title or "",
+                    "author": book.author or "",
+                    "series": book.series or "",
+                    "format": bf.format,
+                    "path": str(actual_path.relative_to(settings.library_dir)) if actual_path.is_relative_to(settings.library_dir) else str(actual_path),
+                    "book_file_count": len(book.files),
+                })
+                continue
+
             expected_rel = get_library_path(meta, actual_path.name)
             expected_abs = settings.library_dir / expected_rel
 
@@ -877,6 +968,70 @@ def library_health(
         "total_files": total_files,
         "misplaced_count": len(issues),
         "issues": issues,
+        "missing_count": len(missing),
+        "missing": missing,
+    }
+
+
+class RemoveMissingRequest(PydanticBaseModel):
+    file_ids: list[int]
+
+
+@router.post("/remove-missing")
+def remove_missing_files(
+    req: RemoveMissingRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Remove BookFile entries whose file no longer exists on disk. Admin only.
+
+    A book left with no files at all is deleted entirely (metadata, statuses,
+    cover). Entries whose file still exists are refused — this endpoint never
+    touches anything that is actually on disk.
+    """
+    require_role(current_user, "admin")
+
+    if not req.file_ids:
+        raise HTTPException(status_code=400, detail="file_ids must not be empty")
+
+    skipped: list[dict] = []
+    by_book: dict[int, list[BookFile]] = {}
+    files = db.query(BookFile).filter(BookFile.id.in_(req.file_ids)).all()
+    for bf in files:
+        if Path(bf.file_path).exists():
+            skipped.append({"file_id": bf.id, "error": "file exists on disk"})
+            continue
+        by_book.setdefault(bf.book_id, []).append(bf)
+
+    removed_file_rows = 0
+    removed_books: list[dict] = []
+    for book_id, dead in by_book.items():
+        book = db.get(Book, book_id)
+        if book is None:
+            continue
+        dead_ids = {bf.id for bf in dead}
+        if all(f.id in dead_ids for f in book.files):
+            # Every file of this book is a dead entry — remove the whole book.
+            # The disk unlink inside is a no-op (the files are already gone).
+            title = book.title
+            _delete_book_record(book, db, current_user)
+            removed_books.append({"book_id": book_id, "title": title})
+        else:
+            for bf in dead:
+                db.delete(bf)
+            db.commit()
+            removed_file_rows += len(dead)
+
+    if removed_file_rows or removed_books:
+        audit(db, "books.missing_removed",
+              user_id=current_user.id,
+              username=current_user.username,
+              details={"file_rows": removed_file_rows, "books_removed": len(removed_books)})
+
+    return {
+        "removed_file_rows": removed_file_rows,
+        "removed_books": removed_books,
+        "skipped": skipped,
     }
 
 
@@ -2204,26 +2359,13 @@ def read_epub(
     return FileResponse(str(file_path), media_type="application/epub+zip")
 
 
-@router.delete("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
-def delete_book(
-    book_id: int,
-    db: Session = Depends(get_db),
-    current_user: User = Depends(get_current_user),
-):
-    require_role(current_user, "member")
+def _delete_book_record(book: Book, db: Session, actor: User) -> None:
+    """Delete a book row, then its files and cover on disk.
 
-    book = db.query(Book).filter(Book.id == book_id).first()
-    if not book:
-        raise HTTPException(status_code=404, detail="Book not found")
-
-    # Members can only delete their own uploads; admins can delete any book
-    from backend.core.permissions import is_admin as _is_admin
-    if not _is_admin(current_user) and book.added_by != current_user.id:
-        raise HTTPException(status_code=403, detail="You can only delete books you uploaded")
-
-    # Delete the row first, remove files after. A crash between the two leaves
-    # orphaned files that the next scan re-imports; the reverse order leaves a
-    # permanent ghost row (files gone, nothing on disk to heal it from).
+    Delete the row first, remove files after. A crash between the two leaves
+    orphaned files that the next scan re-imports; the reverse order leaves a
+    permanent ghost row (files gone, nothing on disk to heal it from).
+    """
     deleted_id, deleted_title = book.id, book.title
     file_paths = [Path(bf.file_path) for bf in book.files]
     cover_file = settings.covers_dir / book.cover_path if book.cover_path else None
@@ -2233,7 +2375,7 @@ def delete_book(
     db.delete(book)
     db.commit()
 
-    audit(db, "books.deleted", user_id=current_user.id, username=current_user.username,
+    audit(db, "books.deleted", user_id=actor.id, username=actor.username,
           resource_type="book", resource_id=deleted_id, resource_title=deleted_title)
 
     from backend.services.metadata_embed import purge_book_cache
@@ -2255,6 +2397,72 @@ def delete_book(
             cover_file.unlink(missing_ok=True)
         except OSError:
             logger.warning("delete_book: could not remove cover %s", cover_file)
+
+
+class BulkDeleteRequest(PydanticBaseModel):
+    book_ids: list[int]
+
+
+@router.post("/bulk-delete")
+def bulk_delete_books(
+    req: BulkDeleteRequest,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    """Delete several books (and their files on disk) in one request.
+
+    Same permission rules as the single delete: members only their own
+    uploads, admins any book. Failures are reported per book instead of
+    aborting the batch.
+    """
+    require_role(current_user, "member")
+
+    if not req.book_ids:
+        raise HTTPException(status_code=400, detail="book_ids must not be empty")
+    if len(req.book_ids) > 500:
+        raise HTTPException(status_code=400, detail="At most 500 books per request")
+
+    from backend.core.permissions import is_admin as _is_admin
+
+    deleted: list[int] = []
+    errors: list[dict] = []
+    for book_id in dict.fromkeys(req.book_ids):  # dedupe, keep order
+        book = db.query(Book).filter(Book.id == book_id).first()
+        if not book:
+            errors.append({"book_id": book_id, "error": "Book not found"})
+            continue
+        if not _is_admin(current_user) and book.added_by != current_user.id:
+            errors.append({"book_id": book_id, "error": "You can only delete books you uploaded"})
+            continue
+        try:
+            _delete_book_record(book, db, current_user)
+            deleted.append(book_id)
+        except Exception as e:
+            db.rollback()
+            logger.warning("bulk_delete: failed to delete book %s: %s", book_id, e)
+            errors.append({"book_id": book_id, "error": str(e)})
+
+    return {"deleted": deleted, "errors": errors}
+
+
+@router.delete("/{book_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_book(
+    book_id: int,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    require_role(current_user, "member")
+
+    book = db.query(Book).filter(Book.id == book_id).first()
+    if not book:
+        raise HTTPException(status_code=404, detail="Book not found")
+
+    # Members can only delete their own uploads; admins can delete any book
+    from backend.core.permissions import is_admin as _is_admin
+    if not _is_admin(current_user) and book.added_by != current_user.id:
+        raise HTTPException(status_code=403, detail="You can only delete books you uploaded")
+
+    _delete_book_record(book, db, current_user)
 
 
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -107,6 +107,7 @@ Multi-select books on the dashboard to:
 - Edit metadata (shared fields across selection)
 - Fetch metadata from external sources
 - Download as a ZIP archive
+- Delete (removes the books and their files from disk — members can only delete their own uploads)
 
 ---
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -26,3 +26,8 @@ dist-ssr
 # Env
 .env
 .env.*
+
+# E2E
+e2e/.data
+test-results/
+playwright-report/

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { test, expect, type Page } from '@playwright/test'
+import { seed, login, apiToken, apiGet, LIBRARY_DIR } from './helpers'
+
+async function openAllBooks(page: Page) {
+  await page.click('text=All Books')
+  await expect(page.getByText(/of \d+ books|^\d+ books/).first()).toBeVisible()
+}
+
+test.describe('dashboard selection and bulk delete', () => {
+  test('select all covers the whole filtered set, not just loaded pages', async ({ page }) => {
+    seed('many', 134)
+    await login(page)
+    await openAllBooks(page)
+
+    // Only the first page (60) is loaded…
+    await expect(page.getByText('60 of 134 books')).toBeVisible()
+    // …but Select selects everything that matches the filter.
+    await page.click('button:has-text("Select")')
+    await expect(page.getByText('134 selected')).toBeVisible()
+  })
+
+  test('bulk delete removes records and files from disk', async ({ page, request }) => {
+    seed('many', 10)
+    await login(page)
+    await openAllBooks(page)
+
+    await page.click('button:has-text("Select")')
+    await expect(page.getByText('10 selected')).toBeVisible()
+    // Narrow to two books, the way a user would: deselect all, pick two cards.
+    await page.click('button:has-text("Deselect all")')
+    await page.getByText('Seeded Book 001').click()
+    await page.getByText('Seeded Book 002').click()
+    await expect(page.getByText('2 selected')).toBeVisible()
+
+    await page.click('button:has-text("Delete")')
+    await expect(page.getByText('This permanently removes the selected books')).toBeVisible()
+    await page.locator('button', { hasText: /^Delete 2 books$/ }).last().click()
+    await expect(page.getByText('Deleted 2 books')).toBeVisible()
+
+    const token = await apiToken(request)
+    const { body: books } = await apiGet<{ title: string }[]>(request, token, '/api/books?limit=100')
+    expect(books).toHaveLength(8)
+    expect(books.map(b => b.title)).not.toContain('Seeded Book 001')
+    expect(fs.existsSync(path.join(LIBRARY_DIR, 'Seeded', 'Seeded Book 001.epub'))).toBe(false)
+    expect(fs.existsSync(path.join(LIBRARY_DIR, 'Seeded', 'Seeded Book 003.epub'))).toBe(true)
+  })
+
+  test('select-all delete beyond the 500 cap chunks into multiple requests', async ({ page, request }) => {
+    test.setTimeout(240_000)
+    seed('many', 520)
+    await login(page)
+    await openAllBooks(page)
+
+    await page.click('button:has-text("Select")')
+    await expect(page.getByText('520 selected')).toBeVisible()
+
+    const bulkDeleteRequests: number[] = []
+    page.on('request', req => {
+      if (req.url().includes('/api/books/bulk-delete') && req.method() === 'POST') {
+        bulkDeleteRequests.push((req.postDataJSON() as { book_ids: number[] }).book_ids.length)
+      }
+    })
+
+    await page.click('button:has-text("Delete")')
+    // The confirm list only holds loaded books; the rest is summarised.
+    await expect(page.getByText(/…and \d+ more not shown/)).toBeVisible()
+    await page.locator('button', { hasText: /^Delete 520 books$/ }).last().click()
+    await expect(page.getByText('Deleted 520 books')).toBeVisible({ timeout: 210_000 })
+
+    expect(bulkDeleteRequests).toEqual([500, 20])
+    const token = await apiToken(request)
+    const { body: books } = await apiGet<{ title: string }[]>(request, token, '/api/books?limit=10')
+    expect(books).toHaveLength(0)
+  })
+
+  test('toggling group series never duplicates books in the grid', async ({ page }) => {
+    // Data whose grouped and flat orderings differ (see seed.py scenario_race)
+    // — a prerequisite for the leak to surface as visible duplicates.
+    seed('race')
+    await login(page)
+    await openAllBooks(page)
+
+    // The reported race (issue #165 follow-up): a next-page request of the
+    // grouped view is still in flight when the user ungroups. The ungroup's
+    // reset resolves fast; the stale grouped page resolves later and — before
+    // the fix — got appended onto the flat list. The flat view then loads the
+    // same books again further down: duplicates in the viewport.
+    let slowPages = true
+    let pageRequests = 0
+    await page.route('**/api/books?*', async route => {
+      const url = new URL(route.request().url())
+      if (Number(url.searchParams.get('skip') ?? '0') > 0) {
+        pageRequests++
+        if (slowPages) await new Promise(r => setTimeout(r, 1500))
+      }
+      await route.continue()
+    })
+
+    // Group, then scroll the grid (wheel fires at the pointer, so hover it
+    // first) until the grouped view requests its next page…
+    await page.click('button:has-text("Group series")')
+    await page.waitForTimeout(600)
+    await page.getByText('Middle Solo 001').first().hover()
+    await page.mouse.wheel(0, 20000)
+    await expect.poll(() => pageRequests, { timeout: 5000 }).toBeGreaterThan(0)
+    // …and ungroup while that request is still held in flight.
+    await page.click('button:has-text("Group series")')
+    await page.waitForTimeout(2500) // stale grouped page lands (or is discarded)
+
+    // Load the whole flat view; every book must appear exactly once.
+    slowPages = false
+    await page.getByText('Alpha Saga Vol 01').first().hover()
+    for (let i = 0; i < 10; i++) {
+      await page.mouse.wheel(0, 20000)
+      await page.waitForTimeout(400)
+    }
+    const titles = (await page.locator('main p').allTextContents())
+      .map(t => t.trim())
+      .filter(t => /^(Alpha Saga Vol|Middle Solo|Zeta Saga Vol)/.test(t))
+    const dupes = titles.filter((t, i) => titles.indexOf(t) !== i)
+    expect([...new Set(dupes)]).toEqual([])
+    expect(titles.length).toBe(160)
+  })
+})

--- a/frontend/e2e/duplicates.spec.ts
+++ b/frontend/e2e/duplicates.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type Page } from '@playwright/test'
+import { seed, login, apiToken, apiGet } from './helpers'
+
+// Queued-decision resolution in the Duplicates tab: pick keeper + action per
+// group, one Apply All, one refresh.
+test.describe('duplicates apply-all', () => {
+  test.beforeEach(async ({ page }) => {
+    seed('duplicates')
+    await login(page)
+    await page.goto('/admin')
+    await page.click('button:has-text("Duplicates")')
+    await expect(page.getByText('Duplicate Detection')).toBeVisible()
+  })
+
+  function group(page: Page, containsText: string) {
+    return page.locator('div.rounded-xl', { hasText: containsText }).first()
+  }
+
+  test('mixed decisions apply in one pass and survive one refresh', async ({ page, request }) => {
+    // Merge the healthy Naruto hash pair (keep the default = first book).
+    await group(page, 'Naruto Vol. 1 (copy)').locator('button:has-text("Merge")').click()
+
+    // Delete the One Piece scan ghost, keeping the real Vol. 1.
+    const op = group(page, 'one_piece_v01[scan]')
+    await op.locator('label', { hasText: 'One Piece Vol. 1' }).first().locator('input[type=radio]').check()
+    await op.locator('button:has-text("Delete")').first().click()
+
+    // Dismiss the Bleach ISBN pair — it's an omnibus, not a duplicate.
+    await group(page, 'Bleach Vol. 01 Omnibus').locator('button:has-text("Dismiss")').click()
+
+    // The plan bar spells out what will happen.
+    await expect(page.getByText('merge 1 group · delete 1 book (removes files) · dismiss 1 group')).toBeVisible()
+
+    await page.click('button:has-text("Apply All (3)")')
+    await page.click('button:has-text("Confirm — apply 3 decisions")')
+    await expect(page.getByText('Applied 3 groups')).toBeVisible()
+
+    // End state: keeper holds both Naruto files, ghost gone, Bleach dismissed
+    // (both books alive but no group shown), overlap groups resolved with them.
+    await expect(page.getByText('No duplicates found. Your library looks clean.')).toBeVisible()
+
+    const token = await apiToken(request)
+    const { body: books } = await apiGet<{ id: number; title: string }[]>(
+      request, token, '/api/books?limit=100')
+    const titles = books.map(b => b.title).sort()
+    expect(titles).toEqual([
+      'Bleach Vol. 01 Omnibus',
+      'Bleach Vol. 1',
+      'Naruto Vol. 1',
+      'One Piece Vol. 1',
+    ])
+    const keeper = books.find(b => b.title === 'Naruto Vol. 1')!
+    const { body: detail } = await apiGet<{ files: unknown[] }>(request, token, `/api/books/${keeper.id}`)
+    expect(detail.files).toHaveLength(2)
+
+    // Dismissal persists across a manual refresh too.
+    await page.click('button:has-text("Refresh")')
+    await expect(page.getByText('No duplicates found. Your library looks clean.')).toBeVisible()
+  })
+
+  test('a decision that fails is reported, the rest still apply', async ({ page }) => {
+    // The Naruto pair appears twice: as an exact-match group and as a
+    // same-series-volume group. Queue "delete others, keep Vol. 1" on the
+    // exact-match group and "merge, keep the copy" on the series group: the
+    // delete runs first (render order), so the merge's keeper is gone by the
+    // time it executes — it must fail loudly, not silently.
+    const exact = page
+      .locator('div.rounded-xl', { has: page.getByText('Exact Match'), hasText: 'Naruto Vol. 1 (copy)' })
+      .first()
+    await exact.locator('label', { hasText: /^Naruto Vol\. 1(?! \(copy\))/ }).first().locator('input[type=radio]').check()
+    await exact.locator('button:has-text("Delete")').first().click()
+
+    const seriesGroup = page
+      .locator('div.rounded-xl', { has: page.getByText('Same Series Volume'), hasText: 'Naruto Vol. 1 (copy)' })
+      .first()
+    await seriesGroup.locator('label', { hasText: 'Naruto Vol. 1 (copy)' }).first().locator('input[type=radio]').check()
+    await seriesGroup.locator('button:has-text("Merge")').click()
+
+    await page.click('button:has-text("Apply All (2)")')
+    await page.click('button:has-text("Confirm — apply 2 decisions")')
+
+    await expect(page.getByText('Applied 1 group, 1 failed')).toBeVisible()
+    await expect(page.getByText('Naruto Vol. 1 (copy):')).toBeVisible()
+  })
+
+  test('decisions can be toggled off and cleared', async ({ page }) => {
+    const naruto = group(page, 'Naruto Vol. 1 (copy)')
+    await naruto.locator('button:has-text("Merge")').click()
+    await expect(page.getByText('Apply All (1)')).toBeVisible()
+
+    // Clicking the queued action again unqueues it.
+    await naruto.locator('button:has-text("Merge")').click()
+    await expect(page.getByText('Apply All (1)')).not.toBeVisible()
+
+    // Clear drops every queued decision at once.
+    await naruto.locator('button:has-text("Merge")').click()
+    await group(page, 'Bleach Vol. 01 Omnibus').locator('button:has-text("Dismiss")').click()
+    await expect(page.getByText('Apply All (2)')).toBeVisible()
+    await page.click('button:has-text("Clear")')
+    await expect(page.getByText('Apply All (2)')).not.toBeVisible()
+  })
+})

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,44 @@
+import { execFileSync } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { APIRequestContext, Page } from '@playwright/test'
+import { expect } from '@playwright/test'
+
+const E2E_DIR = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(E2E_DIR, '..', '..')
+const PYTHON = process.env.E2E_PYTHON ?? path.join(ROOT, '.venv', 'bin', 'python')
+
+export const ADMIN = { username: 'e2e', password: 'e2e-password-1' }
+export const LIBRARY_DIR = path.join(E2E_DIR, '.data', 'library')
+
+/** Reset the sandbox DB + library and load a scenario (see e2e/seed.py). */
+export function seed(scenario: 'orphans' | 'duplicates' | 'many' | 'race' | 'reset', count?: number) {
+  const args = [path.join(E2E_DIR, 'seed.py'), scenario]
+  if (count !== undefined) args.push(String(count))
+  execFileSync(PYTHON, args, { stdio: 'pipe' })
+}
+
+/** Log in through the login form, the way a user does. */
+export async function login(page: Page) {
+  await page.goto('/login')
+  await page.fill('input[type="text"]', ADMIN.username)
+  await page.fill('input[type="password"]', ADMIN.password)
+  await page.click('button[type="submit"]')
+  await page.waitForURL('**/')
+}
+
+/** Bearer token for API-level assertions about the end state. */
+export async function apiToken(request: APIRequestContext): Promise<string> {
+  const resp = await request.post('/api/auth/login', {
+    data: { username: ADMIN.username, password: ADMIN.password },
+  })
+  expect(resp.ok()).toBeTruthy()
+  return (await resp.json()).access_token
+}
+
+export async function apiGet<T>(request: APIRequestContext, token: string, url: string): Promise<{ status: number; body: T }> {
+  const resp = await request.get(url, { headers: { Authorization: `Bearer ${token}` } })
+  let body: T = undefined as T
+  try { body = await resp.json() } catch { /* non-JSON (e.g. 404 detail) */ }
+  return { status: resp.status(), body }
+}

--- a/frontend/e2e/library-cleanup.spec.ts
+++ b/frontend/e2e/library-cleanup.spec.ts
@@ -1,0 +1,73 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { test, expect } from '@playwright/test'
+import { seed, login, apiToken, apiGet, LIBRARY_DIR } from './helpers'
+
+// The issue #165 journey: files deleted from disk outside of Tome left ghost
+// records behind. The user finds them marked in Duplicates, cleans them up
+// via Library Health, and never loses a real file.
+test.describe('library cleanup (issue #165)', () => {
+  test.beforeEach(async ({ page }) => {
+    seed('orphans')
+    await login(page)
+  })
+
+  test('dead copies are marked MISSING in the duplicates tab', async ({ page }) => {
+    await page.goto('/admin')
+    await page.click('button:has-text("Duplicates")')
+    await expect(page.getByText('Duplicate Detection')).toBeVisible()
+    // Each scan ghost carries the badge in its exact-match group AND in the
+    // overlapping same-series-volume group (2 ghosts × 2 groups).
+    await expect(page.getByText('MISSING')).toHaveCount(4)
+  })
+
+  test('library health lists orphans and removes them without touching real files', async ({ page, request }) => {
+    await page.goto('/admin')
+    await page.click('button:has-text("Library")')
+    await page.click('button:has-text("Scan Library")')
+
+    // Three dead entries: two whole-book ghosts + AoT's stale extra file.
+    await expect(page.getByText('Orphaned entries')).toBeVisible()
+    await expect(page.getByText('book entry will be removed')).toHaveCount(3)
+    await expect(page.getByText('file entry only')).toHaveCount(1)
+
+    // Two-step confirm, then the summary.
+    await page.click('button:has-text("Remove Dead Entries")')
+    await page.click('button:has-text("Confirm — remove 4 entries")')
+    await expect(page.getByText('Dead entries removed')).toBeVisible()
+    await expect(page.getByText('3 book entries removed · 1 file entry removed')).toBeVisible()
+    await expect(page.getByText('Orphaned entries')).not.toBeVisible()
+
+    // End state via API: ghosts gone, healthy books intact.
+    const token = await apiToken(request)
+    const { body: books } = await apiGet<{ id: number; title: string }[]>(
+      request, token, '/api/books?limit=100')
+    const titles = books.map(b => b.title).sort()
+    expect(titles).toEqual([
+      'Attack on Titan Vol. 1',
+      'One Piece Vol. 1',
+      'One Piece Vol. 2',
+    ])
+
+    // AoT kept exactly its one real file; real files still on disk.
+    const aot = books.find(b => b.title === 'Attack on Titan Vol. 1')!
+    const { body: detail } = await apiGet<{ files: unknown[] }>(request, token, `/api/books/${aot.id}`)
+    expect(detail.files).toHaveLength(1)
+    expect(fs.existsSync(path.join(LIBRARY_DIR, 'One Piece', 'One Piece Vol. 1.cbz'))).toBe(true)
+    expect(fs.existsSync(path.join(LIBRARY_DIR, 'Attack on Titan', 'Attack on Titan Vol. 1.cbz'))).toBe(true)
+  })
+
+  test('remove dead entries refuses when the files are actually alive', async ({ page }) => {
+    // A second scan right after cleanup must find nothing to remove — and a
+    // library whose files all exist shows no orphan section at all.
+    await page.goto('/admin')
+    await page.click('button:has-text("Library")')
+    await page.click('button:has-text("Scan Library")')
+    await page.click('button:has-text("Remove Dead Entries")')
+    await page.click('button:has-text("Confirm — remove 4 entries")')
+    await expect(page.getByText('Dead entries removed')).toBeVisible()
+
+    await page.click('button:has-text("Scan Library")')
+    await expect(page.getByText('Orphaned entries')).not.toBeVisible()
+  })
+})

--- a/frontend/e2e/seed.py
+++ b/frontend/e2e/seed.py
@@ -1,0 +1,200 @@
+"""Seed scenarios for the Playwright E2E suite.
+
+Runs against the sandbox instance started by e2e/start.sh (SQLite in WAL mode,
+so writing from a second process while uvicorn is up is fine). Every scenario
+starts from a clean slate: all book data wiped, library dir recreated, the
+`e2e` admin ensured.
+
+Usage: seed.py <orphans|duplicates|many> [count]
+"""
+import sys
+from pathlib import Path
+
+E2E_DATA = Path(__file__).resolve().parent / ".data"
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+import os  # noqa: E402
+os.environ["TOME_SECRET_KEY"] = "e2e-secret"
+os.environ["TOME_DATA_DIR"] = str(E2E_DATA / "data")
+os.environ["TOME_LIBRARY_DIR"] = str(E2E_DATA / "library")
+os.environ["TOME_INCOMING_DIR"] = str(E2E_DATA / "bindery")
+
+import hashlib  # noqa: E402
+import shutil  # noqa: E402
+
+from sqlalchemy import text  # noqa: E402
+
+from backend.core.database import SessionLocal  # noqa: E402
+from backend.core.security import hash_password  # noqa: E402
+from backend.models.book import Book, BookFile  # noqa: E402
+from backend.models.user import User  # noqa: E402
+
+LIBRARY = E2E_DATA / "library"
+
+ADMIN_USER = "e2e"
+ADMIN_PASSWORD = "e2e-password-1"
+
+
+def reset(db) -> int:
+    for table in (
+        "user_book_status",
+        "book_tags",
+        "book_files",
+        "duplicate_dismissals",
+        "books_fts",
+        "books",
+    ):
+        db.execute(text(f"DELETE FROM {table}"))
+
+    shutil.rmtree(LIBRARY, ignore_errors=True)
+    LIBRARY.mkdir(parents=True)
+
+    admin = db.query(User).filter(User.username == ADMIN_USER).first()
+    if admin is None:
+        admin = User(
+            username=ADMIN_USER,
+            email="e2e@example.com",
+            hashed_password=hash_password(ADMIN_PASSWORD),
+            is_active=True,
+            is_admin=True,
+            role="admin",
+            must_change_password=False,
+        )
+        db.add(admin)
+        db.flush()
+    return admin.id
+
+
+def _write_file(rel_path: str, content: bytes) -> Path:
+    p = LIBRARY / rel_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(content)
+    return p
+
+
+def _add_book(db, admin_id, title, *, author=None, series=None, series_index=None,
+              path=None, content=None, dead=False, isbn=None, content_hash=None,
+              fmt="cbz"):
+    """Create a Book + one BookFile. `dead=True` records a path that does not
+    exist on disk; otherwise the file is written with `content`."""
+    if content_hash is None and content is not None:
+        content_hash = hashlib.sha256(content).hexdigest()
+    book = Book(title=title, author=author, series=series, series_index=series_index,
+                status="active", added_by=admin_id, content_hash=content_hash, isbn=isbn)
+    db.add(book)
+    db.flush()
+    abs_path = LIBRARY / path
+    if not dead:
+        _write_file(path, content or title.encode())
+    db.add(BookFile(book_id=book.id, file_path=str(abs_path), format=fmt,
+                    file_size=(abs_path.stat().st_size if not dead else 11111)))
+    db.flush()
+    return book
+
+
+def scenario_orphans(db, admin_id):
+    """Pablo's situation (#165): hash-identical re-imports whose originals were
+    deleted from disk, one fully dead book, one book with a dead extra file."""
+    op1 = b"one piece vol 1 bytes"
+    op2 = b"one piece vol 2 bytes"
+    _add_book(db, admin_id, "One Piece Vol. 1", author="Eiichiro Oda", series="One Piece",
+              series_index=1, path="One Piece/One Piece Vol. 1.cbz", content=op1)
+    _add_book(db, admin_id, "one_piece_v01[scan]", author="Eiichiro Oda", series="One Piece",
+              series_index=1, path="One Piece/one_piece_v01[scan].cbz", dead=True,
+              content_hash=hashlib.sha256(op1).hexdigest())
+    _add_book(db, admin_id, "One Piece Vol. 2", author="Eiichiro Oda", series="One Piece",
+              series_index=2, path="One Piece/One Piece Vol. 2.cbz", content=op2)
+    _add_book(db, admin_id, "one_piece_v02[scan]", author="Eiichiro Oda", series="One Piece",
+              series_index=2, path="One Piece/one_piece_v02[scan].cbz", dead=True,
+              content_hash=hashlib.sha256(op2).hexdigest())
+    _add_book(db, admin_id, "Bleach Vol. 1", author="Tite Kubo", series="Bleach",
+              series_index=1, path="Bleach/bleach_v01.cbz", dead=True, content_hash="b" * 64)
+    aot = _add_book(db, admin_id, "Attack on Titan Vol. 1", author="Hajime Isayama",
+                    series="Attack on Titan", series_index=1,
+                    path="Attack on Titan/Attack on Titan Vol. 1.cbz",
+                    content=b"aot vol 1 bytes")
+    db.add(BookFile(book_id=aot.id, file_path=str(LIBRARY / "Attack on Titan/aot_v01_old.pdf"),
+                    format="pdf", file_size=999))
+    db.flush()
+
+
+def scenario_duplicates(db, admin_id):
+    """Three resolvable groups: a healthy hash pair (merge), a hash pair with a
+    dead copy (delete others), and an ISBN pair (dismiss). The Naruto pair also
+    surfaces as a same-series-volume group — the overlap the failure-path test
+    relies on."""
+    naruto = b"naruto vol 1 bytes"
+    op1 = b"one piece vol 1 bytes"
+    _add_book(db, admin_id, "Naruto Vol. 1", author="Masashi Kishimoto", series="Naruto",
+              series_index=1, path="Naruto/Naruto Vol. 1.cbz", content=naruto)
+    _add_book(db, admin_id, "Naruto Vol. 1 (copy)", author="Masashi Kishimoto", series="Naruto",
+              series_index=1, path="Naruto/Naruto Vol. 1 (copy).cbz", content=b"naruto copy bytes",
+              content_hash=hashlib.sha256(naruto).hexdigest())
+    _add_book(db, admin_id, "One Piece Vol. 1", author="Eiichiro Oda", series="One Piece",
+              series_index=1, path="One Piece/One Piece Vol. 1.cbz", content=op1)
+    _add_book(db, admin_id, "one_piece_v01[scan]", author="Eiichiro Oda", series="One Piece",
+              series_index=1, path="One Piece/one_piece_v01[scan].cbz", dead=True,
+              content_hash=hashlib.sha256(op1).hexdigest())
+    _add_book(db, admin_id, "Bleach Vol. 1", author="Tite Kubo", series="Bleach",
+              series_index=1, path="Bleach/bleach_v01.cbz", content=b"bleach bytes",
+              isbn="978-1-56931-441-3")
+    _add_book(db, admin_id, "Bleach Vol. 01 Omnibus", author="Tite Kubo", series="Bleach",
+              series_index=1.5, path="Bleach/bleach_v01_omnibus.cbz", content=b"omnibus bytes",
+              isbn="978-1-56931-441-3")
+
+
+def scenario_race(db, admin_id):
+    """Data where the grouped and flat orderings genuinely differ, so a stale
+    page from one view leaks books the other view loads again later (the
+    group/ungroup viewport-duplicates race). Flat order: 40 Alpha volumes,
+    80 solos, 40 Zeta volumes. Grouped order: Alpha stack, 80 solos, Zeta
+    stack — page boundaries land on different books in each view."""
+    for i in range(1, 41):
+        _add_book(db, admin_id, f"Alpha Saga Vol {i:02d}", author="Race Author",
+                  series="Alpha Saga", series_index=float(i),
+                  path=f"Alpha/Alpha {i:02d}.epub", content=f"alpha {i}".encode(), fmt="epub")
+    for i in range(1, 81):
+        _add_book(db, admin_id, f"Middle Solo {i:03d}", author="Race Author",
+                  path=f"Middle/Middle {i:03d}.epub", content=f"middle {i}".encode(), fmt="epub")
+    for i in range(1, 41):
+        _add_book(db, admin_id, f"Zeta Saga Vol {i:02d}", author="Race Author",
+                  series="Zeta Saga", series_index=float(i),
+                  path=f"Zeta/Zeta {i:02d}.epub", content=f"zeta {i}".encode(), fmt="epub")
+
+
+def scenario_many(db, admin_id, count):
+    """`count` distinct books for pagination / select-all / bulk tests."""
+    for i in range(1, count + 1):
+        _add_book(db, admin_id, f"Seeded Book {i:03d}", author="Seed Author",
+                  series="Seeded Series" if i % 2 == 0 else None,
+                  series_index=float(i) if i % 2 == 0 else None,
+                  path=f"Seeded/Seeded Book {i:03d}.epub",
+                  content=f"seeded {i}".encode(), fmt="epub")
+
+
+def main():
+    scenario = sys.argv[1] if len(sys.argv) > 1 else "orphans"
+    db = SessionLocal()
+    try:
+        admin_id = reset(db)
+        if scenario == "orphans":
+            scenario_orphans(db, admin_id)
+        elif scenario == "duplicates":
+            scenario_duplicates(db, admin_id)
+        elif scenario == "race":
+            scenario_race(db, admin_id)
+        elif scenario == "many":
+            scenario_many(db, admin_id, int(sys.argv[2]) if len(sys.argv) > 2 else 134)
+        elif scenario == "reset":
+            pass
+        else:
+            raise SystemExit(f"unknown scenario: {scenario}")
+        db.commit()
+        print(f"seeded scenario={scenario} books={db.query(Book).count()}")
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/e2e/start.sh
+++ b/frontend/e2e/start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Boot a throwaway Tome instance for the E2E suite.
+#
+# Builds the frontend (the backend serves frontend/dist), prepares a fresh
+# data/library sandbox under e2e/.data, and execs uvicorn on port 8199.
+# Launched and torn down by Playwright's webServer config.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."   # frontend/
+npm run build
+
+E2E_DIR="$(pwd)/e2e/.data"
+rm -rf "$E2E_DIR"
+mkdir -p "$E2E_DIR/data" "$E2E_DIR/library" "$E2E_DIR/bindery"
+
+ROOT="$(cd .. && pwd)"
+PY="${E2E_PYTHON:-$ROOT/.venv/bin/python}"
+
+export TOME_SECRET_KEY=e2e-secret
+export TOME_DATA_DIR="$E2E_DIR/data"
+export TOME_LIBRARY_DIR="$E2E_DIR/library"
+export TOME_INCOMING_DIR="$E2E_DIR/bindery"
+export TOME_UPDATE_CHECK=false
+
+cd "$ROOT"
+exec "$PY" -m uvicorn backend.main:app --port 8199

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -27,6 +27,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.62.1",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -2189,6 +2190,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -6835,35 +6852,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "screenshots": "node scripts/screenshots.mjs",
-    "screenshots:showcase": "node scripts/screenshots.mjs --showcase"
+    "screenshots:showcase": "node scripts/screenshots.mjs --showcase",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.62.1",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from '@playwright/test'
+
+// E2E suite: boots a real backend (uvicorn, throwaway SQLite + library under
+// e2e/.data) serving the freshly built frontend, then drives it like a user.
+// Specs share one server and one DB, so they run serially and each test seeds
+// its own scenario via e2e/seed.py.
+export default defineConfig({
+  testDir: './e2e',
+  workers: 1,
+  fullyParallel: false,
+  timeout: 60_000,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['github']] : [['list']],
+  use: {
+    baseURL: 'http://127.0.0.1:8199',
+    trace: 'retain-on-failure',
+  },
+  webServer: {
+    command: 'bash e2e/start.sh',
+    url: 'http://127.0.0.1:8199/api/health',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+    stdout: 'ignore',
+    stderr: 'pipe',
+  },
+})

--- a/frontend/src/components/LibraryHealth.tsx
+++ b/frontend/src/components/LibraryHealth.tsx
@@ -350,15 +350,15 @@ export function LibraryHealthTab() {
 
       {healthData && healthData.missing.length > 0 && (
         <div className="rounded-xl border border-destructive/20 bg-card overflow-hidden">
-          <div className="flex items-center justify-between gap-3 px-4 py-3 border-b border-border bg-destructive/5">
+          <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-3 border-b border-border bg-destructive/5">
             <div className="flex items-center gap-2 min-w-0">
               <FileX className="w-4 h-4 text-destructive shrink-0" />
-              <span className="text-xs font-medium">Orphaned entries</span>
+              <span className="text-xs font-medium whitespace-nowrap">Orphaned entries</span>
               <span className="text-xs text-muted-foreground truncate">
                 {healthData.missing.length} file{healthData.missing.length !== 1 ? 's' : ''} in the database but missing from disk
               </span>
             </div>
-            <div className="flex items-center gap-2 shrink-0">
+            <div className="flex items-center gap-2 shrink-0 ml-auto">
               {confirmRemoveMissing && (
                 <button
                   onClick={() => setConfirmRemoveMissing(false)}

--- a/frontend/src/components/LibraryHealth.tsx
+++ b/frontend/src/components/LibraryHealth.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useShiftSelect } from '@/lib/useShiftSelect'
-import { FolderOpen, ArrowRight, Loader2, Check, AlertCircle, ChevronDown, ChevronRight, Trash } from 'lucide-react'
+import { FolderOpen, ArrowRight, Loader2, Check, AlertCircle, ChevronDown, ChevronRight, Trash, FileX } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
 
@@ -16,10 +16,29 @@ interface HealthIssue {
   expected_path: string
 }
 
+interface MissingEntry {
+  book_id: number
+  file_id: number
+  title: string
+  author: string
+  series: string
+  format: string
+  path: string
+  book_file_count: number
+}
+
 interface HealthData {
   total_files: number
   misplaced_count: number
   issues: HealthIssue[]
+  missing_count: number
+  missing: MissingEntry[]
+}
+
+interface RemoveMissingResult {
+  removed_file_rows: number
+  removed_books: { book_id: number; title: string }[]
+  skipped: { file_id: number; error: string }[]
 }
 
 interface ReorganizeResult {
@@ -81,6 +100,9 @@ export function LibraryHealthTab() {
   const [reorganizing, setReorganizing] = useState(false)
   const [purging, setPurging] = useState(false)
   const [purgeResult, setPurgeResult] = useState<string[] | null>(null)
+  const [removingMissing, setRemovingMissing] = useState(false)
+  const [confirmRemoveMissing, setConfirmRemoveMissing] = useState(false)
+  const [missingResult, setMissingResult] = useState<RemoveMissingResult | null>(null)
   const [dryRunResult, setDryRunResult] = useState<ReorganizeResult | null>(null)
   const [result, setResult] = useState<ReorganizeResult | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -104,6 +126,8 @@ export function LibraryHealthTab() {
     setError(null)
     setDryRunResult(null)
     setResult(null)
+    setMissingResult(null)
+    setConfirmRemoveMissing(false)
     setSelected(new Set())
     try {
       const data = await api.get<HealthData>('/books/library-health')
@@ -142,6 +166,27 @@ export function LibraryHealthTab() {
     }
   }
 
+  async function removeMissing() {
+    if (!healthData?.missing.length) return
+    setRemovingMissing(true)
+    setError(null)
+    try {
+      const res = await api.post<RemoveMissingResult>('/books/remove-missing', {
+        file_ids: healthData.missing.map(m => m.file_id),
+      })
+      setMissingResult(res)
+      setConfirmRemoveMissing(false)
+      // Re-scan to refresh both lists
+      const data = await api.get<HealthData>('/books/library-health')
+      setHealthData(data)
+      setGroups(groupIssues(data.issues))
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Removing dead entries failed')
+    } finally {
+      setRemovingMissing(false)
+    }
+  }
+
   function toggleGroup(groupIdx: number, collapsed: boolean) {
     setGroups(prev => prev.map((g, i) => i === groupIdx ? { ...g, collapsed } : g))
   }
@@ -175,9 +220,16 @@ export function LibraryHealthTab() {
             <h2 className="text-sm font-semibold">Library Health</h2>
             {healthData && (
               <p className="text-xs text-muted-foreground mt-0.5">
-                {healthData.misplaced_count === 0
+                {healthData.misplaced_count === 0 && healthData.missing_count === 0
                   ? `All ${healthData.total_files} files are correctly placed.`
-                  : `${healthData.misplaced_count} of ${healthData.total_files} files need reorganization.`}
+                  : [
+                      healthData.misplaced_count > 0
+                        ? `${healthData.misplaced_count} of ${healthData.total_files} files need reorganization`
+                        : null,
+                      healthData.missing_count > 0
+                        ? `${healthData.missing_count} ${healthData.missing_count === 1 ? 'entry is' : 'entries are'} missing from disk`
+                        : null,
+                    ].filter(Boolean).join(' · ') + '.'}
               </p>
             )}
           </div>
@@ -266,6 +318,97 @@ export function LibraryHealthTab() {
               {purgeResult.map((f, i) => <li key={i}>{f}</li>)}
             </ul>
           )}
+        </div>
+      )}
+
+      {missingResult && (
+        <div className="rounded-xl border border-success/20 bg-success/5 p-4 text-xs space-y-1">
+          <p className="font-medium text-success flex items-center gap-1.5">
+            <Check className="w-3.5 h-3.5" />
+            Dead entries removed
+          </p>
+          <p className="text-muted-foreground">
+            {[
+              missingResult.removed_books.length > 0
+                ? `${missingResult.removed_books.length} book ${missingResult.removed_books.length === 1 ? 'entry' : 'entries'} removed`
+                : null,
+              missingResult.removed_file_rows > 0
+                ? `${missingResult.removed_file_rows} file ${missingResult.removed_file_rows === 1 ? 'entry' : 'entries'} removed`
+                : null,
+              missingResult.skipped.length > 0
+                ? `${missingResult.skipped.length} skipped (file exists on disk)`
+                : null,
+            ].filter(Boolean).join(' · ') || 'Nothing to remove.'}
+          </p>
+          {missingResult.removed_books.length > 0 && (
+            <ul className="mt-1 space-y-0.5 text-muted-foreground">
+              {missingResult.removed_books.map(b => <li key={b.book_id}>{b.title}</li>)}
+            </ul>
+          )}
+        </div>
+      )}
+
+      {healthData && healthData.missing.length > 0 && (
+        <div className="rounded-xl border border-destructive/20 bg-card overflow-hidden">
+          <div className="flex items-center justify-between gap-3 px-4 py-3 border-b border-border bg-destructive/5">
+            <div className="flex items-center gap-2 min-w-0">
+              <FileX className="w-4 h-4 text-destructive shrink-0" />
+              <span className="text-xs font-medium">Orphaned entries</span>
+              <span className="text-xs text-muted-foreground truncate">
+                {healthData.missing.length} file{healthData.missing.length !== 1 ? 's' : ''} in the database but missing from disk
+              </span>
+            </div>
+            <div className="flex items-center gap-2 shrink-0">
+              {confirmRemoveMissing && (
+                <button
+                  onClick={() => setConfirmRemoveMissing(false)}
+                  disabled={removingMissing}
+                  className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-accent transition-colors disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+              )}
+              <button
+                onClick={() => confirmRemoveMissing ? removeMissing() : setConfirmRemoveMissing(true)}
+                disabled={removingMissing}
+                className="px-3 py-1.5 text-xs rounded-lg bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center gap-1.5"
+                title="Removes the database entries only — no files are touched"
+              >
+                {removingMissing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash className="w-3.5 h-3.5" />}
+                {removingMissing
+                  ? 'Removing...'
+                  : confirmRemoveMissing
+                  ? `Confirm — remove ${healthData.missing.length} ${healthData.missing.length === 1 ? 'entry' : 'entries'}`
+                  : 'Remove Dead Entries'}
+              </button>
+            </div>
+          </div>
+          <ul className="divide-y divide-border">
+            {healthData.missing.map(m => {
+              const missingForBook = healthData.missing.filter(x => x.book_id === m.book_id).length
+              const wholeBook = missingForBook >= m.book_file_count
+              return (
+                <li key={m.file_id} className="flex items-start gap-3 px-4 py-3 text-xs">
+                  <div className="min-w-0 space-y-1 flex-1">
+                    <p className="font-medium truncate">
+                      {m.title}
+                      {m.author && <span className="text-muted-foreground font-normal"> — {m.author}</span>}
+                    </p>
+                    <p className="text-muted-foreground font-mono truncate line-through">{m.path}</p>
+                  </div>
+                  <span className="shrink-0 text-muted-foreground uppercase tracking-wide">{m.format}</span>
+                  <span className={cn(
+                    'shrink-0 text-[10px] px-1.5 py-0.5 rounded border',
+                    wholeBook
+                      ? 'border-destructive/30 text-destructive bg-destructive/10'
+                      : 'border-border text-muted-foreground bg-muted',
+                  )}>
+                    {wholeBook ? 'book entry will be removed' : 'file entry only'}
+                  </span>
+                </li>
+              )
+            })}
+          </ul>
         </div>
       )}
 
@@ -381,7 +524,7 @@ export function LibraryHealthTab() {
         </div>
       )}
 
-      {healthData && healthData.misplaced_count === 0 && (
+      {healthData && healthData.misplaced_count === 0 && healthData.missing_count === 0 && (
         <div className="flex flex-col items-center justify-center py-12 text-muted-foreground gap-2">
           <Check className="w-8 h-8 text-success" />
           <p className="text-sm">All files are correctly placed.</p>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1301,7 +1301,7 @@ interface DuplicateBookOut {
   cover_path: string | null
   series: string | null
   year: number | null
-  files: { id: number; format: string; file_size: number | null }[]
+  files: { id: number; format: string; file_size: number | null; path_exists: boolean }[]
   tags: string[]
   library_ids: number[]
 }
@@ -1337,18 +1337,24 @@ function formatBytes(bytes: number | null): string {
   return `${(bytes / 1024 / 1024).toFixed(1)} MB`
 }
 
+type GroupDecision = 'merge' | 'delete' | 'dismiss'
+
 function DuplicatesTab() {
   const [groups, setGroups] = useState<DuplicateGroup[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [keepIds, setKeepIds] = useState<Record<string, number>>({})
-  const [merging, setMerging] = useState<string | null>(null)
-  const [dismissing, setDismissing] = useState<string | null>(null)
-  const [actionError, setActionError] = useState<Record<string, string>>({})
+  const [decisions, setDecisions] = useState<Record<string, GroupDecision>>({})
+  const [applying, setApplying] = useState(false)
+  const [applyProgress, setApplyProgress] = useState<{ done: number; total: number } | null>(null)
+  const [confirmApply, setConfirmApply] = useState(false)
+  const [applyResult, setApplyResult] = useState<{ applied: number; failed: { label: string; error: string }[] } | null>(null)
 
   function fetchGroups() {
     setLoading(true)
     setError(null)
+    setDecisions({})
+    setConfirmApply(false)
     api.get<DuplicatesResponse>('/admin/duplicates')
       .then(d => {
         setGroups(d.groups)
@@ -1367,33 +1373,60 @@ function DuplicatesTab() {
 
   useEffect(() => { fetchGroups() }, [])
 
-  async function handleMerge(group: DuplicateGroup) {
-    const keepId = keepIds[group.group_id]
-    if (keepId == null) return
-    const removeIds = group.books.map(b => b.id).filter(id => id !== keepId)
-    setMerging(group.group_id)
-    setActionError(prev => { const n = { ...prev }; delete n[group.group_id]; return n })
-    try {
-      await api.post('/admin/duplicates/merge', { keep_id: keepId, remove_ids: removeIds })
-      fetchGroups()
-    } catch (e) {
-      setActionError(prev => ({ ...prev, [group.group_id]: e instanceof Error ? e.message : 'Merge failed' }))
-    } finally {
-      setMerging(null)
-    }
+  function toggleDecision(groupId: string, action: GroupDecision) {
+    setConfirmApply(false)
+    setDecisions(prev => {
+      const next = { ...prev }
+      if (next[groupId] === action) delete next[groupId]
+      else next[groupId] = action
+      return next
+    })
   }
 
-  async function handleDismiss(group: DuplicateGroup) {
-    setDismissing(group.group_id)
-    setActionError(prev => { const n = { ...prev }; delete n[group.group_id]; return n })
-    try {
-      await api.post('/admin/duplicates/dismiss', { book_ids: group.books.map(b => b.id) })
-      fetchGroups()
-    } catch (e) {
-      setActionError(prev => ({ ...prev, [group.group_id]: e instanceof Error ? e.message : 'Dismiss failed' }))
-    } finally {
-      setDismissing(null)
+  const decidedGroups = groups.filter(g => decisions[g.group_id])
+  const mergeCount = decidedGroups.filter(g => decisions[g.group_id] === 'merge').length
+  const dismissCount = decidedGroups.filter(g => decisions[g.group_id] === 'dismiss').length
+  const deleteBookCount = decidedGroups
+    .filter(g => decisions[g.group_id] === 'delete')
+    .reduce((n, g) => n + g.books.filter(b => b.id !== keepIds[g.group_id]).length, 0)
+
+  async function applyAll() {
+    if (!decidedGroups.length) return
+    setApplying(true)
+    setApplyResult(null)
+    setApplyProgress({ done: 0, total: decidedGroups.length })
+    let applied = 0
+    const failed: { label: string; error: string }[] = []
+    for (let i = 0; i < decidedGroups.length; i++) {
+      const group = decidedGroups[i]
+      const action = decisions[group.group_id]
+      const keepId = keepIds[group.group_id]
+      const removeIds = group.books.map(b => b.id).filter(id => id !== keepId)
+      const label = group.books.find(b => b.id === keepId)?.title ?? group.books[0]?.title ?? 'group'
+      try {
+        if (action === 'merge') {
+          await api.post('/admin/duplicates/merge', { keep_id: keepId, remove_ids: removeIds })
+        } else if (action === 'delete') {
+          const res = await api.post<{ deleted: number[]; errors: { book_id: number; error: string }[] }>(
+            '/books/bulk-delete',
+            { book_ids: removeIds },
+          )
+          if (res.errors.length) {
+            throw new Error(`${res.errors.length} book${res.errors.length !== 1 ? 's' : ''} could not be deleted`)
+          }
+        } else {
+          await api.post('/admin/duplicates/dismiss', { book_ids: group.books.map(b => b.id) })
+        }
+        applied++
+      } catch (e) {
+        failed.push({ label, error: e instanceof Error ? e.message : 'Failed' })
+      }
+      setApplyProgress({ done: i + 1, total: decidedGroups.length })
     }
+    setApplyResult({ applied, failed })
+    setApplying(false)
+    setApplyProgress(null)
+    fetchGroups()
   }
 
   if (loading) {
@@ -1428,6 +1461,25 @@ function DuplicatesTab() {
         </button>
       </div>
 
+      {applyResult && (
+        <div className={cn(
+          'rounded-xl border p-4 text-xs space-y-1',
+          applyResult.failed.length
+            ? 'border-warning/20 bg-warning/5'
+            : 'border-success/20 bg-success/5',
+        )}>
+          <p className={cn('font-medium', applyResult.failed.length ? 'text-warning' : 'text-success')}>
+            Applied {applyResult.applied} group{applyResult.applied !== 1 ? 's' : ''}
+            {applyResult.failed.length > 0 && `, ${applyResult.failed.length} failed`}
+          </p>
+          {applyResult.failed.length > 0 && (
+            <ul className="space-y-0.5 text-muted-foreground">
+              {applyResult.failed.map((f, i) => <li key={i}>{f.label}: {f.error}</li>)}
+            </ul>
+          )}
+        </div>
+      )}
+
       {groups.length === 0 ? (
         <div className="text-center py-16 text-muted-foreground text-sm">
           No duplicates found. Your library looks clean.
@@ -1435,15 +1487,16 @@ function DuplicatesTab() {
       ) : (
         <div className="flex flex-col gap-4">
           <p className="text-xs text-muted-foreground">
-            {groups.length} duplicate group{groups.length !== 1 ? 's' : ''} found. Select which book to keep, then merge or dismiss each group.
+            {groups.length} duplicate group{groups.length !== 1 ? 's' : ''} found. Pick which book to keep and an action per group — Merge, Delete Others, or Dismiss — then apply everything at once.
           </p>
           {groups.map(group => {
-            const isMerging = merging === group.group_id
-            const isDismissing = dismissing === group.group_id
-            const busy = isMerging || isDismissing
-            const err = actionError[group.group_id]
+            const decision = decisions[group.group_id]
+            const othersCount = group.books.filter(b => b.id !== keepIds[group.group_id]).length
             return (
-              <div key={group.group_id} className="border border-border rounded-xl bg-card overflow-hidden">
+              <div key={group.group_id} className={cn(
+                'border rounded-xl bg-card overflow-hidden transition-colors',
+                decision ? 'border-primary/40' : 'border-border',
+              )}>
                 {/* Group header */}
                 <div className="flex items-center justify-between px-4 py-3 border-b border-border bg-muted/30">
                   <span className={cn(
@@ -1453,23 +1506,47 @@ function DuplicatesTab() {
                     {MATCH_REASON_LABEL[group.match_reason]}
                   </span>
                   <div className="flex items-center gap-2">
-                    {err && <span className="text-xs text-destructive">{err}</span>}
                     <button
-                      onClick={() => handleDismiss(group)}
-                      disabled={busy}
-                      className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border border-border hover:bg-accent transition-colors text-muted-foreground disabled:opacity-50"
-                      title="Dismiss this group — it will not appear again"
+                      onClick={() => toggleDecision(group.group_id, 'dismiss')}
+                      disabled={applying}
+                      className={cn(
+                        'flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border transition-colors disabled:opacity-50',
+                        decision === 'dismiss'
+                          ? 'bg-accent text-foreground border-primary/40'
+                          : 'border-border hover:bg-accent text-muted-foreground',
+                      )}
+                      title="Queue: not a duplicate — never show this group again"
                     >
-                      {isDismissing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <X className="w-3.5 h-3.5" />}
+                      <X className="w-3.5 h-3.5" />
                       Dismiss
                     </button>
                     <button
-                      onClick={() => handleMerge(group)}
-                      disabled={busy || keepIds[group.group_id] == null}
-                      className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+                      onClick={() => toggleDecision(group.group_id, 'merge')}
+                      disabled={applying || keepIds[group.group_id] == null}
+                      className={cn(
+                        'flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border transition-colors disabled:opacity-50',
+                        decision === 'merge'
+                          ? 'bg-primary text-primary-foreground border-primary'
+                          : 'border-border hover:bg-accent text-muted-foreground',
+                      )}
+                      title="Queue: fold the other copies into the kept book"
                     >
-                      {isMerging ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <GitMerge className="w-3.5 h-3.5" />}
+                      <GitMerge className="w-3.5 h-3.5" />
                       Merge
+                    </button>
+                    <button
+                      onClick={() => toggleDecision(group.group_id, 'delete')}
+                      disabled={applying || keepIds[group.group_id] == null}
+                      className={cn(
+                        'flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border transition-colors disabled:opacity-50',
+                        decision === 'delete'
+                          ? 'bg-destructive text-destructive-foreground border-destructive'
+                          : 'border-border hover:bg-accent text-muted-foreground',
+                      )}
+                      title="Queue: keep the selected book and delete the others — their files are removed from disk"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                      {decision === 'delete' ? `Delete ${othersCount} other${othersCount !== 1 ? 's' : ''}` : 'Delete Others'}
                     </button>
                   </div>
                 </div>
@@ -1526,9 +1603,16 @@ function DuplicatesTab() {
                             {book.files.map(f => (
                               <span
                                 key={f.id}
-                                className="text-[10px] px-1.5 py-0.5 rounded bg-muted text-muted-foreground border border-border font-mono"
+                                className={cn(
+                                  'text-[10px] px-1.5 py-0.5 rounded border font-mono',
+                                  f.path_exists
+                                    ? 'bg-muted text-muted-foreground border-border'
+                                    : 'bg-destructive/10 text-destructive border-destructive/20',
+                                )}
+                                title={f.path_exists ? undefined : 'File is missing from disk'}
                               >
                                 {f.format.toUpperCase()} {formatBytes(f.file_size)}
+                                {!f.path_exists && ' — MISSING'}
                               </span>
                             ))}
                           </div>
@@ -1543,6 +1627,52 @@ function DuplicatesTab() {
               </div>
             )
           })}
+
+          {(decidedGroups.length > 0 || applying) && (
+            <div className="sticky bottom-4 z-10 flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-border bg-card shadow-lg">
+              <span className="text-xs text-muted-foreground">
+                {[
+                  mergeCount > 0 ? `merge ${mergeCount} group${mergeCount !== 1 ? 's' : ''}` : null,
+                  deleteBookCount > 0 ? `delete ${deleteBookCount} book${deleteBookCount !== 1 ? 's' : ''} (removes files)` : null,
+                  dismissCount > 0 ? `dismiss ${dismissCount} group${dismissCount !== 1 ? 's' : ''}` : null,
+                ].filter(Boolean).join(' · ')}
+              </span>
+              <div className="flex items-center gap-2 shrink-0">
+                {confirmApply && !applying && (
+                  <button
+                    onClick={() => setConfirmApply(false)}
+                    className="px-3 py-1.5 text-xs rounded-md border border-border hover:bg-accent transition-colors text-muted-foreground"
+                  >
+                    Cancel
+                  </button>
+                )}
+                <button
+                  onClick={() => { setDecisions({}); setConfirmApply(false) }}
+                  disabled={applying}
+                  className="px-3 py-1.5 text-xs rounded-md border border-border hover:bg-accent transition-colors text-muted-foreground disabled:opacity-50"
+                >
+                  Clear
+                </button>
+                <button
+                  onClick={() => confirmApply ? applyAll() : setConfirmApply(true)}
+                  disabled={applying}
+                  className={cn(
+                    'flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md transition-opacity disabled:opacity-50',
+                    deleteBookCount > 0
+                      ? 'bg-destructive text-destructive-foreground hover:opacity-90'
+                      : 'bg-primary text-primary-foreground hover:opacity-90',
+                  )}
+                >
+                  {applying && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+                  {applying
+                    ? `Applying ${applyProgress?.done ?? 0}/${applyProgress?.total ?? decidedGroups.length}…`
+                    : confirmApply
+                    ? `Confirm — apply ${decidedGroups.length} decision${decidedGroups.length !== 1 ? 's' : ''}`
+                    : `Apply All (${decidedGroups.length})`}
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1629,15 +1629,16 @@ function DuplicatesTab() {
           })}
 
           {(decidedGroups.length > 0 || applying) && (
-            <div className="sticky bottom-4 z-10 flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-border bg-card shadow-lg">
-              <span className="text-xs text-muted-foreground">
+            <div className="sticky bottom-16 sm:bottom-4 z-10 flex flex-wrap items-center justify-between gap-3 px-4 py-3 rounded-xl border border-border bg-card shadow-lg">
+              {/* bottom-16 below sm clears the fixed keyboard-shortcuts FAB */}
+              <span className="text-xs text-muted-foreground min-w-0">
                 {[
                   mergeCount > 0 ? `merge ${mergeCount} group${mergeCount !== 1 ? 's' : ''}` : null,
                   deleteBookCount > 0 ? `delete ${deleteBookCount} book${deleteBookCount !== 1 ? 's' : ''} (removes files)` : null,
                   dismissCount > 0 ? `dismiss ${dismissCount} group${dismissCount !== 1 ? 's' : ''}` : null,
                 ].filter(Boolean).join(' · ')}
               </span>
-              <div className="flex items-center gap-2 shrink-0">
+              <div className="flex items-center gap-2 shrink-0 ml-auto">
                 {confirmApply && !applying && (
                   <button
                     onClick={() => setConfirmApply(false)}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -131,12 +131,11 @@ interface BulkDeleteModalProps {
   books: Book[]
   selectedIds: Set<number>
   onCancel: () => void
-  onConfirm: (onProgress: (done: number, total: number) => void) => Promise<void>
+  onConfirm: () => Promise<void>
 }
 
 function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: BulkDeleteModalProps) {
   const [deleting, setDeleting] = useState(false)
-  const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
 
   if (!open) return null
 
@@ -144,10 +143,8 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
 
   async function handleDelete() {
     setDeleting(true)
-    setProgress({ done: 0, total: selectedIds.size })
-    await onConfirm((done, total) => setProgress({ done, total }))
+    await onConfirm()
     setDeleting(false)
-    setProgress(null)
   }
 
   return (
@@ -211,14 +208,19 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
                   </div>
                 )
               })}
+              {selectedIds.size > selectedBooks.length && (
+                <p className="text-xs text-muted-foreground py-2">
+                  …and {selectedIds.size - selectedBooks.length} more not shown
+                </p>
+              )}
             </div>
           </div>
 
           {/* Footer */}
           <div className="flex items-center justify-end gap-2 px-6 py-4 border-t border-border shrink-0">
-            {progress && (
+            {deleting && (
               <span className="text-xs text-muted-foreground mr-auto">
-                Deleting {progress.done}/{progress.total}...
+                Deleting {selectedIds.size} book{selectedIds.size !== 1 ? 's' : ''}...
               </span>
             )}
             <button
@@ -548,7 +550,18 @@ export function DashboardPage() {
       return handleToggle(id, index, shiftKey, prev)
     })
   }
-  function selectAll() { setSelected(new Set(books.map(b => b.id))) }
+  async function selectAll() {
+    // Select the whole filtered set, not just the pages the infinite scroll
+    // has loaded (issue #165 follow-up). Loaded books are selected instantly
+    // so the UI responds; the full id list replaces them when it arrives.
+    setSelected(new Set(books.map(b => b.id)))
+    try {
+      const res = await api.get<{ ids: number[] }>(`/books/ids?${buildFilterParams()}`)
+      setSelected(new Set(res.ids))
+    } catch {
+      // keep the loaded-books selection as fallback
+    }
+  }
   function clearSelection() { setSelected(new Set()) }
   function exitSelectionMode() { setSelectionMode(false); setSelected(new Set()) }
 
@@ -595,21 +608,29 @@ export function DashboardPage() {
     }
   }
 
-  async function bulkDelete(onProgress?: (done: number, total: number) => void) {
+  async function bulkDelete() {
     if (!selected.size) return
     setBulkPending(true)
-    let deleted = 0
     const ids = [...selected]
-    for (let i = 0; i < ids.length; i++) {
-      try {
-        await api.delete(`/books/${ids[i]}`)
-        deleted++
-      } catch {
-        // continue with rest
+    const CHUNK = 500 // server caps bulk-delete at 500 ids per request
+    let deleted = 0
+    let failed = 0
+    try {
+      for (let i = 0; i < ids.length; i += CHUNK) {
+        const res = await api.post<{ deleted: number[]; errors: { book_id: number; error: string }[] }>(
+          '/books/bulk-delete',
+          { book_ids: ids.slice(i, i + CHUNK) },
+        )
+        deleted += res.deleted.length
+        failed += res.errors.length
       }
-      onProgress?.(i + 1, ids.length)
+      toastSuccess(`Deleted ${deleted} book${deleted !== 1 ? 's' : ''}`)
+      if (failed) {
+        toastError(`${failed} book${failed !== 1 ? 's' : ''} could not be deleted`)
+      }
+    } catch (e) {
+      toastError(e instanceof Error ? e.message : 'Delete failed')
     }
-    toastSuccess(`Deleted ${deleted} book${deleted !== 1 ? 's' : ''}`)
     setDeleteModalOpen(false)
     clearSelection()
     loadBooks()
@@ -731,6 +752,25 @@ export function DashboardPage() {
 
   const PAGE_SIZE = 60
 
+  function buildFilterParams(): URLSearchParams {
+    const params = new URLSearchParams()
+    if (search) params.set('q', search)
+    if (filterSeries) params.set('series', filterSeries)
+    if (filterNoSeries) params.set('no_series', 'true')
+    if (filterAuthor) params.set('author', filterAuthor)
+    if (filterTag) params.set('tag', filterTag)
+    if (filterFormat) params.set('format', filterFormat)
+    if (filterLanguage) params.set('language', filterLanguage)
+    if (filterLibrary) params.set('library_id', String(filterLibrary))
+    if (filterReadingStatus) params.set('reading_status', filterReadingStatus)
+    if (filterMinRating) params.set('min_rating', String(filterMinRating))
+    if (filterMissing) params.set('missing', filterMissing)
+    if (contentType) params.set('content_type', contentType)
+    if (filterOwnership) params.set('ownership', filterOwnership)
+    if (filterAddedBy) params.set('added_by', String(filterAddedBy))
+    return params
+  }
+
   const loadBooks = useCallback((reset = true) => {
     const skip = reset ? 0 : booksRef.current.length
 
@@ -746,26 +786,15 @@ export function DashboardPage() {
       setLoadingMore(true)
     }
 
-    const signal = reset ? abortRef.current!.signal : undefined
-    const params = new URLSearchParams()
+    // Load-more requests share the reset's controller: a new reset (filter
+    // change, group toggle) aborts any in-flight page so its stale results
+    // can't be appended onto the fresh list (viewport-duplicates bug).
+    const signal = abortRef.current?.signal
+    const params = buildFilterParams()
     params.set('sort', sort)
     params.set('order', order)
     params.set('skip', String(skip))
     params.set('limit', String(PAGE_SIZE))
-    if (search) params.set('q', search)
-    if (filterSeries) params.set('series', filterSeries)
-    if (filterNoSeries) params.set('no_series', 'true')
-    if (filterAuthor) params.set('author', filterAuthor)
-    if (filterTag) params.set('tag', filterTag)
-    if (filterFormat) params.set('format', filterFormat)
-    if (filterLanguage) params.set('language', filterLanguage)
-    if (filterLibrary) params.set('library_id', String(filterLibrary))
-    if (filterReadingStatus) params.set('reading_status', filterReadingStatus)
-    if (filterMinRating) params.set('min_rating', String(filterMinRating))
-    if (filterMissing) params.set('missing', filterMissing)
-    if (contentType) params.set('content_type', contentType)
-    if (filterOwnership) params.set('ownership', filterOwnership)
-    if (filterAddedBy) params.set('added_by', String(filterAddedBy))
     if (groupActive) params.set('group_by_series', 'true')
     api.getWithHeaders<Book[]>(`/books?${params}`, signal)
       .then(({ data: newBooks, headers }) => {
@@ -774,7 +803,13 @@ export function DashboardPage() {
           const raw = headers.get('x-total-count')
           setTotalCount(raw !== null ? Number(raw) : null)
         }
-        const merged = reset ? newBooks : [...booksRef.current, ...newBooks]
+        let merged: Book[]
+        if (reset) {
+          merged = newBooks
+        } else {
+          const seen = new Set(booksRef.current.map(b => b.id))
+          merged = [...booksRef.current, ...newBooks.filter(b => !seen.has(b.id))]
+        }
         booksRef.current = merged
         setBooks(merged)
         hasMoreRef.current = newBooks.length === PAGE_SIZE
@@ -796,9 +831,17 @@ export function DashboardPage() {
         toastError('Failed to load books')
       })
       .finally(() => {
-        if (signal?.aborted) return
-        if (reset) { setLoading(false); setRefreshing(false) }
-        else setLoadingMore(false)
+        if (reset) {
+          // An aborted reset was superseded by a newer one that owns the
+          // loading flags — leave them alone.
+          if (signal?.aborted) return
+          setLoading(false)
+          setRefreshing(false)
+        } else {
+          // Always clear, even when aborted: this request is finished and a
+          // stuck loadingMore would stall the infinite scroll for good.
+          setLoadingMore(false)
+        }
       })
   }, [sort, order, search, filterSeries, filterNoSeries, filterAuthor, filterTag, filterFormat, filterLanguage, filterLibrary, filterReadingStatus, filterMinRating, filterMissing, contentType, filterOwnership, filterAddedBy, groupActive])
 

--- a/tests/test_library_integrity.py
+++ b/tests/test_library_integrity.py
@@ -1,0 +1,321 @@
+"""Tests for the library-integrity cleanup surfaces (issue #165).
+
+Covers:
+- POST /books/bulk-delete (server-side bulk delete with per-book permissions)
+- GET /books/library-health missing-file detection
+- POST /books/remove-missing (drop dead BookFile rows / empty books)
+- Orphan-aware duplicate merge (dead file rows are dropped, not reassigned)
+- path_exists flag on duplicate group files
+"""
+from pathlib import Path
+
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from backend.core.security import hash_password, create_access_token
+from backend.models.book import Book, BookFile
+from backend.models.audit_log import AuditLog
+from backend.models.user import User
+
+
+def _make_user(db: Session, username: str, role: str, is_admin: bool = False) -> tuple[User, str]:
+    user = User(
+        username=username,
+        email=f"{username}@example.com",
+        hashed_password=hash_password("password123"),
+        is_active=True,
+        is_admin=is_admin,
+        role=role,
+        must_change_password=False,
+    )
+    db.add(user)
+    db.flush()
+    return user, create_access_token(subject=user.id)
+
+
+def _hdr(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _real_file(tmp_path: Path, name: str) -> str:
+    p = tmp_path / name
+    p.write_bytes(b"ebook bytes")
+    return str(p)
+
+
+# ── Bulk delete ───────────────────────────────────────────────────────────────
+
+def test_bulk_delete_admin(client: TestClient, make_book):
+    a = make_book(title="Bulk A")
+    b = make_book(title="Bulk B")
+
+    resp = client.post("/api/books/bulk-delete", json={"book_ids": [a.id, b.id, 999999]})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body["deleted"]) == {a.id, b.id}
+    assert body["errors"] == [{"book_id": 999999, "error": "Book not found"}]
+
+    assert client.get(f"/api/books/{a.id}").status_code == 404
+    assert client.get(f"/api/books/{b.id}").status_code == 404
+
+
+def test_bulk_delete_member_only_own_uploads(client: TestClient, db: Session, make_book):
+    member, m_token = _make_user(db, "bulkmember", "member")
+
+    admins_book = make_book(title="Admin Owned")
+    own = Book(title="Member Owned", status="active", added_by=member.id)
+    db.add(own)
+    db.flush()
+    db.add(BookFile(book_id=own.id, file_path=f"/library/{own.id}/own.epub",
+                    format="epub", file_size=1024))
+    db.flush()
+
+    resp = client.post(
+        "/api/books/bulk-delete",
+        json={"book_ids": [own.id, admins_book.id]},
+        headers=_hdr(m_token),
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["deleted"] == [own.id]
+    assert body["errors"] == [
+        {"book_id": admins_book.id, "error": "You can only delete books you uploaded"}
+    ]
+    # The admin's book survived
+    assert client.get(f"/api/books/{admins_book.id}").status_code == 200
+
+
+def test_bulk_delete_empty_request_rejected(client: TestClient):
+    resp = client.post("/api/books/bulk-delete", json={"book_ids": []})
+    assert resp.status_code == 400
+
+
+def test_bulk_delete_over_cap_rejected(client: TestClient):
+    resp = client.post("/api/books/bulk-delete", json={"book_ids": list(range(1, 502))})
+    assert resp.status_code == 400
+    assert "500" in resp.json()["detail"]
+
+
+def test_bulk_delete_dedupes_repeated_ids(client: TestClient, make_book):
+    book = make_book(title="Dedupe Me")
+    resp = client.post("/api/books/bulk-delete", json={"book_ids": [book.id, book.id, book.id]})
+    assert resp.status_code == 200
+    body = resp.json()
+    # One deletion, no phantom "not found" errors from the repeats
+    assert body["deleted"] == [book.id]
+    assert body["errors"] == []
+
+
+def test_bulk_delete_removes_files_on_disk(client: TestClient, make_book, tmp_path):
+    path = _real_file(tmp_path, "on_disk.epub")
+    book = make_book(title="On Disk", file_path=path)
+
+    resp = client.post("/api/books/bulk-delete", json={"book_ids": [book.id]})
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] == [book.id]
+    assert not Path(path).exists()
+
+
+def test_bulk_delete_audited_per_book(client: TestClient, db: Session, make_book):
+    a = make_book(title="Audit A")
+    b = make_book(title="Audit B")
+
+    client.post("/api/books/bulk-delete", json={"book_ids": [a.id, b.id]})
+
+    deleted_ids = {
+        r.resource_id
+        for r in db.query(AuditLog).filter(AuditLog.action == "books.deleted").all()
+    }
+    assert {a.id, b.id} <= deleted_ids
+
+
+# ── Library health: missing files ─────────────────────────────────────────────
+
+def test_library_health_reports_missing_files(client: TestClient, make_book, tmp_path):
+    dead = make_book(title="Ghost Book")  # default path never exists on disk
+    alive = make_book(title="Alive Book", file_path=_real_file(tmp_path, "alive.epub"))
+
+    resp = client.get("/api/books/library-health")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    missing_book_ids = {m["book_id"] for m in body["missing"]}
+    assert dead.id in missing_book_ids
+    assert alive.id not in missing_book_ids
+    assert body["missing_count"] == len(body["missing"])
+
+    entry = next(m for m in body["missing"] if m["book_id"] == dead.id)
+    assert entry["title"] == "Ghost Book"
+    assert entry["book_file_count"] == 1
+    # A missing file must not additionally show up as misplaced
+    assert dead.id not in {i["book_id"] for i in body["issues"]}
+
+
+def test_remove_missing_deletes_dead_rows_and_empty_books(
+    client: TestClient, db: Session, make_book, tmp_path
+):
+    # Book whose only file is dead — the whole record should go
+    ghost = make_book(title="Full Ghost")
+    ghost_file_id = ghost.files[0].id
+
+    # Book with one dead and one real file — only the dead row should go
+    partial = make_book(title="Partial", file_path=_real_file(tmp_path, "partial.epub"))
+    dead_row = BookFile(book_id=partial.id, file_path=f"/library/{partial.id}/gone.cbz",
+                        format="cbz", file_size=2048)
+    db.add(dead_row)
+    db.flush()
+
+    resp = client.post(
+        "/api/books/remove-missing",
+        json={"file_ids": [ghost_file_id, dead_row.id]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["removed_file_rows"] == 1
+    assert body["removed_books"] == [{"book_id": ghost.id, "title": "Full Ghost"}]
+    assert body["skipped"] == []
+
+    assert client.get(f"/api/books/{ghost.id}").status_code == 404
+    partial_resp = client.get(f"/api/books/{partial.id}")
+    assert partial_resp.status_code == 200
+    assert len(partial_resp.json()["files"]) == 1
+
+
+def test_remove_missing_refuses_files_that_exist(
+    client: TestClient, make_book, tmp_path
+):
+    path = _real_file(tmp_path, "still_here.epub")
+    book = make_book(title="Still Here", file_path=path)
+    file_id = book.files[0].id
+
+    resp = client.post("/api/books/remove-missing", json={"file_ids": [file_id]})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["removed_file_rows"] == 0
+    assert body["removed_books"] == []
+    assert body["skipped"] == [{"file_id": file_id, "error": "file exists on disk"}]
+    assert Path(path).exists()
+    assert client.get(f"/api/books/{book.id}").status_code == 200
+
+
+def test_remove_missing_empty_request_rejected(client: TestClient):
+    resp = client.post("/api/books/remove-missing", json={"file_ids": []})
+    assert resp.status_code == 400
+
+
+def test_remove_missing_audited(client: TestClient, db: Session, make_book):
+    ghost = make_book(title="Audited Ghost")
+    resp = client.post("/api/books/remove-missing", json={"file_ids": [ghost.files[0].id]})
+    assert resp.status_code == 200
+
+    row = (
+        db.query(AuditLog)
+        .filter(AuditLog.action == "books.missing_removed")
+        .order_by(AuditLog.id.desc())
+        .first()
+    )
+    assert row is not None
+    import json
+    assert json.loads(row.details) == {"file_rows": 0, "books_removed": 1}
+
+
+def test_remove_missing_requires_admin(client: TestClient, db: Session, make_book):
+    _member, m_token = _make_user(db, "rmmember", "member")
+    book = make_book(title="Member Cannot Remove")
+    resp = client.post(
+        "/api/books/remove-missing",
+        json={"file_ids": [book.files[0].id]},
+        headers=_hdr(m_token),
+    )
+    assert resp.status_code == 403
+
+
+# ── /books/ids (select-all across the whole filtered set) ────────────────────
+
+def test_book_ids_respects_filters(client: TestClient, make_book):
+    a = make_book(title="Ids Series A1", series="Ids Series", series_index=1.0)
+    b = make_book(title="Ids Series A2", series="Ids Series", series_index=2.0)
+    other = make_book(title="Ids Other", series="Different Series")
+
+    resp = client.get("/api/books/ids", params={"series": "Ids Series"})
+    assert resp.status_code == 200
+    ids = resp.json()["ids"]
+    assert set(ids) == {a.id, b.id}
+    assert other.id not in ids
+
+
+def test_book_ids_respects_visibility(client: TestClient, db: Session, make_book):
+    """A member's own unfiled upload must not leak into another member's ids."""
+    member1, _ = _make_user(db, "idsmember1", "member")
+    _member2, m2_token = _make_user(db, "idsmember2", "member")
+
+    admin_book = make_book(title="Ids Admin Book")  # unfiled admin upload → public
+    private = Book(title="Ids Private Upload", status="active", added_by=member1.id)
+    db.add(private)
+    db.flush()
+    db.add(BookFile(book_id=private.id, file_path=f"/library/{private.id}/p.epub",
+                    format="epub", file_size=1024))
+    db.flush()
+
+    resp = client.get("/api/books/ids", headers=_hdr(m2_token))
+    assert resp.status_code == 200
+    ids = set(resp.json()["ids"])
+    assert admin_book.id in ids
+    assert private.id not in ids
+
+
+# ── Orphan-aware merge ────────────────────────────────────────────────────────
+
+def test_merge_drops_dead_file_rows(client: TestClient, make_book, tmp_path):
+    keep = make_book(title="Keeper", file_path=_real_file(tmp_path, "keeper.epub"),
+                     content_hash="feedface" * 8)
+    remove = make_book(title="Dead Copy", content_hash="feedface" * 8)
+
+    resp = client.post(
+        "/api/admin/duplicates/merge",
+        json={"keep_id": keep.id, "remove_ids": [remove.id]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["merged"] == 1
+    assert body["dropped_missing_files"] == 1
+
+    kept = client.get(f"/api/books/{keep.id}").json()
+    assert len(kept["files"]) == 1  # the dead row was NOT carried over
+
+
+def test_merge_still_transfers_real_files(client: TestClient, make_book, tmp_path):
+    keep = make_book(title="Keeper 2", file_path=_real_file(tmp_path, "keeper2.epub"),
+                     content_hash="cafebabe" * 8)
+    remove = make_book(title="Real Copy", file_path=_real_file(tmp_path, "copy2.epub"),
+                       content_hash="cafebabe" * 8)
+
+    resp = client.post(
+        "/api/admin/duplicates/merge",
+        json={"keep_id": keep.id, "remove_ids": [remove.id]},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["dropped_missing_files"] == 0
+
+    kept = client.get(f"/api/books/{keep.id}").json()
+    assert len(kept["files"]) == 2
+
+
+# ── path_exists flag on duplicate groups ──────────────────────────────────────
+
+def test_duplicates_expose_path_exists(client: TestClient, make_book, tmp_path):
+    alive = make_book(title="Alive Twin", file_path=_real_file(tmp_path, "twin.epub"),
+                      content_hash="0badf00d" * 8)
+    dead = make_book(title="Dead Twin", content_hash="0badf00d" * 8)
+
+    resp = client.get("/api/admin/duplicates")
+    assert resp.status_code == 200
+
+    group = next(
+        g for g in resp.json()["groups"]
+        if g["match_reason"] == "content_hash"
+        and {b["id"] for b in g["books"]} == {alive.id, dead.id}
+    )
+    by_id = {b["id"]: b for b in group["books"]}
+    assert by_id[alive.id]["files"][0]["path_exists"] is True
+    assert by_id[dead.id]["files"][0]["path_exists"] is False

--- a/website/src/pages/docs/admin.astro
+++ b/website/src/pages/docs/admin.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro'
 import SectionHero from '../../components/SectionHero.astro'
 import DocsMeta from '../../components/DocsMeta.astro'
 import Callout from '../../components/Callout.astro'
+import UnreleasedNote from '../../components/UnreleasedNote.astro'
 import { ThemedShot } from '../../components/ThemedShot'
 import { withBase } from '../../lib/path'
 ---
@@ -52,15 +53,27 @@ import { withBase } from '../../lib/path'
   </table>
 
   <h3>Resolving duplicates</h3>
+  <UnreleasedNote />
   <p>
-    For each duplicate group, you have two options:
+    Resolution works in one pass: for each group, pick the book to keep and queue an action, then
+    apply everything with a single <strong>Apply All</strong>. Nothing happens until you confirm,
+    and a summary afterwards reports what was applied and anything that failed. Three actions are
+    available per group:
   </p>
   <ul>
-    <li><strong>Merge</strong> — keep one book, delete the others. Reading status and sessions are
-      preserved on the kept book.</li>
-    <li><strong>Dismiss</strong> — mark the pair as not-a-duplicate. Dismissed pairs are stored
+    <li><strong>Merge</strong> — fold the other copies into the kept book. Files, tags, library
+      memberships, and reading status carry over. File entries whose file is missing from disk are
+      dropped rather than carried along.</li>
+    <li><strong>Delete Others</strong> — keep the selected book and delete the other copies,
+      including their files on disk. Useful when the copies really are redundant files, not
+      alternate formats worth merging.</li>
+    <li><strong>Dismiss</strong> — mark the group as not-a-duplicate. Dismissed pairs are stored
       permanently and excluded from future scans.</li>
   </ul>
+  <p>
+    Copies whose file no longer exists on disk are badged <strong>MISSING</strong> on their format
+    chip, so dead entries are easy to tell apart from the real copy before you decide.
+  </p>
 
   <Callout variant="info" title="Fuzzy matches need review">
     The fuzzy title strategy intentionally casts a wide net. It may flag different volumes of the
@@ -69,9 +82,31 @@ import { withBase } from '../../lib/path'
 
   <h2>Library health</h2>
   <p>
-    The Library Health tab scans the filesystem for books whose on-disk path doesn't match their
-    expected location based on current metadata. This happens when you rename a series, change an
-    author, or import books before their metadata was corrected.
+    The Library Health tab scans the filesystem for two kinds of problems: books whose on-disk
+    path doesn't match their expected location based on current metadata, and orphaned entries —
+    books whose file no longer exists on disk at all.
+  </p>
+
+  <h3>Orphaned entries</h3>
+  <UnreleasedNote />
+  <p>
+    If files were deleted or moved outside of Tome (from a shell, another tool, or a cleanup gone
+    wrong), their database entries stay behind: the books error on open, and re-importing the same
+    file gets skipped as a duplicate of the dead entry. The scan lists every such entry with a
+    badge showing what removal would do: <em>book entry will be removed</em> when no file is left,
+    or <em>file entry only</em> when the book keeps another file that still exists.
+  </p>
+  <p>
+    <strong>Remove Dead Entries</strong> (confirm-gated) cleans them up in one click — dead file
+    entries are removed, and books left with no files are deleted entirely. Entries whose file
+    actually exists on disk are always refused: this action only ever touches the database, never
+    your files.
+  </p>
+
+  <h3>Misplaced files</h3>
+  <p>
+    Path mismatches happen when you rename a series, change an author, or import books before
+    their metadata was corrected.
   </p>
   <p>
     Misplaced files are grouped by series and author. For each one, Tome shows the current path


### PR DESCRIPTION
Relates to #165 (and the follow-up reports in its thread).

### What broke for the reporter

Files deleted from disk outside of Tome left ghost book records behind: they error on open, re-imports get skipped as hash-duplicates against the dead entries, and nothing in the app could find or fix them.

### Changes

**Cleanup surfaces**
- Library Health detects orphaned entries (file missing from disk) and removes them on confirm: dead file rows dropped, books left with no files deleted entirely. Entries whose file exists are refused - the action never touches disk.
- Admin Duplicates: files missing from disk are badged per copy, and groups are resolved via queued decisions - pick keeper + action (Merge / Delete Others / Dismiss) per group, one Apply All, one refresh, per-group failure reporting. Replaces the execute-per-group flow that reset selections on every action.
- `POST /books/bulk-delete` (per-book permissions, max 500 per request) replaces the dashboard's client-side delete loop; failures are reported instead of silently swallowed.

**Bugs found along the way**
- Duplicate merge never actually transferred file rows: reassigning the FK left the row in the removed book's collection, so the delete-orphan cascade swept it. Merge now reassigns via the relationship and drops dead file references instead of poisoning the keeper.
- "Select all" only selected viewport-loaded books - now selects the whole filtered set via new `GET /books/ids` (list filters extracted into `_filtered_books_query`, shared by both endpoints). Deletes chunk at 500/request.
- Toggling "Group series" could duplicate or truncate the grid: an in-flight page request from the previous view landed after the toggle and was appended (a stale short page even flipped hasMore off, stalling the scroll). Page requests now share the reset's AbortController and appends dedupe by id.

### Testing

- 18 backend tests (`tests/test_library_integrity.py`); full suite green.
- New Playwright E2E suite (`frontend/e2e/`, `npm run test:e2e`): boots a sandboxed backend + built frontend, seeds scenarios, and drives the real UI - the #165 cleanup journey, Apply All incl. failure path, select-all across unloaded pages, 520-book chunked delete, and the group-toggle race. The select-all and race tests were mutation-validated: they fail on the unfixed code.
- New `e2e` CI job gates the image build alongside pytest.

Known limitation (deliberately not addressed here): if the library mount is down, every file looks missing and Library Health will list the whole library as orphaned. Remove Dead Entries is admin-only and confirm-gated, but a threshold guard is a candidate follow-up.