### PR TITLE
fix(sync): "Sync now" pulls before pushing + experimental KOSync position bridge (#175)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- Experimental KOSync position bridge (`TOME_KOSYNC_POSITION_BRIDGE`, off by
+  default) — with it enabled, a device running the TomeSync plugin picks up
+  reading progress pushed by third-party KOSync clients (Crosspoint, Readest,
+  stock KOReader sync) on the same book. The bridge is read-only: KOSync
+  pushes still never overwrite plugin or web positions on the server; the
+  plugin's pull just sees whichever known position is newest. Since KOSync
+  clients send no resolvable locator, the jump lands at the right percentage,
+  not the exact line. Marked experimental until it has seen real multi-client
+  use. (#175)
+
+### Fixed
+- "Sync now" in the TomeSync plugin (build 39) now pulls the server position
+  before pushing, using the same forward/backward conflict strategy as book
+  open. Previously it only pushed, so tapping it on a device that was behind
+  overwrote newer progress from another device. (#175)
+
 ## [2.2.0] - 2026-08-09
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Did click? **Don't run it on your laptop long-term.** Move `~/Tome` to an always
 | `TOME_AUTO_IMPORT` | No | `false` | Auto-import files from the bindery on a schedule |
 | `TOME_AUTO_IMPORT_INTERVAL` | No | `300` | Seconds between auto-import scans |
 | `TOME_SCAN_WORKERS` | No | `1` | Parallel scan workers (>1 = multi-process; ~60–80 MB each) |
+| `TOME_KOSYNC_POSITION_BRIDGE` | No | `false` | Experimental: let TomeSync plugin devices pick up progress pushed by third-party KOSync clients (read-only bridge) |
 
 ### Supported Formats
 

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -3,6 +3,7 @@
 Auth: Bearer API key (not JWT) for all /api/tome-sync/ endpoints.
 Plugin download: Bearer JWT for /api/plugin/koreader.
 """
+import calendar
 import io
 import json
 import logging
@@ -75,8 +76,14 @@ logger = logging.getLogger(__name__)
 # bypassing wifi_enable_action so "prompt" never dialogs onto the sleep
 # screen). onNetworkConnected also runs the history backfill now (was
 # launch-only) and no longer requires an open book to flush pending state.
-TOMESYNC_PLUGIN_BUILD = 38
-TOMESYNC_PLUGIN_SEMVER = "1.11.1"
+# BUILD 39: "Sync now" pulls before it pushes (issue #175) — the server
+# position runs through the same forward/backward pull-conflict strategy as
+# book open, so a device that is behind no longer overwrites newer progress
+# from another device; the push happens after the pull settles. Pairs with the
+# server-side TOME_KOSYNC_POSITION_BRIDGE read bridge (experimental, off by
+# default), which lets that pull also see third-party KOSync client pushes.
+TOMESYNC_PLUGIN_BUILD = 39
+TOMESYNC_PLUGIN_SEMVER = "1.12.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -107,6 +114,30 @@ def _get_position(db: Session, user_id: int, book_id: int) -> Optional[TomeSyncP
     return (
         db.query(TomeSyncPosition)
         .filter(TomeSyncPosition.user_id == user_id, TomeSyncPosition.book_id == book_id)
+        .first()
+    )
+
+
+def _newest_kosync_progress(db: Session, user_id: int, book_id: int):
+    """Newest KOSync push for this (Tome user, book), or None.
+
+    Read side of the #175 interop bridge (TOME_KOSYNC_POSITION_BRIDGE): joins
+    the user's document maps to KOSyncProgress through their linked KOSync
+    account(s). Both stores are server-stamped, so comparing timestamps is
+    free of device clock skew.
+    """
+    from backend.models.kosync import KOSyncDocumentMap, KOSyncProgress, KOSyncUser
+
+    return (
+        db.query(KOSyncProgress)
+        .join(KOSyncUser, KOSyncProgress.user_id == KOSyncUser.id)
+        .join(
+            KOSyncDocumentMap,
+            (KOSyncDocumentMap.document == KOSyncProgress.document)
+            & (KOSyncDocumentMap.tome_user_id == KOSyncUser.user_id),
+        )
+        .filter(KOSyncUser.user_id == user_id, KOSyncDocumentMap.book_id == book_id)
+        .order_by(KOSyncProgress.timestamp.desc())
         .first()
     )
 
@@ -281,6 +312,31 @@ def get_position(
         raise HTTPException(status_code=404, detail="Book not found")
 
     pos = _get_position(db, user.id, book_id)
+
+    # Experimental interop bridge (issue #175, TOME_KOSYNC_POSITION_BRIDGE):
+    # serve the newest KOSync push when it beats the stored plugin/web
+    # position — the mirror of kosync.py's GET, which serves the Tome position
+    # to KOSync clients when that side is newer. Read-only: TomeSyncPosition
+    # is never written from KOSync data, so the #156 write-side rule holds.
+    # The locator travels as-is (a stock-KOReader xpointer resolves exactly on
+    # the device; anything else makes the plugin fall back to the percentage).
+    if settings.kosync_position_bridge:
+        ks = _newest_kosync_progress(db, user.id, book_id)
+        if ks is not None:
+            pos_ts = (
+                calendar.timegm(pos.updated_at.utctimetuple())
+                if pos is not None and pos.updated_at is not None
+                else None
+            )
+            if pos_ts is None or ks.timestamp > pos_ts:
+                return {
+                    "book_id": book_id,
+                    "progress": ks.progress,
+                    "percentage": ks.percentage,
+                    "device": ks.device or "kosync",
+                    "updated_at": datetime.utcfromtimestamp(ks.timestamp).isoformat() + "Z",
+                }
+
     if not pos:
         raise HTTPException(status_code=404, detail="No position stored")
 
@@ -2871,6 +2927,61 @@ function TomeSync:_pushPosition()
     }})
 end
 
+-- "Sync now" position sync (issue #175): pull first, then push. This was
+-- push-only, so a device that was behind overwrote newer progress from
+-- another device on the server. The pull reuses the same conflict strategy
+-- as book open (forward silent/prompt, backward never, by default); the push
+-- is deferred until the pull has settled — including through the prompt — so
+-- the final server state reflects the outcome.
+function TomeSync:_syncPositionNow()
+    local ok, pos, code = pcall(apiRequest, "GET", "/tome-sync/position/" .. self.book_id)
+    if ok and pos and code == 200 then
+        local server_pct = pos.percentage or 0
+        local local_pct  = self:_getCurrentPercentage()
+        -- Shifts the session's start by the jump so the jumped-over range is
+        -- not credited as reading (progress made before the jump stays counted).
+        local function shiftSessionStart()
+            if self.progress_start then
+                self.progress_start = math.max(0, math.min(1,
+                    self.progress_start + (server_pct - local_pct)))
+            end
+        end
+        local mode = nil
+        if server_pct > (local_pct + 0.01) and server_pct < 0.99 then
+            mode = G_reader_settings:readSetting("tomesync_pull_forward") or "silent"
+        elseif server_pct < (local_pct - 0.01) and server_pct > 0.01 then
+            mode = G_reader_settings:readSetting("tomesync_pull_backward") or "never"
+        end
+        if mode == "silent" then
+            shiftSessionStart()
+            self:_gotoServerPosition(pos, server_pct)
+            self:_pushPosition()
+            return
+        elseif mode == "prompt" then
+            -- Menu context, book already open — no Profiles auto-exec dispatch
+            -- to protect here, unlike the open-time prompt.
+            UIManager:show(ConfirmBox:new{{
+                text = string.format(
+                    "TomeSync: Server position is at %.0f%% (this device: %.0f%%).\\nJump there?",
+                    server_pct * 100, local_pct * 100
+                ),
+                ok_text = "Jump",
+                ok_callback = function()
+                    shiftSessionStart()
+                    self:_gotoServerPosition(pos, server_pct)
+                    self:_pushPosition()
+                end,
+                cancel_callback = function()
+                    -- Explicit keep-local: the device wins, last-write-wins.
+                    self:_pushPosition()
+                end,
+            }})
+            return
+        end
+    end
+    self:_pushPosition()
+end
+
 -- ── Rating sync (bidirectional, per open book) ───────────────────────────────
 -- KOReader's native Book status screen stores a 1–5 star rating + a free-text
 -- review in the per-book sidecar under `summary` (`rating` / `note`). Tome holds
@@ -4848,7 +4959,7 @@ function TomeSync:_menuItems()
             callback     = function()
                 whenConnected(function()
                     if self.book_id then
-                        self:_pushPosition()
+                        self:_syncPositionNow()
                         self:_syncAnnotations()
                         self:_pushRatingOnLeave()
                     end

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -85,6 +85,17 @@ class Settings(BaseSettings):
     # email/Amazon). Set to false to disable — the flag remains the kill switch.
     send_to_koreader: bool = True
 
+    # KOSync → plugin position bridge (env TOME_KOSYNC_POSITION_BRIDGE).
+    # Experimental, off by default. The KOSync endpoint is deliberately a
+    # one-way bridge (issue #156): third-party pushes never write
+    # TomeSyncPosition. With this flag on, the PLUGIN's position pull
+    # additionally considers the newest KOSync push for the same book —
+    # read-side only, TomeSyncPosition is still never written from KOSync
+    # data — so a device running the Tome plugin picks up progress made on a
+    # third-party KOSync client (Crosspoint, Readest, stock KOReader sync).
+    # See issue #175.
+    kosync_position_bridge: bool = False
+
     # JWT settings
     jwt_algorithm: str = "HS256"
     jwt_expire_minutes: int = 60 * 24 * 7  # 7 days

--- a/tests/test_kosync_position_bridge.py
+++ b/tests/test_kosync_position_bridge.py
@@ -1,0 +1,221 @@
+"""Reverse KOSync position bridge tests (issue #175, TOME_KOSYNC_POSITION_BRIDGE).
+
+The KOSync endpoint is a deliberately one-way bridge (#156): third-party
+pushes never write TomeSyncPosition. With the flag ON, the PLUGIN's position
+pull (GET /api/tome-sync/position/{book_id}) additionally considers the
+newest KOSync push for the same book — read-side only. Covered here:
+
+- flag off (the default): behaviour is unchanged, newer KOSync data or not
+- flag on: a newer KOSync push is served to the plugin; an older one is not
+- flag on: KOSync data alone satisfies the pull (no 404) — the #175 setup,
+  where only the third-party client has synced the book so far
+- the bridge never writes TomeSyncPosition, and never leaks across users
+
+tome-sync endpoints authenticate by API key only (not JWT) — mirroring
+test_reading_progress.py.
+"""
+import time
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy.orm import Session
+from starlette.testclient import TestClient
+
+from backend.core.config import settings
+from backend.core.database import get_db
+from backend.core.security import hash_password
+from backend.models.kosync import KOSyncDocumentMap, KOSyncProgress, KOSyncUser
+from backend.models.tome_sync import ApiKey, TomeSyncPosition
+from backend.models.user import User
+
+
+MD5 = "ab" * 16  # any 32-hex string (KOReader partial-MD5)
+
+
+# ── helpers / fixtures ────────────────────────────────────────────────────────
+
+@pytest.fixture()
+def ts_client(db: Session):
+    """Yield (TestClient, user, api_key_headers) with the test db wired in."""
+    from backend.main import create_app
+    app = create_app()
+
+    def override_get_db():
+        yield db
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    user = User(
+        username="bridgeuser", email="bridge@example.com",
+        hashed_password=hash_password("pass"), is_active=True,
+        role="member", must_change_password=False,
+    )
+    db.add(user)
+    db.flush()
+    plaintext = ApiKey.generate()
+    db.add(ApiKey(user_id=user.id, key_hash=ApiKey.hash_key(plaintext),
+                  key_prefix=plaintext[:11], label="test"))
+    db.flush()
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c, user, {"Authorization": f"Bearer {plaintext}"}
+
+    app.dependency_overrides.clear()
+
+
+def _seed_kosync_push(db, tome_user, book, percentage, age_seconds=0,
+                      device="crosspoint", document=MD5, progress="/body/DocFragment[8]/body/p[3]"):
+    """A linked KOSync account + document map + one progress push, the state a
+    real third-party client leaves behind after PUT /api/v1/syncs/progress."""
+    acc = db.query(KOSyncUser).filter_by(user_id=tome_user.id).first()
+    if acc is None:
+        acc = KOSyncUser(username=f"ks-{tome_user.username}", userkey="k" * 32,
+                         user_id=tome_user.id)
+        db.add(acc)
+        db.flush()
+    if not db.query(KOSyncDocumentMap).filter_by(
+            tome_user_id=tome_user.id, document=document).first():
+        db.add(KOSyncDocumentMap(tome_user_id=tome_user.id, document=document,
+                                 book_id=book.id))
+    db.add(KOSyncProgress(user_id=acc.id, document=document, progress=progress,
+                          percentage=percentage, device=device,
+                          timestamp=int(time.time()) - age_seconds))
+    db.flush()
+    return acc
+
+
+def _seed_plugin_position(db, user, book, percentage, age_seconds=0, device="kindle"):
+    db.add(TomeSyncPosition(
+        user_id=user.id, book_id=book.id, percentage=percentage,
+        progress="/body/DocFragment[5]/body/p[1]", device=device,
+        updated_at=datetime.utcnow() - timedelta(seconds=age_seconds)))
+    db.flush()
+
+
+# ── flag off: behaviour unchanged ─────────────────────────────────────────────
+
+def test_flag_off_ignores_newer_kosync_push(ts_client, db, make_book):
+    c, user, headers = ts_client
+    book = make_book(title="Bridge Book")
+    _seed_plugin_position(db, user, book, 0.839, age_seconds=7200)
+    _seed_kosync_push(db, user, book, 0.859)  # newer, but the flag is off
+    db.commit()
+
+    r = c.get(f"/api/tome-sync/position/{book.id}", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["percentage"] == 0.839
+    assert r.json()["device"] == "kindle"
+
+
+def test_flag_off_404_when_only_kosync_data_exists(ts_client, db, make_book):
+    c, user, headers = ts_client
+    book = make_book(title="Bridge Book")
+    _seed_kosync_push(db, user, book, 0.859)
+    db.commit()
+
+    r = c.get(f"/api/tome-sync/position/{book.id}", headers=headers)
+    assert r.status_code == 404
+
+
+# ── flag on: newest known position wins ───────────────────────────────────────
+
+def test_newer_kosync_push_served_to_plugin(ts_client, db, make_book, monkeypatch):
+    # The #175 repro: a KOSync client at 85.9%, plugin device last pushed
+    # 83.9% — the plugin's pull must now see 85.9%.
+    monkeypatch.setattr(settings, "kosync_position_bridge", True)
+    c, user, headers = ts_client
+    book = make_book(title="Bridge Book")
+    _seed_plugin_position(db, user, book, 0.839, age_seconds=7200)
+    _seed_kosync_push(db, user, book, 0.859)
+    db.commit()
+
+    r = c.get(f"/api/tome-sync/position/{book.id}", headers=headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["percentage"] == 0.859
+    assert body["device"] == "crosspoint"
+    assert body["progress"] == "/body/DocFragment[8]/body/p[3]"  # locator as-is
+
+
+def test_older_kosync_push_loses_to_plugin_position(ts_client, db, make_book, monkeypatch):
+    monkeypatch.setattr(settings, "kosync_position_bridge", True)
+    c, user, headers = ts_client
+    book = make_book(title="Bridge Book")
+    _seed_kosync_push(db, user, book, 0.20, age_seconds=7200)
+    _seed_plugin_position(db, user, book, 0.55)
+    db.commit()
+
+    r = c.get(f"/api/tome-sync/position/{book.id}", headers=headers)
+    assert r.json()["percentage"] == 0.55
+    assert r.json()["device"] == "kindle"
+
+
+def test_kosync_only_satisfies_pull(ts_client, db, make_book, monkeypatch):
+    # Book only ever read on the third-party client: the pull must serve it
+    # instead of 404ing.
+    monkeypatch.setattr(settings, "kosync_position_bridge", True)
+    c, user, headers = ts_client
+    book = make_book(title="Bridge Book")
+    _seed_kosync_push(db, user, book, 0.42)
+    db.commit()
+
+    r = c.get(f"/api/tome-sync/position/{book.id}", headers=headers)
+    assert r.status_code == 200
+    assert r.json()["percentage"] == 0.42
+
+
+def test_newest_of_multiple_kosync_pushes_wins(ts_client, db, make_book, monkeypatch):
+    monkeypatch.setattr(settings, "kosync_position_bridge", True)
+    c, user, headers = ts_client
+    book = make_book(title="Bridge Book")
+    _seed_kosync_push(db, user, book, 0.30, age_seconds=7200, device="readest",
+                      document="cd" * 16)
+    _seed_kosync_push(db, user, book, 0.60, device="crosspoint")
+    db.commit()
+
+    r = c.get(f"/api/tome-sync/position/{book.id}", headers=headers)
+    assert r.json()["percentage"] == 0.60
+    assert r.json()["device"] == "crosspoint"
+
+
+def test_no_kosync_data_404_unchanged(ts_client, db, make_book, monkeypatch):
+    monkeypatch.setattr(settings, "kosync_position_bridge", True)
+    c, _user, headers = ts_client
+    book = make_book(title="Bridge Book")
+
+    r = c.get(f"/api/tome-sync/position/{book.id}", headers=headers)
+    assert r.status_code == 404
+
+
+# ── guarantees ────────────────────────────────────────────────────────────────
+
+def test_bridge_read_never_writes_tomesync_position(ts_client, db, make_book, monkeypatch):
+    # The #156 write-side rule holds: serving a bridged position must not
+    # materialise it as TomeSyncPosition.
+    monkeypatch.setattr(settings, "kosync_position_bridge", True)
+    c, user, headers = ts_client
+    book = make_book(title="Bridge Book")
+    _seed_kosync_push(db, user, book, 0.42)
+    db.commit()
+
+    r = c.get(f"/api/tome-sync/position/{book.id}", headers=headers)
+    assert r.status_code == 200
+    assert db.query(TomeSyncPosition).count() == 0
+
+
+def test_bridge_does_not_leak_other_users_pushes(ts_client, db, make_book, monkeypatch):
+    # Same book, but the KOSync push belongs to a different Tome user.
+    monkeypatch.setattr(settings, "kosync_position_bridge", True)
+    c, user, headers = ts_client
+    book = make_book(title="Bridge Book")
+    other = User(username="otheruser", email="other@example.com",
+                 hashed_password=hash_password("pass"), is_active=True,
+                 role="member", must_change_password=False)
+    db.add(other)
+    db.flush()
+    _seed_kosync_push(db, other, book, 0.90)
+    _seed_plugin_position(db, user, book, 0.10)
+    db.commit()
+
+    r = c.get(f"/api/tome-sync/position/{book.id}", headers=headers)
+    assert r.json()["percentage"] == 0.10

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -207,5 +207,10 @@ def test_build_bumped_for_rebake():
     # repaints routed at the hidden FileManager are skipped entirely, so page
     # flips inside the popup never redraw. Menus now use the Menu default
     # (show_parent = the menu itself), which is always the visible window.
-    assert TOMESYNC_PLUGIN_BUILD >= 38
-    assert TOMESYNC_PLUGIN_SEMVER == "1.11.1"
+    # 1.12.0 / build 39 makes "Sync now" pull before it pushes (issue #175):
+    # the server position runs through the same forward/backward pull-conflict
+    # strategy as book open, so a device that is behind no longer overwrites
+    # newer progress from another device. Pairs with the server-side
+    # TOME_KOSYNC_POSITION_BRIDGE read bridge (experimental, default off).
+    assert TOMESYNC_PLUGIN_BUILD >= 39
+    assert TOMESYNC_PLUGIN_SEMVER == "1.12.0"


### PR DESCRIPTION
Fixes #175 - a device running the TomeSync plugin could overwrite newer progress on the server with its own older position when other sync clients were involved.

**Plugin build 39 (1.12.0): "Sync now" pulls before it pushes.** The button was push-only; pulling only happened at book open. It now fetches the server position first and runs it through the existing forward/backward pull-conflict strategy (forward silent by default, prompt/never respected), then pushes once the pull has settled. In prompt mode, declining the jump is an explicit keep-local choice - the device then wins, as before. A jump shifts the session's start marker by the jump delta so the skipped range isn't counted as reading time.

**`TOME_KOSYNC_POSITION_BRIDGE` (experimental, default off).** The KOSync endpoint stays a one-way bridge (#156): third-party pushes never write plugin-visible position state. With this flag on, the plugin's position pull additionally considers the newest KOSync push for the same book - read-side only, mirroring the existing bridge in the other direction (which serves Tome positions to KOSync clients). Together with the pull-first fix, progress made on a KOSync client (Crosspoint, Readest, stock KOReader sync) now reaches plugin devices. Both stores are server-stamped, so newest-wins is free of device clock skew; a same-second tie goes to the plugin's own store, which has the exact locator. Since KOSync clients send no locator the plugin can resolve, a bridged jump lands at the right percentage, not the exact line.

Marked experimental until it has seen real multi-client use; the flag stays as a permanent opt-out either way.

**Testing**
- 9 new backend tests: flag off = behavior unchanged, newer-wins / older-loses, KOSync-only pull satisfies instead of 404ing, newest of multiple pushes, bridge never writes `TomeSyncPosition`, no cross-user leaks. Full suite green (1094 passed).
- Generated build-39 plugin compiles under LuaJIT.
- Live HTTP round-trip of the issue's repro sequence (plugin at 83.9% → KOSync push 85.9% → pull sees 85.9% → no regression) against a scratch server with the flag enabled.
