### PR TITLE
feat(stats): backlog completion estimates at your pace (#187)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ All notable changes to Tome are documented here. Format loosely follows
   shown is derived from that key. A reset item restores the baked-in
   defaults. Also fixes the device-name dialog's ghost text, which never
   showed. Thanks @pabsan-0 for the initial implementation. (#181, #185)
+- Backlog completion estimates: how long a book you haven't started would
+  take at your own pace, and how long a whole pile would. The book page gets
+  an "Est. read time" cell in Details (word count at your measured words per
+  minute, or your average time per finished book of that type when there is
+  no word count - CBZ and PDF), the series page shows "left in this series"
+  over the unstarted volumes, and Stats → Library has a new Backlog tile with
+  a per-type breakdown. The tile's scope - Want to Read, all unread, a
+  library or a shelf - is picked in the tile's edit-mode settings. Days are
+  derived from your minutes-per-day over the last 30 days (90 when the last
+  month was quiet); books Tome can't estimate yet are counted as "not
+  estimated" rather than guessed. The series Reading Stats block no longer
+  shows its own "Est. remaining", the header line replaces it. (#187)
 
 ## [2.3.0] - 2026-08-20
 

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -669,11 +669,17 @@ def get_series_detail(
             "progress_pct": st.progress_pct if st else None,
         })
 
+    # Backlog estimate over the volumes not started yet (#187).
+    from backend.services import backlog_estimate as be
+    unstarted = [b for b in books if (statuses.get(b.id).status if statuses.get(b.id) else "unread") not in ("read", "reading")]
+    backlog = be.summarise(db, unstarted, be.compute_pace(db, current_user.id)) if unstarted else None
+
     return {
         "name": name,
         "author": author,
         "description": description,
         "books": book_list,
+        "backlog": backlog,
     }
 
 
@@ -1325,6 +1331,23 @@ def get_reader_pacing(
             for c in chapters
         ],
     }
+
+
+@router.get("/{book_id}/estimate")
+def get_book_estimate(
+    book_id: int,
+    tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """How long this whole book would take at the user's pace (#187) — for
+    books not started yet. In-progress books get "remaining" from the
+    reading-stats block instead; this is the full-length figure."""
+    from backend.services import backlog_estimate as be
+
+    book = _visible_book_or_404(db, current_user, book_id)
+    pace = be.compute_pace(db, current_user.id, tz_offset)
+    return be.estimate_book(book, pace)
 
 
 # ── Position history (restore a bad sync) ─────────────────────────────────────

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -1057,6 +1057,105 @@ def get_stats(
     }
 
 
+# Shelf params that the backlog scope honours — the list-endpoint filters a
+# saved shelf can carry. Anything else in a shelf's params (sort, view) is ignored.
+_SHELF_FILTER_KEYS = {
+    "q", "series", "author", "tag", "format", "language", "library_id",
+    "reading_status", "min_rating", "missing", "content_type", "added_by", "ownership",
+}
+
+
+def _backlog_books(db: Session, current_user: User, scope: str) -> list[Book]:
+    """Resolve a backlog scope to its unstarted books (visibility-gated).
+
+    Scopes: ``want`` (Want to Read), ``unread`` (no status / unread / want),
+    ``library:<id>``, ``shelf:<id>``. Finished and in-progress books are never
+    part of a backlog, whatever the scope says.
+    """
+    from backend.api.books import _filtered_books_query
+    from backend.models.library import Library, SavedFilter
+
+    kind, _, arg = scope.partition(":")
+    kwargs: dict = {}
+    if kind == "want":
+        kwargs["reading_status"] = "want_to_read"
+    elif kind == "unread":
+        pass
+    elif kind == "library":
+        if not arg.isdigit():
+            raise HTTPException(status_code=422, detail="Bad library scope")
+        lib = db.get(Library, int(arg))
+        if not lib:
+            raise HTTPException(status_code=404, detail="Library not found")
+        kwargs["library_id"] = lib.id
+    elif kind == "shelf":
+        if not arg.isdigit():
+            raise HTTPException(status_code=422, detail="Bad shelf scope")
+        shelf = db.get(SavedFilter, int(arg))
+        if not shelf or (shelf.owner_id not in (None, current_user.id)):
+            raise HTTPException(status_code=404, detail="Shelf not found")
+        try:
+            params = json.loads(shelf.params or "{}")
+        except ValueError:
+            params = {}
+        for k, v in params.items():
+            if k not in _SHELF_FILTER_KEYS or v in (None, ""):
+                continue
+            if k in ("library_id", "min_rating", "added_by"):
+                try:
+                    v = int(v)
+                except (TypeError, ValueError):
+                    continue
+            kwargs[k] = v
+    else:
+        raise HTTPException(status_code=422, detail="Unknown scope")
+
+    query, _jr, _er = _filtered_books_query(db, current_user, **kwargs)
+    books = query.distinct().all()
+    if not books:
+        return []
+    started = {
+        r[0] for r in db.query(UserBookStatus.book_id).filter(
+            UserBookStatus.user_id == current_user.id,
+            UserBookStatus.book_id.in_([b.id for b in books]),
+            UserBookStatus.status.in_(("read", "reading")),
+        )
+    }
+    return [b for b in books if b.id not in started]
+
+
+@router.get("/stats/backlog")
+def get_backlog_estimate(
+    scope: str = Query("want", description="want | unread | library:<id> | shelf:<id>"),
+    tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> dict:
+    """How long a backlog would take at the user's pace, by book type (#187)."""
+    from backend.services import backlog_estimate as be
+
+    books = _backlog_books(db, current_user, scope)
+    return {"scope": scope, **be.summarise(db, books, be.compute_pace(db, current_user.id, tz_offset))}
+
+
+@router.get("/stats/backlog-scopes")
+def get_backlog_scopes(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[dict]:
+    """Scope options for the Backlog tile: the fixed pair plus the user's
+    visible libraries and shelves."""
+    from backend.api.libraries import list_libraries, list_saved_filters
+
+    out = [
+        {"id": "want", "label": "Want to Read", "group": None},
+        {"id": "unread", "label": "All unread", "group": None},
+    ]
+    out += [{"id": f"library:{l.id}", "label": l.name, "group": "Libraries"} for l in list_libraries(db=db, current_user=current_user)]
+    out += [{"id": f"shelf:{f.id}", "label": f.name, "group": "Shelves"} for f in list_saved_filters(db=db, current_user=current_user)]
+    return out
+
+
 @router.get("/stats/completion-estimates")
 def get_completion_estimates(
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),

--- a/backend/services/backlog_estimate.py
+++ b/backend/services/backlog_estimate.py
@@ -1,0 +1,175 @@
+"""Backlog completion estimates (issue #187).
+
+How long would a book — or a whole pile of them — take to read at *this
+user's* pace? Unlike ``stats/completion-estimates`` (progress-so-far on books
+being read), this works for books that haven't been started.
+
+Per book, in order of preference:
+
+1. ``words``    — ``word_count / measured wpm``. The wpm rule mirrors the web
+                  reader's pacing endpoint: finished, word-counted books with
+                  at least 5 minutes of reconciled read-time.
+2. ``default``  — ``word_count / 250`` when the user has no wpm history yet.
+3. ``type_avg`` — mean reconciled read-time per *finished* book of the same
+                  book type. This is what CBZ/PDF (no word count) fall back to.
+4. ``None``     — nothing to go on (no word count, no finished books of that
+                  type). The UI says "not estimated" rather than inventing one.
+
+"Days" = total minutes / the user's average minutes per calendar day over the
+last 30 days (90 when the last month is empty, so a short break doesn't blank
+the forecast). ``None`` when neither window has any reading — a rate of zero
+isn't a forecast.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Iterable, Optional
+
+from sqlalchemy.orm import Session
+
+from backend.models.book import Book
+from backend.models.library import BookType
+from backend.models.user_book_status import UserBookStatus
+from backend.services import reconciled_reading as rr
+from backend.services.reading_day import date_modifier
+
+DEFAULT_WPM = 250
+WPM_MIN_SECONDS = 300
+PACE_WINDOW_DAYS = 30
+PACE_FALLBACK_WINDOW_DAYS = 90
+# A type average needs at least this many finished books before it's quoted.
+TYPE_AVG_MIN_BOOKS = 2
+
+
+@dataclass
+class Pace:
+    wpm: Optional[float]
+    minutes_per_day: Optional[float]
+    window_days: int = PACE_WINDOW_DAYS
+    # book_type_id (None = untyped) -> (avg seconds per finished book, sample size)
+    type_avg: dict[Optional[int], tuple[int, int]] = field(default_factory=dict)
+
+    def as_dict(self) -> dict:
+        return {
+            "wpm": self.wpm,
+            "default_wpm": DEFAULT_WPM,
+            "minutes_per_day": self.minutes_per_day,
+            "window_days": self.window_days,
+        }
+
+
+def compute_pace(db: Session, user_id: int, tz_offset: int = 0) -> Pace:
+    tzm = date_modifier(tz_offset)
+    covered = rr.covered_book_ids(db, user_id)
+
+    # All-time reconciled seconds per book — feeds both wpm and type averages.
+    secs_by_book = rr.book_seconds(db, user_id, tzm, covered, None, None)
+    finished = (
+        db.query(Book.id, Book.word_count, Book.book_type_id)
+        .join(UserBookStatus, UserBookStatus.book_id == Book.id)
+        .filter(
+            UserBookStatus.user_id == user_id,
+            UserBookStatus.status == "read",
+            Book.status == "active",
+        )
+        .all()
+    )
+
+    words = secs = 0
+    per_type: dict[Optional[int], list[int]] = {}
+    for bid, wc, type_id in finished:
+        s = int(secs_by_book.get(bid, (0, 0, 0))[0])
+        if s < WPM_MIN_SECONDS:
+            continue
+        if wc:
+            words += int(wc)
+            secs += s
+        per_type.setdefault(type_id, []).append(s)
+
+    wpm = round(words * 60 / secs, 1) if secs > 0 else None
+    type_avg = {
+        t: (sum(v) // len(v), len(v))
+        for t, v in per_type.items()
+        if len(v) >= TYPE_AVG_MIN_BOOKS
+    }
+
+    minutes_per_day = None
+    window = PACE_WINDOW_DAYS
+    for window in (PACE_WINDOW_DAYS, PACE_FALLBACK_WINDOW_DAYS):
+        cutoff = datetime.utcnow() - timedelta(days=window)
+        recent_secs, _, _ = rr.totals(db, user_id, tzm, covered, cutoff, None)
+        if recent_secs > 0:
+            minutes_per_day = round(recent_secs / 60 / window, 1)
+            break
+
+    return Pace(wpm=wpm, minutes_per_day=minutes_per_day, window_days=window, type_avg=type_avg)
+
+
+def estimate_seconds(book: Book, pace: Pace) -> tuple[Optional[int], Optional[str]]:
+    """(seconds, method) for one book; (None, None) when there's nothing to go on."""
+    if book.word_count:
+        if pace.wpm:
+            return round(book.word_count / pace.wpm * 60), "words"
+        return round(book.word_count / DEFAULT_WPM * 60), "default"
+    avg = pace.type_avg.get(book.book_type_id)
+    if avg:
+        return avg[0], "type_avg"
+    return None, None
+
+
+def days_for(seconds: Optional[int], pace: Pace) -> Optional[float]:
+    if seconds is None or not pace.minutes_per_day:
+        return None
+    return round(seconds / 60 / pace.minutes_per_day, 1)
+
+
+def estimate_book(book: Book, pace: Pace) -> dict:
+    seconds, method = estimate_seconds(book, pace)
+    return {
+        "seconds": seconds,
+        "days": days_for(seconds, pace),
+        "method": method,
+        "pace": pace.as_dict(),
+    }
+
+
+def summarise(db: Session, books: Iterable[Book], pace: Pace) -> dict:
+    """Aggregate estimate over a set of books, broken down by book type."""
+    type_labels = {t.id: t.label for t in db.query(BookType.id, BookType.label).all()}
+
+    total = estimated = unestimated = 0
+    total_seconds = 0
+    by_type: dict[Optional[int], dict] = {}
+    for b in books:
+        total += 1
+        seconds, method = estimate_seconds(b, pace)
+        row = by_type.setdefault(
+            b.book_type_id,
+            {"label": type_labels.get(b.book_type_id, "Uncategorized"), "books": 0,
+             "seconds": 0, "unestimated": 0, "type_avg": 0},
+        )
+        row["books"] += 1
+        if seconds is None:
+            unestimated += 1
+            row["unestimated"] += 1
+            continue
+        estimated += 1
+        total_seconds += seconds
+        row["seconds"] += seconds
+        if method == "type_avg":
+            row["type_avg"] += 1
+
+    rows = sorted(by_type.values(), key=lambda r: (-r["seconds"], r["label"]))
+    for r in rows:
+        r["days"] = days_for(r["seconds"], pace) if r["seconds"] else None
+
+    return {
+        "books": total,
+        "estimated": estimated,
+        "unestimated": unestimated,
+        "seconds": total_seconds,
+        "days": days_for(total_seconds, pace) if estimated else None,
+        "by_type": rows,
+        "pace": pace.as_dict(),
+    }

--- a/frontend/src/components/SeriesReadingStats.tsx
+++ b/frontend/src/components/SeriesReadingStats.tsx
@@ -128,10 +128,9 @@ export function SeriesReadingStats({ seriesName }: SeriesReadingStatsProps) {
       ? [{ label: 'avg / volume', value: formatDuration(own.avg_volume_seconds) }] : []),
   ]
 
+  // "Est. remaining" used to live here (avg finished volume × unfinished). The
+  // series header now carries the backlog forecast (#187) — one number, not two.
   const bottomStats: { label: string; value: string }[] = []
-  if (own.estimated_remaining_seconds != null) {
-    bottomStats.push({ label: 'Est. remaining', value: formatDuration(own.estimated_remaining_seconds) })
-  }
   if (own.longest_volume != null) {
     bottomStats.push({
       label: 'Longest volume',

--- a/frontend/src/components/stats/BacklogEstimate.tsx
+++ b/frontend/src/components/stats/BacklogEstimate.tsx
@@ -1,0 +1,73 @@
+// Backlog tile (#187): how long a pile of unstarted books would take at the
+// user's pace, by book type. Scope (Want to Read / all unread / a library / a
+// shelf) is tile config, picked in the edit-mode popover.
+import { useEffect, useState } from 'react'
+import { api } from '@/lib/api'
+import { describePace, formatEstimateDays, formatEstimateHours, type BacklogSummary } from '@/lib/backlog'
+import { ProgressRow } from './ProgressRow'
+
+export const DEFAULT_BACKLOG_SCOPE = 'want'
+
+export function BacklogEstimate({ scope = DEFAULT_BACKLOG_SCOPE }: { scope?: string }) {
+  const [data, setData] = useState<BacklogSummary | null>(null)
+  const [error, setError] = useState(false)
+
+  useEffect(() => {
+    let alive = true
+    setData(null)
+    setError(false)
+    api.get<BacklogSummary>(`/stats/backlog?scope=${encodeURIComponent(scope)}&tz_offset=${new Date().getTimezoneOffset()}`)
+      .then(d => { if (alive) setData(d) })
+      .catch(() => { if (alive) setError(true) })
+    return () => { alive = false }
+  }, [scope])
+
+  if (error) return <p className="text-sm text-muted-foreground text-center py-4">Could not load this scope.</p>
+  if (!data) return <p className="text-sm text-muted-foreground text-center py-4">Loading…</p>
+  if (data.books === 0) return <p className="text-sm text-muted-foreground text-center py-4">No unstarted books in this scope.</p>
+
+  const { pace } = data
+  const usesTypeAvg = data.by_type.some(t => t.type_avg > 0)
+  const paceNote = pace.minutes_per_day
+    ? `you read ~${Math.round(pace.minutes_per_day)} min a day (last ${pace.window_days} days)`
+    : 'no recent reading, so no day estimate'
+
+  if (data.estimated === 0) {
+    return (
+      <p className="text-sm text-muted-foreground py-4">
+        {data.books} {data.books === 1 ? 'book' : 'books'}, none estimated yet. Finish a couple of books of each type so Tome can measure your pace.
+      </p>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-baseline gap-2 flex-wrap" title={describePace(pace, usesTypeAvg ? 'type_avg' : (pace.wpm ? 'words' : 'default'))}>
+        <span className="text-3xl font-semibold tabular-nums text-foreground leading-none">{formatEstimateHours(data.seconds)}</span>
+        {data.days != null && (
+          <span className="text-sm text-muted-foreground">
+            about <span className="text-foreground font-medium tabular-nums">{formatEstimateDays(data.days).replace(/^~/, '')}</span> at your pace
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">
+        {data.books} {data.books === 1 ? 'book' : 'books'} &middot; {paceNote}
+        {usesTypeAvg && <> &middot; books without a word count use your average for that type</>}
+        {data.unestimated > 0 && <> &middot; {data.unestimated} not estimated yet</>}
+      </p>
+      <div className="flex flex-col gap-3">
+        {data.by_type.map(t => (
+          <ProgressRow
+            key={t.label}
+            label={t.label}
+            value={t.seconds > 0
+              ? `${formatEstimateHours(t.seconds)}${t.days != null ? ` · ${formatEstimateDays(t.days)}` : ''}`
+              : 'not estimated yet'}
+            pct={data.seconds > 0 ? (t.seconds / data.seconds) * 100 : 0}
+            sub={`${t.books} ${t.books === 1 ? 'book' : 'books'}${t.unestimated > 0 && t.seconds > 0 ? ` · ${t.unestimated} not estimated` : ''}`}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/backlog.ts
+++ b/frontend/src/lib/backlog.ts
@@ -1,0 +1,69 @@
+// Backlog completion estimates (#187) — shared types + formatting for the
+// book page cell, the series header line and the Stats "Backlog" tile.
+
+export interface EstimatePace {
+  wpm: number | null
+  default_wpm: number
+  minutes_per_day: number | null
+  window_days: number
+}
+
+export type EstimateMethod = 'words' | 'default' | 'type_avg'
+
+export interface BookEstimate {
+  seconds: number | null
+  days: number | null
+  method: EstimateMethod | null
+  pace: EstimatePace
+}
+
+export interface BacklogByType {
+  label: string
+  books: number
+  seconds: number
+  unestimated: number
+  type_avg: number
+  days: number | null
+}
+
+export interface BacklogSummary {
+  books: number
+  estimated: number
+  unestimated: number
+  seconds: number
+  days: number | null
+  by_type: BacklogByType[]
+  pace: EstimatePace
+}
+
+export interface BacklogScope {
+  id: string
+  label: string
+  group: 'Libraries' | 'Shelves' | null
+}
+
+/** "~45 min" / "~11 h" — coarse on purpose, these are estimates. */
+export function formatEstimateHours(seconds: number): string {
+  if (seconds < 3600) return `~${Math.max(1, Math.round(seconds / 60))} min`
+  return `~${Math.round(seconds / 3600)} h`
+}
+
+/** "~13 days" / "~4 weeks" / "~3.7 months" at the user's daily pace. */
+export function formatEstimateDays(days: number): string {
+  const d = Math.round(days)
+  if (d < 1) return 'under a day'
+  if (d < 14) return `~${d} day${d === 1 ? '' : 's'}`
+  if (d < 60) return `~${Math.round(d / 7)} weeks`
+  return `~${(d / 30).toFixed(1).replace(/\.0$/, '')} months`
+}
+
+/** One-line explanation of where a figure came from, for tooltips. */
+export function describePace(pace: EstimatePace, method: EstimateMethod | null): string {
+  const parts: string[] = []
+  if (method === 'words') parts.push(`Word count at your measured ${Math.round(pace.wpm ?? 0)} wpm`)
+  else if (method === 'default') parts.push(`Word count at a default ${pace.default_wpm} wpm (no finished books to measure your pace yet)`)
+  else if (method === 'type_avg') parts.push('Your average time per finished book of this type (no word count)')
+  if (pace.minutes_per_day) parts.push(`days at ~${Math.round(pace.minutes_per_day)} min a day (last ${pace.window_days} days)`)
+  else parts.push('no recent reading, so no day estimate')
+  return parts.join(' · ')
+}

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -6,7 +6,7 @@ import {
   Calendar, Globe, Hash, Building2, FileText, Trash2, Loader2,
   Sparkles, Library, Check, BookMarked, ChevronLeft, ChevronRight, Home,
   Tag as TagIcon, StickyNote, ChevronDown, Archive, AlignLeft,
-  Plus, TrendingUp, TrendingDown, Minus, History as HistoryIcon, Share2
+  Plus, TrendingUp, TrendingDown, Minus, History as HistoryIcon, Share2, Timer
 } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
@@ -27,6 +27,7 @@ import type { BookDetail, BookFile, Library as LibraryType, BookStatus, ReadingS
 import { formatBytes } from '@/lib/books'
 import { useBookTypes } from '@/lib/bookTypes'
 import { cn, formatDuration, formatDate } from '@/lib/utils'
+import { describePace, formatEstimateDays, formatEstimateHours, type BookEstimate } from '@/lib/backlog'
 
 interface Facets {
   authors: string[]
@@ -206,6 +207,7 @@ export function BookDetailPage() {
   const [confirmingHighlight, setConfirmingHighlight] = useState<number | null>(null)
   const [highlightsOpen, setHighlightsOpen] = useState(true)
   const [readingStats, setReadingStats] = useState<ReadingStatsResponse | null>(null)
+  const [estimate, setEstimate] = useState<BookEstimate | null>(null)
   // Collapsed state persists across books/visits — the stats tower (hero +
   // intensity + time-per-chapter) has grown tall enough that "keep it closed"
   // is a real preference, not a per-page whim.
@@ -300,6 +302,7 @@ export function BookDetailPage() {
       .catch(() => {})  // KOSync is optional — silent fail is fine
     api.get<Annotation[]>(`/books/${id}/annotations`).then(setAnnotations).catch(() => {})
     api.get<ReadingStatsResponse>(`/books/${id}/reading-stats?tz_offset=${new Date().getTimezoneOffset()}`).then(setReadingStats).catch(() => {})
+    api.get<BookEstimate>(`/books/${id}/estimate?tz_offset=${new Date().getTimezoneOffset()}`).then(setEstimate).catch(() => {})
   }, [id])
 
   // Animate progress bar from 0 after it loads
@@ -1014,6 +1017,22 @@ export function BookDetailPage() {
         <MetaField icon={<AlignLeft className="w-3.5 h-3.5" />} label="Words"
           value={book.word_count != null ? `${book.word_count.toLocaleString()} words` : ''}
           editing={false} onChange={() => {}} />
+        {/* How long the whole book would take at your pace (#187). In-progress
+            books additionally get "Est. remaining" in the Reading Stats block. */}
+        {!editing && estimate?.seconds != null && (
+          <div className="flex items-start gap-2">
+            <span className="text-muted-foreground mt-0.5 shrink-0"><Timer className="w-3.5 h-3.5" /></span>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-muted-foreground/70 mb-0.5">Est. read time</p>
+              <p className="text-sm text-foreground" title={describePace(estimate.pace, estimate.method)}>
+                {formatEstimateHours(estimate.seconds)}
+                {estimate.days != null && (
+                  <span className="text-muted-foreground"> &middot; {formatEstimateDays(estimate.days)}</span>
+                )}
+              </p>
+            </div>
+          </div>
+        )}
         {/* Hardcover match — only when the sync matcher has linked this book */}
         {!editing && book.hardcover_slug && (
           <div className="flex items-start gap-2">

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -37,6 +37,7 @@ import { formatBytes } from '@/lib/books'
 import { useBookTypes } from '@/lib/bookTypes'
 import { useShiftSelect } from '@/lib/useShiftSelect'
 import { cn } from '@/lib/utils'
+import { describePace, formatEstimateDays, formatEstimateHours, type BacklogSummary } from '@/lib/backlog'
 import { SeriesReadingStats } from '@/components/SeriesReadingStats'
 
 type SortField = 'title' | 'author' | 'year' | 'added_at' | 'rating'
@@ -65,6 +66,7 @@ interface SeriesDetailBook {
 interface SeriesDetail {
   name: string
   author: string | null
+  backlog: BacklogSummary | null
   description: string | null
   books: SeriesDetailBook[]
 }
@@ -1645,6 +1647,13 @@ export function DashboardPage() {
                                     <span>{readCount} read &middot; {readingCount} reading &middot; {total - readCount - readingCount} unread</span>
                                     <span>{total} volumes</span>
                                   </div>
+                                  {seriesDetail.backlog && seriesDetail.backlog.estimated > 0 && (
+                                    <p className="text-[10px] text-muted-foreground mb-1.5" title={describePace(seriesDetail.backlog.pace, seriesDetail.backlog.by_type.some(t => t.type_avg > 0) ? 'type_avg' : 'words')}>
+                                      <span className="text-foreground font-medium tabular-nums">{formatEstimateHours(seriesDetail.backlog.seconds)}</span> left in this series
+                                      {seriesDetail.backlog.days != null && <> &middot; {formatEstimateDays(seriesDetail.backlog.days)} at your pace</>}
+                                      {seriesDetail.backlog.unestimated > 0 && <> &middot; {seriesDetail.backlog.unestimated} not estimated</>}
+                                    </p>
+                                  )}
                                   <div className="h-2 rounded-full bg-muted overflow-hidden flex">
                                     <div className="h-full bg-primary transition-all" style={{ width: `${readPct}%` }} />
                                     <div className="h-full bg-primary/50 transition-all" style={{ width: `${readingPct}%` }} />

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -55,6 +55,8 @@ import {
 import { SeriesCompletionGrid } from '@/components/stats/SeriesCompletionGrid'
 import { AuthorAffinity } from '@/components/stats/AuthorAffinity'
 import { CompletionByType } from '@/components/stats/CompletionByType'
+import { BacklogEstimate, DEFAULT_BACKLOG_SCOPE } from '@/components/stats/BacklogEstimate'
+import type { BacklogScope } from '@/lib/backlog'
 import { LibraryGrowthChart } from '@/components/stats/LibraryGrowthChart'
 import {
   RatingDistribution,
@@ -88,7 +90,7 @@ import {
 // metric. days = 0 follows the page range; days = N shows the last N days of the
 // fetched window (sliced client-side, no extra fetches) — so two copies of one
 // widget can show different timeframes.
-type TileConfig = { chartType: ChartKind; days: number; metric?: string; series?: string; autoFit?: boolean }
+type TileConfig = { chartType: ChartKind; days: number; metric?: string; series?: string; autoFit?: boolean; scope?: string; scopeLabel?: string }
 
 // ── Widget catalog (renders shared Stats components from live data) ─────────────
 
@@ -108,6 +110,8 @@ type WidgetDef = {
   metrics?: { id: string; label: string }[]
   /** Config picks a series (options come from the user's series_completion). */
   seriesPicker?: boolean
+  /** Config picks a backlog scope (status / library / shelf). */
+  scopePicker?: boolean
   defaultConfig?: TileConfig
   /** Dynamic tile-header title, e.g. the picked metric's name. */
   titleFor?: (config: TileConfig) => string
@@ -411,6 +415,16 @@ const WIDGETS: WidgetDef[] = [
     render: ({ stats }) => <SeriesCompletionGrid data={stats.series_completion} />,
   },
   {
+    id: 'backlog-estimate',
+    title: 'Backlog',
+    size: { w: 12, h: 2, minW: 4, minH: 2 },
+    autoH: true,
+    scopePicker: true,
+    defaultConfig: { chartType: 'bar', days: 0, scope: DEFAULT_BACKLOG_SCOPE, scopeLabel: 'Want to Read', autoFit: true },
+    titleFor: (cfg) => `Backlog · ${cfg.scopeLabel ?? 'Want to Read'}`,
+    render: (_ctx, cfg) => <BacklogEstimate scope={cfg.scope} />,
+  },
+  {
     id: 'author-affinity',
     title: 'Top Authors by Reading Time',
     size: { w: 6, h: 2, minW: 3, minH: 2 },
@@ -629,6 +643,7 @@ const WIDGET_DESC: Record<string, string> = {
   'monthly-comparison': 'Hours & finishes, last 12 months',
   'year-in-review': 'Your year, at a glance (1y/All)',
   'series-completion': 'How far through each series',
+  'backlog-estimate': 'How long your unread pile would take',
   'author-affinity': 'Most-read authors',
   'completion-by-type': 'Finish rate by book type',
   'category-breakdown': 'Time split across categories',
@@ -659,7 +674,7 @@ const NATURAL_PREVIEW = new Set(['stat-time', 'stat-sessions', 'stat-finished', 
 // internally. Everything else (charts) clips (overflow-hidden) so nothing spills out.
 const SCROLL_IDS = new Set([
   'currently-reading', 'estimates', 'session-timeline', 'series-completion', 'per-book-table',
-  'author-affinity', 'completion-by-type', 'pace-by-format', 'session-log', 'recently-finished',
+  'author-affinity', 'completion-by-type', 'pace-by-format', 'session-log', 'recently-finished', 'backlog-estimate',
   'goal',
 ])
 
@@ -674,7 +689,7 @@ const GALLERY_GROUPS: { label: string; ids: string[] }[] = [
   },
   {
     label: 'Library',
-    ids: ['year-in-review', 'library-completion', 'series-completion', 'series-spotlight', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'book-length', 'rereads', 'per-book-table'],
+    ids: ['year-in-review', 'library-completion', 'series-completion', 'series-spotlight', 'backlog-estimate', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'book-length', 'rereads', 'per-book-table'],
   },
   {
     label: 'Taste',
@@ -714,6 +729,7 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
   // Library — all full width, stacked in page order
   'year-in-review': { x: 0, y: 0, w: 12, h: 2 },
   'series-completion': { x: 0, y: 2, w: 12, h: 4 },
+  'backlog-estimate': { x: 0, y: 6, w: 12, h: 2 },
   'author-affinity': { x: 0, y: 6, w: 12, h: 3 },
   'completion-by-type': { x: 0, y: 9, w: 12, h: 2 },
   'category-breakdown': { x: 0, y: 11, w: 12, h: 2 },
@@ -743,7 +759,7 @@ type TabState = { id: string; label: string; tiles: Tile[]; layout: Layout }
 const TAB_DEFS: { id: string; label: string; ids: string[] }[] = [
   { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log'] },
   { id: 'habits', label: 'Habits', ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
-  { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
+  { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'backlog-estimate', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
   { id: 'taste', label: 'Taste', ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'] },
   { id: 'timeline', label: 'Timeline', ids: ['reading-timeline'] },
   // Phase 4 word-count tiles (words-read / true-wpm / book-length) are gallery-only
@@ -816,6 +832,12 @@ function ConfigPopover({
   onChange: (partial: Partial<TileConfig>) => void
   onClose: () => void
 }) {
+  // Backlog scopes (libraries + shelves) are the user's own — fetched on open.
+  const [scopes, setScopes] = useState<BacklogScope[] | null>(null)
+  useEffect(() => {
+    if (!def.scopePicker) return
+    api.get<BacklogScope[]>('/stats/backlog-scopes').then(setScopes).catch(() => setScopes([]))
+  }, [def.scopePicker])
   // Close on outside click / Escape via a document listener rather than a fixed
   // overlay: the tile's RGL transform traps `position: fixed` inside the tile, so
   // an overlay can't cover the rest of the page. The opening click is stopped at
@@ -839,6 +861,33 @@ function ConfigPopover({
       className="no-drag absolute right-2 top-9 z-50 w-48 rounded-lg border border-border bg-card p-3 text-xs shadow-xl"
       onPointerDown={(e) => e.stopPropagation()}
       >
+        {def.scopePicker && (
+          <>
+            <p className="mb-1.5 font-medium text-muted-foreground">Scope</p>
+            {scopes ? (
+              <select
+                value={config.scope ?? DEFAULT_BACKLOG_SCOPE}
+                onChange={(e) => {
+                  const picked = scopes.find((s) => s.id === e.target.value)
+                  onChange({ scope: e.target.value, scopeLabel: picked?.label })
+                }}
+                className="w-full rounded-md border border-border bg-background px-1.5 py-1 text-xs text-foreground focus:border-primary focus:outline-none"
+              >
+                {scopes.filter((s) => !s.group).map((s) => <option key={s.id} value={s.id}>{s.label}</option>)}
+                {(['Libraries', 'Shelves'] as const).map((g) => {
+                  const items = scopes.filter((s) => s.group === g)
+                  return items.length > 0 ? (
+                    <optgroup key={g} label={g}>
+                      {items.map((s) => <option key={s.id} value={s.id}>{s.label}</option>)}
+                    </optgroup>
+                  ) : null
+                })}
+              </select>
+            ) : (
+              <p className="text-muted-foreground/70">Loading…</p>
+            )}
+          </>
+        )}
         {def.seriesPicker && (
           <>
             <p className="mb-1.5 font-medium text-muted-foreground">Series</p>
@@ -917,7 +966,7 @@ function ConfigPopover({
           </>
         )}
         {def.autoH && (
-          <div className={cn((def.chartTypes || def.metrics || def.seriesPicker) && 'mt-3 border-t border-border pt-3')}>
+          <div className={cn((def.chartTypes || def.metrics || def.seriesPicker || def.scopePicker) && 'mt-3 border-t border-border pt-3')}>
             <div className="flex items-center justify-between gap-2">
               <span className="font-medium text-muted-foreground">Auto-fit height</span>
               <button
@@ -1141,7 +1190,7 @@ function TileShell({
     // re-renders. RGL's calcGridItemWHPx rounds the resulting px, so this is exact.
     onMeasure(Math.max(1, Math.round(((desired + 2 + 16) / 120) * 100) / 100))
   })
-  const configurable = !!def.chartTypes || !!def.metrics || !!def.seriesPicker || !!def.autoH
+  const configurable = !!def.chartTypes || !!def.metrics || !!def.seriesPicker || !!def.scopePicker || !!def.autoH
   const tiltOn = editMode && !dragging && !cfgOpen
 
   function onMove(e: MouseEvent<HTMLDivElement>) {

--- a/tests/test_backlog_estimate.py
+++ b/tests/test_backlog_estimate.py
@@ -1,0 +1,188 @@
+"""Backlog completion estimates (#187): per-book, per-series and scoped."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from backend.models.library import BookType, Library, SavedFilter
+from backend.models.tome_sync import ReadingSession
+from backend.models.user_book_status import UserBookStatus
+from backend.services import backlog_estimate as be
+
+
+def _session(db: Session, user_id: int, book_id: int, seconds: int, days_ago: int = 1) -> None:
+    started = datetime.utcnow() - timedelta(days=days_ago)
+    db.add(ReadingSession(
+        user_id=user_id, book_id=book_id, started_at=started,
+        ended_at=started + timedelta(seconds=seconds),
+        duration_seconds=seconds, pages_turned=10,
+    ))
+    db.flush()
+
+
+def _book(db: Session, make_book, title: str, *, word_count: int | None = None,
+          book_type_id: int | None = None, **kw):
+    """make_book doesn't take word_count/book_type_id — set them after."""
+    b = make_book(title=title, **kw)
+    b.word_count = word_count
+    b.book_type_id = book_type_id
+    db.flush()
+    return b
+
+
+def _status(db: Session, user_id: int, book_id: int, status: str) -> None:
+    db.add(UserBookStatus(user_id=user_id, book_id=book_id, status=status))
+    db.flush()
+
+
+def _finish(db: Session, user_id: int, book_id: int, seconds: int, days_ago: int = 1) -> None:
+    _session(db, user_id, book_id, seconds, days_ago)
+    _status(db, user_id, book_id, "read")
+
+
+# ── service ───────────────────────────────────────────────────────────────────
+
+def test_no_history_uses_default_wpm(db, admin_user, make_book):
+    user, _ = admin_user
+    book = _book(db, make_book, "Fresh", word_count=25_000)
+    pace = be.compute_pace(db, user.id)
+    assert pace.wpm is None and pace.minutes_per_day is None
+    est = be.estimate_book(book, pace)
+    assert est["method"] == "default"
+    assert est["seconds"] == round(25_000 / be.DEFAULT_WPM * 60)
+    assert est["days"] is None  # no recent reading → no day forecast
+
+
+def test_measured_wpm_and_days(db, admin_user, make_book):
+    user, _ = admin_user
+    done = _book(db, make_book, "Done", word_count=60_000)
+    _finish(db, user.id, done.id, seconds=3600, days_ago=2)  # 1000 wpm, 1 h in the last 30 days
+    target = _book(db, make_book, "Next", word_count=30_000)
+
+    pace = be.compute_pace(db, user.id)
+    assert pace.wpm == 1000.0
+    assert pace.window_days == 30
+    assert pace.minutes_per_day == 2.0  # 60 min / 30 days
+
+    est = be.estimate_book(target, pace)
+    assert est["method"] == "words"
+    assert est["seconds"] == 1800
+    assert est["days"] == 15.0
+
+
+def test_short_finish_ignored_for_wpm(db, admin_user, make_book):
+    """Sub-5-minute 'finishes' (a mis-tap on Mark read) don't poison the pace."""
+    user, _ = admin_user
+    done = _book(db, make_book, "Tap", word_count=90_000)
+    _finish(db, user.id, done.id, seconds=120)
+    assert be.compute_pace(db, user.id).wpm is None
+
+
+def test_type_average_fallback_needs_two_finished(db, admin_user, make_book):
+    user, _ = admin_user
+    manga = BookType(slug="manga-t", label="Manga")
+    db.add(manga); db.flush()
+    v1 = _book(db, make_book, "V1", book_type_id=manga.id)
+    v2 = _book(db, make_book, "V2", book_type_id=manga.id)
+    target = _book(db, make_book, "V3", book_type_id=manga.id)  # no word count
+
+    _finish(db, user.id, v1.id, seconds=1200)
+    pace = be.compute_pace(db, user.id)
+    assert be.estimate_book(target, pace)["method"] is None  # one finished volume isn't a sample
+
+    _finish(db, user.id, v2.id, seconds=1800)
+    pace = be.compute_pace(db, user.id)
+    est = be.estimate_book(target, pace)
+    assert est["method"] == "type_avg"
+    assert est["seconds"] == 1500
+
+
+def test_ninety_day_fallback_window(db, admin_user, make_book):
+    user, _ = admin_user
+    done = _book(db, make_book, "Old", word_count=10_000)
+    _finish(db, user.id, done.id, seconds=9000, days_ago=45)  # outside 30d, inside 90d
+    pace = be.compute_pace(db, user.id)
+    assert pace.window_days == 90
+    assert pace.minutes_per_day == round(150 / 90, 1)
+
+
+def test_summarise_by_type_and_unestimated(db, admin_user, make_book):
+    user, _ = admin_user
+    novels = BookType(slug="novels-t", label="Novels")
+    comics = BookType(slug="comics-t", label="Comics")
+    db.add_all([novels, comics]); db.flush()
+    books = [
+        _book(db, make_book, "A", word_count=25_000, book_type_id=novels.id),
+        _book(db, make_book, "B", word_count=50_000, book_type_id=novels.id),
+        _book(db, make_book, "C", book_type_id=comics.id),  # nothing to go on
+    ]
+    s = be.summarise(db, books, be.compute_pace(db, user.id))
+    assert (s["books"], s["estimated"], s["unestimated"]) == (3, 2, 1)
+    assert s["seconds"] == round(75_000 / be.DEFAULT_WPM * 60)
+    assert [r["label"] for r in s["by_type"]] == ["Novels", "Comics"]
+    assert s["by_type"][1]["unestimated"] == 1 and s["by_type"][1]["seconds"] == 0
+
+
+# ── endpoints ─────────────────────────────────────────────────────────────────
+
+def test_book_estimate_endpoint(client: TestClient, db, make_book):
+    book = _book(db, make_book, "E", word_count=12_500)
+    r = client.get(f"/api/books/{book.id}/estimate")
+    assert r.status_code == 200
+    assert r.json()["seconds"] == 3000 and r.json()["method"] == "default"
+    assert client.get("/api/books/999999/estimate").status_code == 404
+
+
+def test_series_detail_backlog_counts_unstarted_only(client: TestClient, db, admin_user, make_book):
+    user, _ = admin_user
+    v1 = _book(db, make_book, "S1", series="Saga", series_index=1, word_count=10_000)
+    v2 = _book(db, make_book, "S2", series="Saga", series_index=2, word_count=10_000)
+    v3 = _book(db, make_book, "S3", series="Saga", series_index=3, word_count=10_000)
+    _status(db, user.id, v1.id, "read")
+    _status(db, user.id, v2.id, "reading")
+    r = client.get("/api/books/series-detail", params={"name": "Saga"})
+    assert r.status_code == 200
+    backlog = r.json()["backlog"]
+    assert backlog["books"] == 1 and backlog["seconds"] == round(10_000 / 250 * 60)
+    del v3
+
+
+def test_stats_backlog_scopes(client: TestClient, db, admin_user, make_book):
+    user, _ = admin_user
+    lib = Library(name="Shelfish", is_public=True)
+    db.add(lib); db.flush()
+    want = _book(db, make_book, "W", word_count=5_000)
+    plain = _book(db, make_book, "P", word_count=5_000)
+    finished = _book(db, make_book, "F", word_count=5_000)
+    in_lib = _book(db, make_book, "L", word_count=5_000)
+    in_lib.libraries.append(lib)
+    _status(db, user.id, want.id, "want_to_read")
+    _status(db, user.id, finished.id, "read")
+    db.flush()
+
+    assert client.get("/api/stats/backlog", params={"scope": "want"}).json()["books"] == 1
+    assert client.get("/api/stats/backlog", params={"scope": "unread"}).json()["books"] == 3
+    assert client.get("/api/stats/backlog", params={"scope": f"library:{lib.id}"}).json()["books"] == 1
+
+    # A shelf is a saved filter: its params drive the scope, finished books are still excluded.
+    shelf = SavedFilter(name="Fives", owner_id=user.id, params=json.dumps({"q": "", "sort": "title"}))
+    db.add(shelf); db.flush()
+    assert client.get("/api/stats/backlog", params={"scope": f"shelf:{shelf.id}"}).json()["books"] == 3
+
+    assert client.get("/api/stats/backlog", params={"scope": "bogus"}).status_code == 422
+    assert client.get("/api/stats/backlog", params={"scope": "library:999"}).status_code == 404
+    del plain
+
+
+def test_backlog_scopes_lists_libraries_and_shelves(client: TestClient, db, admin_user):
+    user, _ = admin_user
+    db.add(Library(name="Pile", is_public=True))
+    db.add(SavedFilter(name="Winter", owner_id=user.id, params="{}"))
+    db.flush()
+    scopes = client.get("/api/stats/backlog-scopes").json()
+    assert [s["id"] for s in scopes[:2]] == ["want", "unread"]
+    assert any(s["label"] == "Pile" and s["group"] == "Libraries" for s in scopes)
+    assert any(s["label"] == "Winter" and s["group"] == "Shelves" for s in scopes)


### PR DESCRIPTION
Closes #187.

How long would a book you haven't started take at *your* pace, and how long would a whole pile? The mockups from the issue thread, built for real.

## What's in it

**Three surfaces**
- **Book page → Details**: an "Est. read time" cell (`~11 h · ~13 days`), tooltip explains the basis.
- **Series page header**: "`~70 h` left in this series · ~81 days at your pace" over the unstarted volumes. The Reading Stats block's old "Est. remaining" (avg finished volume × unfinished) is removed so there's one number, not two that disagree.
- **Stats → Library → Backlog tile**: headline hours + days, per-type breakdown bars. Scope (Want to Read / all unread / a library / a shelf) lives in the tile's edit-mode settings, shown in the tile title. The stats page itself stays static outside Edit.

**Estimate rules** (`backend/services/backlog_estimate.py`)
1. `word_count ÷ measured wpm` (same wpm rule as the reader's chapter pacing: finished word-counted books with ≥5 min read-time)
2. `word_count ÷ 250` when there is no wpm history yet
3. average read-time per finished book of the same type when there is no word count (CBZ/PDF); needs 2 finished books of that type
4. otherwise "not estimated", shown as such rather than invented

Days = total minutes ÷ minutes-per-day over the last 30 days (90 when the last month was quiet); no day figure without recent reading.

**Endpoints**
- `GET /books/{id}/estimate`
- `backlog` object on `GET /books/series-detail`
- `GET /stats/backlog?scope=want|unread|library:<id>|shelf:<id>` (shelf params map onto the list filters; finished and in-progress books are never part of a backlog)
- `GET /stats/backlog-scopes`

## Notes
- Existing saved Library boards don't grow the tile automatically; Edit → Add tile, same as every other new tile.
- 10 new tests (`tests/test_backlog_estimate.py`); full suite 1134 passed; `npm run build` clean.