### PR TITLE
feat(tomesync): device-side connection settings + Quick Connect pairing (build 41)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Added
+- The TomeSync plugin's connection settings are now editable on the device
+  (plugin build 41). The server URL baked in at download time can be changed
+  under TomeSync → Settings — the fix for a device stranded by a server that
+  moved address, which could never self-update its way out. Credentials are
+  never typed on the device: "Sign in with code" runs the existing Quick
+  Connect flow (enter a short code in the web UI under Settings → Security →
+  Quick Connect) and the device receives its own API key; the account name
+  shown is derived from that key. A reset item restores the baked-in
+  defaults. Also fixes the device-name dialog's ghost text, which never
+  showed. Thanks @pabsan-0 for the initial implementation. (#181, #185)
+
 ## [2.3.0] - 2026-08-20
 
 ![Series-first Bindery review: two pending series cards, one adopting the exact identity of a series already in the library](https://raw.githubusercontent.com/bndct-devops/tome/main/docs/screenshots/bindery-series-review.png)

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -82,8 +82,17 @@ logger = logging.getLogger(__name__)
 # from another device; the push happens after the pull settles. Pairs with the
 # server-side TOME_KOSYNC_POSITION_BRIDGE read bridge (experimental, off by
 # default), which lets that pull also see third-party KOSync client pushes.
-TOMESYNC_PLUGIN_BUILD = 40
-TOMESYNC_PLUGIN_SEMVER = "1.13.0"
+# BUILD 41: device-side connection settings (#181, #185) — baked server URL /
+# API key / username become DEFAULT_* fallbacks overridable in Settings. The
+# server URL is user-editable (a device whose baked URL went stale cannot
+# self-update its way out, so the fix must live on the device); the API key is
+# never typed — "Sign in with code" runs the existing Quick Connect flow
+# (initiate → code entered in web UI → poll → JWT → mint plugin API key); the
+# username is display-only, derived from /auth/me at pairing time. Plus an
+# input_hint fix (ghost text never showed; the field was misnamed "hint") and
+# a settings-menu reorder. Co-developed with @pabsan-0.
+TOMESYNC_PLUGIN_BUILD = 41
+TOMESYNC_PLUGIN_SEMVER = "1.14.0"
 TOMESYNC_PLUGIN_VERSION = str(TOMESYNC_PLUGIN_BUILD)
 
 
@@ -1792,11 +1801,20 @@ local function liveSetting(key, default)
     if v == nil or v == "" then return default end
     return v
 end
--- Connection credentials. Defaults can be overridden in Settings so the user
--- can point at their own Tome server without editing the plugin source.
+-- Connection settings. The server URL is user-editable in Settings so a device
+-- whose baked address went stale can be repointed without reinstalling (it
+-- cannot self-update its way out — updates come from the old, dead URL). The
+-- API key and username are never typed: "Sign in with code" (Quick Connect
+-- pairing) writes both, and the username is only ever the server's answer to
+-- "who does this key belong to" — the key alone decides the account.
 local function serverURL()     return liveSetting("tomesync_server_url", DEFAULT_SERVER_URL) end
 local function apiKey()        return liveSetting("tomesync_api_key",    DEFAULT_API_KEY) end
 local function username()      return liveSetting("tomesync_username",   DEFAULT_USERNAME) end
+local function hasOverrides()
+    return G_reader_settings:readSetting("tomesync_server_url") ~= nil
+        or G_reader_settings:readSetting("tomesync_api_key") ~= nil
+        or G_reader_settings:readSetting("tomesync_username") ~= nil
+end
 
 -- Short timeout so unreachable server doesn't freeze the UI
 
@@ -1872,7 +1890,9 @@ local function idleCapSeconds()
     return mins * 60
 end
 
-local function apiRequest(method, path, body)
+-- opts.token: bearer override for the few calls that authenticate with
+-- something other than the plugin API key (the Quick Connect pairing JWT).
+local function apiRequest(method, path, body, opts)
     -- Skip immediately if WiFi is not connected — zero blocking
     if not NetworkMgr:isConnected() then
         return nil, "offline"
@@ -1891,7 +1911,7 @@ local function apiRequest(method, path, body)
     local resp_chunks = {{}}
 
     local headers = {{
-        ["Authorization"] = "Bearer " .. apiKey(),
+        ["Authorization"] = "Bearer " .. ((opts and opts.token) or apiKey()),
         ["Content-Type"]  = "application/json",
         ["Accept"]        = "application/json",
     }}
@@ -2743,6 +2763,86 @@ function TomeSync:_editStringSetting(key, title, hint, description)
     }}
     UIManager:show(dialog)
     dialog:onShowKeyboard()
