### PR TITLE
fix(hardcover): shelf mirror must only touch wishes it created + startup repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,9 @@ All notable changes to Tome are documented here. Format loosely follows
   progress remain push-only as before. Shelving a book Tome doesn't have at
   all creates a wish on your Tome wishlist instead (with cover and author from
   the Hardcover catalogue), un-shelving it on Hardcover dismisses that wish
-  again, and re-shelving it reopens the same wish. Books already in the
-  library that merely lack a catalogue match are recognised and skipped
-  rather than wished for twice.
+  again, and re-shelving it reopens the same wish. A shelved book that is
+  already in the library but was never catalogue-matched adopts its match
+  straight from the shelf entry and lands queued, instead of being skipped.
 - Library Health now detects orphaned entries — books whose files no longer
   exist on disk (for example after files were deleted or moved outside of
   Tome). A new section lists them and a one-click "Remove Dead Entries" action
@@ -66,6 +66,12 @@ All notable changes to Tome are documented here. Format loosely follows
   any failures. (#165)
 
 ### Fixed
+- The Hardcover shelf sync's first cycle could wrongly dismiss open series
+  follows and user-created wishes whose metadata came from Hardcover (they
+  share the "hardcover" source marker with wishes the sync creates). The
+  shelf mirror now only ever touches wishes it created itself, and on the
+  first start after updating, wrongly-dismissed follows and wishes are
+  reopened automatically — admin-dismissed wishes stay closed.
 - OPDS feed links now carry the correct public scheme behind a TLS-terminating
   reverse proxy. The feed built its links from the request as the app server
   saw it — plain http — so every navigation, download, and cover link came out

--- a/backend/main.py
+++ b/backend/main.py
@@ -331,6 +331,16 @@ async def lifespan(app: FastAPI):
     with SessionLocal() as db:
         seed_book_types(db)
 
+    # Repair collateral from the first 2.2.0 build's Hardcover shelf mirror
+    # (wrongly-dismissed follows/wishes; see repair_shelf_sync_collateral).
+    # Idempotent, no-op on clean installs.
+    from backend.services.hardcover_sync import repair_shelf_sync_collateral
+    try:
+        with SessionLocal() as db:
+            repair_shelf_sync_collateral(db)
+    except Exception:
+        logger.exception("Hardcover shelf-sync repair failed (continuing startup)")
+
     # Start background auto-import task if enabled
     auto_import_task: asyncio.Task | None = None
     if settings.auto_import:

--- a/backend/services/hardcover_sync.py
+++ b/backend/services/hardcover_sync.py
@@ -78,6 +78,14 @@ AUTHOR_SIM_MIN = 0.7
 # ISBNs too (Podium!) and have no page counts — never pin one.
 AUDIO_FORMAT_ID = 2
 
+# Marks wishes CREATED BY the shelf pull — the only wishes the shelf mirror is
+# allowed to dismiss/reopen. Deliberately distinct from source="hardcover",
+# which user-created wishes (metadata search) and series follows also carry:
+# filtering the mirror on that dismissed every open follow on first sync
+# (their "series:<id>" source_ids can never appear in a shelf of book ids).
+SHELF_WISH_SOURCE = "hardcover_shelf"
+SHELF_WISH_NOTE = "Added from your Hardcover Want to Read shelf"
+
 # ── GraphQL documents ─────────────────────────────────────────────────────────
 # Pinned to the beta schema as of 2026-07. Responses are parsed defensively;
 # schema drift surfaces as a per-row error, not a crash.
@@ -771,6 +779,49 @@ async def _push_row(client: httpx.AsyncClient, token: str, user: User,
     row.hardcover_fail_count = 0
 
 
+def repair_shelf_sync_collateral(db: Session) -> dict:
+    """One-time startup repair for the first shipped 2.2.0 build, whose shelf
+    mirror filtered wishes on source="hardcover" without kind — dismissing
+    every open series follow (kind="follow") and every user-created wish whose
+    metadata happened to come from Hardcover, on the first sync cycle.
+
+    Precisely reversible because the legitimate paths are distinguishable:
+    users DELETE their own wishes/follows (rows vanish), and an admin dismiss
+    writes a "wishlist.dismissed" audit entry. A dismissed source="hardcover"
+    row with no such audit entry can only be the bug's work → reopen it.
+
+    Also reclassifies wishes the shelf sync itself created under the old
+    ambiguous source (identified by their fixed note text) to
+    SHELF_WISH_SOURCE, keeping their dismiss/reopen mirroring intact.
+    Idempotent; safe to run every boot. Commits."""
+    from backend.models.audit_log import AuditLog
+
+    reclassified = (
+        db.query(Wish)
+        .filter(Wish.kind == "wish", Wish.source == "hardcover",
+                Wish.note == SHELF_WISH_NOTE)
+        .update({"source": SHELF_WISH_SOURCE}, synchronize_session=False)
+    )
+    admin_dismissed = (
+        db.query(AuditLog.resource_id)
+        .filter(AuditLog.action == "wishlist.dismissed",
+                AuditLog.resource_id.isnot(None))
+    )
+    reopened = (
+        db.query(Wish)
+        .filter(Wish.status == "dismissed", Wish.source == "hardcover",
+                ~Wish.id.in_(admin_dismissed))
+        .update({"status": "open"}, synchronize_session=False)
+    )
+    db.commit()
+    if reclassified or reopened:
+        logger.info(
+            "Hardcover shelf-sync repair: reopened %d wrongly-dismissed "
+            "wishes/follows, reclassified %d shelf-created wishes",
+            reopened, reclassified)
+    return {"reopened": reopened, "reclassified": reclassified}
+
+
 def mark_token_expired(db: Session, user: User) -> None:
     """Flip token status and notify once."""
     if user.hardcover_token_status == "expired":
@@ -1035,18 +1086,21 @@ async def _wishes_from_shelf(db: Session, client: httpx.AsyncClient, token: str,
     from backend.services.wish_matcher import find_matching_books
     from backend.services.wishlist import create_wish
 
-    stats = {"wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    stats = {"wished": 0, "wish_dismissed": 0, "wish_reopened": 0, "adopted": 0}
     if not settings.wishlist_enabled:
         return stats
 
-    # The shelf is authoritative for the wishes it created: un-shelving
-    # dismisses, re-shelving reopens. Both silent — the user made the change
-    # themselves on Hardcover; no notification. Fulfilled wishes are final and
-    # never reopened (the book is here; a lingering shelf entry changes nothing).
+    # The shelf is authoritative for the wishes it created — and ONLY those
+    # (SHELF_WISH_SOURCE; never follows, never user-created wishes that merely
+    # cite Hardcover as their metadata source). Un-shelving dismisses,
+    # re-shelving reopens. Both silent — the user made the change themselves on
+    # Hardcover; no notification. Fulfilled wishes are final and never
+    # reopened (the book is here; a lingering shelf entry changes nothing).
     hc_wishes = (
         db.query(Wish)
-        .filter(Wish.user_id == user.id, Wish.status.in_(("open", "dismissed")),
-                Wish.source == "hardcover", Wish.source_id.isnot(None))
+        .filter(Wish.user_id == user.id, Wish.kind == "wish",
+                Wish.status.in_(("open", "dismissed")),
+                Wish.source == SHELF_WISH_SOURCE, Wish.source_id.isnot(None))
         .all()
     )
     shelf_ids = {str(bid) for bid in shelf}
@@ -1064,7 +1118,8 @@ async def _wishes_from_shelf(db: Session, client: httpx.AsyncClient, token: str,
     }
     existing_wish_ids = {w.source_id for w in hc_wishes} | {
         w.source_id for w in
-        db.query(Wish).filter(Wish.user_id == user.id, Wish.source == "hardcover",
+        db.query(Wish).filter(Wish.user_id == user.id,
+                              Wish.source == SHELF_WISH_SOURCE,
                               Wish.status == "fulfilled").all()
     }
     unresolved = [bid for bid in shelf
@@ -1082,20 +1137,53 @@ async def _wishes_from_shelf(db: Session, client: httpx.AsyncClient, token: str,
         authors = [((c.get("author") or {}).get("name") or "").strip()
                    for c in (b.get("contributions") or [])]
         author = next((a for a in authors if a), None)
-        # Owned-but-unmatched guard: a plausible library copy means the book is
-        # here already — skip the wish rather than asking for a duplicate.
+        # Owned-but-unmatched: a plausible library copy means the book is here
+        # already — never wish for it. With exactly ONE candidate the shelf
+        # entry itself IS the missing catalogue match (matching is lazy and an
+        # unread book never triggers it), so adopt it and queue the book
+        # instead of dead-ending. Multiple candidates are too ambiguous to
+        # write a book-level match.
         probe = Wish(user_id=user.id, title=title, author=author, kind="wish")
-        if find_matching_books(db, probe):
-            logger.info(
-                "Hardcover pull: shelf entry %r looks already owned (unmatched) — "
-                "no wish created", title)
+        candidates = find_matching_books(db, probe)
+        if candidates:
+            cand = candidates[0]
+            if (len(candidates) == 1 and cand.hardcover_book_id is None
+                    and cand.status == "active"
+                    and _isbn_hit_plausible(cand, title)):
+                cand.hardcover_book_id = int(b["id"])
+                cand.hardcover_slug = b.get("slug")
+                cand.hardcover_match_method = "shelf"
+                cand.hardcover_matched_at = datetime.utcnow()
+                if budget.spend():
+                    await _adopt_best_edition(client, token, cand)
+                row = (
+                    db.query(UserBookStatus)
+                    .filter_by(user_id=user.id, book_id=cand.id)
+                    .first()
+                )
+                if row is None:
+                    db.add(UserBookStatus(
+                        user_id=user.id, book_id=cand.id, status="want_to_read",
+                        hardcover_synced_status="want_to_read",
+                        hardcover_user_book_id=shelf.get(int(b["id"])),
+                    ))
+                elif row.status == "unread":
+                    row.status = "want_to_read"
+                    row.hardcover_synced_status = "want_to_read"
+                    row.hardcover_user_book_id = shelf.get(int(b["id"]))
+                stats["adopted"] += 1
+            else:
+                logger.info(
+                    "Hardcover pull: shelf entry %r looks already owned "
+                    "(unmatched, %d candidates) — no wish created",
+                    title, len(candidates))
             continue
         cover = ((b.get("image") or {}).get("url") or "").strip() or None
         try:
             create_wish(db, user, WishCreate(
                 title=title, author=author, cover_url=cover,
-                source="hardcover", source_id=str(int(b["id"])),
-                note="Added from your Hardcover Want to Read shelf",
+                source=SHELF_WISH_SOURCE, source_id=str(int(b["id"])),
+                note=SHELF_WISH_NOTE,
             ))
             stats["wished"] += 1
         except HTTPException as exc:
@@ -1111,7 +1199,7 @@ async def run_sync_cycle(reason: str = "interval", only_user_id: Optional[int] =
     budget = _Budget(MAX_REQUESTS_PER_CYCLE)
     totals = {"users": 0, "pushed": 0, "failed": 0, "skipped_unmatched": 0,
               "pulled": 0, "reverted": 0, "wished": 0, "wish_dismissed": 0,
-              "wish_reopened": 0, "exhausted": False}
+              "wish_reopened": 0, "adopted": 0, "exhausted": False}
     with SessionLocal() as db:
         q = db.query(User).filter(
             User.hardcover_token.isnot(None),
@@ -1152,12 +1240,13 @@ async def run_sync_cycle(reason: str = "interval", only_user_id: Optional[int] =
                     logger.info("Hardcover pull failed for %s: %s", user.username, exc)
                     continue
                 for k in ("pulled", "reverted", "wished", "wish_dismissed",
-                          "wish_reopened"):
+                          "wish_reopened", "adopted"):
                     # A partial-fetch abort returns without the wish counters.
                     totals[k] += pull_stats.get(k, 0)
     totals["exhausted"] = budget.exhausted
     if any(totals[k] for k in ("pushed", "failed", "pulled", "reverted",
-                               "wished", "wish_dismissed", "wish_reopened")):
+                               "wished", "wish_dismissed", "wish_reopened",
+                               "adopted")):
         logger.info("Hardcover sync (%s): %s", reason, totals)
     return totals
 

--- a/tests/test_hardcover_sync.py
+++ b/tests/test_hardcover_sync.py
@@ -995,7 +995,7 @@ async def test_pull_wtr_applies_to_missing_and_unread(db, admin_user, make_book)
     async with httpx.AsyncClient() as client:
         stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
 
-    assert stats == {"pulled": 2, "reverted": 0, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    assert stats == {"pulled": 2, "reverted": 0, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0, "adopted": 0}
     for book, ub_id in ((matched_new, 501), (matched_unread, 502)):
         row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
         assert row.status == "want_to_read"
@@ -1020,7 +1020,7 @@ async def test_pull_wtr_never_downgrades_engagement(db, admin_user, make_book):
     async with httpx.AsyncClient() as client:
         stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
 
-    assert stats == {"pulled": 0, "reverted": 0, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    assert stats == {"pulled": 0, "reverted": 0, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0, "adopted": 0}
     row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
     assert row.status == "reading"
 
@@ -1048,7 +1048,7 @@ async def test_pull_wtr_convergence_removed_vs_moved(db, admin_user, make_book):
     async with httpx.AsyncClient() as client:
         stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
 
-    assert stats == {"pulled": 0, "reverted": 1, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    assert stats == {"pulled": 0, "reverted": 1, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0, "adopted": 0}
     removed_row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=removed.id).one()
     assert removed_row.status == "unread"
     assert removed_row.hardcover_synced_status is None
@@ -1074,7 +1074,7 @@ async def test_pull_wtr_tome_only_row_untouched_by_convergence(db, admin_user, m
     async with httpx.AsyncClient() as client:
         stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
 
-    assert stats == {"pulled": 0, "reverted": 0, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0}
+    assert stats == {"pulled": 0, "reverted": 0, "wished": 0, "wish_dismissed": 0, "wish_reopened": 0, "adopted": 0}
     row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
     assert row.status == "want_to_read"
 
@@ -1134,7 +1134,7 @@ async def test_pull_wtr_unresolved_entry_creates_wish(db, admin_user):
         stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
     assert stats["wished"] == 1
 
-    wish = db.query(Wish).filter_by(user_id=user.id, source="hardcover", source_id="999").one()
+    wish = db.query(Wish).filter_by(user_id=user.id, source=hs.SHELF_WISH_SOURCE, source_id="999").one()
     assert wish.status == "open"
     assert wish.title == "Not In Tome Yet"
     assert wish.author == "Shelf Author"
@@ -1144,7 +1144,7 @@ async def test_pull_wtr_unresolved_entry_creates_wish(db, admin_user):
     async with httpx.AsyncClient() as client:
         stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
     assert stats["wished"] == 0
-    assert db.query(Wish).filter_by(user_id=user.id, source="hardcover").count() == 1
+    assert db.query(Wish).filter_by(user_id=user.id, source=hs.SHELF_WISH_SOURCE).count() == 1
 
 
 @respx.mock
@@ -1175,7 +1175,7 @@ async def test_pull_wtr_unshelve_dismisses_hardcover_wish(db, admin_user):
 
     user, _ = admin_user
     _link_pull_user(user)
-    db.add(Wish(user_id=user.id, title="Was Shelved", source="hardcover",
+    db.add(Wish(user_id=user.id, title="Was Shelved", source=hs.SHELF_WISH_SOURCE,
                 source_id="999", status="open", kind="wish"))
     db.flush()
 
@@ -1197,9 +1197,9 @@ async def test_pull_wtr_reshelve_reopens_dismissed_wish(db, admin_user):
 
     user, _ = admin_user
     _link_pull_user(user)
-    db.add(Wish(user_id=user.id, title="Shelved Again", source="hardcover",
+    db.add(Wish(user_id=user.id, title="Shelved Again", source=hs.SHELF_WISH_SOURCE,
                 source_id="999", status="dismissed", kind="wish"))
-    db.add(Wish(user_id=user.id, title="Already Fulfilled", source="hardcover",
+    db.add(Wish(user_id=user.id, title="Already Fulfilled", source=hs.SHELF_WISH_SOURCE,
                 source_id="888", status="fulfilled", kind="wish"))
     db.flush()
 
@@ -1212,3 +1212,112 @@ async def test_pull_wtr_reshelve_reopens_dismissed_wish(db, admin_user):
     assert stats["wished"] == 0  # reopened, not recreated
     assert db.query(Wish).filter_by(user_id=user.id, source_id="999").one().status == "open"
     assert db.query(Wish).filter_by(user_id=user.id, source_id="888").one().status == "fulfilled"
+
+
+# ── regression: the mirror must never touch follows or user-created wishes ────
+
+@respx.mock
+async def test_pull_wtr_never_touches_follows_or_native_wishes(db, admin_user):
+    """The prod incident: series follows (kind='follow', source='hardcover')
+    and user-created wishes whose metadata came from Hardcover were dismissed
+    by the shelf mirror on the first sync. Both must survive an empty shelf."""
+    from backend.models.wish import Wish
+
+    user, _ = admin_user
+    _link_pull_user(user)
+    for i in range(4):
+        db.add(Wish(user_id=user.id, title=f"Followed Series {i}", kind="follow",
+                    status="open", source="hardcover", source_id=f"series:{i}"))
+    db.add(Wish(user_id=user.id, title="Native Series Wish", kind="wish",
+                status="open", source="hardcover", source_id="12345",
+                series="Native Series"))
+    db.flush()
+
+    respx.post(HARDCOVER_URL).mock(side_effect=_shelf_with_books_responder([], []))
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+
+    assert stats["wish_dismissed"] == 0
+    assert db.query(Wish).filter_by(user_id=user.id, status="open").count() == 5
+
+
+def test_repair_reopens_bug_dismissed_rows_only(db, admin_user):
+    """Startup repair: reopen rows the buggy mirror dismissed (no audit entry),
+    leave admin-dismissed wishes closed, reclassify shelf-created wishes."""
+    from backend.models.audit_log import AuditLog
+    from backend.models.wish import Wish
+
+    user, _ = admin_user
+    bug_follow = Wish(user_id=user.id, title="Bug-Dismissed Follow", kind="follow",
+                      status="dismissed", source="hardcover", source_id="series:1")
+    bug_wish = Wish(user_id=user.id, title="Bug-Dismissed Wish", kind="wish",
+                    status="dismissed", source="hardcover", source_id="111")
+    admin_closed = Wish(user_id=user.id, title="Admin-Dismissed Wish", kind="wish",
+                        status="dismissed", source="hardcover", source_id="222")
+    old_shelf_wish = Wish(user_id=user.id, title="Shelf-Created", kind="wish",
+                          status="open", source="hardcover", source_id="333",
+                          note=hs.SHELF_WISH_NOTE)
+    google_wish = Wish(user_id=user.id, title="Google Wish", kind="wish",
+                       status="dismissed", source="google_books", source_id="g1")
+    db.add_all([bug_follow, bug_wish, admin_closed, old_shelf_wish, google_wish])
+    db.flush()
+    db.add(AuditLog(user_id=user.id, username="testadmin",
+                    action="wishlist.dismissed", resource_type="wish",
+                    resource_id=admin_closed.id))
+    db.flush()
+
+    result = hs.repair_shelf_sync_collateral(db)
+    assert result == {"reopened": 2, "reclassified": 1}
+
+    assert db.get(Wish, bug_follow.id).status == "open"
+    assert db.get(Wish, bug_wish.id).status == "open"
+    assert db.get(Wish, admin_closed.id).status == "dismissed"
+    assert db.get(Wish, old_shelf_wish.id).source == hs.SHELF_WISH_SOURCE
+    assert db.get(Wish, google_wish.id).status == "dismissed"  # not hardcover's mess
+
+    # Idempotent: second run is a no-op
+    assert hs.repair_shelf_sync_collateral(db) == {"reopened": 0, "reclassified": 0}
+
+
+@respx.mock
+async def test_pull_wtr_adopts_owned_unmatched_book(db, admin_user, make_book):
+    """A shelf entry whose book exists in the library but was never
+    catalogue-matched adopts the match from the shelf and gets queued,
+    instead of dead-ending as neither status nor wish."""
+    from backend.models.wish import Wish
+
+    user, _ = admin_user
+    _link_pull_user(user)
+    book = make_book(title="Owned Unmatched Novel", author="Local Author")
+    assert book.hardcover_book_id is None
+
+    def responder(request):
+        body = request.read().decode()
+        if "query WantToReadShelf" in body:
+            return httpx.Response(200, json={"data": {"user_books": [
+                {"id": 501, "book_id": 999}]}})
+        if "query BooksByIds" in body:
+            return httpx.Response(200, json={"data": {"books": [
+                {"id": 999, "title": "Owned Unmatched Novel", "slug": "owned-unmatched",
+                 "contributions": [{"author": {"name": "Local Author"}}]}]}})
+        if "query BookEdition" in body:
+            return httpx.Response(200, json={"data": {"books": [
+                {"id": 999, "pages": 320, "slug": "owned-unmatched",
+                 "editions": [{"id": 777, "pages": 320, "users_count": 5,
+                               "reading_format_id": 1, "language": {"code2": "en"}}]}]}})
+        return httpx.Response(200, json={"data": {}})
+
+    respx.post(HARDCOVER_URL).mock(side_effect=responder)
+    async with httpx.AsyncClient() as client:
+        stats = await hs.pull_want_to_read(db, client, user, hs._Budget(50))
+
+    assert stats["adopted"] == 1
+    assert stats["wished"] == 0
+    assert book.hardcover_book_id == 999
+    assert book.hardcover_match_method == "shelf"
+    assert book.hardcover_edition_id == 777
+    row = db.query(UserBookStatus).filter_by(user_id=user.id, book_id=book.id).one()
+    assert row.status == "want_to_read"
+    assert row.hardcover_user_book_id == 501
+    assert not hs.needs_sync(row)
+    assert db.query(Wish).filter_by(user_id=user.id).count() == 0


### PR DESCRIPTION
## The bug (first 2.2.0 build)

The Hardcover shelf mirror identified "wishes created by the shelf sync" by `source="hardcover"` — but that marker is shared: series follows are `Wish` rows with `kind="follow"`, `source="hardcover"`, `source_id="series:<id>"`, and user-created wishes carry `source="hardcover"` whenever Hardcover was the metadata search source. On the first sync cycle none of their source_ids appear in the shelf's book-id set, so the mirror dismissed **every open series follow and any such wish** for linked users. Rows were dismissed, not deleted.

## The fix

- **Scoping**: shelf-created wishes get their own source value, `hardcover_shelf`; the dismiss/reopen mirror filters on it plus `kind="wish"`. It structurally cannot touch follows or user-created wishes anymore.
- **Startup repair** (idempotent, no-op on clean installs): reopens exactly the bug's collateral. Legitimate removals are distinguishable — users hard-DELETE their own wishes/follows, and admin dismissals write a `wishlist.dismissed` audit entry — so a dismissed `source="hardcover"` row with no audit entry can only be the bug's work. Old shelf-created wishes (identified by their fixed note text) are reclassified to the new source.
- **Owned-but-unmatched shelf entries no longer dead-end**: previously such an entry produced neither a status (book never catalogue-matched, matching is lazy) nor a wish (owned-guard). With exactly one plausible library candidate, the shelf entry's own book id is adopted as the match (method `"shelf"`, edition re-picked language-aware) and the book lands on Want to Read. Ambiguous multi-candidate cases still skip.

## Testing

- 1086 backend tests pass; 4 new: the prod-incident regression (follows + native wishes survive an empty shelf), repair precision (bug-dismissed reopened, admin-dismissed stays closed, reclassification, idempotency), and match adoption end to end
- Repair verified against the exact prod shape: dismissed follows (`series:<id>`), a dismissed native series wish, an admin-dismissed wish with audit entry