### PR TITLE
Want to Read status with bidirectional Hardcover shelf sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ All notable changes to Tome are documented here. Format loosely follows
   only, same as before.
 
 ### Added
+- New "Want to Read" reading status — the missing state between the wishlist
+  and actually starting a book: owned, not started, queued next. Set it from
+  the book page (next to Shelved), filter by it on the dashboard, and it
+  self-promotes to Reading the moment real progress arrives from KOReader or
+  the web reader. Series "continue" suggestions prefer a queued volume over a
+  plain unread one, and the Library Completion stats tile shows a queued
+  count. When an admin fulfils your wish, the arriving book lands on your
+  Want to Read automatically — the intent that created the wish carries over
+  (never overwriting a book you're already reading). Volumes arriving for a
+  followed series do the same.
+- Hardcover sync now covers Want to Read — in both directions. Queueing a
+  book in Tome shelves it as "Want to Read" on your Hardcover profile, and
+  books you shelve on Hardcover appear as Want to Read in Tome (for books
+  Tome has matched to the Hardcover catalogue). Removing a book from the
+  Hardcover shelf reverts it in Tome only when both sides had agreed on it;
+  a book you're actively reading in Tome is never touched, and ratings and
+  progress remain push-only as before. Shelving a book Tome doesn't have at
+  all creates a wish on your Tome wishlist instead (with cover and author from
+  the Hardcover catalogue), un-shelving it on Hardcover dismisses that wish
+  again, and re-shelving it reopens the same wish. Books already in the
+  library that merely lack a catalogue match are recognised and skipped
+  rather than wished for twice.
 - Library Health now detects orphaned entries — books whose files no longer
   exist on disk (for example after files were deleted or moved outside of
   Tome). A new section lists them and a one-click "Remove Dead Entries" action

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -185,7 +185,7 @@ def _filtered_books_query(
         query = query.filter(Book.language.in_(raw_matches) if raw_matches else Book.id == -1)
     if library_id:
         query = query.join(Book.libraries).filter(Library.id == library_id)
-    if reading_status in ("reading", "read", "shelved"):
+    if reading_status in ("reading", "read", "shelved", "want_to_read"):
         query = query.join(
             UserBookStatus,
             (UserBookStatus.book_id == Book.id) & (UserBookStatus.user_id == current_user.id)
@@ -1420,7 +1420,12 @@ def restore_position(
     else:
         if status_row.status == "read":
             status_row.finished_at = None
-        status_row.status = "reading" if entry.percentage > 0 else "unread"
+        if entry.percentage > 0:
+            status_row.status = "reading"
+        elif status_row.status != "want_to_read":
+            # A zero-position restore resets to unread — but a queued book
+            # stays queued (it never had a position to lose).
+            status_row.status = "unread"
     db.commit()
     audit(db, "books.position_restored", user_id=current_user.id, username=current_user.username,
           resource_type="book", resource_id=book_id,

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -813,6 +813,7 @@ def get_stats(
     tbr_read = status_counts.get("read", 0)
     tbr_reading = status_counts.get("reading", 0)
     tbr_shelved = status_counts.get("shelved", 0)
+    tbr_want = status_counts.get("want_to_read", 0)
     type_rows = (
         db.query(
             func.coalesce(BookType.label, "Uncategorized"),
@@ -831,8 +832,9 @@ def get_stats(
         "read": tbr_read,
         "reading": tbr_reading,
         "shelved": tbr_shelved,
+        "want_to_read": tbr_want,
         # books with no status row are implicitly unread
-        "unread": max(owned - tbr_read - tbr_reading - tbr_shelved, 0),
+        "unread": max(owned - tbr_read - tbr_reading - tbr_shelved - tbr_want, 0),
         "pct": round(tbr_read / owned * 100, 1) if owned else 0,
         "by_type": sorted(
             [

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -113,8 +113,8 @@ def set_book_status(
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
-    if body.status not in ("unread", "reading", "read", "shelved"):
-        raise HTTPException(400, "status must be unread, reading, read, or shelved")
+    if body.status not in ("unread", "reading", "read", "shelved", "want_to_read"):
+        raise HTTPException(400, "status must be unread, reading, read, shelved, or want_to_read")
     from backend.models.book import Book
     book = db.get(Book, book_id)
     if not book:

--- a/backend/main.py
+++ b/backend/main.py
@@ -312,6 +312,14 @@ async def lifespan(app: FastAPI):
             conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_error VARCHAR(255)"))
             conn.execute(text("ALTER TABLE user_book_status ADD COLUMN hardcover_fail_count INTEGER NOT NULL DEFAULT 0"))
             conn.commit()
+        # Hardcover Want-to-Read pull resolves shelf entries by matched book id
+        # every cycle — create_all only builds indexes for brand-new tables, and
+        # this must run after the hardcover_book_id column-add above.
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_books_hardcover_book_id "
+            "ON books (hardcover_book_id)"
+        ))
+        conn.commit()
     ReadingGoal.__table__.create(bind=engine, checkfirst=True)
     init_fts(engine)
     backfill_fts(engine)

--- a/backend/models/book.py
+++ b/backend/models/book.py
@@ -45,7 +45,7 @@ class Book(Base):
     # hardcover_pages is the matched edition's page count, captured at match time
     # — Tome stores no page counts of its own, and progress→pages math must use
     # the edition's own pagination anyway.
-    hardcover_book_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
+    hardcover_book_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, index=True)
     hardcover_edition_id: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     hardcover_pages: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     # isbn13 | isbn10 | search | manual (user-pinned, never auto-cleared) |

--- a/backend/services/book_progress.py
+++ b/backend/services/book_progress.py
@@ -182,7 +182,8 @@ def apply_progress_to_status(
         status_row.progress_pct = 1.0
         status_row.finished_at = datetime.utcnow()
         _nudge_hardcover()
-    elif status_row.status == "unread" and pct > 0:
+    elif status_row.status in ("unread", "want_to_read") and pct > 0:
+        # First real progress self-promotes a queued (want_to_read) book too.
         status_row.status = "reading"
 
     return status_row

--- a/backend/services/hardcover_sync.py
+++ b/backend/services/hardcover_sync.py
@@ -1,4 +1,10 @@
-"""One-way Tome → Hardcover sync of ratings and reading progress.
+"""Tome ↔ Hardcover sync of ratings, reading progress, and Want to Read.
+
+Direction: ratings/progress/reading/read are ONE-WAY Tome → Hardcover. The
+Want to Read shelf is the single bidirectional piece — Tome pushes
+``want_to_read`` as status 1 and pulls the shelf back each cycle (see
+``pull_want_to_read``): entries land on unread/missing Tome rows, and removing
+a shelf entry on Hardcover reverts a previously-agreed ``want_to_read`` row.
 
 Design (docs/plans/hardcover-sync-plan.md):
 
@@ -39,6 +45,7 @@ from datetime import datetime
 from typing import Optional
 
 import httpx
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from backend.core.config import settings
@@ -47,14 +54,16 @@ from backend.models.book import Book
 from backend.models.notification import Notification
 from backend.models.user import User
 from backend.models.user_book_status import UserBookStatus
+from backend.models.wish import Wish
 
 logger = logging.getLogger(__name__)
 
 HARDCOVER_URL = "https://api.hardcover.app/v1/graphql"
 
 # Hardcover user_book status ids. unread/shelved are deliberately unmapped —
-# they are never pushed.
-STATUS_ID = {"reading": 2, "read": 3}
+# they are never pushed. want_to_read maps to Hardcover's "Want to Read" shelf
+# and is the one status that also syncs BACK from Hardcover (see pull_want_to_read).
+STATUS_ID = {"want_to_read": 1, "reading": 2, "read": 3}
 
 MIN_REQUEST_SPACING = 1.1      # seconds between requests, all users combined (60/min limit)
 MAX_REQUESTS_PER_CYCLE = 300   # cap so a 2000-book backlog spreads over cycles
@@ -124,6 +133,28 @@ query BookEdition($id: Int!) {
             reading_format_id
             language { code2 }
         }
+    }
+}
+"""
+
+Q_WTR_SHELF = """
+query WantToReadShelf($uid: Int!, $offset: Int!) {
+    user_books(where: {user_id: {_eq: $uid}, status_id: {_eq: 1}},
+               order_by: {id: asc}, limit: 100, offset: $offset) {
+        id
+        book_id
+    }
+}
+"""
+
+Q_BOOKS_BY_IDS = """
+query BooksByIds($ids: [Int!]!) {
+    books(where: {id: {_in: $ids}}) {
+        id
+        title
+        slug
+        image { url }
+        contributions { author { name } }
     }
 }
 """
@@ -628,9 +659,13 @@ def needs_sync(row: UserBookStatus) -> bool:
     if row.status in STATUS_ID:
         if row.status != row.hardcover_synced_status:
             return True
-        pct = row.progress_pct or 0.0
-        if pct - (row.hardcover_synced_pct or 0.0) >= 0.01:
-            return True
+        # Progress only matters for books actually being read: a want_to_read
+        # row may carry leftover sample progress, which must not create a
+        # read-row on Hardcover's Want to Read shelf.
+        if row.status != "want_to_read":
+            pct = row.progress_pct or 0.0
+            if pct - (row.hardcover_synced_pct or 0.0) >= 0.01:
+                return True
     return False
 
 
@@ -696,8 +731,9 @@ async def _push_row(client: httpx.AsyncClient, token: str, user: User,
             row.hardcover_synced_status = row.status
 
     # Progress (page-based, forward-only — see needs_sync). No pages on the
-    # edition → status-only sync.
-    if status_id is not None:
+    # edition → status-only sync. Skipped entirely for want_to_read: queued
+    # books get a shelf entry, never a read-row.
+    if status_id is not None and row.status != "want_to_read":
         pages = _progress_pages(row, book.hardcover_pages)
         pct = 1.0 if row.status == "read" else (row.progress_pct or 0.0)
         if pages is not None and pct - (row.hardcover_synced_pct or 0.0) >= 0.01:
@@ -862,12 +898,220 @@ async def sync_user(db: Session, client: httpx.AsyncClient, user: User,
     return stats
 
 
+async def pull_want_to_read(db: Session, client: httpx.AsyncClient, user: User,
+                            budget: _Budget) -> dict:
+    """Pull the user's Hardcover Want to Read shelf into Tome.
+
+    The one inbound direction. Rules (docs/plans/want-to-read-plan.md):
+    - Shelf entries resolve via ``Book.hardcover_book_id`` — only books Tome
+      has already matched apply; the rest are picked up once matched later.
+    - Additive apply: a resolved entry only fills a missing status row or
+      upgrades an explicit "unread" to ``want_to_read``. Engagement
+      (reading/read/shelved) always wins — never downgraded.
+    - Echo prevention: applied rows get ``hardcover_synced_status`` stamped so
+      the push reconciler sees no diff.
+    - Convergence: a Tome row that is ``want_to_read`` AND was last agreed with
+      Hardcover (snapshot says want_to_read) but whose entry left the shelf is
+      checked individually — gone entirely → revert to unread; merely moved to
+      another Hardcover status → leave both sides alone (no fighting).
+    - An incomplete shelf fetch (budget/API trouble) aborts the WHOLE pull for
+      this user — applying a partial shelf would mass-revert agreed rows.
+    """
+    stats = {"pulled": 0, "reverted": 0}
+    token = user_token(user)
+    if not token or user.hardcover_user_id is None:
+        return stats
+
+    # 1. Full shelf fetch (paginated). Partial → abort, see docstring.
+    shelf: dict[int, int] = {}  # hardcover book_id -> hardcover user_book id
+    offset = 0
+    while True:
+        if not budget.spend():
+            logger.info("Hardcover pull: budget exhausted mid-shelf-fetch for %s — "
+                        "skipping pull this cycle", user.username)
+            return stats
+        data = await _gql(client, token, Q_WTR_SHELF,
+                          {"uid": user.hardcover_user_id, "offset": offset})
+        rows = data.get("user_books")
+        if rows is None:
+            logger.info("Hardcover pull: unexpected shelf response shape for %s — "
+                        "skipping pull this cycle", user.username)
+            return stats
+        for r in rows:
+            if r.get("book_id") is not None and r.get("id") is not None:
+                shelf[int(r["book_id"])] = int(r["id"])
+        if len(rows) < 100:
+            break
+        offset += 100
+
+    # 2. Additive apply onto matched books.
+    if shelf:
+        matched_books = (
+            db.query(Book)
+            .filter(Book.hardcover_book_id.in_(shelf.keys()), Book.status == "active")
+            .all()
+        )
+        for book in matched_books:
+            row = (
+                db.query(UserBookStatus)
+                .filter_by(user_id=user.id, book_id=book.id)
+                .first()
+            )
+            if row is None:
+                db.add(UserBookStatus(
+                    user_id=user.id, book_id=book.id, status="want_to_read",
+                    hardcover_synced_status="want_to_read",
+                    hardcover_user_book_id=shelf[book.hardcover_book_id],
+                ))
+                stats["pulled"] += 1
+            elif row.status == "unread":
+                row.status = "want_to_read"
+                row.hardcover_synced_status = "want_to_read"
+                row.hardcover_user_book_id = shelf[book.hardcover_book_id]
+                stats["pulled"] += 1
+
+    # 3. Convergence: previously-agreed rows whose entry left the shelf.
+    agreed = (
+        db.query(UserBookStatus, Book)
+        .join(Book, UserBookStatus.book_id == Book.id)
+        .filter(
+            UserBookStatus.user_id == user.id,
+            UserBookStatus.status == "want_to_read",
+            UserBookStatus.hardcover_synced_status == "want_to_read",
+            Book.hardcover_book_id.isnot(None),
+        )
+        .all()
+    )
+    for row, book in agreed:
+        if book.hardcover_book_id in shelf:
+            continue
+        # Distinguish removed from moved: a targeted lookup per candidate
+        # (candidates are rare — only just-unshelved books reach here).
+        if not budget.spend():
+            break
+        data = await _gql(client, token, Q_USER_BOOK,
+                          {"uid": user.hardcover_user_id, "bid": book.hardcover_book_id})
+        existing = data.get("user_books") or []
+        if existing:
+            # Moved to another Hardcover status (reading/read/…): leave the
+            # Tome row queued and the snapshot intact so nothing re-pushes.
+            continue
+        row.status = "unread"
+        row.hardcover_synced_status = None
+        row.hardcover_user_book_id = None
+        row.hardcover_read_id = None
+        stats["reverted"] += 1
+
+    db.commit()
+
+    # 4. Shelf entries with NO Tome book at all become wishes (full circle:
+    # shelve a volume on Hardcover → it lands on the Tome wishlist). Runs after
+    # the status commit so an API/schema failure here can never cost applied
+    # statuses. Guarded against the owned-but-unmatched case: if the library
+    # already has a plausible copy (title/author fuzzy), no wish is created —
+    # the book just hasn't been catalogue-matched yet.
+    try:
+        stats.update(await _wishes_from_shelf(db, client, token, user, shelf, budget))
+        db.commit()
+    except (HardcoverAPIError, HardcoverRateLimited):
+        db.rollback()
+        logger.info("Hardcover pull: wish sync skipped for %s (API trouble)", user.username)
+    return stats
+
+
+async def _wishes_from_shelf(db: Session, client: httpx.AsyncClient, token: str,
+                             user: User, shelf: dict[int, int],
+                             budget: _Budget) -> dict:
+    """Create wishes for shelf entries that resolve to no Tome book, and keep
+    Hardcover-sourced wishes mirroring the shelf: un-shelving dismisses them,
+    re-shelving reopens them. Fulfilled wishes are final either way.
+
+    Consequence: for wishes this sync created, the shelf outranks an in-Tome
+    dismissal — an admin-dismissed one reopens next cycle while the book stays
+    shelved. Dedup for creation is create_wish's (user, source, source_id)
+    uniqueness. Does not commit — the caller owns the transaction.
+    """
+    from backend.schemas.wish import WishCreate
+    from backend.services.wish_matcher import find_matching_books
+    from backend.services.wishlist import create_wish
+
+    stats = {"wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    if not settings.wishlist_enabled:
+        return stats
+
+    # The shelf is authoritative for the wishes it created: un-shelving
+    # dismisses, re-shelving reopens. Both silent — the user made the change
+    # themselves on Hardcover; no notification. Fulfilled wishes are final and
+    # never reopened (the book is here; a lingering shelf entry changes nothing).
+    hc_wishes = (
+        db.query(Wish)
+        .filter(Wish.user_id == user.id, Wish.status.in_(("open", "dismissed")),
+                Wish.source == "hardcover", Wish.source_id.isnot(None))
+        .all()
+    )
+    shelf_ids = {str(bid) for bid in shelf}
+    for wish in hc_wishes:
+        if wish.status == "open" and wish.source_id not in shelf_ids:
+            wish.status = "dismissed"
+            stats["wish_dismissed"] += 1
+        elif wish.status == "dismissed" and wish.source_id in shelf_ids:
+            wish.status = "open"
+            stats["wish_reopened"] += 1
+
+    known_ids = {
+        hc_id for (hc_id,) in
+        db.query(Book.hardcover_book_id).filter(Book.hardcover_book_id.in_(shelf.keys()))
+    }
+    existing_wish_ids = {w.source_id for w in hc_wishes} | {
+        w.source_id for w in
+        db.query(Wish).filter(Wish.user_id == user.id, Wish.source == "hardcover",
+                              Wish.status == "fulfilled").all()
+    }
+    unresolved = [bid for bid in shelf
+                  if bid not in known_ids and str(bid) not in existing_wish_ids]
+    if not unresolved:
+        return stats
+
+    if not budget.spend():
+        return stats
+    data = await _gql(client, token, Q_BOOKS_BY_IDS, {"ids": unresolved})
+    for b in data.get("books") or []:
+        title = (b.get("title") or "").strip()
+        if not title or b.get("id") is None:
+            continue
+        authors = [((c.get("author") or {}).get("name") or "").strip()
+                   for c in (b.get("contributions") or [])]
+        author = next((a for a in authors if a), None)
+        # Owned-but-unmatched guard: a plausible library copy means the book is
+        # here already — skip the wish rather than asking for a duplicate.
+        probe = Wish(user_id=user.id, title=title, author=author, kind="wish")
+        if find_matching_books(db, probe):
+            logger.info(
+                "Hardcover pull: shelf entry %r looks already owned (unmatched) — "
+                "no wish created", title)
+            continue
+        cover = ((b.get("image") or {}).get("url") or "").strip() or None
+        try:
+            create_wish(db, user, WishCreate(
+                title=title, author=author, cover_url=cover,
+                source="hardcover", source_id=str(int(b["id"])),
+                note="Added from your Hardcover Want to Read shelf",
+            ))
+            stats["wished"] += 1
+        except HTTPException as exc:
+            # Cap reached / raced duplicate — skip quietly, retry next cycle.
+            logger.info("Hardcover pull: wish for %r not created (%s)", title, exc.detail)
+    return stats
+
+
 async def run_sync_cycle(reason: str = "interval", only_user_id: Optional[int] = None) -> dict:
     """One reconcile pass over all linked, enabled users."""
     from backend.core.database import SessionLocal
 
     budget = _Budget(MAX_REQUESTS_PER_CYCLE)
-    totals = {"users": 0, "pushed": 0, "failed": 0, "skipped_unmatched": 0, "exhausted": False}
+    totals = {"users": 0, "pushed": 0, "failed": 0, "skipped_unmatched": 0,
+              "pulled": 0, "reverted": 0, "wished": 0, "wish_dismissed": 0,
+              "wish_reopened": 0, "exhausted": False}
     with SessionLocal() as db:
         q = db.query(User).filter(
             User.hardcover_token.isnot(None),
@@ -890,8 +1134,30 @@ async def run_sync_cycle(reason: str = "interval", only_user_id: Optional[int] =
                     break
                 for k in ("pushed", "failed", "skipped_unmatched"):
                     totals[k] += stats[k]
+                # Inbound: Want to Read shelf pull (the one bidirectional piece).
+                # Runs after the push pass so freshly-pushed rows already carry
+                # their snapshot and read back as agreed, not as new pulls.
+                try:
+                    pull_stats = await pull_want_to_read(db, client, user, budget)
+                except HardcoverRateLimited:
+                    db.rollback()
+                    logger.warning("Hardcover pull: rate limited — ending cycle early")
+                    break
+                except HardcoverAuthError:
+                    db.rollback()
+                    mark_token_expired(db, user)
+                    continue
+                except HardcoverAPIError as exc:
+                    db.rollback()
+                    logger.info("Hardcover pull failed for %s: %s", user.username, exc)
+                    continue
+                for k in ("pulled", "reverted", "wished", "wish_dismissed",
+                          "wish_reopened"):
+                    # A partial-fetch abort returns without the wish counters.
+                    totals[k] += pull_stats.get(k, 0)
     totals["exhausted"] = budget.exhausted
-    if totals["pushed"] or totals["failed"]:
+    if any(totals[k] for k in ("pushed", "failed", "pulled", "reverted",
+                               "wished", "wish_dismissed", "wish_reopened")):
         logger.info("Hardcover sync (%s): %s", reason, totals)
     return totals
 

--- a/backend/services/shelf_resolver.py
+++ b/backend/services/shelf_resolver.py
@@ -65,7 +65,7 @@ def shelf_query(db: Session, user: User, params: dict):
         except (TypeError, ValueError):
             pass
     rs = params.get("reading_status")
-    if rs in ("reading", "read", "shelved"):
+    if rs in ("reading", "read", "shelved", "want_to_read"):
         query = query.join(
             UserBookStatus,
             (UserBookStatus.book_id == Book.id) & (UserBookStatus.user_id == user.id)

--- a/backend/services/wish_matcher.py
+++ b/backend/services/wish_matcher.py
@@ -338,9 +338,12 @@ def match_on_book_created(db: Session, book: "Book") -> list[Wish]:
             )
 
             # Standing whole-series wish (series set, no series_index): notify the
-            # requester that a volume arrived. Keeps the wish open.
+            # requester that a volume arrived and queue it on their Want to Read
+            # (guarded upsert, never downgrades). Keeps the wish open.
             if wish.series and wish.series_index is None and wish.status == "open":
                 _notify_volume_available(db, wish, book)
+                from backend.services.wishlist import queue_book_for_requester
+                queue_book_for_requester(db, wish.user_id, book.id)
         if matches:
             db.flush()
         return matches

--- a/backend/services/wishlist.py
+++ b/backend/services/wishlist.py
@@ -84,6 +84,30 @@ def create_wish(db: Session, user: User, payload: WishCreate) -> Wish:
     return wish
 
 
+def queue_book_for_requester(db: Session, user_id: int, book_id: int) -> bool:
+    """Carry a wish's intent across fulfilment: mark the arriving book
+    want_to_read for the requester.
+
+    Guarded — only creates a missing status row or upgrades an explicit
+    "unread"; never downgrades reading/read/shelved. Idempotent. Returns True
+    when a change was made. Does not commit — the caller owns the transaction.
+    """
+    from backend.models.user_book_status import UserBookStatus
+
+    row = (
+        db.query(UserBookStatus)
+        .filter_by(user_id=user_id, book_id=book_id)
+        .first()
+    )
+    if row is None:
+        db.add(UserBookStatus(user_id=user_id, book_id=book_id, status="want_to_read"))
+        return True
+    if row.status == "unread":
+        row.status = "want_to_read"
+        return True
+    return False
+
+
 def fulfill_wish(db: Session, wish: Wish, book: Optional["Book"], admin: User) -> Wish:  # type: ignore[name-defined]
     """Mark a wish as fulfilled, create an in-app notification, attempt email.
 
@@ -102,6 +126,11 @@ def fulfill_wish(db: Session, wish: Wish, book: Optional["Book"], admin: User) -
     wish.fulfilled_by = admin.id
     wish.fulfilled_at = datetime.utcnow()
     db.flush()
+
+    # The intent that created the wish carries over: the arriving book lands
+    # on the requester's Want to Read queue (guarded, never downgrades).
+    if book is not None:
+        queue_book_for_requester(db, wish.user_id, book.id)
 
     # In-app notification (always) — wording differs for a series completion
     if book is not None:

--- a/frontend/src/components/HardcoverSync.tsx
+++ b/frontend/src/components/HardcoverSync.tsx
@@ -20,7 +20,7 @@ interface HardcoverStatus {
 
 /**
  * Settings card: link a personal Hardcover account and push ratings + reading
- * progress one-way to it. Linking is the opt-in; the toggle pauses without
+ * progress to it (Want to Read syncs both ways). Linking is the opt-in; the toggle pauses without
  * unlinking. Match auditing/fixing lives on the dedicated /hardcover page —
  * this card only manages the connection. Renders nothing when the server has
  * the feature killed (404) — the parent section hides with us via onAvailable.
@@ -102,7 +102,7 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
     try {
       const r = await api.post<{ started: boolean }>('/hardcover/sync-now', {})
       if (r.started) {
-        toast.info('Sync started — pushing your ratings and progress to Hardcover')
+        toast.info('Sync started — pushing ratings and progress, syncing Want to Read both ways')
         setStatus(s => s ? { ...s, sync_running: true } : s)
       } else {
         toast.info('A sync is already running')
@@ -125,9 +125,9 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
             <div>
               <p className="text-sm font-medium text-foreground">Hardcover Sync</p>
               <p className="text-xs text-muted-foreground mt-0.5">
-                Push your ratings and reading progress to your Hardcover profile — one-way,
-                nothing is ever deleted there. Needs your personal API token (separate from
-                the server's metadata token).
+                Push your ratings and reading progress to your Hardcover profile — nothing
+                is ever deleted there. Your Hardcover Want to Read shelf syncs both ways.
+                Needs your personal API token (separate from the server's metadata token).
               </p>
             </div>
           </div>

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -57,7 +57,7 @@ export interface StatsResponse {
   }
   lifetime: { seconds: number; sessions: number; pages: number; books_finished: number; active_days: number; longest_streak_days: number }
   records: { longest_session_seconds: number; longest_session_title: string | null; biggest_day_seconds: number; biggest_day_date: string | null; most_pages_day: number; most_pages_date: string | null }
-  tbr: { owned: number; read: number; reading: number; shelved: number; unread: number; pct: number; by_type: { type: string; owned: number; read: number; pct: number }[] }
+  tbr: { owned: number; read: number; reading: number; shelved: number; want_to_read: number; unread: number; pct: number; by_type: { type: string; owned: number; read: number; pct: number }[] }
   language: { language: string; code: string; seconds: number; books: number }[]
   words: {
     total_words: number

--- a/frontend/src/components/stats/widgets/insights.tsx
+++ b/frontend/src/components/stats/widgets/insights.tsx
@@ -69,7 +69,7 @@ export function LibraryCompletion({ data }: { data: StatsResponse['tbr'] }) {
     <div className="flex flex-col gap-3">
       <div className="flex items-baseline gap-2">
         <span className="text-2xl font-bold text-foreground">{data.pct}%</span>
-        <span className="text-xs text-muted-foreground">{data.read} of {data.owned} owned read{data.reading ? ` · ${data.reading} reading` : ''}</span>
+        <span className="text-xs text-muted-foreground">{data.read} of {data.owned} owned read{data.reading ? ` · ${data.reading} reading` : ''}{data.want_to_read ? ` · ${data.want_to_read} want to read` : ''}</span>
       </div>
       <div className="flex flex-col gap-2">
         {data.by_type.map((t) => (

--- a/frontend/src/lib/books.ts
+++ b/frontend/src/lib/books.ts
@@ -111,7 +111,7 @@ export interface SavedFilter {
   sort_order: number
 }
 
-export type ReadingStatus = 'unread' | 'reading' | 'read' | 'shelved'
+export type ReadingStatus = 'unread' | 'reading' | 'read' | 'shelved' | 'want_to_read'
 
 export interface Arc {
   id: number

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -354,6 +354,7 @@ export function BookDetailPage() {
     reading: 'Marked as reading',
     read: 'Marked as read',
     shelved: 'Shelved — kept your progress',
+    want_to_read: 'Added to Want to Read',
   }
 
   async function handleStatusChange(s: ReadingStatus) {
@@ -699,10 +700,27 @@ export function BookDetailPage() {
           {s}
         </button>
       ))}
-      {/* Shelved — set apart from the linear unread→reading→read progression.
-          Keeps your reading position; just removes the book from Continue
-          Reading, series progress, and stats until you pick it back up. */}
+      {/* Want to Read + Shelved — set apart from the linear unread→reading→read
+          progression. Want to Read = queued next (self-promotes to reading on
+          first progress); Shelved keeps your reading position but removes the
+          book from Continue Reading, series progress, and stats until you pick
+          it back up. */}
       <span className="mx-1 h-4 w-px bg-border self-center" aria-hidden />
+      <button
+        key={bookStatus === 'want_to_read' ? `want_to_read-${statusPopKey}` : 'want_to_read'}
+        disabled={statusSaving}
+        onClick={() => handleStatusChange('want_to_read')}
+        title="Want to Read — queue this book up next"
+        className={cn(
+          'px-2.5 py-1 rounded-md text-xs font-medium border transition-all inline-flex items-center gap-1.5',
+          bookStatus === 'want_to_read'
+            ? 'bg-primary/10 border-primary text-primary animate-[pop_0.2s_ease-out]'
+            : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
+        )}
+      >
+        <BookMarked className="w-3.5 h-3.5" />
+        Want to Read
+      </button>
       <button
         key={bookStatus === 'shelved' ? `shelved-${statusPopKey}` : 'shelved'}
         disabled={statusSaving}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -57,7 +57,7 @@ interface SeriesDetailBook {
   title: string
   series_index: number | null
   cover_path: string | null
-  reading_status: 'unread' | 'reading' | 'read' | 'shelved'
+  reading_status: 'unread' | 'reading' | 'read' | 'shelved' | 'want_to_read'
   progress_pct: number | null
 }
 
@@ -384,6 +384,9 @@ export function DashboardPage() {
     if (books.length === 0) return null
     const reading = books.find(b => b.reading_status === 'reading')
     if (reading) return reading
+    // Explicit intent beats position: a queued (want-to-read) volume is next.
+    const queued = books.find(b => b.reading_status === 'want_to_read')
+    if (queued) return queued
     // Find first unread where previous volume (by index order) is read
     for (let i = 1; i < books.length; i++) {
       if (books[i].reading_status === 'unread' && books[i - 1].reading_status === 'read') {
@@ -1980,7 +1983,7 @@ export function DashboardPage() {
               </div>
               <div className="flex items-center gap-2 flex-wrap">
                 <span className="text-xs text-muted-foreground font-medium w-14">Status</span>
-                {(['', 'unread', 'reading', 'read', 'shelved'] as const).map(s => (
+                {(['', 'unread', 'want_to_read', 'reading', 'read', 'shelved'] as const).map(s => (
                   <button
                     key={s}
                     onClick={() => setFilter('reading_status', s)}
@@ -1991,7 +1994,7 @@ export function DashboardPage() {
                         : 'border-border bg-card text-muted-foreground hover:text-foreground'
                     )}
                   >
-                    {s === '' ? 'All' : s.charAt(0).toUpperCase() + s.slice(1)}
+                    {s === '' ? 'All' : s === 'want_to_read' ? 'Want to Read' : s.charAt(0).toUpperCase() + s.slice(1)}
                   </button>
                 ))}
               </div>

--- a/tests/test_book_status.py
+++ b/tests/test_book_status.py
@@ -239,3 +239,66 @@ def test_mark_read_at_full_progress(client: TestClient, make_book):
     data = _get_status(client, book.id)
     assert data["status"] == "read"
     assert data["progress_pct"] == pytest.approx(1.0)
+
+
+# ── want_to_read ──────────────────────────────────────────────────────────────
+
+def test_want_to_read_accepted_and_filterable(client: TestClient, make_book):
+    """want_to_read is a valid fifth status and drives the list filter."""
+    queued = make_book(title="Queued Book")
+    plain = make_book(title="Plain Unread Book")
+
+    data = _put_status(client, queued.id, {"status": "want_to_read"})
+    assert data["status"] == "want_to_read"
+
+    resp = client.get("/api/books", params={"reading_status": "want_to_read"})
+    assert resp.status_code == 200
+    ids = [b["id"] for b in resp.json()]
+    assert queued.id in ids and plain.id not in ids
+
+    # A queued book is no longer "unread" for the filter
+    resp = client.get("/api/books", params={"reading_status": "unread"})
+    ids = [b["id"] for b in resp.json()]
+    assert queued.id not in ids and plain.id in ids
+
+
+def test_want_to_read_keeps_progress(client: TestClient, make_book):
+    """Unlike unread, queueing a sampled book keeps its position (like shelved)."""
+    book = make_book(title="Sampled Then Queued")
+    _put_status(client, book.id, {"status": "reading", "progress_pct": 0.1, "cfi": "x"})
+
+    data = _put_status(client, book.id, {"status": "want_to_read"})
+    assert data["progress_pct"] == pytest.approx(0.1)
+    assert data["cfi"] == "x"
+
+
+def test_invalid_status_rejected(client: TestClient, make_book):
+    book = make_book(title="Bad Status")
+    resp = client.put(f"/api/books/{book.id}/status", json={"status": "wishlisted"})
+    assert resp.status_code == 400
+
+
+def test_want_to_read_promotes_to_reading_on_progress(db: Session, client: TestClient, admin_user, make_book):
+    """First real progress self-promotes a queued book (device/web sync path)."""
+    from backend.services.book_progress import apply_progress_to_status
+
+    user, _ = admin_user
+    book = make_book(title="Queued Promotion")
+    _put_status(client, book.id, {"status": "want_to_read"})
+
+    row = apply_progress_to_status(db, user_id=user.id, book_id=book.id, pct=0.05)
+    db.flush()
+    assert row.status == "reading"
+
+
+def test_want_to_read_finishes_straight_to_read(db: Session, client: TestClient, admin_user, make_book):
+    from backend.services.book_progress import apply_progress_to_status
+
+    user, _ = admin_user
+    book = make_book(title="Queued Straight To Read")
+    _put_status(client, book.id, {"status": "want_to_read"})
+
+    row = apply_progress_to_status(db, user_id=user.id, book_id=book.id, pct=1.0)
+    db.flush()
+    assert row.status == "read"
+    assert row.finished_at is not None

--- a/tests/test_hardcover_sync.py
+++ b/tests/test_hardcover_sync.py
@@ -903,3 +903,312 @@ def test_sync_now_retries_unmatched_books(client, db, admin_user, make_book, mon
     # Explicit click clears the failed-match marker so the matcher tries again.
     assert book.hardcover_match_method is None
     assert book.hardcover_matched_at is None
+
+
+# ── want_to_read: reconciler diff + push ──────────────────────────────────────
+
+def test_needs_sync_want_to_read():
+    # Newly queued → status push needed
+    assert hs.needs_sync(_row(status="want_to_read"))
+    # Agreed on both sides → quiet, even with leftover sample progress
+    assert not hs.needs_sync(_row(status="want_to_read",
+                                  hardcover_synced_status="want_to_read",
+                                  progress_pct=0.15))
+
+
+@respx.mock
+async def test_push_row_want_to_read_no_read_row(db, admin_user, make_book):
+    """Queued books get a shelf entry (status 1) but never a progress read-row,
+    even when they carry leftover sample progress and the edition has pages."""
+    user, _ = admin_user
+    user.hardcover_user_id = 42
+    book = make_book(title="Queued Push")
+    book.hardcover_book_id = 77
+    book.hardcover_edition_id = 555
+    book.hardcover_pages = 400
+    row = UserBookStatus(user_id=user.id, book_id=book.id, status="want_to_read",
+                         progress_pct=0.2)
+    db.add(row)
+    db.flush()
+
+    seen = []
+
+    def responder(request):
+        body = request.read().decode()
+        seen.append(body)
+        assert "InsertRead" not in body and "UpdateRead" not in body \
+            and "query Reads" not in body, "want_to_read must never touch read rows"
+        if "query UserBook" in body:
+            return httpx.Response(200, json={"data": {"user_books": []}})
+        if "mutation InsertUserBook" in body:
+            assert '"status_id": 1' in body or '"status_id":1' in body
+            return httpx.Response(200, json={"data": {"insert_user_book": {"id": 1001, "error": None}}})
+        return httpx.Response(200, json={"data": {}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        await hs._push_row(client, "tok", user, row, book)
+
+    assert row.hardcover_user_book_id == 1001
+    assert row.hardcover_synced_status == "want_to_read"
+    assert not hs.needs_sync(row)
+
+
+# ── want_to_read: pull direction ──────────────────────────────────────────────
+
+def _link_pull_user(user):
+    from backend.core.crypto import encrypt_secret
+    user.hardcover_token = encrypt_secret("Bearer hc_tok")
+    user.hardcover_token_status = "ok"
+    user.hardcover_sync_enabled = True
+    user.hardcover_user_id = 42
+
+
+def _shelf_responder(shelf_entries, user_book_lookups=None):
+    """Responder serving the WTR shelf query and targeted UserBook lookups."""
+    def responder(request):
+        body = request.read().decode()
+        if "query WantToReadShelf" in body:
+            return httpx.Response(200, json={"data": {"user_books": shelf_entries}})
+        if "query UserBook" in body:
+            import json as _json
+            bid = _json.loads(body)["variables"]["bid"]
+            found = (user_book_lookups or {}).get(bid, [])
+            return httpx.Response(200, json={"data": {"user_books": found}})
+        return httpx.Response(200, json={"data": {}})
+    return responder
+
+
+@respx.mock
+async def test_pull_wtr_applies_to_missing_and_unread(db, admin_user, make_book):
+    user, _ = admin_user
+    _link_pull_user(user)
+    matched_new = make_book(title="Shelved On HC")
+    matched_new.hardcover_book_id = 77
+    matched_unread = make_book(title="Unread In Tome")
+    matched_unread.hardcover_book_id = 88
+    db.add(UserBookStatus(user_id=user.id, book_id=matched_unread.id, status="unread"))
+    db.flush()
+
+    respx.post(HARDCOVER_URL).mock(side_effect=_shelf_responder(
+        [{"id": 501, "book_id": 77}, {"id": 502, "book_id": 88}]))
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+
+    assert stats == {"pulled": 2, "reverted": 0, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    for book, ub_id in ((matched_new, 501), (matched_unread, 502)):
+        row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
+        assert row.status == "want_to_read"
+        assert row.hardcover_synced_status == "want_to_read"
+        assert row.hardcover_user_book_id == ub_id
+        # Echo prevention: the push reconciler must see no diff
+        assert not hs.needs_sync(row)
+
+
+@respx.mock
+async def test_pull_wtr_never_downgrades_engagement(db, admin_user, make_book):
+    user, _ = admin_user
+    _link_pull_user(user)
+    book = make_book(title="Reading In Tome")
+    book.hardcover_book_id = 77
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="reading",
+                          progress_pct=0.6))
+    db.flush()
+
+    respx.post(HARDCOVER_URL).mock(side_effect=_shelf_responder(
+        [{"id": 501, "book_id": 77}]))
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+
+    assert stats == {"pulled": 0, "reverted": 0, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
+    assert row.status == "reading"
+
+
+@respx.mock
+async def test_pull_wtr_convergence_removed_vs_moved(db, admin_user, make_book):
+    """Both sides had agreed want_to_read. Entry gone from HC entirely → revert
+    to unread; entry merely moved to another HC status → leave both sides be."""
+    user, _ = admin_user
+    _link_pull_user(user)
+    removed = make_book(title="Unshelved On HC")
+    removed.hardcover_book_id = 77
+    moved = make_book(title="Moved To Reading On HC")
+    moved.hardcover_book_id = 88
+    for book in (removed, moved):
+        db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="want_to_read",
+                              hardcover_synced_status="want_to_read",
+                              hardcover_user_book_id=600 + book.id))
+    db.flush()
+
+    respx.post(HARDCOVER_URL).mock(side_effect=_shelf_responder(
+        [],  # WTR shelf is now empty
+        user_book_lookups={77: [], 88: [{"id": 999, "status_id": 2, "user_book_reads": []}]},
+    ))
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+
+    assert stats == {"pulled": 0, "reverted": 1, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    removed_row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=removed.id).one()
+    assert removed_row.status == "unread"
+    assert removed_row.hardcover_synced_status is None
+    moved_row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=moved.id).one()
+    assert moved_row.status == "want_to_read"
+    assert moved_row.hardcover_synced_status == "want_to_read"
+    # Snapshot intact → nothing re-pushes over the user's HC-side change
+    assert not hs.needs_sync(moved_row)
+
+
+@respx.mock
+async def test_pull_wtr_tome_only_row_untouched_by_convergence(db, admin_user, make_book):
+    """A Tome-set want_to_read that was never pushed (no snapshot) must survive
+    an empty HC shelf — convergence only reverts previously-agreed rows."""
+    user, _ = admin_user
+    _link_pull_user(user)
+    book = make_book(title="Tome Only Queue")
+    book.hardcover_book_id = 77
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="want_to_read"))
+    db.flush()
+
+    respx.post(HARDCOVER_URL).mock(side_effect=_shelf_responder([]))
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+
+    assert stats == {"pulled": 0, "reverted": 0, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
+    assert row.status == "want_to_read"
+
+
+@respx.mock
+async def test_pull_wtr_partial_fetch_aborts(db, admin_user, make_book):
+    """Budget exhaustion mid-fetch must abort the whole pull — applying a
+    partial shelf would mass-revert agreed rows."""
+    user, _ = admin_user
+    _link_pull_user(user)
+    book = make_book(title="Agreed Queued")
+    book.hardcover_book_id = 77
+    db.add(UserBookStatus(user_id=user.id, book_id=book.id, status="want_to_read",
+                          hardcover_synced_status="want_to_read"))
+    db.flush()
+
+    respx.post(HARDCOVER_URL).mock(side_effect=_shelf_responder([]))
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(0))
+
+    assert stats == {"pulled": 0, "reverted": 0}
+    row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
+    assert row.status == "want_to_read"  # untouched
+
+
+# ── want_to_read pull: unresolved entries → wishlist ──────────────────────────
+
+def _shelf_with_books_responder(shelf_entries, books_by_ids):
+    def responder(request):
+        body = request.read().decode()
+        if "query WantToReadShelf" in body:
+            return httpx.Response(200, json={"data": {"user_books": shelf_entries}})
+        if "query BooksByIds" in body:
+            return httpx.Response(200, json={"data": {"books": books_by_ids}})
+        if "query UserBook" in body:
+            return httpx.Response(200, json={"data": {"user_books": []}})
+        return httpx.Response(200, json={"data": {}})
+    return responder
+
+
+@respx.mock
+async def test_pull_wtr_unresolved_entry_creates_wish(db, admin_user):
+    """A shelf entry with no Tome book becomes a wish — and stays deduped."""
+    from backend.models.wish import Wish
+
+    user, _ = admin_user
+    _link_pull_user(user)
+
+    responder = _shelf_with_books_responder(
+        [{"id": 501, "book_id": 999}],
+        [{"id": 999, "title": "Not In Tome Yet", "slug": "not-in-tome",
+          "image": {"url": "https://img.example/x.jpg"},
+          "contributions": [{"author": {"name": "Shelf Author"}}]}],
+    )
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+    assert stats["wished"] == 1
+
+    wish = db.query(Wish).filter_by(user_id=user.id, source="hardcover", source_id="999").one()
+    assert wish.status == "open"
+    assert wish.title == "Not In Tome Yet"
+    assert wish.author == "Shelf Author"
+    assert wish.cover_url == "https://img.example/x.jpg"
+
+    # Second cycle: the existing wish blocks re-creation (no API refetch needed)
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+    assert stats["wished"] == 0
+    assert db.query(Wish).filter_by(user_id=user.id, source="hardcover").count() == 1
+
+
+@respx.mock
+async def test_pull_wtr_owned_but_unmatched_creates_no_wish(db, admin_user, make_book):
+    """A library book that simply lacks a catalogue match must not spawn a wish."""
+    from backend.models.wish import Wish
+
+    user, _ = admin_user
+    _link_pull_user(user)
+    make_book(title="Already Owned Novel", author="Owned Author")  # no hardcover_book_id
+
+    responder = _shelf_with_books_responder(
+        [{"id": 501, "book_id": 999}],
+        [{"id": 999, "title": "Already Owned Novel", "slug": "owned",
+          "contributions": [{"author": {"name": "Owned Author"}}]}],
+    )
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+    assert stats["wished"] == 0
+    assert db.query(Wish).filter_by(user_id=user.id).count() == 0
+
+
+@respx.mock
+async def test_pull_wtr_unshelve_dismisses_hardcover_wish(db, admin_user):
+    """Un-shelving on Hardcover auto-dismisses the wish it created."""
+    from backend.models.wish import Wish
+
+    user, _ = admin_user
+    _link_pull_user(user)
+    db.add(Wish(user_id=user.id, title="Was Shelved", source="hardcover",
+                source_id="999", status="open", kind="wish"))
+    db.flush()
+
+    respx.post(HARDCOVER_URL).mock(side_effect=_shelf_with_books_responder([], []))
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+    assert stats["wish_dismissed"] == 1
+
+    wish = db.query(Wish).filter_by(user_id=user.id, source_id="999").one()
+    assert wish.status == "dismissed"
+
+
+@respx.mock
+async def test_pull_wtr_reshelve_reopens_dismissed_wish(db, admin_user):
+    """Re-shelving a previously un-shelved book reopens its dismissed wish
+    instead of being blocked by the dedup — the shelf is authoritative for
+    the wishes it created. Fulfilled wishes stay final."""
+    from backend.models.wish import Wish
+
+    user, _ = admin_user
+    _link_pull_user(user)
+    db.add(Wish(user_id=user.id, title="Shelved Again", source="hardcover",
+                source_id="999", status="dismissed", kind="wish"))
+    db.add(Wish(user_id=user.id, title="Already Fulfilled", source="hardcover",
+                source_id="888", status="fulfilled", kind="wish"))
+    db.flush()
+
+    respx.post(HARDCOVER_URL).mock(side_effect=_shelf_with_books_responder(
+        [{"id": 501, "book_id": 999}, {"id": 502, "book_id": 888}], []))
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+
+    assert stats["wish_reopened"] == 1
+    assert stats["wished"] == 0  # reopened, not recreated
+    assert db.query(Wish).filter_by(user_id=user.id, source_id="999").one().status == "open"
+    assert db.query(Wish).filter_by(user_id=user.id, source_id="888").one().status == "fulfilled"

--- a/tests/test_wishlist.py
+++ b/tests/test_wishlist.py
@@ -712,3 +712,66 @@ def test_series_coverage_author_disambiguation(client: TestClient, db: Session, 
     w = client.get("/api/wishlist?status=open").json()[0]
     titles = {v["title"] for v in (w["series_coverage"] or [])}
     assert titles == {"Ugland Vol 1"}
+
+
+# ── Want to Read handoff ──────────────────────────────────────────────────────
+
+def test_fulfill_queues_book_for_requester(client: TestClient, db: Session, admin_user, make_book):
+    """Fulfilling a wish sets the requester's status to want_to_read."""
+    from backend.models.user_book_status import UserBookStatus
+
+    member, member_token = _make_member(db, "member_queue")
+    client.headers["Authorization"] = f"Bearer {member_token}"
+    wish_id = client.post("/api/wishlist", json=_wish_payload()).json()["id"]
+
+    book = make_book(title="Wished Arrival")
+    _admin, admin_token = admin_user
+    client.headers["Authorization"] = f"Bearer {admin_token}"
+    resp = client.post(f"/api/admin/wishlist/{wish_id}/fulfill", json={"book_id": book.id})
+    assert resp.status_code == 200, resp.text
+
+    row = db.query(UserBookStatus).filter_by(user_id=member.id, book_id=book.id).one()
+    assert row.status == "want_to_read"
+
+
+def test_fulfill_never_downgrades_engagement(client: TestClient, db: Session, admin_user, make_book):
+    """A requester already reading the arriving book keeps their status."""
+    from backend.models.user_book_status import UserBookStatus
+
+    member, member_token = _make_member(db, "member_reading")
+    client.headers["Authorization"] = f"Bearer {member_token}"
+    wish_id = client.post("/api/wishlist", json=_wish_payload()).json()["id"]
+
+    book = make_book(title="Already Reading Arrival")
+    db.add(UserBookStatus(user_id=member.id, book_id=book.id, status="reading", progress_pct=0.4))
+    db.flush()
+
+    _admin, admin_token = admin_user
+    client.headers["Authorization"] = f"Bearer {admin_token}"
+    resp = client.post(f"/api/admin/wishlist/{wish_id}/fulfill", json={"book_id": book.id})
+    assert resp.status_code == 200, resp.text
+
+    row = db.query(UserBookStatus).filter_by(user_id=member.id, book_id=book.id).one()
+    assert row.status == "reading"
+    assert row.progress_pct == 0.4
+
+
+def test_series_wish_volume_arrival_queues(client: TestClient, db: Session, admin_user, make_book):
+    """A volume matching a standing whole-series wish lands queued for the requester."""
+    from backend.models.user_book_status import UserBookStatus
+    from backend.services.wish_matcher import match_on_book_created
+
+    member, member_token = _make_member(db, "member_series_queue")
+    client.headers["Authorization"] = f"Bearer {member_token}"
+    resp = client.post("/api/wishlist", json={
+        "title": "Great Series", "series": "Great Series", "author": "Serial Author",
+    })
+    assert resp.status_code == 201, resp.text
+
+    book = make_book(title="Great Series Vol. 3", series="Great Series",
+                     series_index=3, author="Serial Author")
+    match_on_book_created(db, book)
+    db.flush()
+
+    row = db.query(UserBookStatus).filter_by(user_id=member.id, book_id=book.id).first()
+    assert row is not None and row.status == "want_to_read"


### PR DESCRIPTION
## What

A fifth reading status, **Want to Read** — the missing state between the wishlist and actually starting a book: owned, not started, queued next. Plus the first inbound Hardcover sync direction: the Want to Read shelf now syncs both ways, and shelf entries Tome doesn't own become wishes.

## Status core

- Book page gets a Want to Read chip (next to Shelved); dashboard gets a filter chip
- Queueing keeps progress/CFI (like Shelved — only Unread clears)
- First real progress from KOReader or the web reader self-promotes the book to Reading
- Series continue-suggestions prefer a queued volume over plain unread; a zero-position restore no longer demotes a queued book
- Stats Library Completion tile shows a queued count

## Wish handoff

Fulfilling a wish — and each arriving volume of a followed series — sets the requester's status to `want_to_read`, guarded: only fills a missing/unread row, never downgrades reading/read/shelved.

## Hardcover push

`want_to_read` maps to Hardcover's Want to Read shelf (status 1). Queued books get a shelf entry but never a progress read-row, even with leftover sample progress.

## Hardcover pull (new direction)

Each sync cycle (and Sync now) fetches the user's Want to Read shelf:

- **Additive apply**: resolved entries (via `Book.hardcover_book_id`) fill missing/unread rows only; engagement always wins. Applied rows are snapshot-stamped so nothing echoes back.
- **Convergence**: removal on Hardcover reverts a row only when both sides had agreed it was want-to-read; an entry merely *moved* to another Hardcover status leaves both sides alone (engagement stays push-only — only Tome witnesses actual reading).
- **Safety**: a partial shelf fetch aborts the whole pull, so it can never mass-revert.
- **Wishes**: shelf entries with no Tome book become wishes (title/author/cover from the catalogue). Un-shelving dismisses the wish, re-shelving reopens it — the shelf is authoritative for wishes it created. Owned-but-unmatched library books are recognised by title/author and skipped.

## Schema

No new columns. New index on `books.hardcover_book_id` (startup migration, ordered after the legacy column-add).

## Testing

- 1079 backend tests pass; ~19 new ones across status validation/filtering, progress promotion, wish handoff, push mapping, pull apply/convergence/echo-prevention, and the wish-from-shelf lifecycle
- Frontend `tsc -b` + build green
- Verified live end to end against a real Hardcover account (dev instance): push, pull into status, pull into wishlist, shelf-removal revert, wish dismiss + reopen

Known limitation: a shelf entry only resolves once Tome has catalogue-matched the book, which happens lazily on first push need; until then the entry is skipped each cycle (or wished for, if the book isn't in Tome at all).