+end
+
+-- Settings > Sign in with code: Quick Connect pairing. The device asks the
+-- server for a short code, the user enters it in the Tome web UI on an
+-- already-signed-in browser, and the device exchanges the resulting JWT for a
+-- freshly minted plugin API key. No token typing on the device, ever.
+function TomeSync:_signInWithCode()
+    if not NetworkMgr:isConnected() then
+        UIManager:show(InfoMessage:new{{ text = "Connect to WiFi first.", timeout = 3 }})
+        return
+    end
+    local resp = apiRequest("POST", "/auth/quick-connect/initiate", {{}})
+    if type(resp) ~= "table" or not resp.code or not resp.poll_token then
+        UIManager:show(InfoMessage:new{{
+            text = "Could not reach " .. serverURL()
+                   .. "\\nCheck the server URL, then try again.",
+            timeout = 5,
+        }})
+        return
+    end
+    local qc_code, poll_token = resp.code, resp.poll_token
+    local deadline = os.time() + 5 * 60   -- codes expire server-side after 5 min
+    local cancelled = false
+    local waiting
+    waiting = InfoMessage:new{{
+        text = "Pairing code:  " .. qc_code .. "\\n\\n"
+               .. "In Tome (signed in, any browser) open\\n"
+               .. "Settings > Security > Quick Connect\\n"
+               .. "and enter this code.\\n\\n"
+               .. "Waiting\\u{{2026}}  Tap to cancel.",
+        dismiss_callback = function() cancelled = true end,
+    }}
+    UIManager:show(waiting)
+
+    local function finish(jwt)
+        local key_resp = apiRequest("POST", "/plugin/api-keys",
+            {{ label = "KOReader Plugin (" .. deviceName() .. ", paired)" }},
+            {{ token = jwt }})
+        if type(key_resp) ~= "table" or not key_resp.key then
+            UIManager:close(waiting)
+            UIManager:show(InfoMessage:new{{
+                text = "Pairing failed while creating the API key.", timeout = 5 }})
+            return
+        end
+        local me = apiRequest("GET", "/auth/me", nil, {{ token = jwt }})
+        G_reader_settings:saveSetting("tomesync_api_key", key_resp.key)
+        if type(me) == "table" and type(me.username) == "string" and me.username ~= "" then
+            G_reader_settings:saveSetting("tomesync_username", me.username)
+        else
+            G_reader_settings:delSetting("tomesync_username")
+        end
+        UIManager:close(waiting)
+        UIManager:show(InfoMessage:new{{
+            text = "Signed in as " .. username() .. "\\n" .. serverURL(),
+            timeout = 4,
+        }})
+    end
+
+    local function poll()
+        if cancelled then return end
+        if os.time() > deadline then
+            UIManager:close(waiting)
+            UIManager:show(InfoMessage:new{{
+                text = "Pairing code expired. Try again.", timeout = 4 }})
+            return
+        end
+        local r, c = apiRequest("POST", "/auth/quick-connect/poll",
+            {{ code = qc_code, poll_token = poll_token }})
+        if type(r) == "table" and r.status == "authorized" and r.access_token then
+            finish(r.access_token)
+        elseif c == 410 then   -- consumed or expired server-side
+            UIManager:close(waiting)
+            UIManager:show(InfoMessage:new{{
+                text = "Pairing code expired. Try again.", timeout = 4 }})
+        else
+            -- pending, or a transient network error: keep polling to the deadline
+            UIManager:scheduleIn(3, poll)
+        end
+    end
+    UIManager:scheduleIn(3, poll)
 end
 
 function TomeSync:_syncReadingStats(manual)
