### PR TITLE
fix(opds): correct public scheme in feed links behind TLS proxy (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Fixed
+- OPDS feed links now carry the correct public scheme behind a TLS-terminating
+  reverse proxy. The feed built its links from the request as the app server
+  saw it — plain http — so every navigation, download, and cover link came out
+  as `http://` even when the catalog was reached over https. OPDS now resolves
+  the public origin the same way the KOReader plugin URL and OIDC redirect do:
+  `TOME_PUBLIC_URL` when set, otherwise the `X-Forwarded-Proto` header. (#167)
 - KOReader plugin (build 38 / 1.11.1): popup menus — the series browser,
   Authors, Shelves, the Inbox and the TomeSync menu itself — could freeze on
   their first page when a full-screen home-screen plugin (such as

--- a/backend/api/opds.py
+++ b/backend/api/opds.py
@@ -12,6 +12,7 @@ from backend.core.database import get_db
 from backend.core.security import get_current_user_basic
 from backend.core.config import settings
 from backend.core.permissions import book_visibility_filter, is_admin as _is_admin
+from backend.core.urls import public_base_url
 from backend.models.book import Book, BookFile
 from backend.models.library import Library
 from backend.models.user import User
@@ -29,7 +30,10 @@ PER_PAGE = 50
 
 
 def _base_url(request: Request) -> str:
-    return str(request.base_url).rstrip("/")
+    # Resolve the public origin (TOME_PUBLIC_URL / X-Forwarded-Proto aware) —
+    # a naive request.base_url emits http:// links behind a TLS-terminating
+    # proxy, and OPDS clients then send Basic-Auth credentials to them (#167).
+    return public_base_url(request)
 
 
 def _apply_visibility(query, db: Session, user: User):

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -53,6 +53,60 @@ def test_feed_robust_against_global_namespace_clobber():
         ET.register_namespace("", "http://www.w3.org/2005/Atom")
 
 
+def _hrefs(xml_text: str) -> list[str]:
+    import re
+    return [m for m in re.findall(r'href="([^"]+)"', xml_text) if m.startswith("http")]
+
+
+class _AdminUser:
+    id = 1
+    is_admin = True
+    role = "admin"
+    username = "t"
+
+
+def test_opds_links_honor_forwarded_proto(client):
+    """Behind a TLS-terminating proxy (X-Forwarded-Proto: https) every feed
+    link must be https — a naive request.base_url emits http:// (GH #167)."""
+    client.app.dependency_overrides[get_current_user_basic] = lambda: _AdminUser()
+    try:
+        resp = client.get("/opds", headers={"X-Forwarded-Proto": "https"})
+        assert resp.status_code == 200
+        hrefs = _hrefs(resp.text)
+        assert hrefs, "expected absolute links in the feed"
+        assert all(h.startswith("https://") for h in hrefs), hrefs
+    finally:
+        client.app.dependency_overrides.pop(get_current_user_basic, None)
+
+
+def test_opds_links_honor_public_url(client, monkeypatch):
+    """TOME_PUBLIC_URL is authoritative when set."""
+    from backend.core.config import settings
+    monkeypatch.setattr(settings, "public_url", "https://tome.example.org")
+    client.app.dependency_overrides[get_current_user_basic] = lambda: _AdminUser()
+    try:
+        resp = client.get("/opds")
+        assert resp.status_code == 200
+        hrefs = _hrefs(resp.text)
+        assert hrefs
+        assert all(h.startswith("https://tome.example.org/") for h in hrefs), hrefs
+    finally:
+        client.app.dependency_overrides.pop(get_current_user_basic, None)
+
+
+def test_opds_links_plain_http_unchanged(client):
+    """No proxy headers, no TOME_PUBLIC_URL: links keep the request origin."""
+    client.app.dependency_overrides[get_current_user_basic] = lambda: _AdminUser()
+    try:
+        resp = client.get("/opds")
+        assert resp.status_code == 200
+        hrefs = _hrefs(resp.text)
+        assert hrefs
+        assert all(h.startswith("http://testserver/") for h in hrefs), hrefs
+    finally:
+        client.app.dependency_overrides.pop(get_current_user_basic, None)
+
+
 def test_opds_root_endpoint_serves_default_namespace(client):
     """End-to-end: the live /opds endpoint returns atom+xml with a default ns."""
 


### PR DESCRIPTION
Fixes #167.

Behind a TLS-terminating reverse proxy the app server sees plain http, and the OPDS router built every feed link from raw `request.base_url` — so navigation, acquisition, and cover links all came out `http://` even when the catalog was reached over https. Beyond being wrong, OPDS clients following those links send Basic-Auth credentials toward a plaintext URL.

`_base_url()` now routes through `public_base_url()` (backend/core/urls.py) — the same origin resolution the KOReader plugin URL and the OIDC redirect already use: `TOME_PUBLIC_URL` when set, else `X-Forwarded-Proto`, else the request origin untouched. This was the last remaining naive `request.base_url` in the backend.

Tests: feed links are https under `X-Forwarded-Proto: https`, use `TOME_PUBLIC_URL` verbatim when configured, and stay unchanged for plain-HTTP/LAN setups.