### PR TITLE
chore(deps): security bumps — pdfjs-dist 6.2.108 + build-time deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Security
+- Updated `pdfjs-dist` to 6.2.108, clearing an arbitrary-JavaScript-execution
+  advisory triggered by opening a malicious PDF (GHSA / CVE for PDF.js). This
+  one is real in Tome: the web reader renders library PDFs with PDF.js in the
+  app's origin, so a crafted PDF opened in the reader could run script with
+  access to the session. Anyone hosting PDFs for multiple users should update.
+- Updated `fast-uri` (build-time, via vite-plugin-pwa's workbox tooling) to
+  3.1.5, clearing a host-confusion advisory. Not reachable in Tome - it only
+  parses our own build configuration during `vite build`.
+- Updated `js-yaml` to 4.3.1 in the frontend (dev-only, eslint's config
+  loader) and the website build, clearing a quadratic-CPU advisory. Neither
+  parses untrusted input.
+- Updated `postcss` to 8.5.26 in the website build, picking up the completed
+  fix for the source-map advisory partially addressed in v2.1.1. Build-time
+  only, same as before.
+
 ### Added
 - Library Health now detects orphaned entries — books whose files no longer
   exist on disk (for example after files were deleted or moved outside of

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
         "clsx": "^2.1.1",
         "html-to-image": "^1.11.13",
         "lucide-react": "^1.7.0",
-        "pdfjs-dist": "^6.0.227",
+        "pdfjs-dist": "^6.2.108",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-grid-layout": "^2.2.3",
@@ -4985,9 +4985,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -6099,9 +6099,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -6820,9 +6820,9 @@
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "6.0.227",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.0.227.tgz",
-      "integrity": "sha512-/P6M4SXw+70waMVLUM7rdRtvo+dEzqE1t6W/zQNvBETo2MaRa5rrvCcAYdfWGiUzadTgM0lJmRApUrW0d9zgKg==",
+      "version": "6.2.108",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-6.2.108.tgz",
+      "integrity": "sha512-YxFb+SQcodN2rnX9Tn3dHYlqfb7NjlzzfONPpJd+AKoKtUjEdevTfbC07d5TcczzOK6261auRkP/M8OBHs9vFQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22.13.0 || >=24"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "clsx": "^2.1.1",
     "html-to-image": "^1.11.13",
     "lucide-react": "^1.7.0",
-    "pdfjs-dist": "^6.0.227",
+    "pdfjs-dist": "^6.2.108",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-grid-layout": "^2.2.3",
@@ -49,6 +49,6 @@
   },
   "overrides": {
     "@babel/core": "^7.29.6",
-    "js-yaml": "^4.2.0"
+    "js-yaml": "^4.3.1"
   }
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4091,9 +4091,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -4573,9 +4573,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -4923,9 +4923,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -4942,7 +4942,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
Clears all five open Dependabot alerts (#51–#55) ahead of the release.

**The one that matters — pdfjs-dist 6.0.227 → 6.2.108** (GHSA: arbitrary JS execution on opening a malicious PDF). Reachable in Tome: the web reader renders library PDFs with PDF.js inside the app origin, so a crafted PDF opened in the reader could run script with access to the session. Verified the reader on 6.2.108 against a real PDF: renders correctly, toolbar/zoom/pagination intact, no console errors.

**Build/dev-time only, not reachable at runtime:**
- fast-uri → 3.1.5 (frontend, via vite-plugin-pwa → workbox → ajv; parses only our own build config)
- js-yaml → 4.3.1 (frontend override: eslint's config loader; website: Astro build tooling)
- postcss → 8.5.26 (website; completes the partial fix noted in v2.1.1)

Lockfile/manifest + changelog only — no code changes. Frontend and website both build clean.