@@ -5125,12 +5225,15 @@ function TomeSync:_menuItems()
         callback       = function() self:_editDeviceName() end,
     }})
     table.insert(settings_items, {{
-        text_func      = function() return "Server URL: " .. serverURL() end,
-        help_text      = "The address of your Tome server, i.e. "
+        text_func      = function()
+            local custom = G_reader_settings:readSetting("tomesync_server_url")
+            return "Server URL: " .. serverURL() .. (custom and " (custom)" or "")
+        end,
+        help_text      = "The address of your Tome server, e.g. "
                        .. "http://192.168.1.10:8080 or "
-                       .. "https://tome.example.com. Tome already bakes in this "
-                       .. "config for you when downloading TomeSync from the "
-                       .. "Tome UI. Clear it to restore the baked in default.",
+                       .. "https://tome.example.com. The plugin download bakes "
+                       .. "this in for you; set it here if the server has "
+                       .. "moved. Clear it to restore the baked-in default.",
         keep_menu_open = true,
         callback       = function()
             self:_editStringSetting("tomesync_server_url", "Server URL",
@@ -5138,27 +5241,56 @@ function TomeSync:_menuItems()
         end,
     }})
     table.insert(settings_items, {{
-        text_func      = function() return "Username: " .. username() end,
-        help_text      = "The account name Tome associates with this device's "
-                       .. "sessions and history. Tome already bakes in this "
-                       .. "config for you when downloading TomeSync from the "
-                       .. "Tome UI. Clear to restore the baked in default.",
+        text_func      = function() return "Account: " .. username() end,
+        help_text      = "The Tome account this device syncs as. It is decided "
+                       .. "by the API key, not editable here - use \\"Sign in "
+                       .. "with code\\" below to switch accounts.",
         keep_menu_open = true,
         callback       = function()
-            self:_editStringSetting("tomesync_username", "Username",
-                DEFAULT_USERNAME, "Your Tome account username.")
+            local paired = G_reader_settings:readSetting("tomesync_api_key") ~= nil
+            UIManager:show(InfoMessage:new{{
+                text = "Account: " .. username()
+                       .. "\\nServer: " .. serverURL()
+                       .. "\\nAPI key: " .. (paired and "paired on this device"
+                                                    or "baked in at download"),
+                timeout = 5,
+            }})
         end,
     }})
     table.insert(settings_items, {{
-        text_func      = function() return "API key: " .. (G_reader_settings:readSetting("tomesync_api_key") and "\\u{{2022}}\\u{{2022}}\\u{{2022}}\\u{{2022}}" or "(default)") end,
-        help_text      = "The auth key for your Tome account. Tome already "
-                       .. "bakes in this config for you when downloading "
-                       .. "TomeSync from the Tome's UI. Clear to restore the "
-                       .. "baked in default.",
+        text           = "Sign in with code",
+        help_text      = "Connect this device to a Tome account without typing "
+                       .. "any credentials: the plugin shows a short code, you "
+                       .. "enter it in the Tome web UI (Settings > Security > "
+                       .. "Quick Connect), and the device receives its own API "
+                       .. "key. Use this after changing the server URL, or to "
+                       .. "switch accounts.",
+        keep_menu_open = true,
+        callback       = function() self:_signInWithCode() end,
+    }})
+    table.insert(settings_items, {{
+        text           = "Reset connection to baked-in defaults",
+        help_text      = "Forget the server URL, API key and account set on "
+                       .. "this device and go back to what was baked in when "
+                       .. "the plugin was downloaded.",
+        enabled_func   = function() return hasOverrides() end,
         keep_menu_open = true,
         callback       = function()
-            self:_editStringSetting("tomesync_api_key", "API key",
-                DEFAULT_API_KEY:sub(1, 6) .. "\\u{{2026}}", "Your Tome account API key.")
+            UIManager:show(ConfirmBox:new{{
+                text = "Reset server URL, API key and account to the baked-in "
+                       .. "defaults?",
+                ok_text = "Reset",
+                ok_callback = function()
+                    G_reader_settings:delSetting("tomesync_server_url")
+                    G_reader_settings:delSetting("tomesync_api_key")
+                    G_reader_settings:delSetting("tomesync_username")
+                    UIManager:show(InfoMessage:new{{
+                        text = "Connection reset.\\nServer: " .. serverURL()
+                               .. "\\nAccount: " .. username(),
+                        timeout = 4,
+                    }})
+                end,
+            }})
         end,
     }})
 

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -1780,11 +1780,23 @@ do
     insert_after(fm_order, "tools", "calibre", "tomesync")
 end
 
--- ── Config (baked in at download time) ───────────────────────────────────────
+-- ── Config (defaults baked in at download time) ─────────────────────────────
 
-local SERVER_URL = "{server_url}"
-local API_KEY    = "{api_key}"
-local USERNAME   = "{username}"
+-- Defaults baked in at download time; overridable in Settings > Server.
+local DEFAULT_SERVER_URL = "{server_url}"
+local DEFAULT_API_KEY    = "{api_key}"
+local DEFAULT_USERNAME   = "{username}"
+
+local function liveSetting(key, default)
+    local v = G_reader_settings:readSetting(key)
+    if v == nil or v == "" then return default end
+    return v
+end
+-- Connection credentials. Defaults can be overridden in Settings so the user
+-- can point at their own Tome server without editing the plugin source.
+local function serverURL()     return liveSetting("tomesync_server_url", DEFAULT_SERVER_URL) end
+local function apiKey()        return liveSetting("tomesync_api_key",    DEFAULT_API_KEY) end
+local function username()      return liveSetting("tomesync_username",   DEFAULT_USERNAME) end
 
 -- Short timeout so unreachable server doesn't freeze the UI
 
@@ -1874,12 +1886,12 @@ local function apiRequest(method, path, body)
         return nil, "backoff"
     end
 
-    local url = SERVER_URL .. "/api" .. path
+    local url = serverURL() .. "/api" .. path
     local req_body = body and rapidjson.encode(body) or nil
     local resp_chunks = {{}}
 
     local headers = {{
-        ["Authorization"] = "Bearer " .. API_KEY,
+        ["Authorization"] = "Bearer " .. apiKey(),
         ["Content-Type"]  = "application/json",
         ["Accept"]        = "application/json",
     }}
@@ -1944,7 +1956,7 @@ local function downloadFile(book_id, file_id, dest_path, total_size, progress_cb
         return false, "offline"
     end
 
-    local url = SERVER_URL .. "/api/tome-sync/download/" .. book_id .. "/" .. file_id
+    local url = serverURL() .. "/api/tome-sync/download/" .. book_id .. "/" .. file_id
     local fh = io.open(dest_path, "wb")
     if not fh then
         return false, "cannot open file for writing"
@@ -1982,7 +1994,7 @@ local function downloadFile(book_id, file_id, dest_path, total_size, progress_cb
         url     = url,
         method  = "GET",
         headers = {{
-            ["Authorization"] = "Bearer " .. API_KEY,
+            ["Authorization"] = "Bearer " .. apiKey(),
         }},
         sink = sink,
     }})
