### PR TITLE
feat: add monitoring with maping

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from pathlib import Path
 
+from maping import Recorder
+from maping.asgi import MapingMiddleware
+
 from backend.core.database import engine, Base, init_fts, backfill_fts
 from backend.core.config import settings
 from backend.services.safe_fetch import fetch_safe_image, UnsafeURLError
@@ -58,6 +61,9 @@ from backend.models.book import BookChapter  # noqa: F401
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    recorder: Recorder = app.state.maping_recorder
+    await recorder.start()
+
     Base.metadata.create_all(bind=engine)
 
     # A staged restore was applied before the engine existed (see
@@ -388,6 +394,8 @@ async def lifespan(app: FastAPI):
                 await task
             except asyncio.CancelledError:
                 pass
+
+    await recorder.shutdown()
 
 
 async def _auto_import_loop() -> None:
@@ -744,6 +752,8 @@ def create_app() -> FastAPI:
         openapi_url="/api/openapi.json",
     )
 
+    app.state.maping_recorder = Recorder()
+
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["http://localhost:5173"],  # Vite dev server
@@ -823,4 +833,7 @@ def create_app() -> FastAPI:
     return app
 
 
-app = create_app()
+# Not wrapped inside create_app() itself: tests call create_app() directly
+# and construct their own TestClient against it.
+_app = create_app()
+app = MapingMiddleware(_app, recorder=_app.state.maping_recorder)


### PR DESCRIPTION
## Summary

I noticed this FastAPI project doesn't seem to have application monitoring, so I added it using [MAPING](https://mapi-ng.com), a lightweight API monitoring tool I'm developing.

The integration provides endpoint-level traffic, error rates, latency percentiles, and request/response sizes.

**This PR is safe to merge as-is:** without a `MAPING_KEY`, the integration stays inactive and doesn't affect the application.

If you'd like to try it, MAPING has a **free tier with no credit card required**. Creating an account at [mapi-ng.com](https://mapi-ng.com) gives you the `MAPING_KEY` needed to enable monitoring.

## Changes

- Add the MAPING Python client
- Configure MAPING monitoring for the FastAPI application
- Read the ingest key from the `MAPING_KEY` environment variable
- Remain inactive when `MAPING_KEY` isn't configured

## Screenshots

This is MAPING running against this project during my test of the integration:

<img width="1299" height="771" alt="tome_mapi-ng" src="https://github.com/user-attachments/assets/9245a5fb-0acc-4852-a119-d34b7ae4849e" />


## Checklist

- [x] Tests pass
- [x] Manually tested the MAPING integration
- [x] No secrets or credentials committed

## Notes

Full disclosure: I'm the author of MAPING.

**What I'm mainly looking for is feedback from real FastAPI projects: whether the integration is useful, what feels awkward, and what's missing.**

The hosted service isn't required: MAPING can also be fully self-hosted with all features available, so adopting the client doesn't lock the project into mapi-ng.com.

If monitoring isn't relevant to this project, feel free to close the PR, no worries.
---

By submitting this PR, I confirm my contributions are licensed under AGPL-3.0.
