### PR TITLE
fix(docker): PUID/PGID support + no orphaned copy on failed Bindery move (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,26 @@ All notable changes to Tome are documented here. Format loosely follows
   clients send no resolvable locator, the jump lands at the right percentage,
   not the exact line. Marked experimental until it has seen real multi-client
   use. (#175)
+- The Docker image now honours `PUID` / `PGID` (LinuxServer.io convention) to
+  run Tome as the host user that owns your mounts. Defaults to `1000:1000`,
+  which is exactly what the image did before, so existing installs need no
+  changes. Set them to your NAS docker user on Synology / QNAP / TrueNAS,
+  where ACLs are granted to that user rather than to uid 1000. On start the
+  entrypoint also fixes ownership of `/data` (never `/books` or `/bindery`),
+  so switching UID on an existing install no longer breaks on the 0600
+  `secret.key`. Compose files that already pass `user:` keep working. (#177)
 
 ### Fixed
+- Bindery accept and auto-import no longer leave an orphaned copy in the
+  library when the file can be copied into `/books` but not deleted from
+  `/bindery` (a permission failure on the source, as on Synology ACLs that
+  allow create but not delete). Previously every retry produced another
+  `Title (2).epub` with no book record; the half-finished copy is now removed
+  before the error is reported. (#177)
+- Starting Tome as a different UID than the one that created `/data` now
+  fails with a message that names the fix (PUID/PGID, chown, or
+  `TOME_SECRET_KEY`) instead of a bare `PermissionError` traceback on
+  `secret.key`. (#177)
 - "Sync now" in the TomeSync plugin (build 39) now pulls the server position
   before pushing, using the same forward/backward conflict strategy as book
   open. Previously it only pushed, so tapping it on a device that was behind

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN npm run build
 FROM python:3.12-slim
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends unrar-free && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends unrar-free gosu && rm -rf /var/lib/apt/lists/*
 
 COPY pyproject.toml ./
 COPY backend/__init__.py ./backend/
@@ -30,9 +30,15 @@ ENV TOME_DATA_DIR=/data \
 RUN useradd -m -u 1000 tome \
     && mkdir -p /data /books /bindery \
     && chown tome:tome /data /books /bindery
-USER tome
+COPY docker/entrypoint.sh /usr/local/bin/tome-entrypoint
+RUN chmod +x /usr/local/bin/tome-entrypoint
+
+# The entrypoint starts as root only to remap the "tome" user to PUID/PGID
+# (default 1000:1000) and fix /data ownership, then drops privileges via gosu.
+# Passing `user:` in compose still works: the entrypoint just execs as that user.
 
 VOLUME ["/data", "/books", "/bindery"]
 EXPOSE 8080
 
+ENTRYPOINT ["tome-entrypoint"]
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Did click? **Don't run it on your laptop long-term.** Move `~/Tome` to an always
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
+| `PUID` / `PGID` | No | `1000` / `1000` | Host UID/GID the container runs as. Set to the owner of your mounts (Synology/QNAP/TrueNAS: your docker user; Unraid: `99`/`100`) |
 | `TOME_SECRET_KEY` | Yes | -- | JWT signing secret |
 | `TOME_DATA_DIR` | No | `/data` | DB and cover cache |
 | `TOME_LIBRARY_DIR` | No | `/books` | Library root |

--- a/backend/api/bindery.py
+++ b/backend/api/bindery.py
@@ -14,7 +14,6 @@ Endpoints:
 """
 import logging
 import os
-import shutil
 from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -33,7 +32,7 @@ from backend.services.book_types import assign_book_to_type_library
 from backend.services.filename_parser import parse_filename
 from backend.services.metadata import extract_metadata, sha256_file
 from backend.services.metadata_fetch import fetch_candidates
-from backend.services.organizer import get_library_path, resolve_unique_path
+from backend.services.organizer import get_library_path, move_into_library, resolve_unique_path
 from backend.services.safe_fetch import fetch_safe_image, UnsafeURLError
 
 router = APIRouter(tags=["bindery"])
@@ -313,10 +312,9 @@ def bindery_accept(
             # Determine destination path
             rel = get_library_path(path_meta, full_path.name)
             dest = resolve_unique_path(settings.library_dir, rel)
-            dest.parent.mkdir(parents=True, exist_ok=True)
 
-            # Move the file
-            shutil.move(str(full_path), str(dest))
+            # Move the file (cleans up a half-finished cross-device copy on failure)
+            move_into_library(full_path, dest)
 
             # Determine cover: use extracted cover or download from cover_url
             cover_path: str | None = meta.get("cover_path")

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -172,10 +172,27 @@ class Settings(BaseSettings):
 
         key_file = self.secret_key_file
         if key_file.exists():
-            return key_file.read_text().strip()
+            try:
+                return key_file.read_text().strip()
+            except PermissionError as exc:
+                raise RuntimeError(
+                    f"Cannot read {key_file}: it was created by a different user "
+                    f"(the file is mode 0600). Tome is running as uid={os.getuid()} "
+                    f"gid={os.getgid()}. Either run the container with PUID/PGID "
+                    f"matching the owner of your /data directory, chown /data on "
+                    f"the host to the uid Tome runs as, or set TOME_SECRET_KEY "
+                    f"explicitly."
+                ) from exc
 
         new_key = secrets.token_urlsafe(64)
-        key_file.write_text(new_key)
+        try:
+            key_file.write_text(new_key)
+        except PermissionError as exc:
+            raise RuntimeError(
+                f"Cannot write {key_file}: /data is not writable by uid={os.getuid()} "
+                f"gid={os.getgid()}. Run the container with PUID/PGID matching the "
+                f"owner of your /data directory, or chown it on the host."
+            ) from exc
         try:
             key_file.chmod(0o600)
         except OSError:

--- a/backend/services/organizer.py
+++ b/backend/services/organizer.py
@@ -10,6 +10,7 @@ Rules (in priority order):
 All path components are sanitized to be filesystem-safe.
 """
 import re
+import shutil
 from pathlib import Path
 
 
@@ -115,3 +116,42 @@ def resolve_unique_path(base_dir: Path, rel_path: Path) -> Path:
         if not candidate.exists():
             return candidate
         n += 1
+
+
+def move_into_library(src: Path, dest: Path) -> None:
+    """Move ``src`` to ``dest``, creating parents, without leaving debris on failure.
+
+    ``/bindery`` and ``/books`` are usually separate mounts, so ``shutil.move``
+    falls back to copy-then-unlink. When the copy succeeds but the unlink is
+    refused (typical on NAS ACLs that grant create-but-not-delete, see #177),
+    a plain ``shutil.move`` leaves a complete orphan in the library that no
+    DB row points at, and every retry mints another ``Title (2).ext``. Here
+    the freshly written destination and any parent directories created for
+    it are removed again before the error is re-raised, so the library is
+    left exactly as it was found. (Leftover empty dirs matter too: they keep
+    the uid of the failed attempt, and block a retry under a corrected
+    PUID/PGID.)
+    """
+    created_dirs: list[Path] = []
+    parent = dest.parent
+    while not parent.exists():
+        created_dirs.append(parent)
+        parent = parent.parent
+    dest.parent.mkdir(parents=True, exist_ok=True)
+
+    existed_before = dest.exists()
+    try:
+        shutil.move(str(src), str(dest))
+    except OSError:
+        if not existed_before and dest.exists() and src.exists():
+            try:
+                dest.unlink()
+            except OSError:
+                pass
+        # innermost first; rmdir only removes empty dirs so this is safe
+        for d in created_dirs:
+            try:
+                d.rmdir()
+            except OSError:
+                break
+        raise

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -12,7 +12,6 @@ Two distinct operations:
 """
 import logging
 import multiprocessing
-import shutil
 from concurrent.futures import ProcessPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -24,7 +23,7 @@ from backend.core.config import settings
 from backend.models.book import Book, BookFile
 from backend.services.metadata import SUPPORTED_FORMATS, extract_metadata, get_format, sha256_file
 from backend.services.ko_hash import ko_partial_md5, record_ko_hash
-from backend.services.organizer import get_library_path, resolve_unique_path
+from backend.services.organizer import get_library_path, move_into_library, resolve_unique_path
 
 # Below this many new files, the serial path wins (process-pool startup isn't
 # worth it). Above it, scan_library fans the CPU-bound extract/hash out to a
@@ -221,10 +220,9 @@ def _import_file(
     # Determine destination inside library
     rel_path = get_library_path(meta, src.name)
     dest = resolve_unique_path(library_dir, rel_path)
-    dest.parent.mkdir(parents=True, exist_ok=True)
 
-    # Move the file
-    shutil.move(str(src), str(dest))
+    # Move the file (cleans up a half-finished cross-device copy on failure)
+    move_into_library(src, dest)
     logger.info("Moved %s → %s", src.name, dest.relative_to(library_dir))
 
     # Clean up empty parent dirs in incoming

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,12 @@ services:
       # Drop new files here for Bindery to pick up
       - ./bindery:/bindery
     environment:
+      # Optional. Run Tome as this host UID/GID (default 1000:1000) so it can
+      # read/write your mounts. Set to the user that owns ./books and ./bindery
+      # on the host - on Synology / QNAP / TrueNAS use your docker user's ids
+      # (`id <user>`). Only needed if you see PermissionError in the logs.
+      # - PUID=1000
+      # - PGID=1000
       # Optional. If unset, Tome generates a long random key on first start
       # and saves it to /data/secret.key.
       # - TOME_SECRET_KEY=

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# Tome container entrypoint.
+#
+# Maps the internal "tome" user to the host UID/GID given by PUID/PGID
+# (LinuxServer.io convention) so bind-mounted /data, /books and /bindery are
+# accessed as the same user that owns them on the host. Defaults to 1000:1000,
+# which is exactly what the image did before this script existed, so existing
+# installs are unaffected.
+#
+# If the container is started with an explicit `user:` (or `--user`) it is not
+# root here and cannot remap anything; in that case it simply execs the app as
+# whatever user it was given, which is the pre-existing behaviour.
+set -eu
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+if [ "$(id -u)" = "0" ]; then
+    case "$PUID$PGID" in
+        *[!0-9]*) echo "tome: PUID/PGID must be numeric (got PUID=$PUID PGID=$PGID)" >&2; exit 1 ;;
+    esac
+
+    if [ "$(id -g tome)" != "$PGID" ]; then
+        groupmod -o -g "$PGID" tome
+    fi
+    if [ "$(id -u tome)" != "$PUID" ]; then
+        usermod -o -u "$PUID" tome
+    fi
+
+    # Tome's own state must be writable by the runtime user. Only touch files
+    # that are not already owned correctly, so a large cover cache on a default
+    # install costs one directory walk and zero chown calls. The library and
+    # bindery are the user's data (and may be mounted read-only): never chown.
+    for d in "${TOME_DATA_DIR:-/data}" /home/tome; do
+        [ -d "$d" ] || continue
+        find "$d" \( ! -user "$PUID" -o ! -group "$PGID" \) -exec chown -h "$PUID:$PGID" {} + 2>/dev/null || true
+    done
+
+    echo "tome: running as uid=$PUID gid=$PGID"
+    exec gosu tome "$@"
+fi
+
+exec "$@"

--- a/docs/examples/docker-compose.unraid.yml
+++ b/docs/examples/docker-compose.unraid.yml
@@ -13,6 +13,13 @@ services:
       - /mnt/user/data/media/ebooks:/books
       - /mnt/user/appdata/tome/bindery:/bindery
     environment:
+      # Unraid shares are usually owned by nobody:users (99:100). If Tome
+      # logs PermissionError on /books or /bindery, run it as that user.
+      # Leave commented on an existing install that already works: files Tome
+      # created so far are owned by uid 1000, and switching would need a
+      # chown of those.
+      # - PUID=99
+      # - PGID=100
       # Generate a long random value, or omit and Tome will generate one on
       # first start and save it to /data/secret.key.
       # - TOME_SECRET_KEY=

--- a/tests/test_move_into_library.py
+++ b/tests/test_move_into_library.py
@@ -1,0 +1,125 @@
+"""move_into_library must not leave a half-finished copy behind (#177).
+
+``/bindery`` and ``/books`` are usually separate mounts, so ``shutil.move``
+copies then unlinks. On NAS ACLs that grant create-but-not-delete the copy
+succeeds and the unlink raises; the library must be left untouched.
+"""
+import shutil
+from pathlib import Path
+
+import pytest
+
+from backend.core.config import Settings
+from backend.services import organizer
+from backend.services.organizer import move_into_library
+
+
+def _copy_then_fail_unlink(src: str, dst: str) -> None:
+    """Simulate a cross-device move whose source unlink is refused."""
+    shutil.copy2(src, dst)
+    raise PermissionError(13, "Permission denied", src)
+
+
+def test_move_succeeds_normally(tmp_path: Path) -> None:
+    src = tmp_path / "in" / "book.epub"
+    src.parent.mkdir()
+    src.write_bytes(b"epub")
+    dest = tmp_path / "lib" / "Author" / "book.epub"
+    (tmp_path / "lib").mkdir()
+
+    move_into_library(src, dest)
+
+    assert not src.exists()
+    assert dest.read_bytes() == b"epub"
+
+
+def test_failed_unlink_rolls_back_created_parent_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty dirs created for the move must go too: they keep the failed
+    attempt's uid and would block a retry under a corrected PUID/PGID."""
+    src = tmp_path / "in" / "book.epub"
+    src.parent.mkdir()
+    src.write_bytes(b"epub")
+    lib = tmp_path / "lib"
+    lib.mkdir()
+    dest = lib / "Series" / "Sub" / "book.epub"
+
+    monkeypatch.setattr(shutil, "move", _copy_then_fail_unlink)
+    with pytest.raises(PermissionError):
+        move_into_library(src, dest)
+
+    assert not (lib / "Series").exists()
+    assert lib.exists(), "the library root itself is never touched"
+    assert src.exists()
+
+
+def test_failure_keeps_preexisting_parent_dirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    src = tmp_path / "in" / "book.epub"
+    src.parent.mkdir()
+    src.write_bytes(b"epub")
+    lib = tmp_path / "lib"
+    (lib / "Series").mkdir(parents=True)
+    (lib / "Series" / "other.epub").write_bytes(b"x")
+    dest = lib / "Series" / "book.epub"
+
+    monkeypatch.setattr(shutil, "move", _copy_then_fail_unlink)
+    with pytest.raises(PermissionError):
+        move_into_library(src, dest)
+
+    assert (lib / "Series" / "other.epub").exists()
+    assert not dest.exists()
+
+
+def test_failed_unlink_removes_orphan_copy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    src = tmp_path / "in" / "book.epub"
+    src.parent.mkdir()
+    src.write_bytes(b"epub")
+    dest = tmp_path / "lib" / "Author" / "book.epub"
+    (tmp_path / "lib").mkdir()
+
+    monkeypatch.setattr(shutil, "move", _copy_then_fail_unlink)
+
+    with pytest.raises(PermissionError):
+        move_into_library(src, dest)
+
+    assert src.exists(), "source must be untouched"
+    assert not dest.exists(), "orphaned library copy must be cleaned up"
+    # A retry resolves to the same path again rather than 'book (2).epub'
+    assert organizer.resolve_unique_path(tmp_path / "lib", Path("Author") / "book.epub") == dest
+
+
+def test_failure_never_deletes_preexisting_dest(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defensive: if dest somehow already existed, a failed move must not remove it."""
+    src = tmp_path / "in" / "book.epub"
+    src.parent.mkdir()
+    src.write_bytes(b"new")
+    dest = tmp_path / "lib" / "book.epub"
+    dest.parent.mkdir()
+    dest.write_bytes(b"old")
+
+    def _fail(src_: str, dst_: str) -> None:
+        raise PermissionError(13, "Permission denied", src_)
+
+    monkeypatch.setattr(shutil, "move", _fail)
+
+    with pytest.raises(PermissionError):
+        move_into_library(src, dest)
+
+    assert dest.read_bytes() == b"old"
+    assert src.exists()
+
+
+def test_secret_key_unreadable_gives_actionable_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A secret.key created by another uid must fail with the PUID/PGID hint, not a bare traceback."""
+    s = Settings(secret_key=None, data_dir=tmp_path)
+    key = tmp_path / "secret.key"
+    key.write_text("k")
+
+    def _deny(*a, **k):
+        raise PermissionError(13, "Permission denied", str(key))
+
+    monkeypatch.setattr(Path, "read_text", _deny)
+
+    with pytest.raises(RuntimeError) as ei:
+        s.resolve_secret_key()
+    assert "PUID/PGID" in str(ei.value)
+    assert "secret.key" in str(ei.value)

--- a/website/src/pages/docs/configuration.astro
+++ b/website/src/pages/docs/configuration.astro
@@ -21,6 +21,7 @@ import { withBase } from '../../lib/path'
       <tr><th>Variable</th><th>Default</th><th>Purpose</th></tr>
     </thead>
     <tbody>
+      <tr><td><code>PUID</code> / <code>PGID</code></td><td><code>1000</code> / <code>1000</code></td><td>Host UID/GID the container runs as — set to the owner of your mounts (see <a href="#file-ownership">File ownership</a>)</td></tr>
       <tr><td><code>TOME_SECRET_KEY</code></td><td>auto-generated</td><td>JWT signing key</td></tr>
       <tr><td><code>TOME_DATA_DIR</code></td><td><code>/data</code></td><td>SQLite DB, covers, secret key</td></tr>
       <tr><td><code>TOME_LIBRARY_DIR</code></td><td><code>/books</code></td><td>Ebook library root</td></tr>
@@ -71,6 +72,29 @@ import { withBase } from '../../lib/path'
     refuses to start with that exact value. Either unset it (to auto-generate) or use a real
     random string.
   </Callout>
+
+  <h2 id="file-ownership">File ownership (PUID / PGID)</h2>
+  <p>
+    Inside the container Tome runs as an unprivileged user. <code>PUID</code> and <code>PGID</code>
+    set that user's numeric UID and GID (the same convention as LinuxServer.io images), so
+    the bind-mounted <code>/data</code>, <code>/books</code> and <code>/bindery</code> are read
+    and written as the user that owns them on the host. The default is <code>1000:1000</code>,
+    which is what the image always ran as, so an existing install needs no change.
+  </p>
+  <p>
+    Set them when the logs show <code>PermissionError</code> on <code>/books</code> or
+    <code>/bindery</code>. On Synology, QNAP and TrueNAS the share ACL is granted to your
+    docker user, not to uid 1000; run <code>id &lt;user&gt;</code> on the host and pass those
+    ids. On Unraid shares are usually <code>99:100</code>.
+  </p>
+  <p>
+    On start the container fixes ownership of <code>/data</code> to match, so switching
+    <code>PUID</code> on an existing install works without a manual <code>chown</code>. It never
+    touches <code>/books</code> or <code>/bindery</code> — those are your files (and may be
+    read-only mounts). If Tome already created files there under the old uid, chown those
+    yourself. Compose files that pass <code>user: "uid:gid"</code> instead still work; in
+    that mode the container cannot fix <code>/data</code> ownership for you.
+  </p>
 
   <h2>Paths</h2>
   <p>

--- a/website/src/pages/docs/troubleshooting.astro
+++ b/website/src/pages/docs/troubleshooting.astro
@@ -22,7 +22,7 @@ import { withBase } from '../../lib/path'
   <ul>
     <li><strong>The scan is still running.</strong> Watch the progress bar at the top of the dashboard — a fresh scan of a few thousand files can take a minute.</li>
     <li><strong>The file format isn't supported.</strong> Tome handles EPUB, CBZ, CBR, and PDF. Anything else gets ignored silently.</li>
-    <li><strong>Filesystem permissions.</strong> The container runs as UID 1000. If your <code>/books</code> mount is owned by root with mode 700, Tome can't read it. Fix the host-side ownership.</li>
+    <li><strong>Filesystem permissions.</strong> The container runs as UID 1000 by default. If your <code>/books</code> mount is owned by another user, set <code>PUID</code> / <code>PGID</code> to that user (see below).</li>
   </ul>
 
   <h2>Covers are missing</h2>
@@ -118,12 +118,26 @@ import { withBase } from '../../lib/path'
     constant factor, not a runaway query.
   </p>
 
-  <h2>Permission errors on /books</h2>
+  <h2>Permission errors on /books or /bindery</h2>
   <p>
-    The container runs as UID 1000 (user <code>tome</code>). If the host-side owner of your
-    library folder is different, you'll see <code>PermissionError</code> in the logs and books
-    won't import. Either <code>chown -R 1000:1000 /path/to/books</code> on the host, or pass
-    <code>user: "&lt;your-uid&gt;:&lt;your-gid&gt;"</code> in your compose file to override.
+    The container runs as UID 1000 (user <code>tome</code>) unless told otherwise. If the
+    host-side owner of your library or bindery folder is different, you'll see
+    <code>PermissionError</code> in the logs, books won't import, and Bindery accepts fail
+    with <code>Permission denied</code> on the source file. Set <code>PUID</code> and
+    <code>PGID</code> in your compose file to the host user that owns those folders
+    (<code>id &lt;user&gt;</code>), then recreate the container:
+  </p>
+  <pre><code>environment:
+  - PUID=1026
+  - PGID=100</code></pre>
+  <p>
+    Synology is the common case: File Station grants the share ACL to your docker user, and
+    uid 1000 typically ends up able to <em>create</em> files in the bindery but not delete
+    them, so an accept copies the book into <code>/books</code> and then fails removing the
+    original. Use the docker user's ids from <em>Control Panel → User</em> (or
+    <code>id</code> over SSH). Ownership of <code>/data</code> is fixed automatically on
+    start; <code>/books</code> and <code>/bindery</code> are never chowned by Tome. See
+    <a href={withBase("/docs/configuration#file-ownership")}>Configuration → File ownership</a>.
   </p>
 
   <Callout variant="info" title="Still stuck?">


### PR DESCRIPTION
Closes #177

## Problem

The image runs as a fixed uid 1000 with no way to remap it. On hosts where share permissions are granted to a specific user rather than to uid 1000 (Synology and other NAS ACLs), Tome can copy a Bindery file into `/books` but not delete it from `/bindery`, so every accept fails with `PermissionError`. Two follow-on problems made it worse:

- `shutil.move` across the two mounts is copy-then-unlink, so each failed accept left a complete orphan copy in `/books` with no book record, and every retry produced another `Title (2).epub`.
- The documented workaround (`user: "uid:gid"` in compose) breaks on any existing install because `/data/secret.key` is created 0600 by uid 1000 and unreadable by the new user, with only a bare traceback to explain it.

## Changes

- **`docker/entrypoint.sh` + `Dockerfile`**: `PUID` / `PGID` support (LinuxServer.io convention). The container starts as root only to `usermod`/`groupmod` the `tome` user and fix ownership of `/data` and `/home/tome` (only entries not already owned; `/books` and `/bindery` are never touched), then drops to `tome` via `gosu`. Defaults are `1000:1000`, so existing installs behave exactly as before with no compose changes. A compose `user:` override is detected (not root) and just execs through as today.
- **`organizer.move_into_library`** (Bindery accept + auto-import): on a failed cross-device move, removes the half-finished destination copy and any parent directories created for it, so the library is left as found. Removing the empty dirs matters: they carry the failed attempt's uid and would block the retry after `PUID` is corrected.
- **`config.resolve_secret_key`**: `PermissionError` on reading or writing `secret.key` becomes a `RuntimeError` that names the fix (PUID/PGID, chown, or `TOME_SECRET_KEY`).
- Docs: configuration page (File ownership section + table row), troubleshooting (permission errors section rewritten around PUID/PGID with a Synology walkthrough), README env table, `docker-compose.yml` and Unraid example (commented, opt-in), CHANGELOG.

## Testing

- `pytest tests`: 1101 passed (6 new in `tests/test_move_into_library.py`).
- Built image, run against named volumes (real Linux ownership), amd64 and arm64:
  - default run: PID 1 is `1000:1000`, `secret.key` owned by 1000, identical to the old image
  - existing `/data` then `PUID=1234 PGID=5678`: starts, `secret.key`/`tome.db` re-owned, existing login still valid, `/books` untouched
  - `--user` override with mismatched `/data`: exits with the actionable message; `--user` matching the owner: works
  - reproduced the reported failure with a sticky-bit bindery (uid 1000 can read and create but not unlink): accept reports the error, `/books` has zero files after repeated attempts
  - same bindery with `PUID` set to the file owner: accept succeeds, source removed, one file in `/books`
  - non-numeric `PUID` rejected at start

## Notes

- Behavioural side effect: `docker exec tome sh` now lands as root (no `USER` directive); the app itself still runs unprivileged.
- The Docker job only runs on `main` pushes, hence the manual multi-arch build above.