@@ -2130,9 +2142,9 @@ local function fetchText(path)
     local chunks = {{}}
     socketutil:set_timeout(10, 60)
     local ok, code = http.request({{
-        url     = SERVER_URL .. "/api" .. path,
+        url     = serverURL() .. "/api" .. path,
         method  = "GET",
-        headers = {{ ["Authorization"] = "Bearer " .. API_KEY }},
+        headers = {{ ["Authorization"] = "Bearer " .. apiKey() }},
         sink    = ltn12.sink.table(chunks),
     }})
     socketutil:reset_timeout()
@@ -2662,7 +2674,7 @@ function TomeSync:_editDeviceName()
     dialog = InputDialog:new{{
         title       = "Device name",
         input       = current,
-        hint        = autoDeviceName(),
+        input_hint  = autoDeviceName(),
         description = "How this device is labelled in Tome's reading log and "
                       .. "stats. Leave empty to use the automatic name "
                       .. "(\\"" .. autoDeviceName() .. "\\"). Give each "
@@ -2690,6 +2702,41 @@ function TomeSync:_editDeviceName()
                     end
                     UIManager:show(InfoMessage:new{{
                         text = "Device name: " .. deviceName(), timeout = 2 }})
+                end,
+            }},
+        }}}},
+    }}
+    UIManager:show(dialog)
+    dialog:onShowKeyboard()
+end
+
+function TomeSync:_editStringSetting(key, title, hint, description)
+    local current = G_reader_settings:readSetting(key) or ""
+    local dialog
+    dialog = InputDialog:new{{
+        title       = title,
+        input       = current,
+        input_hint  = hint,
+        description = description,
+        buttons     = {{{{
+            {{
+                text     = "Cancel",
+                id       = "close",
+                callback = function() UIManager:close(dialog) end,
+            }},
+            {{
+                text             = "Save",
+                is_enter_default = true,
+                callback         = function()
+                    local v = dialog:getInputText():gsub("^%s+", ""):gsub("%s+$", "")
+                    if v == "" then
+                        G_reader_settings:delSetting(key)
+                    else
+                        G_reader_settings:saveSetting(key, v)
+                    end
+                    UIManager:close(dialog)
+                    UIManager:show(InfoMessage:new{{
+                        text = title .. ": " .. (v ~= "" and v or hint), timeout = 2 }})
                 end,
             }},
         }}}},
@@ -4927,14 +4974,14 @@ function TomeSync:_menuItems()
                 local ok, result, code = pcall(apiRequest, "GET", "/health")
                 if ok and type(code) == "number" and code >= 200 and code < 300 then
                     UIManager:show(InfoMessage:new{{
-                        text = "Connected to " .. SERVER_URL
-                               .. "\\nUser: " .. USERNAME,
+                        text = "Connected to " .. serverURL()
+                               .. "\\nUser: " .. username(),
                         timeout = 4,
                     }})
                 else
                     local err = tostring(result or "unknown error")
                     UIManager:show(InfoMessage:new{{
-                        text = "Connection failed!\\n" .. SERVER_URL
+                        text = "Connection failed!\\n" .. serverURL()
                                .. "\\nError: " .. err,
                         timeout = 6,
                     }})
@@ -4984,15 +5031,6 @@ function TomeSync:_menuItems()
             G_reader_settings:saveSetting("tomesync_auto_check",
                 not G_reader_settings:isTrue("tomesync_auto_check"))
         end,
-    }})
-    table.insert(settings_items, {{
-        text_func      = function() return "Device name: " .. deviceName() end,
-        help_text      = "The label Tome shows for this device (reading log, "
-                       .. "\\"Where you read\\"). Defaults to the device model; "
-                       .. "set a name if you use several devices of the same "
-                       .. "kind.",
-        keep_menu_open = true,
-        callback       = function() self:_editDeviceName() end,
     }})
     table.insert(settings_items, {{
         text         = "Auto-sync reading history on launch",
@@ -5068,12 +5106,60 @@ function TomeSync:_menuItems()
     end
     table.insert(settings_items, {{
         text           = "Idle time cap",
+        separator      = true,
         help_text      = "Longest gap between page turns that still counts as "
                        .. "reading. If the device is left awake without turning "
                        .. "pages - you fell asleep, or the cover did not put it "
                        .. "to sleep - time beyond the cap is not booked to the "
                        .. "reading session.",
         sub_item_table = idleCapItems(),
+    }})
+    table.insert(settings_items, {{
+        text_func      = function() return "Device name: " .. deviceName() end,
+        separator      = true,
+        help_text      = "The label Tome shows for this device (reading log, "
+                       .. "\\"Where you read\\"). Defaults to the device model; "
+                       .. "set a name if you use several devices of the same "
+                       .. "kind.",
+        keep_menu_open = true,
+        callback       = function() self:_editDeviceName() end,
+    }})
+    table.insert(settings_items, {{
+        text_func      = function() return "Server URL: " .. serverURL() end,
+        help_text      = "The address of your Tome server, i.e. "
+                       .. "http://192.168.1.10:8080 or "
+                       .. "https://tome.example.com. Tome already bakes in this "
+                       .. "config for you when downloading TomeSync from the "
+                       .. "Tome UI. Clear it to restore the baked in default.",
+        keep_menu_open = true,
+        callback       = function()
+            self:_editStringSetting("tomesync_server_url", "Server URL",
+                DEFAULT_SERVER_URL, "Your Tome instance address.")
+        end,
+    }})
+    table.insert(settings_items, {{
+        text_func      = function() return "Username: " .. username() end,
+        help_text      = "The account name Tome associates with this device's "
+                       .. "sessions and history. Tome already bakes in this "
+                       .. "config for you when downloading TomeSync from the "
+                       .. "Tome UI. Clear to restore the baked in default.",
+        keep_menu_open = true,
+        callback       = function()
+            self:_editStringSetting("tomesync_username", "Username",
+                DEFAULT_USERNAME, "Your Tome account username.")
+        end,
+    }})
+    table.insert(settings_items, {{
+        text_func      = function() return "API key: " .. (G_reader_settings:readSetting("tomesync_api_key") and "\\u{{2022}}\\u{{2022}}\\u{{2022}}\\u{{2022}}" or "(default)") end,
+        help_text      = "The auth key for your Tome account. Tome already "
+                       .. "bakes in this config for you when downloading "
+                       .. "TomeSync from the Tome's UI. Clear to restore the "
+                       .. "baked in default.",
+        keep_menu_open = true,
+        callback       = function()
+            self:_editStringSetting("tomesync_api_key", "API key",
+                DEFAULT_API_KEY:sub(1, 6) .. "\\u{{2026}}", "Your Tome account API key.")
+        end,
     }})
 
     -- In-book items

--- a/docs/koreader-plugin.md
+++ b/docs/koreader-plugin.md
@@ -12,7 +12,7 @@ Syncs reading progress and sessions between KOReader and your Tome library.
 4. Extract the ZIP to `koreader/plugins/` on your device so you have `koreader/plugins/tomesync.koplugin/main.lua`
 5. Restart KOReader
 
-The plugin is pre-configured with your server URL and API key. No manual configuration needed.
+The plugin is pre-configured with your server URL and API key. No manual configuration needed. If the server address ever changes later, it can be edited on the device — see [Moving servers & switching accounts](#moving-servers--switching-accounts).
 
 **Important:** Download the plugin from the same address your e-reader can reach. If your server is at `<your-server-ip>:8080`, open the settings page at that address before downloading.
 
@@ -251,6 +251,14 @@ The plugin menu is context-aware. It self-registers in the **wrench menu** (afte
 | **Check for updates** | Fetches the latest plugin build from your server and installs it if newer (then prompts to restart). |
 | **Auto-check for updates on launch** | Opt-in toggle. When on, TomeSync checks for updates shortly after startup and prompts only when one is available. |
 | **Auto-sync reading history on launch** | Opt-in toggle, off by default. When on, TomeSync pushes new KOReader reading history to Tome shortly after startup (the first run backfills your whole history; chunked and resumable). Reading time and pages only — never your read/unread status. See [Reading-History Import](#reading-history-import). |
+| **Sync on suspend** | Opt-in toggle. When the device goes to sleep, catches up anything still pending (sessions, ratings, reading history if enabled) so your stats are current without waking the device. Only syncs when WiFi is already connected. |
+| **Aggressive sync (turn WiFi on at suspend)** | Opt-in, requires Sync on suspend. Turns WiFi on at suspend to sync, then lets the device power it back down. Uses more battery. |
+| **Idle time cap** | Longest gap between page turns that still counts as reading (default 10 minutes). Time beyond the cap — you fell asleep, the cover did not sleep the device — is not booked to the session. |
+| **Device name** | The label Tome shows for this device in the reading log and stats. Defaults to the device model; set a name if you use several devices of the same kind. |
+| **Server URL** | The Tome server this device talks to. Baked in at download time; edit it here if the server has moved (marked "(custom)" when overridden). Clear the field to restore the baked-in default. See [Moving servers & switching accounts](#moving-servers--switching-accounts). |
+| **Account** | The Tome account this device syncs as. Display-only — it is decided by the API key, so switching accounts goes through **Sign in with code**. |
+| **Sign in with code** | Connects the device to a Tome account without typing any credentials: the plugin shows a short code, you enter it in the Tome web UI (Settings → Security → Quick Connect), and the device receives its own API key. |
+| **Reset connection to baked-in defaults** | Forgets the server URL, API key and account set on the device and returns to what the plugin download baked in. Only enabled when something is overridden. |
 
 ### Gestures
 
@@ -313,8 +321,34 @@ sideloaded different copy won't sync its rating.
 The plugin authenticates with an API key (`Authorization: Bearer tk_...`), not your login password. Keys are managed in Tome's settings page:
 
 - A key is auto-created when you first download the plugin
+- Pairing a device via **Sign in with code** mints a key of its own (labelled with the device name)
 - You can create additional keys or revoke existing ones
 - Revoking a key immediately disables any plugin using it
+
+---
+
+## Moving servers & switching accounts
+
+The plugin download bakes in your server URL, API key and username, so a fresh
+install needs no configuration. Since plugin build 41 all three can also be
+changed on the device — no re-download or file editing needed.
+
+**The server moved** (new LAN IP, new domain, switched to HTTPS): open
+**TomeSync → Settings → Server URL** and enter the new address. This is the
+only recovery path that works after the fact — self-update can't help, because
+the device would be fetching updates from the old, dead address. If the new
+server does not accept the old API key (a different Tome instance, or the key
+was revoked), follow up with **Sign in with code**.
+
+**Switching accounts** (or signing in after a server change): use
+**Sign in with code**. The plugin shows a short pairing code; enter it in the
+Tome web UI on any signed-in browser under **Settings → Security → Quick
+Connect**. The device then receives its own API key and shows the account it
+now syncs as. Codes expire after 5 minutes; nothing on the device changes
+until pairing completes, so a failed attempt never breaks a working setup.
+
+**Back to square one**: **Reset connection to baked-in defaults** forgets all
+of the above and returns to what the download baked in.
 
 ---
 
@@ -370,7 +404,7 @@ The downloaded plugin has your server URL and API key baked in, so there is noth
 **"Connection failed" on test:**
 - Verify your server is running and reachable from the e-reader's network
 - If you are on a VPN (e.g. Tailscale), make sure it is connected on the e-reader
-- Re-download the plugin if your server address changed
+- If your server address changed, fix it under **Settings → Server URL** — see [Moving servers & switching accounts](#moving-servers--switching-accounts)
 
 **Wrong book matched:**
 - Use "Re-resolve all books" in the plugin menu, then re-open the book
@@ -397,5 +431,5 @@ The plugin consists of three files (plus a backup created on first update):
 |---|---|
 | `_meta.lua` | Plugin metadata (name, description) |
 | `main.lua` | Frozen stable shim — loads the implementation and runs the anti-brick rollback state machine. No config; never replaced by self-update. |
-| `main_impl.lua` | All plugin logic, HTTP client, and config (server URL, API key baked in at download time). The only file self-update replaces. |
+| `main_impl.lua` | All plugin logic, HTTP client, and config (server URL, API key baked in at download time; overridable on-device since build 41). The only file self-update replaces. |
 | `main_impl.lua.bak` | Last confirmed-good implementation, written automatically before each update so the shim can roll back. |

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -54,8 +54,8 @@ def app_client(db: Session):
 
 
 def _baked_url(impl_text: str) -> str:
-    m = re.search(r'local SERVER_URL\s*=\s*"([^"]+)"', impl_text)
-    assert m, "SERVER_URL not found in baked impl"
+    m = re.search(r'local DEFAULT_SERVER_URL\s*=\s*"([^"]+)"', impl_text)
+    assert m, "DEFAULT_SERVER_URL not found in baked impl"
     return m.group(1)
 
 

--- a/tests/test_tomesync_plugin_url.py
+++ b/tests/test_tomesync_plugin_url.py
@@ -217,5 +217,11 @@ def test_build_bumped_for_rebake():
     # literal "KOReader" every install used to send, so devices stop sharing
     # one reading-history watermark; imported history + watermark migrate to
     # the new name on first sync via /tome-sync/stats/rename-device.
-    assert TOMESYNC_PLUGIN_BUILD >= 40
-    assert TOMESYNC_PLUGIN_SEMVER == "1.13.0"
+    # 1.14.0 / build 41 makes the connection device-editable (#181, #185): the
+    # baked server URL / API key / username become overridable defaults; the
+    # URL is edited in Settings (a stranded device can't self-update its way
+    # out of a moved server), credentials arrive via "Sign in with code"
+    # (Quick Connect pairing mints a fresh plugin API key; username derived
+    # from /auth/me, never typed).
+    assert TOMESYNC_PLUGIN_BUILD >= 41
+    assert TOMESYNC_PLUGIN_SEMVER == "1.14.0"

--- a/tests/test_tomesync_selfupdate.py
+++ b/tests/test_tomesync_selfupdate.py
@@ -81,8 +81,8 @@ def test_plugin_zip_has_shim_and_impl(app_client):
     shim = zf.read("tomesync.koplugin/main.lua").decode()
     impl = zf.read("tomesync.koplugin/main_impl.lua").decode()
     # Config is baked into the impl, never the frozen shim.
-    assert "local API_KEY" in impl and "local SERVER_URL" in impl
-    assert "API_KEY" not in shim or "local API_KEY" not in shim
+    assert "local DEFAULT_API_KEY" in impl and "local DEFAULT_SERVER_URL" in impl
+    assert "DEFAULT_API_KEY" not in shim or "local DEFAULT_API_KEY" not in shim
     assert "main_impl.lua" in shim  # shim loads the impl
 
 

--- a/website/src/pages/docs/koreader.astro
+++ b/website/src/pages/docs/koreader.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro'
 import SectionHero from '../../components/SectionHero.astro'
 import DocsMeta from '../../components/DocsMeta.astro'
 import Callout from '../../components/Callout.astro'
+import UnreleasedNote from '../../components/UnreleasedNote.astro'
 import Steps from '../../components/Steps.astro'
 import Kbd from '../../components/Kbd.astro'
 import { Tabs } from '../../components/Tabs'
@@ -269,6 +270,29 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
     shows a "failed to load — reinstall" note; KOReader itself is never affected.
   </Callout>
 
+  <h2 id="changing-servers">Changing servers &amp; switching accounts</h2>
+  <UnreleasedNote />
+  <p>
+    The downloaded plugin comes pre-configured, but the configuration isn't locked in. From
+    plugin build 41, the connection can be changed on the device under
+    <strong>TomeSync → Settings</strong>:
+  </p>
+  <ul>
+    <li><strong>Server URL</strong> — edit this if your server moved (new LAN IP, new domain,
+      switch to HTTPS). This is the one case self-update can't fix for you: a device pointing
+      at a dead address can't fetch anything from it, so the fix has to happen on the device.
+      Clear the field to return to the baked-in address.</li>
+    <li><strong>Sign in with code</strong> — connects the device to an account without typing
+      any credentials. The plugin shows a short pairing code; enter it in Tome on any
+      signed-in browser under <strong>Settings → Security → Quick Connect</strong>, and the
+      device receives its own API key. Codes expire after 5 minutes, and nothing changes on
+      the device until pairing completes — a failed attempt never breaks a working setup.</li>
+    <li><strong>Account</strong> — shows which account the device syncs as. It's decided by
+      the API key, so switching accounts goes through <em>Sign in with code</em>, not a text
+      field.</li>
+    <li><strong>Reset connection to baked-in defaults</strong> — forgets all of the above.</li>
+  </ul>
+
   <h2>Stable book IDs (vs KOSync hashes)</h2>
   <p>
     KOSync identifies books by the MD5 of the file. Edit metadata, re-save, redownload — the
@@ -293,7 +317,7 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
 
   <h2>Troubleshooting</h2>
   <ul>
-    <li><strong>"Test connection" fails</strong> — most often the server URL is wrong or the API key was revoked. Re-download the plugin from Settings.</li>
+    <li><strong>"Test connection" fails</strong> — most often the server URL is wrong or the API key was revoked. Fix the address and re-pair under <a href="#changing-servers">Changing servers &amp; switching accounts</a> (or re-download the plugin from Settings on older builds).</li>
     <li><strong>Reading sessions not showing in stats</strong> — sessions flush on next sync. Pull-to-refresh in KOReader's TomeSync menu.</li>
     <li>See <a href={withBase("/docs/troubleshooting")}>full troubleshooting</a>.</li>
   </ul>


### PR DESCRIPTION
## Summary

Makes the TomeSync plugin's connection editable on the device. Supersedes #185 (which is cherry-picked as the first commit, keeping @pabsan-0's authorship) and closes #181's follow-up ask.

## Changes

**From #185 (kept as-is)**
- Baked `SERVER_URL` / `API_KEY` / `USERNAME` become `DEFAULT_*` fallbacks, overridable via `G_reader_settings`
- Server URL editable in Settings - the recovery path for a device whose server moved address (it can't self-update its way out: updates come from the old, dead URL)
- `hint` → `input_hint` fix on the device-name dialog (ghost text never showed)
- Settings menu reorder (connection block at the bottom, separators)

**Reworked on top**
- Credentials are never typed on the device. "Sign in with code" runs the existing Quick Connect flow: the plugin shows a short code, you enter it in the web UI (Settings → Security → Quick Connect), and the device exchanges the resulting JWT for a freshly minted plugin API key. No new server endpoints.
- Account row is display-only, derived from `/auth/me` at pairing time - the key alone decides the account, so there is no editable username field to mislead
- "Reset connection to baked-in defaults" (confirm-gated, disabled when nothing is overridden); Server URL row shows a "(custom)" marker when overridden
- Pairing failure writes nothing, so a botched pairing can't strand a working install
- Plugin build 40 → 41, semver 1.13.0 → 1.14.0, changelog entry

## Testing

- Full backend suite passes (1124); baked impl syntax-checked with luajit
- KOReader emulator round-trip: paired the device as a second user via Quick Connect, "Test connection" reports the new account with the minted key, reset returns to the baked defaults

## Checklist

- [x] `pytest` passes
- [x] `npm run build` clean (no frontend changes)
- [x] Manually tested the happy path
- [x] Docs updated (if user-facing)
- [x] Screenshots added (if UI change) - see #185 for the settings menu; pairing flow verified in emulator
- [x] No secrets or credentials committed
