### PR TITLE
release: v2.2.0 "Unopened"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-09
+
 ### Security
 - Updated `pdfjs-dist` to 6.2.108, clearing an arbitrary-JavaScript-execution
   advisory triggered by opening a malicious PDF (GHSA / CVE for PDF.js). This

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tome"
-version = "2.1.1"
+version = "2.2.0"
 description = "Self-hosted ebook library"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Changelog stamped as 2.2.0 (2026-08-09), version bumped in pyproject.

Headline: the new **Want to Read** reading status with bidirectional Hardcover shelf sync and the wishlist handoff (#171, scoping fix + match adoption in #172). Also in this release: the library-integrity batch (#165/#168 — Duplicates one-pass Apply All, Delete Others, orphan cleanup, real bulk delete), the OPDS reverse-proxy scheme fix (#167/#169), KOReader plugin build 38's popup-repaint fix (#166), and the pdfjs-dist security update (#170).

After merge: tag `v2.2.0` on the merge commit to build `:latest` / `:2.2` / `:2`; release notes ready in `docs/release-notes-2.2.0.md` for the GitHub release body.

Fix verified on prod before this cut: the startup repair restored the wrongly-dismissed follows/wishes, and the shelf pull + match adoption ran clean against the live Hardcover account.