### PR TITLE
fix(stats): reconcile imported history per sitting + real device identity (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,29 @@ All notable changes to Tome are documented here. Format loosely follows
   `secret.key`. Compose files that already pass `user:` keep working. (#177)
 
 ### Fixed
+- Reading time from a second device no longer vanishes when another device
+  syncs its KOReader reading history for the same book. Imported history used
+  to supersede *every* live device session on that book; it now supersedes
+  only the sessions it actually describes (the sittings its page timings
+  overlap in time), so a week of phone reading stays counted after a Kindle
+  uploads two evenings of the same title. Existing data is fixed on upgrade
+  with no action needed; live sessions also count as normal until their own
+  device's history sync catches up, instead of dropping out early. (#181)
+- KOReader plugin (build 40 / 1.13.0): every device used to report the
+  literal name "KOReader", so all of a user's devices shared one
+  reading-history sync position and were indistinguishable in the reading
+  log. The plugin now reports the device model (`KindlePaperWhite4`,
+  `Kobo_clara`, ...) or a name you set under TomeSync → Settings → Device
+  name, and carries its imported history and sync position over to the new
+  name on first sync - nothing is re-sent or duplicated, and the sync is
+  postponed rather than restarted from scratch if the server has not
+  confirmed the move. Live sessions recorded before the update keep their
+  old label. One caveat for setups where two devices both synced history
+  under the shared old name: the first device to update takes over that
+  history's label; the second re-sends its own history once (deduplicated,
+  so no double counting), which does bring back any of its imported
+  sittings you had deleted in Tome. Update via Check for updates as usual.
+  (#181)
 - Bindery accept and auto-import no longer leave an orphaned copy in the
   library when the file can be copied into `/books` but not deleted from
   `/bindery` (a permission failure on the source, as on Synology ACLs that

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -291,7 +291,7 @@ def get_stats(
     if covered:
         tl_base = tl_base.filter(or_(
             ReadingSession.book_id.notin_(covered),
-            ReadingSession.device.in_(rr.NON_DEVICE_SOURCES),
+            rr.counted_clause(),
         ))
     timeline_rows = (
         tl_base
@@ -1287,8 +1287,10 @@ def list_sessions(
     - ``imported`` — a gap-clustered sitting from imported KOReader page-stats,
       carrying ``range_start``/``range_end`` (epoch seconds) for
       ``DELETE /stats/imported-sessions``. Not trimmable (already idle-capped).
-    Every row also carries ``counted``: device-origin live sessions on a book
-    covered by page-stats are ``counted: false`` — reconciliation excludes them
+    Every row also carries ``counted``: device-origin live sessions whose
+    sitting imported page-stats also describe (see
+    ``reconciled_reading.superseded_clause``) are ``counted: false`` —
+    reconciliation excludes them
     from totals (the imported clusters already describe that reading) but they
     stay listed, labeled, rather than silently hidden.
 
@@ -1379,17 +1381,21 @@ def list_sessions(
     def _iso(epoch: int) -> str:
         return datetime.fromtimestamp(epoch, timezone.utc).replace(tzinfo=None).isoformat() + "Z"
 
+    # Which of this page's live sessions are superseded by imported history —
+    # one probe over the page's ids, same predicate the totals use.
+    page_ids = [e[2].id for e in page if e[1] == "session" and e[2].book_id in covered]
+    superseded_ids: set[int] = set(
+        r[0] for r in db.query(ReadingSession.id)
+        .filter(ReadingSession.id.in_(page_ids), rr.superseded_clause()).all()
+    ) if page_ids else set()
+
     out = []
     for _, kind, r in page:
         if kind == "session":
-            superseded = (
-                r.book_id in covered
-                and (r.device or "") not in rr.NON_DEVICE_SOURCES
-            )
             out.append({
                 "id": r.id,
                 "kind": "session",
-                "counted": not superseded,
+                "counted": r.id not in superseded_ids,
                 "book_id": r.book_id,
                 "book_title": r.book_title or "(deleted book)",
                 "started_at": (r.started_at.isoformat() + "Z") if r.started_at else None,
@@ -1464,9 +1470,10 @@ def delete_imported_session(
     sitting without touching the rest of the book's imported history (the
     per-book purge on BookDetailPage remains the wipe-everything tool).
 
-    Deleting a book's LAST cluster un-covers it, so any device-origin live
-    sessions it has resurface in lists and totals — the fallback source
-    becomes authoritative again, consistent with reconciliation.
+    Deleting a cluster un-supersedes the live device sessions that overlapped
+    it, so they resurface in the totals (they were "not counted" only because
+    this imported history described the same sitting) — consistent with
+    reconciliation; the session log shows them, and they can be deleted too.
     """
     from backend.models.ko_stats import PageStat
 

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -82,8 +82,8 @@ logger = logging.getLogger(__name__)
 # from another device; the push happens after the pull settles. Pairs with the
 # server-side TOME_KOSYNC_POSITION_BRIDGE read bridge (experimental, off by
 # default), which lets that pull also see third-party KOSync client pushes.
-TOMESYNC_PLUGIN_BUILD = 39
-TOMESYNC_PLUGIN_SEMVER = "1.12.0"
+TOMESYNC_PLUGIN_BUILD = 40
+TOMESYNC_PLUGIN_SEMVER = "1.13.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -588,6 +588,29 @@ def import_ko_stats(
         books=[b.model_dump() for b in body.books],
         page_stats=[p.model_dump() for p in body.page_stats],
     )
+
+
+class RenameDeviceRequest(PydanticBaseModel):
+    from_device: str
+    to_device: str
+
+
+@router.post("/tome-sync/stats/rename-device")
+def rename_ko_stats_device(
+    body: RenameDeviceRequest,
+    db: Session = Depends(get_db),
+    user: User = Depends(_get_api_key_user),
+):
+    """Carry a device's imported history + sync watermark over to the name it
+    now reports (plugin build 40 moved every device off the literal "KOReader";
+    Settings > Device name renames later). See `ko_stats_import.rename_device`."""
+    from backend.services.ko_stats_import import rename_device
+    result = rename_device(db, user, from_device=body.from_device, to_device=body.to_device)
+    if result["rows_relabelled"] or result["watermark_moved"]:
+        audit(db, "ko_stats.device_renamed", user_id=user.id, username=user.username,
+              resource_type="ko_page_stats", resource_id=user.id,
+              details={"from": body.from_device, "to": body.to_device, **result})
+    return result
 
 
 # ── Annotation endpoints ──────────────────────────────────────────────────────
@@ -1810,9 +1833,24 @@ local function jval(v)
     return v
 end
 
+-- Device identity as reported to Tome: the label on live sessions and imported
+-- history, and the key of this device's reading-history sync watermark. A
+-- user-set name (Settings > Device name) wins; otherwise KOReader's
+-- Device.model ("KindlePaperWhite4", "Kobo_clara", an Android product name);
+-- "KOReader" only when neither exists. Builds before 40 always reported the
+-- literal "KOReader" (they called a Device method that does not exist in
+-- KOReader), so every device of a user shared ONE history watermark - see
+-- _adoptDeviceName for the one-time migration.
+local LEGACY_DEVICE_NAME = "KOReader"
+local function autoDeviceName()
+    local model = Device and Device.model
+    if type(model) == "string" and model ~= "" then return model end
+    return LEGACY_DEVICE_NAME
+end
 local function deviceName()
-    local ok, name = pcall(function() return Device:getFriendlyDeviceName() end)
-    return (ok and name) or "KOReader"
+    local custom = G_reader_settings:readSetting("tomesync_device_name")
+    if type(custom) == "string" and custom ~= "" then return custom end
+    return autoDeviceName()
 end
 
 local function idleCapSeconds()
@@ -2585,6 +2623,81 @@ function TomeSync:_statsDbPath()
     return require("datastorage"):getSettingsDir() .. "/statistics.sqlite3"
 end
 
+-- Move this device's imported reading history (page-stat rows + sync
+-- watermark) from the name it previously reported to the one it reports now.
+-- Live sessions keep the label they were recorded with: on a multi-device
+-- setup the old label was shared, so they can't be attributed after the fact.
+-- Idempotent server-side; a failed call is simply retried on the next sync.
+function TomeSync:_renameDeviceHistory(from, to)
+    if not from or from == "" or from == to then return true end
+    local ok, resp = pcall(apiRequest, "POST", "/tome-sync/stats/rename-device",
+        {{ from_device = from, to_device = to }})
+    return ok and type(resp) == "table"
+end
+
+-- `tomesync_device_name_adopted` remembers the last name whose history was
+-- migrated. First run on build 40+ moves the pre-40 "KOReader" history; a
+-- later rename in Settings moves it again from the previous name.
+-- Returns true when this device's history is known to be filed under its
+-- current name (nothing to do, or the move succeeded). False = the server did
+-- not confirm; the caller must NOT sync history from watermark 0 in that state,
+-- or sittings the user deleted in Tome would be re-imported.
+function TomeSync:_adoptDeviceName()
+    local name = deviceName()
+    if name == LEGACY_DEVICE_NAME then return true end
+    local adopted = G_reader_settings:readSetting("tomesync_device_name_adopted")
+    if adopted == name then return true end
+    if self:_renameDeviceHistory(adopted or LEGACY_DEVICE_NAME, name) then
+        G_reader_settings:saveSetting("tomesync_device_name_adopted", name)
+        return true
+    end
+    return false
+end
+
+-- Settings > Device name: the label Tome shows for this device. Empty restores
+-- the automatic name (KOReader's device model).
+function TomeSync:_editDeviceName()
+    local current = G_reader_settings:readSetting("tomesync_device_name") or ""
+    local dialog
+    dialog = InputDialog:new{{
+        title       = "Device name",
+        input       = current,
+        hint        = autoDeviceName(),
+        description = "How this device is labelled in Tome's reading log and "
+                      .. "stats. Leave empty to use the automatic name "
+                      .. "(\\"" .. autoDeviceName() .. "\\"). Give each "
+                      .. "device a distinct name - the reading-history sync "
+                      .. "keeps its place per device name.",
+        buttons     = {{{{
+            {{
+                text     = "Cancel",
+                id       = "close",
+                callback = function() UIManager:close(dialog) end,
+            }},
+            {{
+                text             = "Save",
+                is_enter_default = true,
+                callback         = function()
+                    local name = dialog:getInputText():gsub("^%s+", ""):gsub("%s+$", "")
+                    if name == "" then
+                        G_reader_settings:delSetting("tomesync_device_name")
+                    else
+                        G_reader_settings:saveSetting("tomesync_device_name", name)
+                    end
+                    UIManager:close(dialog)
+                    if NetworkMgr:isConnected() then
+                        pcall(function() self:_adoptDeviceName() end)
+                    end
+                    UIManager:show(InfoMessage:new{{
+                        text = "Device name: " .. deviceName(), timeout = 2 }})
+                end,
+            }},
+        }}}},
+    }}
+    UIManager:show(dialog)
+    dialog:onShowKeyboard()
+end
+
 function TomeSync:_syncReadingStats(manual)
     local function tell(msg)
         if manual then UIManager:show(InfoMessage:new{{ text = msg, timeout = 3 }}) end
@@ -2593,6 +2706,16 @@ function TomeSync:_syncReadingStats(manual)
     if not NetworkMgr:isConnected() then tell("Offline - reading history will sync later."); return end
     local path = self:_statsDbPath()
     if lfs.attributes(path, "mode") ~= "file" then tell("No KOReader statistics database found."); return end
+
+    -- Carry this device's history + watermark over from the name it used to
+    -- report, so a name change (incl. the build-40 move off "KOReader") resumes
+    -- instead of re-sending the whole database. Until the server confirms the
+    -- move, don't sync at all: a run from watermark 0 would re-import sittings
+    -- the user deleted in Tome.
+    if not self:_adoptDeviceName() then
+        tell("Could not register this device's name with Tome - reading-history sync postponed.")
+        return
+    end
 
     -- Server is the source of truth for "how far did we get".
     local wm = apiRequest("GET", "/tome-sync/stats/watermark?device=" .. urlEncode(deviceName()))
@@ -4861,6 +4984,15 @@ function TomeSync:_menuItems()
             G_reader_settings:saveSetting("tomesync_auto_check",
                 not G_reader_settings:isTrue("tomesync_auto_check"))
         end,
+    }})
+    table.insert(settings_items, {{
+        text_func      = function() return "Device name: " .. deviceName() end,
+        help_text      = "The label Tome shows for this device (reading log, "
+                       .. "\\"Where you read\\"). Defaults to the device model; "
+                       .. "set a name if you use several devices of the same "
+                       .. "kind.",
+        keep_menu_open = true,
+        callback       = function() self:_editDeviceName() end,
     }})
     table.insert(settings_items, {{
         text         = "Auto-sync reading history on launch",

--- a/backend/main.py
+++ b/backend/main.py
@@ -254,6 +254,11 @@ async def lifespan(app: FastAPI):
             "CREATE INDEX IF NOT EXISTS ix_ko_page_stats_user_book_page "
             "ON ko_page_stats (user_id, book_id, page)"
         ))
+        # Range seek for the per-sitting overlap probe in reconciled_reading.
+        conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_ko_page_stats_user_book_start "
+            "ON ko_page_stats (user_id, book_id, start_time)"
+        ))
         conn.commit()
         # Web-created annotations carry an EPUB CFI so the web reader can
         # re-paint them without a text search (annotations table pre-exists).

--- a/backend/models/ko_stats.py
+++ b/backend/models/ko_stats.py
@@ -47,6 +47,9 @@ class PageStat(Base):
         # The re-reads block group-bys (user, book, page) over the full history;
         # existing DBs get this via the startup CREATE INDEX IF NOT EXISTS.
         Index("ix_ko_page_stats_user_book_page", "user_id", "book_id", "page"),
+        # The reconciliation overlap probe (reconciled_reading.superseded_clause)
+        # is a (user, book, start_time BETWEEN ...) range seek per live session.
+        Index("ix_ko_page_stats_user_book_start", "user_id", "book_id", "start_time"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/backend/services/ko_stats_import.py
+++ b/backend/services/ko_stats_import.py
@@ -342,7 +342,13 @@ def import_batch(
                 ))
             seen_md5[md5] = resolved
 
-    # Idempotent page-stat ingest: INSERT OR IGNORE on the identity unique constraint.
+    # Idempotent page-stat ingest. Identity is (user, book, page, start_time)
+    # regardless of the device label: a device that changes the name it
+    # reports (build 40 moved everyone off the literal "KOReader") re-sends
+    # its history under the new label, and those rows must be no-ops, not a
+    # second copy. The unique constraint still carries `device`, so the
+    # label-agnostic check is a pre-filter here; ON CONFLICT DO NOTHING keeps
+    # same-label re-sends cheap.
     rows = []
     max_start = 0
     for ps in page_stats:
@@ -361,7 +367,20 @@ def import_batch(
     imported = 0
     if rows:
         for chunk in (rows[i:i + 500] for i in range(0, len(rows), 500)):
-            stmt = sqlite_insert(PageStat).values(chunk).on_conflict_do_nothing(
+            bids = {r["book_id"] for r in chunk}
+            lo = min(r["start_time"] for r in chunk)
+            hi = max(r["start_time"] for r in chunk)
+            existing = set(
+                db.query(PageStat.book_id, PageStat.page, PageStat.start_time)
+                .filter(PageStat.user_id == user.id, PageStat.book_id.in_(bids),
+                        PageStat.start_time >= lo, PageStat.start_time <= hi)
+                .all()
+            )
+            fresh = [r for r in chunk
+                     if (r["book_id"], r["page"], r["start_time"]) not in existing]
+            if not fresh:
+                continue
+            stmt = sqlite_insert(PageStat).values(fresh).on_conflict_do_nothing(
                 index_elements=["user_id", "book_id", "page", "start_time", "device"]
             )
             imported += db.execute(stmt).rowcount or 0
@@ -392,6 +411,78 @@ def import_batch(
         "page_rows_skipped": len(rows) - imported,
         "watermark": max_start,
     }
+
+
+def rename_device(db: Session, user, *, from_device: str, to_device: str) -> dict:
+    """Move a device's imported history from the name it used to report to the
+    one it reports now: relabel its page-stat rows and carry its sync watermark
+    over, so the plugin resumes instead of re-sending everything.
+
+    Only page-stats and the watermark. Live `reading_sessions` keep their
+    recorded label - before build 40 every device reported "KOReader", so on a
+    multi-device setup those rows can't be attributed after the fact (and the
+    stats reconcile by time overlap, not by label, so nothing depends on it).
+    Idempotent: a second call finds nothing under `from_device`.
+    """
+    from sqlalchemy import and_, exists
+    from sqlalchemy.orm import aliased
+
+    from_device = (from_device or "").strip()
+    to_device = (to_device or "").strip()
+    if not from_device or not to_device or from_device == to_device:
+        return {"rows_relabelled": 0, "rows_deduplicated": 0, "watermark_moved": False}
+
+    # Rows already present under the new label (a sync ran before the rename
+    # landed) are the same reading twice - drop the old-label copy first, or
+    # the relabel would trip the identity constraint. Self-join via alias.
+    other = aliased(PageStat)
+    dup_ids = [
+        r[0] for r in
+        db.query(PageStat.id)
+        .filter(PageStat.user_id == user.id, PageStat.device == from_device)
+        .filter(exists().where(and_(
+            other.user_id == PageStat.user_id, other.book_id == PageStat.book_id,
+            other.page == PageStat.page, other.start_time == PageStat.start_time,
+            other.device == to_device,
+        )))
+        .all()
+    ]
+    deduped = 0
+    for i in range(0, len(dup_ids), 500):
+        deduped += (
+            db.query(PageStat)
+            .filter(PageStat.id.in_(dup_ids[i:i + 500]))
+            .delete(synchronize_session=False)
+        )
+    relabelled = (
+        db.query(PageStat)
+        .filter(PageStat.user_id == user.id, PageStat.device == from_device)
+        .update({PageStat.device: to_device}, synchronize_session=False)
+    )
+
+    moved = False
+    old_wm = (
+        db.query(StatsImport)
+        .filter(StatsImport.user_id == user.id, StatsImport.device == from_device)
+        .first()
+    )
+    if old_wm:
+        new_wm = (
+            db.query(StatsImport)
+            .filter(StatsImport.user_id == user.id, StatsImport.device == to_device)
+            .first()
+        )
+        if new_wm:
+            new_wm.last_start_time_synced = max(
+                new_wm.last_start_time_synced, old_wm.last_start_time_synced)
+            new_wm.rows_imported += old_wm.rows_imported
+            db.delete(old_wm)
+        else:
+            old_wm.device = to_device
+        moved = True
+    db.commit()
+    return {"rows_relabelled": relabelled, "rows_deduplicated": deduped,
+            "watermark_moved": moved}
 
 
 # ── Startup repair: re-verify stored fuzzy matches (issue #152) ───────────────

--- a/backend/services/reading_stats.py
+++ b/backend/services/reading_stats.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from bisect import bisect_right
 from collections import defaultdict
 from datetime import datetime, timezone
-from typing import Optional
+from typing import NamedTuple, Optional
 
 from sqlalchemy import func, Integer
 from sqlalchemy.orm import Session
@@ -18,6 +18,12 @@ from backend.models.book import Book
 from backend.models.tome_sync import ReadingSession
 from backend.models.user_book_status import UserBookStatus
 from backend.services.reading_day import date_modifier, effective_today, epoch_day, epoch_day_int
+
+
+class _SrcRow(NamedTuple):
+    device: str
+    seconds: int
+    units: int
 
 
 def _covered_fraction(page_rows) -> float:
@@ -136,14 +142,15 @@ def compute_book_reading_stats(
     ]
 
     # ── Reconcile with imported KOReader page-stats ──────────────────────────
-    # Page-stats win per book for *device* reading (same rule as the dashboard's
-    # reconciled_reading), so a book read only on the device isn't shown empty.
-    # Web-reader and manual-log sessions are invisible to KOReader's history and
-    # stay ADDITIVE on top — replacing them made a hand-logged paper session on
-    # a Kindle-synced book vanish without a trace. Untouched when the book has
-    # no page-stats — ps_seconds is 0 and this whole block is skipped.
+    # Page-stats win per *sitting* for device reading (same rule as the
+    # dashboard's reconciled_reading): a live device session that imported
+    # history overlaps is superseded; everything else — web-reader and
+    # manual-log sessions, and device sessions no page-stats describe (a second
+    # device that never synced its history, issue #181) — stays ADDITIVE on top.
+    # Untouched when the book has no page-stats — ps_seconds is 0 and this
+    # whole block is skipped.
     from backend.models.ko_stats import PageStat
-    from backend.services.reconciled_reading import NON_DEVICE_SOURCES, _cluster_rows
+    from backend.services.reconciled_reading import _cluster_rows, counted_clause
 
     ps = (
         db.query(
@@ -199,8 +206,9 @@ def compute_book_reading_stats(
             .all()
         )
 
-        # Additive sessions: web-reader + manual logs merge on top of page-stats.
-        additive = base.filter(ReadingSession.device.in_(NON_DEVICE_SOURCES))
+        # Additive sessions: everything not superseded by page-stats — web-reader
+        # + manual logs, and device sessions with no overlapping imported history.
+        additive = base.filter(counted_clause())
         add_agg = additive.with_entities(
             func.coalesce(func.sum(ReadingSession.duration_seconds), 0),
             func.count(ReadingSession.id),
@@ -269,10 +277,7 @@ def compute_book_reading_stats(
     # having dwelled on 11% of pages), but web/manual sessions record
     # progress_end, so their days contribute points even on a device-synced book.
     day_progress: dict[str, float] = {}
-    prog_base = (
-        base.filter(ReadingSession.device.in_(NON_DEVICE_SOURCES))
-        if ps_seconds > 0 else base
-    )
+    prog_base = base.filter(counted_clause()) if ps_seconds > 0 else base
     prog_rows = (
         prog_base.with_entities(
             func.date(ReadingSession.started_at, day_mod).label("date"),
@@ -294,9 +299,12 @@ def compute_book_reading_stats(
 
     # ── Where the reading time came from (web reader vs device) ───────────────
     if ps_seconds > 0:
-        # Page-stat devices + additive web/manual sessions, so a mixed reader
-        # actually sees the split (device-only rows used to hide the section).
-        src_rows = list(
+        # Page-stat devices + additive sessions, so a mixed reader actually sees
+        # the split (device-only rows used to hide the section). A live device
+        # session that counts may carry the same device label as the page-stat
+        # rows, so merge by label rather than listing it twice.
+        merged: dict[str, list[int]] = {}
+        for r in (
             db.query(
                 func.coalesce(PageStat.device, "koreader").label("device"),
                 func.coalesce(func.sum(PageStat.duration_seconds), 0).label("seconds"),
@@ -306,15 +314,18 @@ def compute_book_reading_stats(
             .group_by("device")
             .all()
         ) + list(
-            base.filter(ReadingSession.device.in_(NON_DEVICE_SOURCES))
+            base.filter(counted_clause())
             .with_entities(
-                ReadingSession.device.label("device"),
+                func.coalesce(ReadingSession.device, "web-reader").label("device"),
                 func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
                 func.count(ReadingSession.id).label("units"),
             )
             .group_by("device")
             .all()
-        )
+        ):
+            e = merged.setdefault(r.device, [0, 0])
+            e[0] += int(r.seconds or 0); e[1] += int(r.units or 0)
+        src_rows = [_SrcRow(d, v[0], v[1]) for d, v in merged.items()]
     else:
         src_rows = (
             base.with_entities(

--- a/backend/services/reconciled_reading.py
+++ b/backend/services/reconciled_reading.py
@@ -3,13 +3,19 @@
 Both sources can describe the *same* Kindle reading (the plugin POSTs live sessions AND
 KOReader's statistics.sqlite3 records every page), so naively summing them double-counts.
 
-Rule (per book, per source): if a book has ANY imported `ko_page_stats`, those are
-authoritative for its *device* reading time (idle-capped, full history) and its live
-device-origin `reading_sessions` are ignored — they describe the same reading twice.
+Rule (per sitting): a device-origin live `reading_session` is *superseded* when imported
+`ko_page_stats` describe the same reading — i.e. a page row of the same book starts inside
+the session's window (`superseded_clause`, ± `OVERLAP_SLACK_SECONDS`). Superseded sessions
+stay in the DB and the session log ("not counted") but drop out of every total; the
+page-stats (idle-capped, page-accurate) carry that sitting instead. A live session no
+page-stats overlap counts as itself — reading on a second device that never synced its
+history, or reading synced live before the history backfill caught up (issue #181: the
+old *per-book* rule discarded a phone's whole week of live sessions the moment a Kindle
+uploaded two sittings of the same book).
 Web-reader and manual-log sessions (`NON_DEVICE_SOURCES`) are invisible to KOReader's
-history, so they stay ADDITIVE even on covered books; replacing them silently discarded
-e.g. a hand-logged paper session on a Kindle-synced book. Books with no page-stats fall
-back to sessions entirely.
+history, so they are never superseded; replacing them silently discarded e.g. a
+hand-logged paper session on a Kindle-synced book. Books with no page-stats fall back to
+sessions entirely.
 
 Invariant: when a user has no page-stats at all, `covered_book_ids` is empty and every
 helper returns exactly what the session-only query would — so existing stats behaviour is
@@ -28,7 +34,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Optional
 
-from sqlalchemy import Integer, func, or_
+from sqlalchemy import Integer, and_, exists, func, or_
 from sqlalchemy.orm import Session
 
 from backend.models.ko_stats import PageStat
@@ -38,14 +44,59 @@ from backend.models.tome_sync import ReadingSession
 # page-stats. Everything else (device names, NULL legacy rows) is device-origin.
 NON_DEVICE_SOURCES = ("web", "web-reader", "manual")
 
+# A live session and page-stats written by the same device share one clock, so a
+# sitting's first page row starts within seconds of the session. The slack only
+# absorbs write-ordering jitter around open/close — it is deliberately small so a
+# second device's reading of the same book minutes later is NOT swallowed.
+OVERLAP_SLACK_SECONDS = 120
+
 
 def _epoch(dt: Optional[datetime]) -> Optional[int]:
     return int(dt.replace(tzinfo=timezone.utc).timestamp()) if dt else None
 
 
 def covered_book_ids(db: Session, user_id: int) -> list[int]:
-    """Book ids that have imported page-stats (page-stats win for these books)."""
+    """Book ids that have imported page-stats. Empty means "no reconciliation at
+    all" (every helper is then the plain session query); non-empty is a cheap
+    pre-filter — only sessions on these books can be superseded, so the
+    per-row overlap probe is skipped for everything else."""
     return [r[0] for r in db.query(PageStat.book_id).filter(PageStat.user_id == user_id).distinct()]
+
+
+def _rs_epoch(col):
+    # ReadingSession datetimes are naive UTC; strftime('%s') reads them as UTC.
+    return func.cast(func.strftime("%s", col), Integer)
+
+
+def superseded_clause():
+    """SQL predicate on ReadingSession: a device-origin live session whose reading
+    is also described by imported page-stats — some `ko_page_stats` row of the
+    same user+book starts inside [started_at - slack, ended_at + slack].
+
+    Auto-correlates against the enclosing ReadingSession query. NULL device is
+    legacy plugin data and counts as device-origin, like everywhere else.
+    """
+    start = _rs_epoch(ReadingSession.started_at)
+    end = func.coalesce(
+        _rs_epoch(ReadingSession.ended_at),
+        start + func.coalesce(ReadingSession.duration_seconds, 0),
+    )
+    overlap = exists().where(
+        PageStat.user_id == ReadingSession.user_id,
+        PageStat.book_id == ReadingSession.book_id,
+        PageStat.start_time >= start - OVERLAP_SLACK_SECONDS,
+        PageStat.start_time <= end + OVERLAP_SLACK_SECONDS,
+    )
+    return and_(
+        or_(ReadingSession.device.is_(None),
+            ReadingSession.device.notin_(NON_DEVICE_SOURCES)),
+        overlap,
+    )
+
+
+def counted_clause():
+    """Negation of `superseded_clause`: sessions that contribute to totals."""
+    return ~superseded_clause()
 
 
 def _ps_filtered(db: Session, user_id: int, cutoff: Optional[datetime], range_end: Optional[datetime]):
@@ -62,11 +113,11 @@ def _rs_filtered(db: Session, user_id: int, covered: list[int],
                  cutoff: Optional[datetime], range_end: Optional[datetime]):
     q = db.query(ReadingSession).filter(ReadingSession.user_id == user_id)
     if covered:
-        # Covered books drop only their device-origin sessions (page-stats
-        # already describe that reading); web/manual sessions stay additive.
+        # Only sessions on covered books can be superseded (cheap pre-filter);
+        # for those, drop exactly the device sittings page-stats already describe.
         q = q.filter(or_(
             ReadingSession.book_id.notin_(covered),
-            ReadingSession.device.in_(NON_DEVICE_SOURCES),
+            counted_clause(),
         ))
     if cutoff is not None:
         q = q.filter(ReadingSession.started_at >= cutoff)

--- a/frontend/src/components/stats/shared.tsx
+++ b/frontend/src/components/stats/shared.tsx
@@ -113,8 +113,8 @@ export interface SessionEntry {
   // get a synthetic string id ("ps-<book>-<start>").
   id: number | string
   kind: 'session' | 'imported'
-  // False for a device live session on a book with imported KOReader history:
-  // the imported sittings already describe that reading, so this row is listed
+  // False for a device live session whose sitting imported KOReader history
+  // also describes (page-stats overlap it in time), so this row is listed
   // (labeled "not counted") but excluded from totals.
   counted: boolean
   book_id: number | null

--- a/frontend/src/components/stats/widgets/overview.tsx
+++ b/frontend/src/components/stats/widgets/overview.tsx
@@ -258,8 +258,8 @@ export function SessionLogHint() {
           reading history. Delete only: KOReader already caps idle time, so there is nothing to trim.
         </span>
         <span>
-          <span className="font-medium text-foreground">not counted</span> — a live device session on
-          a book whose imported history already covers that reading. Listed for completeness,
+          <span className="font-medium text-foreground">not counted</span> — a live device session
+          whose sitting is also described by imported history. Listed for completeness,
           excluded from the totals so nothing is counted twice.
         </span>
         <span>

--- a/tests/test_ko_stats_device_identity.py
+++ b/tests/test_ko_stats_device_identity.py
@@ -1,0 +1,121 @@
+"""Device identity for imported KOReader history (issue #181, plugin build 40).
+
+Before build 40 the plugin reported the literal "KOReader" for every device, so
+all of a user's devices shared one reading-history watermark. Build 40 reports
+Device.model (or a user-set name) and migrates its history over; the server
+dedups page-stats regardless of label so a re-send under a new name is a no-op.
+"""
+from backend.api.tome_sync import TOMESYNC_PLUGIN_BUILD, _main_impl_lua
+from backend.models.ko_stats import PageStat, StatsImport
+from backend.services.ko_stats_import import import_batch, rename_device
+
+BOOKS = [{"ko_id": 1, "md5": "e" * 32, "title": "Identity Test Book",
+          "authors": "A. Author", "pages": 100, "total_read_pages": 10}]
+
+
+def _rows(start, n, page0=1):
+    return [{"ko_id": 1, "page": page0 + i, "start_time": start + i * 60, "duration": 30,
+             "total_pages": 100} for i in range(n)]
+
+
+def test_resend_under_new_device_label_is_a_noop(db, admin_user, make_book):
+    user, _ = admin_user
+    make_book(title="Identity Test Book", author="A. Author")
+    first = import_batch(db, user, device="KOReader", books=BOOKS, page_stats=_rows(1_700_000_000, 5))
+    assert first["page_rows_imported"] == 5
+    # same reading, now labelled with the real device name (watermark 0 → full re-send)
+    again = import_batch(db, user, device="KindlePaperWhite4", books=BOOKS,
+                         page_stats=_rows(1_700_000_000, 5) + _rows(1_700_001_000, 2, page0=6))
+    assert again["page_rows_imported"] == 2          # only the genuinely new rows
+    assert again["page_rows_skipped"] == 5
+    assert db.query(PageStat).filter_by(user_id=user.id).count() == 7
+
+
+def test_watermarks_are_per_device(db, admin_user, make_book):
+    user, _ = admin_user
+    make_book(title="Identity Test Book", author="A. Author")
+    import_batch(db, user, device="Kindle", books=BOOKS, page_stats=_rows(1_700_000_000, 3))
+    import_batch(db, user, device="Phone", books=BOOKS, page_stats=_rows(1_600_000_000, 3, page0=50))
+    wms = {w.device: w.last_start_time_synced for w in db.query(StatsImport).filter_by(user_id=user.id)}
+    assert wms == {"Kindle": 1_700_000_120, "Phone": 1_600_000_120}
+
+
+def test_rename_moves_history_and_watermark(db, admin_user, make_book):
+    """The build-40 adoption: legacy "KOReader" rows + watermark move to the
+    device's real name, so the next sync resumes from where it was."""
+    user, _ = admin_user
+    make_book(title="Identity Test Book", author="A. Author")
+    import_batch(db, user, device="KOReader", books=BOOKS, page_stats=_rows(1_700_000_000, 5))
+
+    res = rename_device(db, user, from_device="KOReader", to_device="KindlePaperWhite4")
+    assert res == {"rows_relabelled": 5, "rows_deduplicated": 0, "watermark_moved": True}
+    assert db.query(PageStat).filter_by(user_id=user.id, device="KOReader").count() == 0
+    assert db.query(PageStat).filter_by(user_id=user.id, device="KindlePaperWhite4").count() == 5
+    wms = {w.device: w.last_start_time_synced for w in db.query(StatsImport).filter_by(user_id=user.id)}
+    assert wms == {"KindlePaperWhite4": 1_700_000_240}
+
+    # idempotent
+    assert rename_device(db, user, from_device="KOReader", to_device="KindlePaperWhite4") == {
+        "rows_relabelled": 0, "rows_deduplicated": 0, "watermark_moved": False}
+
+
+def test_rename_dedups_rows_already_synced_under_new_name(db, admin_user, make_book):
+    """A sync under the new name that ran before the rename landed: the
+    old-label copies of the same rows are dropped, not relabelled into a
+    constraint violation; watermarks merge to the max."""
+    user, _ = admin_user
+    make_book(title="Identity Test Book", author="A. Author")
+    import_batch(db, user, device="KOReader", books=BOOKS, page_stats=_rows(1_700_000_000, 5))
+    # new name already holds rows 3-5 (same reading) plus one newer row
+    db.add_all([
+        PageStat(user_id=user.id, book_id=db.query(PageStat.book_id).first()[0], page=p,
+                 total_pages=100, start_time=1_700_000_000 + (p - 1) * 60, duration_seconds=30,
+                 device="Kindle")
+        for p in (3, 4, 5, 6)
+    ])
+    db.add(StatsImport(user_id=user.id, device="Kindle", last_start_time_synced=1_700_000_300,
+                       rows_imported=4))
+    db.flush()
+
+    res = rename_device(db, user, from_device="KOReader", to_device="Kindle")
+    assert res == {"rows_relabelled": 2, "rows_deduplicated": 3, "watermark_moved": True}
+    assert db.query(PageStat).filter_by(user_id=user.id).count() == 6
+    assert db.query(PageStat).filter_by(user_id=user.id, device="KOReader").count() == 0
+    wms = {w.device: (w.last_start_time_synced, w.rows_imported)
+           for w in db.query(StatsImport).filter_by(user_id=user.id)}
+    assert wms == {"Kindle": (1_700_000_300, 9)}
+
+
+def test_rename_endpoint_requires_plugin_key(client, db, admin_user, make_book):
+    user, _ = admin_user
+    from backend.models.tome_sync import ApiKey
+    plain = ApiKey.generate()
+    db.add(ApiKey(user_id=user.id, key_hash=ApiKey.hash_key(plain), key_prefix=plain[:11], label="t"))
+    db.flush()
+    make_book(title="Identity Test Book", author="A. Author")
+    import_batch(db, user, device="KOReader", books=BOOKS, page_stats=_rows(1_700_000_000, 2))
+    r = client.post("/api/tome-sync/stats/rename-device",
+                    json={"from_device": "KOReader", "to_device": "Kobo_clara"},
+                    headers={"Authorization": f"Bearer {plain}"})
+    assert r.status_code == 200, r.text
+    assert r.json()["rows_relabelled"] == 2
+    r = client.get("/api/tome-sync/stats/watermark?device=Kobo_clara",
+                   headers={"Authorization": f"Bearer {plain}"})
+    assert r.json()["last_start_time_synced"] == 1_700_000_060
+
+
+# ── plugin source shape ────────────────────────────────────────────────────────
+
+def test_plugin_reports_a_real_device_name():
+    impl = _main_impl_lua("http://localhost:8080", "tk_test", "tester")
+    assert TOMESYNC_PLUGIN_BUILD >= 40
+    assert "getFriendlyDeviceName" not in impl          # never existed in KOReader
+    assert 'G_reader_settings:readSetting("tomesync_device_name")' in impl
+    assert "Device.model" in impl
+    # adoption runs before the watermark is fetched
+    i_adopt = impl.index("if not self:_adoptDeviceName() then")
+    i_wm = impl.index('apiRequest("GET", "/tome-sync/stats/watermark?device="')
+    assert i_adopt < i_wm          # ...and an unconfirmed move postpones the sync
+    assert "reading-history sync postponed" in impl
+    assert '"/tome-sync/stats/rename-device"' in impl
+    assert 'return "Device name: " .. deviceName()' in impl

--- a/tests/test_reading_log_sources.py
+++ b/tests/test_reading_log_sources.py
@@ -55,7 +55,9 @@ def test_web_sessions_additive_in_dashboard_totals(client, db, admin_user, make_
     when = datetime.utcfromtimestamp(BASE + 5 * DAY)
     db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when, ended_at=when,
                           duration_seconds=900, device="web"))          # additive
-    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=when, ended_at=when,
+    # the device's live recording of the SAME sitting the page-stats describe
+    same = datetime.utcfromtimestamp(BASE)
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=same, ended_at=same,
                           duration_seconds=1200, device="Kindle"))      # double-counts → dropped
     db.flush()
 

--- a/tests/test_session_hygiene.py
+++ b/tests/test_session_hygiene.py
@@ -270,8 +270,9 @@ def test_imported_clusters_listed_device_sessions_labeled(hygiene_client, make_b
     base = 1_700_000_000  # 2023-11-14
     _add_page_stats(db, user, book, base=base, count=5, dur=60)                 # sitting 1: 300s
     _add_page_stats(db, user, book, base=base + 7200, count=3, dur=120, page0=10)  # sitting 2: 360s
-    # Device-origin live session on the covered book — listed, but not counted.
-    superseded = _add_session(db, user, book, start=datetime(2023, 11, 14, 23, 0), seconds=600, pages=10)
+    # Device-origin live session recorded during sitting 1 (base = 22:13:20Z)
+    # — the same reading described twice: listed, but not counted.
+    superseded = _add_session(db, user, book, start=datetime(2023, 11, 14, 22, 14), seconds=600, pages=10)
     # Manual log — additive, listed and counted.
     manual = ReadingSession(user_id=user.id, book_id=book.id,
                             started_at=datetime(2026, 7, 1, 20, 0),
@@ -308,14 +309,16 @@ def test_imported_clusters_listed_device_sessions_labeled(hygiene_client, make_b
 
 def test_imported_cluster_delete(hygiene_client, make_book):
     """Deleting an imported row removes exactly that sitting's page-stats;
-    deleting the last one un-covers the book and its live sessions count again."""
+    deleting the sitting a live session overlaps un-supersedes that session,
+    so it counts again."""
     from backend.models.ko_stats import PageStat
     c, db, user, jwt, _key = hygiene_client
     book = make_book(title="Accidental Open")
-    base = 1_700_000_000
+    base = 1_700_000_000  # 2023-11-14 22:13:20Z
     _add_page_stats(db, user, book, base=base, count=5, dur=60)                 # real sitting
     _add_page_stats(db, user, book, base=base + 7200, count=2, dur=150, page0=50)  # accidental
-    live = _add_session(db, user, book, start=datetime(2023, 11, 15, 9, 0), seconds=400, pages=7)
+    # live device session recorded during the real sitting — superseded by it
+    live = _add_session(db, user, book, start=datetime(2023, 11, 14, 22, 14), seconds=400, pages=7)
     live_id = live.id  # the instance detaches once the endpoint commits/rolls back
     headers = {"Authorization": f"Bearer {jwt}"}
 
@@ -341,12 +344,12 @@ def test_imported_cluster_delete(hygiene_client, make_book):
     )
     assert r.status_code == 404
 
-    # one imported sitting remains; the live device session is listed as not counted
+    # the real sitting remains and still describes the live session: not counted
     rows = c.get(f"/api/stats/sessions?book_id={book.id}", headers=headers).json()["sessions"]
     assert [(r["kind"], r["counted"]) for r in rows] == [("session", False), ("imported", True)]
     remaining = rows[1]
 
-    # delete the last sitting → book is no longer covered → live session counts again
+    # delete that sitting → nothing overlaps the live session → it counts again
     r = c.delete(
         f"/api/stats/imported-sessions?book_id={book.id}"
         f"&start={remaining['range_start']}&end={remaining['range_end']}",

--- a/tests/test_stats_reconciliation.py
+++ b/tests/test_stats_reconciliation.py
@@ -181,3 +181,116 @@ def test_session_timeline_ribbon_reconciled(client, db, admin_user, make_book):
     assert not any(e["duration_seconds"] == 1800 and e["title"] == "Covered Book"
                    and not str(e["id"]).startswith("ps-") and e["started_at"].startswith("2026-01-10")
                    for e in tl)
+
+
+# ── Per-sitting supersession (issue #181) ────────────────────────────────────────
+
+def _live(db, user, book, start, secs, pages=10, device="KOReader"):
+    """A plugin-recorded device session, [start, start+secs]."""
+    from datetime import timedelta
+    row = ReadingSession(user_id=user.id, book_id=book.id, started_at=start,
+                         ended_at=start + timedelta(seconds=secs),
+                         duration_seconds=secs, pages_turned=pages, device=device)
+    db.add(row)
+    db.flush()
+    return row
+
+
+def _pagestats_at(db, user, book, start_epoch, rows, device="KOReader", page0=1):
+    for i, secs in enumerate(rows):
+        db.add(PageStat(user_id=user.id, book_id=book.id, page=page0 + i, total_pages=300,
+                        start_time=start_epoch + i * 60, duration_seconds=secs, device=device))
+
+
+def test_second_device_live_sessions_survive_history_import(client, db, admin_user, make_book):
+    """Issue #181: a week of phone reading (live sessions only) must not vanish
+    when a Kindle later syncs its own reading history for the same book. Both
+    devices report the literal device name "KOReader" (the plugin's fallback),
+    so the rule can't lean on device identity — supersession is per sitting:
+    only the live sessions that imported page-stats overlap in time drop out.
+    """
+    user, _ = admin_user
+    book = make_book(title="Una corte de rosas y espinas")
+
+    # Phone: 5 evenings, one 3600s live session each, no history sync at all.
+    phone = [
+        _live(db, user, book, datetime(2026, 8, 10 + i, 21, 0), 3600, pages=40)
+        for i in range(5)
+    ]
+    # Kindle, Aug 16: two sittings — each recorded BOTH as a live session and as
+    # imported page-stats (the same reading, described twice).
+    k1_start, k2_start = datetime(2026, 8, 16, 12, 10), datetime(2026, 8, 16, 22, 50)
+    kindle_live = [
+        _live(db, user, book, k1_start, 3060, pages=30),   # 51m
+        _live(db, user, book, k2_start, 3780, pages=38),   # 1h3m
+    ]
+    _pagestats_at(db, user, book, _epoch(2026, 8, 16, 12) + 600, [100] * 30)            # 3000s
+    _pagestats_at(db, user, book, _epoch(2026, 8, 16, 22) + 3000, [100] * 37, page0=40)  # 3700s
+    db.flush()
+
+    # Dashboard totals: phone hours + Kindle page-stats, Kindle live sessions dropped.
+    h = client.get("/api/stats?days=0").json()["headline"]
+    assert h["total_reading_seconds"] == 5 * 3600 + 3000 + 3700
+    assert h["pages_turned"] == 5 * 40 + 30 + 37
+
+    # Per-book block: same total, first read is the phone's first evening,
+    # sessions = 5 phone + 2 imported clusters.
+    b = client.get(f"/api/books/{book.id}/reading-stats").json()["own"]
+    assert b["total_seconds"] == 5 * 3600 + 3000 + 3700
+    assert b["sessions"] == 7
+    assert b["first_read"].startswith("2026-08-10")
+    assert b["last_read"].startswith("2026-08-16T2")
+    days = {d["date"]: d["seconds"] for d in b["session_timeline"]}
+    assert days["2026-08-10"] == 3600 and days["2026-08-16"] == 6700
+    # "Where you read": one merged KOReader row, not a page-stat row plus a session row.
+    src = {r["device"]: r for r in b["by_source"]}
+    assert set(src) == {"KOReader"}
+    assert src["KOReader"]["seconds"] == 5 * 3600 + 3000 + 3700
+
+    # Session log: phone rows counted, Kindle live rows labelled not counted.
+    rows = client.get("/api/stats/sessions?limit=50").json()["sessions"]
+    counted = {r["id"]: r["counted"] for r in rows if r["kind"] == "session"}
+    assert all(counted[s.id] for s in phone)
+    assert not any(counted[s.id] for s in kindle_live)
+    assert sum(1 for r in rows if r["kind"] == "imported") == 2
+
+    # Habits ribbon: phone sittings drawn, Kindle live ones replaced by clusters.
+    tl = client.get("/api/stats?days=0").json()["session_timeline"]
+    live_ids = {e["id"] for e in tl if not str(e["id"]).startswith("ps-")}
+    assert {s.id for s in phone} <= live_ids
+    assert not ({s.id for s in kindle_live} & live_ids)
+
+
+def test_live_session_counts_until_its_history_arrives(client, db, admin_user, make_book):
+    """Same device, ordinary flow: the live session posts at close, the page-stats
+    for it arrive on a later launch. Before: it counts. After: it is superseded
+    and the page-stats carry the sitting — totals never double and never dip."""
+    user, _ = admin_user
+    book = make_book(title="Kindle Book")
+    # older synced sitting: page-stats + its live session
+    _pagestats_at(db, user, book, _epoch(2026, 8, 1, 20), [120] * 10)          # 1200s
+    _live(db, user, book, datetime(2026, 8, 1, 20, 0), 1200, pages=10)
+    # tonight's sitting: live only so far
+    tonight = _live(db, user, book, datetime(2026, 8, 2, 20, 0), 1800, pages=15)
+    db.flush()
+    assert client.get("/api/stats?days=0").json()["headline"]["total_reading_seconds"] == 3000
+    row = next(r for r in client.get("/api/stats/sessions").json()["sessions"] if r["id"] == tonight.id)
+    assert row["counted"] is True
+
+    # history sync catches up
+    _pagestats_at(db, user, book, _epoch(2026, 8, 2, 20), [120] * 15, page0=11)  # 1800s
+    db.flush()
+    assert client.get("/api/stats?days=0").json()["headline"]["total_reading_seconds"] == 3000
+    row = next(r for r in client.get("/api/stats/sessions").json()["sessions"] if r["id"] == tonight.id)
+    assert row["counted"] is False
+
+
+def test_manual_session_never_superseded_even_when_overlapping(client, db, admin_user, make_book):
+    """A hand-logged session on a device-synced book is additive even if its
+    window overlaps page-stats (KOReader can't describe a paper session)."""
+    user, _ = admin_user
+    book = make_book(title="Paper and Kindle")
+    _pagestats_at(db, user, book, _epoch(2026, 8, 1, 20), [120] * 10)   # 1200s
+    _live(db, user, book, datetime(2026, 8, 1, 20, 5), 900, device="manual")
+    db.flush()
+    assert client.get("/api/stats?days=0").json()["headline"]["total_reading_seconds"] == 2100

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -212,5 +212,10 @@ def test_build_bumped_for_rebake():
     # strategy as book open, so a device that is behind no longer overwrites
     # newer progress from another device. Pairs with the server-side
     # TOME_KOSYNC_POSITION_BRIDGE read bridge (experimental, default off).
-    assert TOMESYNC_PLUGIN_BUILD >= 39
-    assert TOMESYNC_PLUGIN_SEMVER == "1.12.0"
+    # 1.13.0 / build 40 gives every device a real identity (issue #181): the
+    # reported name is Device.model or a user-set "Device name" instead of the
+    # literal "KOReader" every install used to send, so devices stop sharing
+    # one reading-history watermark; imported history + watermark migrate to
+    # the new name on first sync via /tome-sync/stats/rename-device.
+    assert TOMESYNC_PLUGIN_BUILD >= 40
+    assert TOMESYNC_PLUGIN_SEMVER == "1.13.0"

--- a/website/src/pages/docs/koreader.astro
+++ b/website/src/pages/docs/koreader.astro
@@ -219,8 +219,15 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
     reading: it feeds the per-page <strong>Reading intensity</strong> and
     <strong>Time per chapter</strong> charts on the book page, and its sittings appear in the
     <a href={withBase("/docs/stats")}>session lists</a> tagged <em>imported</em>. The plugin's
-    own live sessions for such a book are excluded from the totals so nothing is counted
-    twice.
+    own live sessions for the same sittings are excluded from the totals so nothing is counted
+    twice; reading of that book on another device that has not synced its history still counts
+    through its live sessions.
+  </p>
+  <p>
+    The sync keeps its place per device, under the name shown in
+    <strong>TomeSync → Settings → Device name</strong>. It defaults to the device model
+    (for example <code>KindlePaperWhite4</code>); set a name if you use several devices of the
+    same kind. Renaming carries the device's imported history and sync position over.
   </p>
 
   <h3>Sync on suspend</h3>

--- a/website/src/pages/docs/stats.astro
+++ b/website/src/pages/docs/stats.astro
@@ -123,10 +123,12 @@ import { withBase } from '../../lib/path'
     whose stray minutes used to be removable only by wiping the book's entire imported
     history. Deleting one removes exactly that sitting's page timings and the totals drop with
     it. They can't be trimmed: KOReader already caps idle time at the source, so there is
-    nothing to cut. Two labels tell the rest of the story: on a book with imported history,
-    the plugin's live sessions describe the same reading a second time, so they stay listed
-    with a <strong>not counted</strong> tag while the imported rows carry the totals — nothing
-    is ever counted twice, and nothing silently disappears. The small info icon next to every
+    nothing to cut. Two labels tell the rest of the story: when imported history describes a
+    sitting the plugin also recorded as a live session, that live session stays listed with a
+    <strong>not counted</strong> tag while the imported row carries the totals — nothing is
+    ever counted twice, and nothing silently disappears. The rule is per sitting, not per
+    book: reading the same book on a second device that never synced its history still
+    counts through its live sessions. The small info icon next to every
     session list explains all labels in place.
   </p>
   <p>


### PR DESCRIPTION
Fixes #181.

## Problem
A user read a book for a week on their phone (TomeSync live sessions only), then set up a Kindle that syncs its KOReader reading history. The moment the Kindle uploaded two sittings of the same book, the phone's whole week dropped out of the totals: imported page-stats superseded *every* device-origin live session on that book. On top of that, every device reported the literal name "KOReader" (the plugin called a `Device` method that does not exist in KOReader), so devices shared one history-sync watermark and were indistinguishable in the reading log.

## Part 1 - reconciliation per sitting (fixes the reporter, no plugin update needed)
- `reconciled_reading.superseded_clause()`: a device live session is excluded only when a `ko_page_stats` row of the same book starts inside its window (±120 s). Everything else counts - reading on a second device that never synced history, and live sessions until their own device's history catches up. Web/manual sessions never superseded (unchanged).
- Same predicate everywhere: all aggregate helpers, the Habits ribbon, the session list's `counted` flag, the per-book block (which also merges "Where you read" rows by device label).
- Composite `(user_id, book_id, start_time)` index on `ko_page_stats` (model + startup `CREATE INDEX IF NOT EXISTS`).
- Query-time only, retroactive, no schema change. Behaviour change worth knowing: deleting an imported sitting now un-supersedes the live session it overlapped (before, only deleting a book's *last* cluster did) - documented.

## Part 2 - device identity (plugin build 40 / 1.13.0)
- `deviceName()`: user-set `Settings > Device name` -> `Device.model` (`KindlePaperWhite4`, `Kobo_clara`, ...) -> `"KOReader"` last resort. Settings row shows the current name; InputDialog to override.
- Migration: before each history sync the plugin calls `POST /tome-sync/stats/rename-device` (from the last adopted name, initially "KOReader") which relabels the device's page-stats, dedups rows already present under the new name, and moves the `StatsImport` watermark. If the server does not confirm, the sync is **postponed** rather than run from watermark 0 (which would re-import sittings the user deleted). Audit-logged.
- `import_batch` dedups on `(user, book, page, start_time)` regardless of label, so a device re-sending its history under a new name never duplicates rows.
- Live sessions keep their recorded label (pre-40 labels were shared across devices; the stats reconcile by time overlap, not label).

## Caveats
- Legacy setups where **two** devices both synced history under "KOReader": the first device to update takes over that history's label; the second re-sends its own history once (deduplicated, no double counting), which brings back any of *its* imported sittings the user had deleted in Tome. Documented in the changelog.
- No unique data is deleted anywhere: only exact-duplicate page rows during rename; sessions untouched.

## Verification
- Full suite green (1124), including new: reporter-shaped two-device test (dashboard, per-book block, session list, ribbon), live-counts-until-history-arrives, manual-never-superseded, and 6 device-identity tests (label-agnostic dedup, per-device watermarks, rename + watermark move, rename with pre-existing new-label rows, endpoint via plugin key, plugin source shape). Three existing tests had "same reading" fixtures placed hours/days apart from their page-stats; aligned them with the sitting they claim to duplicate.
- Prod-shaped: reporter's data seeded into the dev DB (all rows labelled "KOReader"), checked in the live UI. `/api/stats?days=0` latency unchanged on a 50k-page-stat DB (1.13 s before/after).
- KOReader emulator round-trip against dev: legacy "KOReader" history + watermark migrate to `Emulator` on first sync (audit row, watermark carried, no re-send); custom rename `Emulator -> Bens Emulator` and back via the real Save button; live session + position PUT carry the new name; postpone path exercised with the server down (only the rename retries, no sync from zero), then the happy path after.
- Not done: Kindle hardware pass. Nothing device-specific in the change; `Device.model` is a plain field on every KOReader port.
