### PR TITLE
feat(i18n): translatable web UI with Lingui + language picker (#183)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,6 +57,15 @@ jobs:
         run: npm ci --legacy-peer-deps
         working-directory: frontend
 
+      - name: Check message catalogs are up to date
+        # A PR that adds or edits a <Trans>/t`` string must also commit the
+        # re-extracted src/locales/*/messages.po (npm run i18n:extract).
+        run: |
+          npm run i18n:extract
+          git diff --exit-code -- src/locales \
+            || { echo "::error::Message catalogs are stale. Run 'npm run i18n:extract' in frontend/ and commit src/locales."; exit 1; }
+        working-directory: frontend
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
         working-directory: frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ All notable changes to Tome are documented here. Format loosely follows
   month was quiet); books Tome can't estimate yet are counted as "not
   estimated" rather than guessed. The series Reading Stats block no longer
   shows its own "Est. remaining", the header line replaces it. (#187)
+- Language picker in Settings → Appearance. The web UI is now translatable:
+  source strings stay in English, translations live in `frontend/src/locales/`
+  and are community-maintained (see `docs/translating.md`). Anything not yet
+  translated falls back to English. Ships with a Simplified Chinese (zh-CN)
+  catalog that is just getting started; the KOReader plugin and the website
+  stay English for now. (#183)
 
 ## [2.3.0] - 2026-08-20
 

--- a/docs/translating.md
+++ b/docs/translating.md
@@ -1,0 +1,54 @@
+# Translating Tome
+
+Tome's web UI is translatable. English is the source language and lives inline
+in the components; every other language is a community-maintained catalog under
+`frontend/src/locales/<code>/messages.po`. Anything not yet translated falls
+back to English, so a partial translation is fine to ship.
+
+Out of scope for now: the KOReader plugin (KOReader's own gettext catalog is
+project-wide, third-party plugins don't get their own), the website, OPDS feed
+text, and server-generated messages (API errors, notification bodies).
+
+## Improving an existing language
+
+1. Open `frontend/src/locales/<code>/messages.po` in any text editor or a PO
+   editor such as [Poedit](https://poedit.net/).
+2. Fill in `msgstr` for entries that are empty (untranslated) or marked
+   `#, fuzzy` (source changed since it was translated). Leave `msgid` alone.
+3. Open a pull request. Nothing else is needed; catalogs are compiled at build
+   time.
+
+Rules of thumb:
+
+- Keep placeholders exactly as they are: `{0}`, `{count}`, `{name}`. Reorder
+  them freely to suit your grammar, never rename or drop them.
+- Plurals use ICU syntax (`{count, plural, one {# book} other {# books}}`).
+  Keep the `#`; add or remove plural categories as your language needs.
+- Don't translate product names (Tome, KOReader, OPDS, Hardcover, Bindery),
+  keyboard keys, or anything that is clearly an identifier.
+- Match the tone of the English: plain, short, no exclamation marks.
+
+## Adding a new language
+
+1. Pick the BCP-47 code (`de`, `pt-BR`, `zh-TW`). Use the same casing as the
+   examples: lowercase language, uppercase region.
+2. Add it to `locales` in `frontend/lingui.config.ts` and to `LOCALES` in
+   `frontend/src/lib/i18n.ts` (the label is the language's own name, e.g.
+   `Deutsch`, shown untranslated in the picker).
+3. Run `npm run i18n:extract` in `frontend/`. This creates
+   `src/locales/<code>/messages.po` with every source string and empty
+   `msgstr`s.
+4. Translate, then open a pull request. Please mention in the PR whether you
+   are happy to be pinged for future updates to that language.
+
+## For developers: keeping strings translatable
+
+- JSX text: `<Trans>Add to library</Trans>` (from `@lingui/react/macro`).
+- Anything outside JSX (toasts, attributes, `confirm()`): `const { t } = useLingui()` then `` t`Saved` ``.
+- Interpolate with template variables, never concatenate: `` t`${n} books selected` ``.
+- Plurals: `<Plural value={n} one="# book" other="# books" />`.
+- Label maps outside components: `` msg`Unread` `` descriptors, rendered with `i18n._()`.
+- After adding or changing strings run `npm run i18n:extract` and commit the
+  updated `src/locales/*/messages.po`. CI fails on stale catalogs.
+- `npm run lint` warns on user-facing strings that bypass Lingui
+  (`lingui/no-unlocalized-strings`).

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -34,7 +34,7 @@ export default defineConfig([
           '^[A-Z0-9_-]+$',            // CONSTANTS
           '^/',                       // API and router paths
           '^tome_',                   // localStorage keys
-          '^Tome$',                   // product name, never translated
+          '^Tome$', '^GitHub$',       // product names, never translated
           '^[^a-zA-Z]*$',             // punctuation / symbols only
         ],
         ignoreNames: [

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -34,15 +34,17 @@ export default defineConfig([
           '^[A-Z0-9_-]+$',            // CONSTANTS
           '^/',                       // API and router paths
           '^tome_',                   // localStorage keys
+          '^Tome$',                   // product name, never translated
           '^[^a-zA-Z]*$',             // punctuation / symbols only
         ],
         ignoreNames: [
           { regex: { pattern: 'className', flags: 'i' } },
           { regex: { pattern: '^[A-Z0-9_-]+$' } },
-          'style', 'src', 'srcSet', 'href', 'type', 'id', 'key', 'name', 'role',
+          'style', 'src', 'srcSet', 'href', 'type', 'id', 'key', 'name', 'role', 'iconName',
           'width', 'height', 'fill', 'stroke', 'viewBox', 'd',
-          'value', 'to', 'method', 'accept', 'autoComplete', 'inputMode',
+          'value', 'to', 'method', 'accept', 'autoComplete', 'inputMode', 'keys',
           'displayName', 'Authorization', 'family', 'format', 'icon', 'defaultIcon',
+          'menuItem', 'destructive',
         ],
         ignoreFunctions: [
           'cn', 'cva', 'clsx', 'Error', 'console.*', 'require',
@@ -54,6 +56,7 @@ export default defineConfig([
           '*.setItem', '*.getItem', '*.removeItem', 'new Date', '*.toLocaleDateString',
           '*.toLocaleString', '*.toLocaleTimeString', '*.localeCompare',
           'useState', 'useRef', 'navigate', 'open',
+          'getIcon', 'setLibModalInitialIcon', 'setModalInitialIcon', 'setModalDefaultIcon',
         ],
       }],
       'lingui/t-call-in-function': 'error',

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -43,7 +43,7 @@ export default defineConfig([
           'style', 'src', 'srcSet', 'href', 'type', 'id', 'key', 'name', 'role', 'iconName',
           'width', 'height', 'fill', 'stroke', 'viewBox', 'd',
           'transform', 'transformOrigin', 'transition', 'download', 'flipId',
-          'value', 'to', 'method', 'accept', 'autoComplete', 'inputMode', 'keys',
+          'value', 'to', 'method', 'accept', 'autoComplete', 'inputMode', 'keys', 'group',
           'displayName', 'Authorization', 'family', 'format', 'icon', 'defaultIcon',
           'menuItem', 'destructive',
         ],

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -28,7 +28,7 @@ export default defineConfig([
     files: ['src/pages/**/*.tsx', 'src/components/**/*.tsx'],
     plugins: { lingui },
     rules: {
-      'lingui/no-unlocalized-strings': ['warn', {
+      'lingui/no-unlocalized-strings': ['error', {
         ignore: [
           '^(?![A-Z])\\S+$',        // single lowercase tokens: keys, classes, slugs
           '^[A-Z0-9_-]+$',            // CONSTANTS

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -3,6 +3,7 @@ import globals from 'globals'
 import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
+import lingui from 'eslint-plugin-lingui'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
@@ -18,6 +19,46 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+    },
+  },
+  // i18n: flag user-facing strings that bypass Lingui. Warn-level while the
+  // extraction sweep is in progress; flip to 'error' once pages/components are
+  // fully wrapped in <Trans> / t``.
+  {
+    files: ['src/pages/**/*.tsx', 'src/components/**/*.tsx'],
+    plugins: { lingui },
+    rules: {
+      'lingui/no-unlocalized-strings': ['warn', {
+        ignore: [
+          '^(?![A-Z])\\S+$',        // single lowercase tokens: keys, classes, slugs
+          '^[A-Z0-9_-]+$',            // CONSTANTS
+          '^/',                       // API and router paths
+          '^tome_',                   // localStorage keys
+          '^[^a-zA-Z]*$',             // punctuation / symbols only
+        ],
+        ignoreNames: [
+          { regex: { pattern: 'className', flags: 'i' } },
+          { regex: { pattern: '^[A-Z0-9_-]+$' } },
+          'style', 'src', 'srcSet', 'href', 'type', 'id', 'key', 'name', 'role',
+          'width', 'height', 'fill', 'stroke', 'viewBox', 'd',
+          'value', 'to', 'method', 'accept', 'autoComplete', 'inputMode',
+          'displayName', 'Authorization', 'family', 'format', 'icon', 'defaultIcon',
+        ],
+        ignoreFunctions: [
+          'cn', 'cva', 'clsx', 'Error', 'console.*', 'require',
+          'api.*', 'fetch', 'localStorage.*', 'sessionStorage.*', 'URLSearchParams',
+          '*.addEventListener', '*.removeEventListener', '*.getElementById',
+          '*.querySelector', '*.querySelectorAll', '*.postMessage',
+          '*.includes', '*.indexOf', '*.endsWith', '*.startsWith', '*.split',
+          '*.replace', '*.startsWith', '*.setAttribute', '*.getAttribute',
+          '*.setItem', '*.getItem', '*.removeItem', 'new Date', '*.toLocaleDateString',
+          '*.toLocaleString', '*.toLocaleTimeString', '*.localeCompare',
+          'useState', 'useRef', 'navigate', 'open',
+        ],
+      }],
+      'lingui/t-call-in-function': 'error',
+      'lingui/no-single-variables-to-translate': 'error',
+      'lingui/no-expression-in-message': 'error',
     },
   },
 ])

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -34,7 +34,7 @@ export default defineConfig([
           '^[A-Z0-9_-]+$',            // CONSTANTS
           '^/',                       // API and router paths
           '^tome_',                   // localStorage keys
-          '^Tome$', '^GitHub$',       // product names, never translated
+          '^Tome$', '^GitHub$', '^TomeSync$', // product names, never translated
           '^[^a-zA-Z]*$',             // punctuation / symbols only
         ],
         ignoreNames: [

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -42,6 +42,7 @@ export default defineConfig([
           { regex: { pattern: '^[A-Z0-9_-]+$' } },
           'style', 'src', 'srcSet', 'href', 'type', 'id', 'key', 'name', 'role', 'iconName',
           'width', 'height', 'fill', 'stroke', 'viewBox', 'd',
+          'transform', 'transformOrigin', 'transition', 'download', 'flipId',
           'value', 'to', 'method', 'accept', 'autoComplete', 'inputMode', 'keys',
           'displayName', 'Authorization', 'family', 'format', 'icon', 'defaultIcon',
           'menuItem', 'destructive',

--- a/frontend/lingui.config.ts
+++ b/frontend/lingui.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@lingui/cli'
+import { formatter } from '@lingui/format-po'
+
+// Source strings live inline in the components (English); `npm run i18n:extract`
+// pulls them into src/locales/<locale>/messages.po. The Vite plugin compiles the
+// .po files on import, so no separate compile step is needed for dev or build.
+export default defineConfig({
+  sourceLocale: 'en',
+  // File origins without line numbers: an unrelated edit above a string must not
+  // rewrite the catalog (keeps translation PRs and the CI freshness check quiet).
+  format: formatter({ lineNumbers: false }),
+  locales: ['en', 'zh-CN'],
+  catalogs: [
+    {
+      path: '<rootDir>/src/locales/{locale}/messages',
+      include: ['src'],
+    },
+  ],
+})

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,8 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@lingui/core": "^6.6.0",
+        "@lingui/react": "^6.6.0",
         "@radix-ui/react-slot": "^1.2.4",
         "@tailwindcss/vite": "^4.2.2",
         "class-variance-authority": "^0.7.1",
@@ -27,12 +29,18 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@lingui/babel-plugin-lingui-macro": "^6.6.0",
+        "@lingui/cli": "^6.6.0",
+        "@lingui/format-po": "^6.6.0",
+        "@lingui/vite-plugin": "^6.6.0",
         "@playwright/test": "^1.62.1",
+        "@rolldown/plugin-babel": "^0.2.3",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^9.39.4",
+        "eslint-plugin-lingui": "^0.14.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
@@ -1584,6 +1592,17 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
@@ -1858,6 +1877,35 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+      "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "@types/istanbul-reports": "^3.0.0",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.8",
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1912,6 +1960,250 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lingui/babel-plugin-extract-messages": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-6.6.0.tgz",
+      "integrity": "sha512-QfCS4SjZYvVZFaiF44e/mLsdzCqQvRSGoVJWkb8nc51FkNpOZkwFLiwLtRnWgvm0ce7GeG51czMsG7RFPPCXqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lingui/conf": "6.6.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@lingui/babel-plugin-lingui-macro": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-lingui-macro/-/babel-plugin-lingui-macro-6.6.0.tgz",
+      "integrity": "sha512-FEBrnIx66lAeD9LGueRIen8IEj+aT7bDaMVmPNIITQNBCm2iC4mNcUtEV1/rAaVpfKKnh5uTdQowWmddB2D7iw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lingui/conf": "6.6.0",
+        "@lingui/message-utils": "6.6.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.20.12 || ^8.0.0",
+        "@babel/types": "^7.20.7 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@babel/types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lingui/cli": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/cli/-/cli-6.6.0.tgz",
+      "integrity": "sha512-XtsWns8/m5Rtj+Gwr9j3SqPTk9bVztAbdJ6cbDG2qDFwSpGiXLxqxhqbam4cywjlxYMudsyNQ7E6DPPSgL4x8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.21.0",
+        "@babel/generator": "^7.28.5",
+        "@babel/parser": "^7.22.0",
+        "@babel/types": "^7.21.2",
+        "@lingui/babel-plugin-extract-messages": "6.6.0",
+        "@lingui/babel-plugin-lingui-macro": "6.6.0",
+        "@lingui/conf": "6.6.0",
+        "@lingui/core": "6.6.0",
+        "@lingui/format-po": "6.6.0",
+        "@lingui/message-utils": "6.6.0",
+        "chokidar": "5.0.0",
+        "cli-table3": "^0.6.5",
+        "commander": "^14.0.2",
+        "jiti": "^2.6.1",
+        "micromatch": "^4.0.7",
+        "ms": "^2.1.3",
+        "normalize-path": "^3.0.0",
+        "ora": "^9.1.0",
+        "pseudolocale": "^2.2.0",
+        "source-map": "^0.7.6",
+        "tinypool": "^2.1.0"
+      },
+      "bin": {
+        "lingui": "dist/lingui.js"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "peerDependencies": {
+        "esbuild": "^0.28.1",
+        "rolldown": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "esbuild": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lingui/cli/node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@lingui/cli/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@lingui/conf": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/conf/-/conf-6.6.0.tgz",
+      "integrity": "sha512-4NUxQh6VXZSBocAKATuJJ6+dOF/M3OTd5WtbND7eSi5tZtVKF0qFMcKFfx8aiUJFo+KP/wYnBBiDPvPLkJvqcA==",
+      "license": "MIT",
+      "dependencies": {
+        "jest-validate": "^29.4.3",
+        "jiti": "^2.5.1",
+        "lilconfig": "^3.1.3",
+        "normalize-path": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@lingui/core": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/core/-/core-6.6.0.tgz",
+      "integrity": "sha512-vqL7LkU2iDAHcaHYzFGbdYovHLdHamG0Zh7r5F9O7C1J1sEPZSMQfkddk2FFeSZHy5j7Na7hzIGGJTZutgiZRg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lingui/babel-plugin-lingui-macro": "6.6.0",
+        "@lingui/message-utils": "6.6.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "peerDependencies": {
+        "babel-plugin-macros": "2 || 3"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lingui/format-po": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/format-po/-/format-po-6.6.0.tgz",
+      "integrity": "sha512-vOUYBYC+81Gl/tJWqEMM2ah+W06M3zWjb78qNwRtl3UhNhoDbduZpNayDQ7RoEA9NtxNQ75Fx7946+0GPnHy7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lingui/conf": "6.6.0",
+        "@lingui/message-utils": "6.6.0",
+        "pofile-ts": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@lingui/message-utils": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/message-utils/-/message-utils-6.6.0.tgz",
+      "integrity": "sha512-XkEcuMjIUjq7KZfTe83jP6UWQvKskpae/Ve7E8M8HEJ3TujHIPLzKn/quEmot6pKRtGwYxQzktGRfs2sPcZaqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@messageformat/date-skeleton": "^1.1.0",
+        "@messageformat/parser": "^5.0.0",
+        "js-sha256": "^0.10.1"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      }
+    },
+    "node_modules/@lingui/react": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/react/-/react-6.6.0.tgz",
+      "integrity": "sha512-oRZvm8nx47wQB7Y4tQ4K78Ba0Ta0wJLRpT7125zW3J1wq++hMfc9XMqemCau2IDVtCMHGHdlLPiBeyFSIq/0Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lingui/babel-plugin-lingui-macro": "6.6.0",
+        "@lingui/core": "6.6.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "peerDependencies": {
+        "babel-plugin-macros": "2 || 3",
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@lingui/vite-plugin": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@lingui/vite-plugin/-/vite-plugin-6.6.0.tgz",
+      "integrity": "sha512-1kZMeGNk5hYQzrEPA3RcXQKb106VC26GqxpXpjVIhS4r2sT4c4gztk70T65VSwyZ7Uyc1pIpXxys3uY2DTfHKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lingui/cli": "6.6.0",
+        "@lingui/conf": "6.6.0"
+      },
+      "engines": {
+        "node": ">=22.19.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.29.0 || ^8.0.0",
+        "@lingui/babel-plugin-lingui-macro": "^5 || ^6",
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "rolldown": "^1.0.0-rc.5",
+        "vite": "^6.3.0 || ^7 || ^8"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "@lingui/babel-plugin-lingui-macro": {
+          "optional": true
+        },
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "rolldown": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@messageformat/date-skeleton": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@messageformat/date-skeleton/-/date-skeleton-1.1.0.tgz",
+      "integrity": "sha512-rmGAfB1tIPER+gh3p/RgA+PVeRE/gxuQ2w4snFWPF5xtb5mbWR7Cbw7wCOftcUypbD6HVoxrVdyyghPm3WzP5A==",
+      "license": "MIT"
+    },
+    "node_modules/@messageformat/parser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@messageformat/parser/-/parser-5.1.1.tgz",
+      "integrity": "sha512-3p0YRGCcTUCYvBKLIxtDDyrJ0YijGIwrTRu1DT8gIviIDZru8H23+FkY6MJBzM1n9n20CiM4VeDYuBsrrwnLjg==",
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1"
       }
     },
     "node_modules/@napi-rs/canvas": {
@@ -2534,6 +2826,37 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/plugin-babel": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz",
+      "integrity": "sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=22.12.0 || ^24.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/plugin-transform-runtime": "^7.29.0 || ^8.0.0-rc.1",
+        "@babel/runtime": "^7.27.0 || ^8.0.0-rc.1",
+        "rolldown": "^1.0.0-rc.5",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/plugin-transform-runtime": {
+          "optional": true
+        },
+        "@babel/runtime": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-rc.7",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
@@ -3011,6 +3334,12 @@
         "win32"
       ]
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -3376,6 +3705,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/istanbul-lib-report": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
+      "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-coverage": "*"
+      }
+    },
+    "node_modules/@types/istanbul-reports": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
+      "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/istanbul-lib-report": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3387,7 +3740,6 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -3431,6 +3783,21 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/yargs": {
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "node_modules/@types/yargs-parser": {
+      "version": "21.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3794,11 +4161,20 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3972,6 +4348,19 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -4073,6 +4462,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001781",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
@@ -4098,7 +4499,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4111,6 +4511,22 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chokidar": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^5.0.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
@@ -4121,6 +4537,51 @@
       },
       "funding": {
         "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
       }
     },
     "node_modules/clsx": {
@@ -4136,7 +4597,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4149,7 +4609,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -4541,6 +5000,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
@@ -4781,6 +5247,24 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-plugin-lingui": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-lingui/-/eslint-plugin-lingui-0.14.0.tgz",
+      "integrity": "sha512-LI4uZ8yp8OxnKjZTv6iPEKQjQToYszJxBPnZ9ZP1TCjFi+arSFrynyQblwj6YhHiaFpsnr1fU/nK8SSpcHa2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.57.2",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.37.0 || ^9 || ^10",
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
@@ -5065,6 +5549,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -5226,6 +5723,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -5435,7 +5945,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5774,6 +6283,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -5807,6 +6326,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
+      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-map": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
@@ -5838,6 +6370,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -5989,6 +6531,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -6083,6 +6638,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/jest-get-type": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
+      "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
+      "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "camelcase": "^6.2.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "leven": "^3.1.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -6091,6 +6672,12 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
+    },
+    "node_modules/js-sha256": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
+      "integrity": "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -6205,7 +6792,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6474,6 +7060,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -6510,6 +7108,23 @@
       "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-7.0.1.tgz",
+      "integrity": "sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0",
+        "yoctocolors": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -6561,6 +7176,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -6583,6 +7238,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -6623,6 +7284,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -6677,6 +7347,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6693,6 +7379,88 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ora": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.1.tgz",
+      "integrity": "sha512-6VlU9MLXbjVQD04AZCMX28hVtA5bUoadvUqO76MUCVA0ilwJbMiHsITRPfyVm6p/BC0Av/BXMujx39WCe1LEqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.6.2",
+        "cli-cursor": "^5.0.0",
+        "cli-spinners": "^3.2.0",
+        "is-interactive": "^2.0.0",
+        "is-unicode-supported": "^2.1.0",
+        "log-symbols": "^7.0.1",
+        "stdin-discarder": "^0.3.2",
+        "string-width": "^8.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ora/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/own-keys": {
@@ -6898,6 +7666,16 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/pofile-ts": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/pofile-ts/-/pofile-ts-4.0.3.tgz",
+      "integrity": "sha512-sz1pnjgEfPyZ+QvaeX3NtCmbYnEvG01LZRLoN/uXoLtPZtxCIH5IctL7yXXc0fFyk/fqV6K8g3hlNfr6IJwupA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6960,6 +7738,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6976,6 +7786,32 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/pseudolocale": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pseudolocale/-/pseudolocale-2.3.0.tgz",
+      "integrity": "sha512-2RfZuwSSZ8sopelTIIZ2JhmO4GLnHflJQBmtMPF2APWEtmfKOsvqCIWsi8KQJ6EQ0D0+zVllPnLLGijUauSlqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "pseudolocale": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pseudolocale/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -7119,6 +7955,20 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.1.1.tgz",
+      "integrity": "sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/recharts": {
@@ -7319,6 +8169,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/rolldown": {
@@ -7709,6 +8576,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.3.2.tgz",
+      "integrity": "sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -7721,6 +8601,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/string.prototype.matchall": {
@@ -7825,6 +8720,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
@@ -7852,7 +8760,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -7972,6 +8879,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-2.1.0.tgz",
+      "integrity": "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || >=22.0.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/tr46": {
@@ -8178,7 +9108,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -8809,6 +9738,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,13 @@
     "preview": "vite preview",
     "screenshots": "node scripts/screenshots.mjs",
     "screenshots:showcase": "node scripts/screenshots.mjs --showcase",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "i18n:extract": "lingui extract",
+    "i18n:compile": "lingui compile"
   },
   "dependencies": {
+    "@lingui/core": "^6.6.0",
+    "@lingui/react": "^6.6.0",
     "@radix-ui/react-slot": "^1.2.4",
     "@tailwindcss/vite": "^4.2.2",
     "class-variance-authority": "^0.7.1",
@@ -32,12 +36,18 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@lingui/babel-plugin-lingui-macro": "^6.6.0",
+    "@lingui/cli": "^6.6.0",
+    "@lingui/format-po": "^6.6.0",
+    "@lingui/vite-plugin": "^6.6.0",
     "@playwright/test": "^1.62.1",
+    "@rolldown/plugin-babel": "^0.2.3",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^9.39.4",
+    "eslint-plugin-lingui": "^0.14.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",

--- a/frontend/src/components/AppHeader.tsx
+++ b/frontend/src/components/AppHeader.tsx
@@ -6,6 +6,7 @@ import { SyncStatusBadge } from '@/components/SyncStatusBadge'
 import { NotificationBell } from '@/components/NotificationBell'
 import { WhatsNewPanel } from '@/components/WhatsNewPanel'
 import { CommandPalette } from '@/components/CommandPalette'
+import { Trans, useLingui } from '@lingui/react/macro'
 
 /**
  * The one top navbar — menu button, wordmark, a search slot, and the right-side
@@ -21,6 +22,7 @@ export function AppHeader({ onMenuClick, search, actions, onUploadClick }: {
   onUploadClick?: () => void
 }) {
   const { user } = useAuth()
+  const { t } = useLingui()
   // z-40: above content-level stickies (page toolbars at z-20, timeline axis at
   // z-30) so the notification dropdown isn't cut, below modals at z-50.
   return (
@@ -29,7 +31,7 @@ export function AppHeader({ onMenuClick, search, actions, onUploadClick }: {
         <button
           className="md:hidden flex items-center justify-center w-8 h-8 text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-muted shrink-0"
           onClick={onMenuClick}
-          aria-label="Open navigation"
+          aria-label={t`Open navigation`}
         >
           <Menu className="w-5 h-5" />
         </button>
@@ -50,7 +52,7 @@ export function AppHeader({ onMenuClick, search, actions, onUploadClick }: {
               className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-semibold bg-primary text-primary-foreground hover:bg-primary/90 transition-all touch-feedback"
             >
               <Upload className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">Upload</span>
+              <span className="hidden sm:inline"><Trans>Upload</Trans></span>
             </button>
           )}
         </div>
@@ -66,7 +68,7 @@ export function AppHeader({ onMenuClick, search, actions, onUploadClick }: {
 
 /** The header's search box. With `onSubmit` it's a form (Enter submits — the
  *  standalone pages jump to the dashboard results); without, a live filter. */
-export function HeaderSearch({ value, onChange, onClear, onSubmit, inputRef, placeholder = 'Search books… (/)' }: {
+export function HeaderSearch({ value, onChange, onClear, onSubmit, inputRef, placeholder }: {
   value: string
   onChange: (v: string) => void
   onClear: () => void
@@ -74,18 +76,19 @@ export function HeaderSearch({ value, onChange, onClear, onSubmit, inputRef, pla
   inputRef?: RefObject<HTMLInputElement | null>
   placeholder?: string
 }) {
+  const { t } = useLingui()
   const inner = (
     <>
       <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-muted-foreground pointer-events-none" />
       <input
         ref={inputRef}
-        aria-label="Search books"
+        aria-label={t`Search books`}
         // On phones the box can shrink to a sliver (page actions squeeze it) and
         // the placeholder clips mid-letter — hide it there; the icon says enough.
         // Rests quiet (tinted fill, no border), sharpens on focus — filled AND
         // bordered at rest made it the heaviest element in the whole bar.
         className="w-full h-8 pl-9 pr-8 rounded-lg bg-muted/60 border border-transparent text-sm placeholder:text-muted-foreground max-sm:placeholder:text-transparent transition-colors hover:bg-muted focus:bg-card focus:border-border focus:outline-none focus:ring-1 focus:ring-ring"
-        placeholder={placeholder}
+        placeholder={placeholder ?? t`Search books… (/)`}
         value={value}
         onChange={e => onChange(e.target.value)}
       />
@@ -93,7 +96,7 @@ export function HeaderSearch({ value, onChange, onClear, onSubmit, inputRef, pla
         <button
           type="button"
           className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
-          aria-label="Clear search"
+          aria-label={t`Clear search`}
           onClick={onClear}
         >
           <X className="w-3.5 h-3.5" />

--- a/frontend/src/components/AppShell.tsx
+++ b/frontend/src/components/AppShell.tsx
@@ -7,6 +7,8 @@ import { useSidebarLists } from '@/lib/sidebarLists'
 import { Sidebar } from '@/components/Sidebar'
 import { AppHeader, HeaderSearch } from '@/components/AppHeader'
 import { UploadModal } from '@/components/UploadModal'
+import { Trans } from '@lingui/react/macro'
+import { plural } from '@lingui/core/macro'
 
 /**
  * The shared application shell — the same top navbar (Tome wordmark) + persistent
@@ -36,6 +38,7 @@ export function AppShell({
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const [uploadOpen, setUploadOpen] = useState(false)
   const [searchInput, setSearchInput] = useState('')
+  const searchQuery = searchInput.trim()
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   // Global library search from any page: Enter jumps to the dashboard's book
@@ -128,7 +131,7 @@ export function AppShell({
                   onClick={() => navigate(`/?tab=books&q=${encodeURIComponent(searchInput.trim())}`)}
                   className="w-full border-t border-border px-3 py-2 text-left text-xs text-muted-foreground hover:bg-muted hover:text-foreground"
                 >
-                  See all results for &quot;{searchInput.trim()}&quot;
+                  <Trans>See all results for &quot;{searchQuery}&quot;</Trans>
                 </button>
               </div>
             )}
@@ -144,7 +147,10 @@ export function AppShell({
         onDone={() => onUploaded?.()}
         onWishMatches={(wishIds) => {
           const n = wishIds.length
-          toast.info(`This upload satisfies ${n} wish${n !== 1 ? 'es' : ''} — review in Admin > Wishlist`)
+          toast.info(plural(n, {
+            one: 'This upload satisfies # wish — review in Admin > Wishlist',
+            other: 'This upload satisfies # wishes — review in Admin > Wishlist',
+          }))
         }}
       />
 

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from 'react'
 import { BookOpen, Star } from 'lucide-react'
 import { Link, useNavigate } from 'react-router-dom'
+import { useLingui } from '@lingui/react/macro'
 import type { Book, ReadingStatus } from '@/lib/books'
 import { useBookTypes } from '@/lib/bookTypes'
 import { cn } from '@/lib/utils'
 import { CoverImage } from '@/components/CoverImage'
 
+/* eslint-disable lingui/no-unlocalized-strings -- Tailwind class map, not copy */
 const COLOR_CLASSES: Record<string, string> = {
   blue: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
   pink: 'bg-pink-100 text-pink-700 dark:bg-pink-900/40 dark:text-pink-300',
@@ -16,6 +18,7 @@ const COLOR_CLASSES: Record<string, string> = {
   yellow: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300',
   teal: 'bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300',
 }
+/* eslint-enable lingui/no-unlocalized-strings */
 
 export type ViewMode = 'large' | 'small' | 'list'
 
@@ -41,9 +44,10 @@ interface BookCardProps {
 
 /** Compact read-only star rating for cards. Renders nothing when unrated. */
 function RatingStars({ rating, size = 11 }: { rating?: number | null; size?: number }) {
+  const { t } = useLingui()
   if (!rating) return null
   return (
-    <span className="inline-flex items-center gap-px" aria-label={`Rated ${rating} of 5`}>
+    <span className="inline-flex items-center gap-px" aria-label={t`Rated ${rating} of 5`}>
       {[1, 2, 3, 4, 5].map(n => (
         <Star
           key={n}
@@ -60,6 +64,7 @@ export function BookCard({
   onTagClick: _onTagClick, onSeriesClick, onAuthorClick,
   readingStatus, progressPct, rating, flipId, showFormatBadge = true,
 }: BookCardProps) {
+  const { t } = useLingui()
   const navigate = useNavigate()
   const bookTypes = useBookTypes()
   const cardRef = useRef<HTMLDivElement | HTMLAnchorElement>(null)
@@ -71,6 +76,7 @@ export function BookCard({
   }, [focused])
   const bookType = book.book_type_id != null ? bookTypes.find(t => t.id === book.book_type_id) : null
   const typeBadgeClass = bookType
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- Tailwind classes
     ? (COLOR_CLASSES[bookType.color ?? ''] ?? 'bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300')
     : null
 
@@ -203,6 +209,7 @@ export function BookCard({
     const yRatio = y * 2 - 1  // -1 to 1
     setMousePos({ x: x * 100, y: y * 100 })
     if (coverDivRef.current) {
+      // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS transform
       coverDivRef.current.style.transform = `rotateY(${xRatio * 4}deg) rotateX(${yRatio * -4}deg) translateY(-3px)`
     }
   }
@@ -289,8 +296,8 @@ export function BookCard({
               'bg-background/40 backdrop-blur-sm hover:bg-background/60 transition-all',
               'opacity-0 group-hover:opacity-100',
             )}
-            title="Read"
-            aria-label="Read book"
+            title={t`Read`}
+            aria-label={t`Read book`}
             onClick={e => stop(e, () => navigate(`/reader/${book.id}`))}
           >
             <BookOpen className="w-3.5 h-3.5 text-foreground/90" />

--- a/frontend/src/components/BulkMetadataReviewModal.tsx
+++ b/frontend/src/components/BulkMetadataReviewModal.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 import { AlertCircle, Check, ChevronDown, ChevronUp, Loader2, Search, Sparkles, X } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
@@ -78,7 +80,7 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
       }
       setRowState(initial)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Fetch failed')
+      setError(e instanceof Error ? e.message : t`Fetch failed`)
     } finally {
       setLoading(false)
     }
@@ -201,8 +203,8 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
         <div className="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
           <div className="flex items-center gap-2 font-semibold text-sm">
             <Sparkles className="h-4 w-4 text-primary" />
-            Fetch Metadata
-            <span className="text-muted-foreground font-normal">— {bookIds.length} books</span>
+            <Trans>Fetch Metadata</Trans>
+            {(() => { const n = bookIds.length; return <span className="text-muted-foreground font-normal"><Trans>— {n} books</Trans></span> })()}
           </div>
           <button onClick={handleClose} disabled={applying} className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50">
             <X className="h-4 w-4" />
@@ -219,10 +221,10 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
                 onChange={e => setFillMissingOnly(e.target.checked)}
                 className="rounded border-border"
               />
-              <span className="text-muted-foreground">Fill missing fields only</span>
+              <span className="text-muted-foreground"><Trans>Fill missing fields only</Trans></span>
             </label>
             <span className="text-xs text-muted-foreground ml-auto">
-              {matched} matched{needsReview > 0 ? ` · ${needsReview} needs review` : ''}{noMatch > 0 ? ` · ${noMatch} no match` : ''}
+              {t`${matched} matched`}{needsReview > 0 ? t` · ${needsReview} needs review` : ''}{noMatch > 0 ? t` · ${noMatch} no match` : ''}
             </span>
           </div>
         )}
@@ -232,10 +234,10 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
           {doneState && (
             <div className="flex flex-col items-center justify-center py-16 gap-4 text-center">
               <Check className="w-12 h-12 text-success" />
-              <h2 className="text-lg font-semibold">Batch complete</h2>
+              <h2 className="text-lg font-semibold"><Trans>Batch complete</Trans></h2>
               <p className="text-sm text-muted-foreground">
-                Applied metadata to {doneState.applied} books.
-                {doneState.uncertain.length > 0 && ` ${doneState.uncertain.length} had no confident match.`}
+                {(() => { const n = doneState.applied; return <Trans>Applied metadata to {n} books.</Trans> })()}
+                {doneState.uncertain.length > 0 && (() => { const n = doneState.uncertain.length; return t` ${n} had no confident match.` })()}
               </p>
               <div className="flex items-center gap-2">
                 {doneState.uncertain.length > 0 && onReviewUncertain && (
@@ -243,14 +245,14 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
                     onClick={() => { onReviewUncertain(doneState.uncertain); handleClose() }}
                     className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
                   >
-                    Review {doneState.uncertain.length} Uncertain
+                    {(() => { const n = doneState.uncertain.length; return <Trans>Review {n} Uncertain</Trans> })()}
                   </button>
                 )}
                 <button
                   onClick={handleClose}
                   className="px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                 >
-                  Close
+                  <Trans>Close</Trans>
                 </button>
               </div>
             </div>
@@ -259,7 +261,7 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
           {!doneState && loading && (
             <div className="flex flex-col items-center justify-center py-16 gap-3">
               <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-              <p className="text-sm text-muted-foreground">Searching {bookIds.length} books…</p>
+              {(() => { const n = bookIds.length; return <p className="text-sm text-muted-foreground"><Trans>Searching {n} books…</Trans></p> })()}
             </div>
           )}
 
@@ -324,6 +326,7 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
                             <div className="flex items-center gap-1.5 flex-wrap">
                               <p className="text-sm font-medium line-clamp-1">{match.title}</p>
                               <span className="shrink-0 text-[9px] px-1 py-0.5 rounded bg-muted text-muted-foreground border border-border">
+                                {/* eslint-disable-next-line lingui/no-unlocalized-strings -- provider names */}
                                 {match.source === 'hardcover' ? 'Hardcover' : match.source === 'google_books' ? 'Google' : 'OpenLib'}
                               </span>
                             </div>
@@ -344,19 +347,19 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
                                 <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/10 text-primary border border-primary/20">+series</span>
                               )}
                               {!match.description && !match.cover_url && !match.publisher && !match.year && !match.series && (
-                                <span className="text-[10px] text-muted-foreground">no new fields</span>
+                                <span className="text-[10px] text-muted-foreground"><Trans>no new fields</Trans></span>
                               )}
                             </div>
                           </div>
                         </div>
                       ) : (
                         <div className="flex-1 flex items-center gap-1.5">
-                          <span className="text-xs text-muted-foreground italic">No match found</span>
+                          <span className="text-xs text-muted-foreground italic"><Trans>No match found</Trans></span>
                           <button
                             onClick={() => { onManualSearch(result.book_id); handleClose() }}
                             className="text-xs text-primary hover:underline flex items-center gap-1"
                           >
-                            <Search className="h-3 w-3" /> Search manually
+                            <Search className="h-3 w-3" /> <Trans>Search manually</Trans>
                           </button>
                         </div>
                       )}
@@ -397,7 +400,8 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
                               <span className="font-medium line-clamp-1">{c.title}</span>
                               {c.author && <span className="text-muted-foreground ml-1">· {c.author}</span>}
                               <span className="ml-1 text-[9px] px-1 py-0.5 rounded bg-muted text-muted-foreground border border-border">
-                                {c.source === 'hardcover' ? 'Hardcover' : c.source === 'google_books' ? 'Google' : 'OpenLib'}
+                                {/* eslint-disable-next-line lingui/no-unlocalized-strings -- provider names */}
+                              {c.source === 'hardcover' ? 'Hardcover' : c.source === 'google_books' ? 'Google' : 'OpenLib'}
                               </span>
                               {c.year && <span className="text-muted-foreground ml-1">· {c.year}</span>}
                               {c.description && <p className="text-muted-foreground line-clamp-1 mt-0.5">{c.description}</p>}
@@ -420,11 +424,11 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
           <div className="px-6 py-4 border-t border-border flex items-center justify-between gap-3 shrink-0">
             {applying && progress ? (
               <span className="text-xs text-muted-foreground">
-                Applying {progress.done}/{progress.total}…
+                {(() => { const done = progress.done; const total = progress.total; return <Trans>Applying {done}/{total}…</Trans> })()}
               </span>
             ) : (
               <span className="text-xs text-muted-foreground">
-                {!loading && results.length > 0 ? `${approvedCount()} of ${results.length} approved` : ''}
+                {!loading && results.length > 0 ? (() => { const ok = approvedCount(); const total = results.length; return t`${ok} of ${total} approved` })() : ''}
               </span>
             )}
             <div className="flex items-center gap-2">
@@ -433,7 +437,7 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
                 disabled={applying}
                 className="px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50"
               >
-                Cancel
+                <Trans>Cancel</Trans>
               </button>
               <button
                 onClick={applyAll}
@@ -443,7 +447,7 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
                 {applying
                   ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
                   : <Check className="h-3.5 w-3.5" />}
-                Apply {approvedCount() > 0 ? approvedCount() : ''} Approved
+                {(() => { const n = approvedCount(); return n > 0 ? <Trans>Apply {n} Approved</Trans> : <Trans>Apply Approved</Trans> })()}
               </button>
             </div>
           </div>

--- a/frontend/src/components/BulkMetadataReviewModal.tsx
+++ b/frontend/src/components/BulkMetadataReviewModal.tsx
@@ -370,7 +370,7 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
                           <button
                             onClick={() => toggleExpanded(result.book_id)}
                             className="p-1 text-muted-foreground hover:text-foreground transition-colors"
-                            title="Pick different candidate"
+                            title={t`Pick different candidate`}
                           >
                             {state.expanded ? <ChevronUp className="h-3.5 w-3.5" /> : <ChevronDown className="h-3.5 w-3.5" />}
                           </button>

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -13,6 +13,9 @@ import {
 import { api } from '@/lib/api'
 import { useAuth, isAdmin } from '@/contexts/AuthContext'
 import { cn } from '@/lib/utils'
+import { t, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 
 interface BookHit {
   id: number
@@ -37,15 +40,19 @@ interface Item {
   bookId?: number
 }
 
+const GROUP_LABEL: Record<string, MessageDescriptor> = {
+  Books: msg`Books`, Series: msg`Series`, Authors: msg`Authors`, Actions: msg`Actions`,
+}
+
 const NAV_ACTIONS = (admin: boolean): { label: string; to: string; icon: React.ReactNode }[] => [
-  { label: 'Home', to: '/', icon: <Compass className="h-4 w-4" /> },
-  { label: 'All Books', to: '/?tab=books', icon: <LibraryIcon className="h-4 w-4" /> },
-  { label: 'Series', to: '/?tab=series', icon: <Layers className="h-4 w-4" /> },
-  { label: 'Reading Stats', to: '/stats', icon: <ChartColumn className="h-4 w-4" /> },
-  { label: 'Highlights', to: '/highlights', icon: <Quote className="h-4 w-4" /> },
-  { label: 'Wishlist', to: '/wishlist', icon: <Sparkles className="h-4 w-4" /> },
-  { label: 'Settings', to: '/settings', icon: <Settings className="h-4 w-4" /> },
-  ...(admin ? [{ label: 'Admin', to: '/admin', icon: <Shield className="h-4 w-4" /> }] : []),
+  { label: i18n._(msg`Home`), to: '/', icon: <Compass className="h-4 w-4" /> },
+  { label: i18n._(msg`All Books`), to: '/?tab=books', icon: <LibraryIcon className="h-4 w-4" /> },
+  { label: i18n._(msg`Series`), to: '/?tab=series', icon: <Layers className="h-4 w-4" /> },
+  { label: i18n._(msg`Reading Stats`), to: '/stats', icon: <ChartColumn className="h-4 w-4" /> },
+  { label: i18n._(msg`Highlights`), to: '/highlights', icon: <Quote className="h-4 w-4" /> },
+  { label: i18n._(msg`Wishlist`), to: '/wishlist', icon: <Sparkles className="h-4 w-4" /> },
+  { label: i18n._(msg`Settings`), to: '/settings', icon: <Settings className="h-4 w-4" /> },
+  ...(admin ? [{ label: i18n._(msg`Admin`), to: '/admin', icon: <Shield className="h-4 w-4" /> }] : []),
 ]
 
 /** startsWith beats includes; shorter names beat longer at equal rank. */
@@ -176,6 +183,7 @@ export function CommandPalette() {
 
   if (!open) return null
 
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- group keys, labels via GROUP_LABEL
   const groups: Item['group'][] = ['Books', 'Series', 'Authors', 'Actions']
 
   return createPortal(
@@ -201,7 +209,7 @@ export function CommandPalette() {
                   go(items[selected])
                 }
               }}
-              placeholder="Jump to a book, series, author, or page…"
+              placeholder={t`Jump to a book, series, author, or page…`}
               className="h-12 w-full bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-none"
             />
             <kbd className="hidden rounded border border-border px-1.5 py-0.5 text-[10px] text-muted-foreground sm:block">
@@ -210,7 +218,7 @@ export function CommandPalette() {
           </div>
           <div className="max-h-[50vh] overflow-y-auto overscroll-contain py-1.5">
             {items.length === 0 && (
-              <p className="px-4 py-6 text-center text-sm text-muted-foreground">No matches.</p>
+              <p className="px-4 py-6 text-center text-sm text-muted-foreground">{t`No matches.`}</p>
             )}
             {groups.map((g) => {
               const groupItems = items.filter((i) => i.group === g)
@@ -218,7 +226,7 @@ export function CommandPalette() {
               return (
                 <div key={g}>
                   <p className="px-4 pb-1 pt-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
-                    {g}
+                    {i18n._(GROUP_LABEL[g])}
                   </p>
                   {groupItems.map((item) => {
                     const idx = items.indexOf(item)

--- a/frontend/src/components/CoverAudit.tsx
+++ b/frontend/src/components/CoverAudit.tsx
@@ -8,6 +8,10 @@ import { Link } from 'react-router-dom'
 import { ExternalLink, ImageOff, Loader2, RefreshCw, Wand2 } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 
 interface FlaggedBook {
   book_id: number
@@ -28,10 +32,10 @@ interface AuditResponse {
 
 type FixState = 'fixing' | 'fixed' | 'nocandidate' | 'failed'
 
-const REASON_LABEL: Record<FlaggedBook['reason'], string> = {
-  missing: 'No cover',
-  low_res: 'Low resolution',
-  unreadable: 'Unreadable file',
+const REASON_LABEL: Record<FlaggedBook['reason'], MessageDescriptor> = {
+  missing: msg`No cover`,
+  low_res: msg`Low resolution`,
+  unreadable: msg`Unreadable file`,
 }
 
 export function CoverAudit() {
@@ -83,7 +87,7 @@ export function CoverAudit() {
   if (!data) {
     return (
       <div className="flex items-center gap-2 py-10 justify-center text-sm text-muted-foreground">
-        <Loader2 className="w-4 h-4 animate-spin" /> Scanning covers…
+        <Loader2 className="w-4 h-4 animate-spin" /> <Trans>Scanning covers…</Trans>
       </div>
     )
   }
@@ -94,9 +98,12 @@ export function CoverAudit() {
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
         <p className="text-sm text-muted-foreground">
-          {data.books.length === 0
-            ? `All ${data.scanned} covers look healthy.`
-            : `${data.books.length} of ${data.scanned} books flagged (low-res = narrower than ${data.min_width}px).`}
+          {(() => {
+            const scanned = data.scanned
+            if (data.books.length === 0) return t`All ${scanned} covers look healthy.`
+            const flagged = data.books.length, minW = data.min_width
+            return t`${flagged} of ${scanned} books flagged (low-res = narrower than ${minW}px).`
+          })()}
         </p>
         <div className="ml-auto flex items-center gap-2">
           {missingCount > 0 && (
@@ -106,7 +113,7 @@ export function CoverAudit() {
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:bg-primary/90 disabled:opacity-50 transition-all"
             >
               {bulkRunning ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Wand2 className="w-3.5 h-3.5" />}
-              Auto-fix {missingCount} missing
+              <Trans>Auto-fix {missingCount} missing</Trans>
             </button>
           )}
           <button
@@ -115,7 +122,7 @@ export function CoverAudit() {
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-card hover:bg-muted disabled:opacity-50 transition-all"
           >
             <RefreshCw className={cn('w-3.5 h-3.5', loading && 'animate-spin')} />
-            Rescan
+            <Trans>Rescan</Trans>
           </button>
         </div>
       </div>
@@ -124,9 +131,9 @@ export function CoverAudit() {
         <div className="rounded-xl border border-border overflow-hidden">
           <div className="grid grid-cols-[3rem_1fr_8rem_7rem_6rem] items-center gap-2 border-b border-border bg-muted/40 px-3 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             <span />
-            <span>Book</span>
-            <span>Problem</span>
-            <span>Size</span>
+            <span><Trans>Book</Trans></span>
+            <span><Trans>Problem</Trans></span>
+            <span><Trans>Size</Trans></span>
             <span />
           </div>
           {data.books.map(b => {
@@ -161,7 +168,7 @@ export function CoverAudit() {
                     state === 'fixed' && 'text-success',
                   )}
                 >
-                  {state === 'fixed' ? 'Fixed' : REASON_LABEL[b.reason]}
+                  {state === 'fixed' ? t`Fixed` : i18n._(REASON_LABEL[b.reason])}
                 </span>
                 <span className="text-xs text-muted-foreground">
                   {b.width != null ? `${b.width}×${b.height}px` : '—'}
@@ -171,7 +178,7 @@ export function CoverAudit() {
                     <button
                       onClick={() => autoFix(b)}
                       disabled={state === 'fixing' || bulkRunning}
-                      title="Apply the first cover-search candidate"
+                      title={t`Apply the first cover-search candidate`}
                       className="rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
                     >
                       {state === 'fixing' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Wand2 className="h-3.5 w-3.5" />}
@@ -179,7 +186,7 @@ export function CoverAudit() {
                   )}
                   <Link
                     to={`/books/${b.book_id}`}
-                    title="Open book (pick a cover by eye)"
+                    title={t`Open book (pick a cover by eye)`}
                     className="rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground"
                   >
                     <ExternalLink className="h-3.5 w-3.5" />
@@ -192,7 +199,7 @@ export function CoverAudit() {
       )}
       {Object.values(fix).some(s => s === 'nocandidate' || s === 'failed') && (
         <p className="text-xs text-muted-foreground">
-          Some books had no usable candidate or failed to apply — open them and use the cover picker.
+          <Trans>Some books had no usable candidate or failed to apply — open them and use the cover picker.</Trans>
         </p>
       )}
     </div>

--- a/frontend/src/components/CoverPickerModal.tsx
+++ b/frontend/src/components/CoverPickerModal.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { Camera, Check, ImageOff, Loader2, Search, Upload, X } from 'lucide-react'
 import type { BookDetail } from '@/lib/books'
+import { Trans, Plural } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 const API = import.meta.env.VITE_API_URL ?? ''
 
@@ -22,11 +24,13 @@ interface Props {
   onApplied: (updated: BookDetail) => void
 }
 
+/* eslint-disable lingui/no-unlocalized-strings -- provider names */
 const SOURCE_BADGE: Record<string, string> = {
   hardcover: 'HC',
   google_books: 'Google',
   open_library: 'OpenLib',
 }
+/* eslint-enable lingui/no-unlocalized-strings */
 
 export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
   const [candidates, setCandidates] = useState<CoverCandidate[]>([])
@@ -61,9 +65,9 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
       if (!r.ok) throw new Error(await r.text())
       const data: CoverCandidate[] = await r.json()
       setCandidates(data)
-      if (data.length === 0) setError('No cover candidates found.')
+      if (data.length === 0) setError(t`No cover candidates found.`)
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to fetch candidates')
+      setError(e instanceof Error ? e.message : t`Failed to fetch candidates`)
     } finally {
       setLoading(false)
     }
@@ -85,7 +89,7 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
       onApplied(updated)
       handleClose()
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to apply cover')
+      setError(e instanceof Error ? e.message : t`Failed to apply cover`)
     } finally {
       setApplyingUrl(null)
     }
@@ -107,7 +111,7 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
       onApplied(updated)
       handleClose()
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to upload cover')
+      setError(e instanceof Error ? e.message : t`Failed to upload cover`)
     } finally {
       setApplyingUrl(null)
     }
@@ -132,7 +136,7 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
         <div className="flex items-center justify-between px-6 py-4 border-b border-border sticky top-0 bg-background z-10">
           <div className="flex items-center gap-2 font-semibold text-sm">
             <Camera className="h-4 w-4 text-primary" />
-            Change Cover
+            <Trans>Change Cover</Trans>
             <span className="text-muted-foreground font-normal">— {book.title}</span>
           </div>
           <button onClick={handleClose} className="text-muted-foreground hover:text-foreground transition-colors">
@@ -170,7 +174,7 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
           {!loading && candidates.length > 0 && (
             <div>
               <p className="text-xs text-muted-foreground mb-3">
-                {candidates.length} cover{candidates.length !== 1 ? 's' : ''} found — click to apply
+                <Plural value={candidates.length} one="# cover found — click to apply" other="# covers found — click to apply" />
               </p>
               <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
                 {candidates.map((c, i) => {
@@ -218,19 +222,19 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
           )}
 
           {!loading && candidates.length === 0 && !error && (
-            <p className="text-xs text-muted-foreground text-center py-4">No covers found — try a different search or use a custom URL below.</p>
+            <p className="text-xs text-muted-foreground text-center py-4"><Trans>No covers found — try a different search or use a custom URL below.</Trans></p>
           )}
 
           {/* Divider */}
           <div className="flex items-center gap-3">
             <div className="flex-1 border-t border-border" />
-            <span className="text-xs text-muted-foreground shrink-0">or use a custom source</span>
+            <span className="text-xs text-muted-foreground shrink-0"><Trans>or use a custom source</Trans></span>
             <div className="flex-1 border-t border-border" />
           </div>
 
           {/* Custom URL */}
           <div>
-            <p className="text-xs font-medium text-muted-foreground mb-2">Custom URL</p>
+            <p className="text-xs font-medium text-muted-foreground mb-2"><Trans>Custom URL</Trans></p>
             <div className="flex gap-2">
               <input
                 type="url"
@@ -246,14 +250,14 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
                 className="shrink-0 flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 transition-all"
               >
                 {applyingUrl !== null ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
-                Apply
+                <Trans>Apply</Trans>
               </button>
             </div>
           </div>
 
           {/* File upload */}
           <div>
-            <p className="text-xs font-medium text-muted-foreground mb-2">Upload from device</p>
+            <p className="text-xs font-medium text-muted-foreground mb-2"><Trans>Upload from device</Trans></p>
             <input
               ref={fileInputRef}
               type="file"
@@ -273,7 +277,7 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
               {applyingUrl !== null
                 ? <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
                 : <Upload className="h-3.5 w-3.5 text-muted-foreground" />}
-              Choose file…
+              <Trans>Choose file…</Trans>
             </button>
           </div>
 

--- a/frontend/src/components/EntityModal.tsx
+++ b/frontend/src/components/EntityModal.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useRef } from 'react'
 import { Loader2 } from 'lucide-react'
 import { IconPicker } from '@/components/Sidebar'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 interface Props {
   title: string
@@ -38,7 +40,7 @@ export function EntityModal({ title, initialName = '', initialIcon, defaultIcon 
       await onSave(name.trim(), icon)
       onClose()
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save')
+      setError(e instanceof Error ? e.message : t`Failed to save`)
     } finally {
       setSaving(false)
     }
@@ -59,12 +61,12 @@ export function EntityModal({ title, initialName = '', initialIcon, defaultIcon 
           onKeyDown={e => {
             if (e.key === 'Enter') handleSave()
           }}
-          placeholder="Name…"
+          placeholder={t`Name…`}
           className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm focus:outline-none focus:ring-1 focus:ring-ring"
         />
 
         <div className="flex items-center gap-3">
-          <span className="text-sm text-muted-foreground">Icon</span>
+          <span className="text-sm text-muted-foreground"><Trans>Icon</Trans></span>
           <IconPicker value={icon} onChange={setIcon} />
         </div>
 
@@ -75,7 +77,7 @@ export function EntityModal({ title, initialName = '', initialIcon, defaultIcon 
             onClick={onClose}
             className="px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
           <button
             onClick={handleSave}
@@ -83,7 +85,7 @@ export function EntityModal({ title, initialName = '', initialIcon, defaultIcon 
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
           >
             {saving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-            Save
+            <Trans>Save</Trans>
           </button>
         </div>
       </div>

--- a/frontend/src/components/ForcePasswordChange.tsx
+++ b/frontend/src/components/ForcePasswordChange.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { KeyRound, Eye, EyeOff } from 'lucide-react'
 import { api } from '@/lib/api'
 import { useAuth } from '@/contexts/AuthContext'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 export function ForcePasswordChange() {
   const { user, refreshUser } = useAuth()
@@ -16,14 +18,14 @@ export function ForcePasswordChange() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     setError('')
-    if (next.length < 8) { setError('Password must be at least 8 characters.'); return }
-    if (next !== confirm) { setError('Passwords do not match.'); return }
+    if (next.length < 8) { setError(t`Password must be at least 8 characters.`); return }
+    if (next !== confirm) { setError(t`Passwords do not match.`); return }
     setSaving(true)
     try {
       await api.put('/auth/me/password', { current_password: current, new_password: next })
       await refreshUser()
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Failed to update password.')
+      setError(e instanceof Error ? e.message : t`Failed to update password.`)
     } finally {
       setSaving(false)
     }
@@ -37,10 +39,12 @@ export function ForcePasswordChange() {
             <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center mb-3">
               <KeyRound className="w-6 h-6 text-primary" />
             </div>
-            <h1 className="text-lg font-semibold text-foreground">Set your password</h1>
+            <h1 className="text-lg font-semibold text-foreground"><Trans>Set your password</Trans></h1>
             <p className="text-sm text-muted-foreground text-center mt-1">
-              Hi <span className="font-medium text-foreground">{user?.username}</span> — your account was created by an admin.
-              Please set a personal password before continuing.
+              {(() => { const username = user?.username; return (
+              <Trans>Hi <span className="font-medium text-foreground">{username}</span> — your account was created by an admin.
+              Please set a personal password before continuing.</Trans>
+              ) })()}
             </p>
           </div>
 
@@ -48,7 +52,7 @@ export function ForcePasswordChange() {
             <div className="relative">
               <input
                 type={showCurrent ? 'text' : 'password'}
-                placeholder="Temporary password"
+                placeholder={t`Temporary password`}
                 value={current}
                 onChange={e => setCurrent(e.target.value)}
                 required
@@ -63,7 +67,7 @@ export function ForcePasswordChange() {
             <div className="relative">
               <input
                 type={showNext ? 'text' : 'password'}
-                placeholder="New password"
+                placeholder={t`New password`}
                 value={next}
                 onChange={e => setNext(e.target.value)}
                 required
@@ -77,7 +81,7 @@ export function ForcePasswordChange() {
 
             <input
               type="password"
-              placeholder="Confirm new password"
+              placeholder={t`Confirm new password`}
               value={confirm}
               onChange={e => setConfirm(e.target.value)}
               required
@@ -92,7 +96,7 @@ export function ForcePasswordChange() {
               className="mt-1 w-full py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-all flex items-center justify-center gap-2"
             >
               {saving && <div className="w-4 h-4 border-2 border-primary-foreground border-t-transparent rounded-full animate-spin" />}
-              {saving ? 'Saving…' : 'Set password & continue'}
+              {saving ? t`Saving…` : t`Set password & continue`}
             </button>
           </form>
         </div>

--- a/frontend/src/components/HScrollRow.tsx
+++ b/frontend/src/components/HScrollRow.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { cn } from '../lib/utils'
+import { t } from '@lingui/core/macro'
 
 /**
  * Horizontal scroll row with visible affordances: edge fades whenever content
@@ -71,7 +72,7 @@ export function HScrollRow({ children, className, wrapClassName, controlsTop }: 
       {canLeft && (
         <button
           type="button"
-          aria-label="Scroll left"
+          aria-label={t`Scroll left`}
           onClick={() => nudge(-1)}
           className={cn(
             'flex absolute left-1 -translate-y-1/2 w-8 h-8 items-center justify-center rounded-full border border-border bg-card/95 shadow-sm text-muted-foreground hover:text-foreground opacity-70 hover:opacity-100 group-hover/hscroll:opacity-100 focus-visible:opacity-100 transition-opacity',
@@ -84,7 +85,7 @@ export function HScrollRow({ children, className, wrapClassName, controlsTop }: 
       {canRight && (
         <button
           type="button"
-          aria-label="Scroll right"
+          aria-label={t`Scroll right`}
           onClick={() => nudge(1)}
           className={cn(
             'flex absolute right-1 -translate-y-1/2 w-8 h-8 items-center justify-center rounded-full border border-border bg-card/95 shadow-sm text-muted-foreground hover:text-foreground opacity-70 hover:opacity-100 group-hover/hscroll:opacity-100 focus-visible:opacity-100 transition-opacity',

--- a/frontend/src/components/HardcoverSync.tsx
+++ b/frontend/src/components/HardcoverSync.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 import { Link } from 'react-router-dom'
 import { BookMarked, ExternalLink, Loader2, RefreshCw, AlertTriangle } from 'lucide-react'
 import { api } from '@/lib/api'
@@ -65,11 +67,11 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
     setBusy(true)
     try {
       const r = await api.post<{ username: string }>('/hardcover/link', { token: token.trim() })
-      toast.success(`Linked as @${r.username} — initial sync started`)
+      { const username = r.username; toast.success(t`Linked as @${username} — initial sync started`) }
       setToken('')
       await refresh()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Could not link Hardcover account')
+      toast.error(err instanceof Error ? err.message : t`Could not link Hardcover account`)
     } finally {
       setBusy(false)
     }
@@ -81,7 +83,7 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
       await api.delete('/hardcover/link')
       await refresh()
     } catch {
-      toast.error('Could not unlink')
+      toast.error(t`Could not unlink`)
     } finally {
       setBusy(false)
     }
@@ -94,7 +96,7 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
       await api.put('/hardcover/settings', { sync_enabled: next })
     } catch {
       setStatus(prev)
-      toast.error('Could not update sync setting')
+      toast.error(t`Could not update sync setting`)
     }
   }
 
@@ -102,13 +104,13 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
     try {
       const r = await api.post<{ started: boolean }>('/hardcover/sync-now', {})
       if (r.started) {
-        toast.info('Sync started — pushing ratings and progress, syncing Want to Read both ways')
+        toast.info(t`Sync started — pushing ratings and progress, syncing Want to Read both ways`)
         setStatus(s => s ? { ...s, sync_running: true } : s)
       } else {
-        toast.info('A sync is already running')
+        toast.info(t`A sync is already running`)
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Could not start sync')
+      toast.error(err instanceof Error ? err.message : t`Could not start sync`)
     }
   }
 
@@ -123,11 +125,12 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
               <BookMarked className="w-3.5 h-3.5 text-primary" />
             </div>
             <div>
+              {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product name */}
               <p className="text-sm font-medium text-foreground">Hardcover Sync</p>
               <p className="text-xs text-muted-foreground mt-0.5">
-                Push your ratings and reading progress to your Hardcover profile — nothing
+                <Trans>Push your ratings and reading progress to your Hardcover profile — nothing
                 is ever deleted there. Your Hardcover Want to Read shelf syncs both ways.
-                Needs your personal API token (separate from the server's metadata token).
+                Needs your personal API token (separate from the server's metadata token).</Trans>
               </p>
             </div>
           </div>
@@ -137,13 +140,13 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
             rel="noopener noreferrer"
             className="shrink-0 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
           >
-            Get token <ExternalLink className="w-3 h-3" />
+            <Trans>Get token</Trans> <ExternalLink className="w-3 h-3" />
           </a>
         </div>
 
         {!status ? (
           <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Loader2 className="w-3.5 h-3.5 animate-spin" /> Loading…
+            <Loader2 className="w-3.5 h-3.5 animate-spin" /> <Trans>Loading…</Trans>
           </div>
         ) : !status.linked || expired ? (
           <div className="space-y-3">
@@ -151,7 +154,7 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
               <div className="flex items-center gap-2 rounded-lg bg-warning/10 border border-warning/20 px-3 py-2">
                 <AlertTriangle className="w-3.5 h-3.5 text-warning shrink-0" />
                 <p className="text-xs text-warning font-medium">
-                  Your Hardcover token expired (they reset every January 1). Paste a fresh one to resume syncing.
+                  <Trans>Your Hardcover token expired (they reset every January 1). Paste a fresh one to resume syncing.</Trans>
                 </p>
               </div>
             )}
@@ -161,7 +164,7 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
                 value={token}
                 onChange={e => setToken(e.target.value)}
                 onKeyDown={e => { if (e.key === 'Enter') void link() }}
-                placeholder="Paste your Hardcover API token"
+                placeholder={t`Paste your Hardcover API token`}
                 className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
               />
               <button
@@ -170,7 +173,7 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
                 className="px-3 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity inline-flex items-center gap-2"
               >
                 {busy && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-                {expired ? 'Re-link' : 'Link account'}
+                {expired ? t`Re-link` : t`Link account`}
               </button>
             </div>
           </div>
@@ -178,27 +181,27 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
           <div className="space-y-3">
             <div className="flex items-center justify-between gap-3">
               <p className="text-sm text-foreground">
-                Linked as <span className="font-medium">@{status.username}</span>
-                {status.last_synced_at && (
+                {(() => { const username = status.username; return <Trans>Linked as <span className="font-medium">@{username}</span></Trans> })()}
+                {status.last_synced_at && (() => { const when = new Date(status.last_synced_at + 'Z').toLocaleString(); return (
                   <span className="ml-2 text-xs text-muted-foreground">
-                    last synced {new Date(status.last_synced_at + 'Z').toLocaleString()}
+                    <Trans>last synced {when}</Trans>
                   </span>
-                )}
+                ) })()}
               </p>
               <button
                 onClick={() => void unlink()}
                 disabled={busy}
                 className="text-xs text-muted-foreground hover:text-destructive transition-colors"
               >
-                Unlink
+                <Trans>Unlink</Trans>
               </button>
             </div>
 
             <div className="flex items-center justify-between gap-3">
               <div>
-                <p className="text-sm text-foreground">Sync automatically</p>
+                <p className="text-sm text-foreground"><Trans>Sync automatically</Trans></p>
                 <p className="text-xs text-muted-foreground mt-0.5">
-                  Ratings push shortly after you change them; progress goes out in batches.
+                  <Trans>Ratings push shortly after you change them; progress goes out in batches.</Trans>
                 </p>
               </div>
               <button
@@ -224,14 +227,14 @@ export function HardcoverSync({ onAvailable }: { onAvailable?: (v: boolean) => v
                 className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-md border border-border text-xs font-medium text-foreground hover:bg-muted transition-colors disabled:opacity-50"
               >
                 <RefreshCw className={cn('w-3.5 h-3.5', status.sync_running && 'animate-spin')} />
-                {status.sync_running ? 'Syncing…' : 'Sync now'}
+                {status.sync_running ? t`Syncing…` : t`Sync now`}
               </button>
               {/* Match auditing/fixing lives on the dedicated page */}
               <Link to="/hardcover" className="text-xs text-primary hover:underline">
-                {status.matched_count ?? 0} synced
-                {(status.unmatched_count ?? 0) > 0 && ` · ${status.unmatched_count} not matched`}
-                {(status.error_count ?? 0) > 0 && ` · ${status.error_count} errors`}
-                {' '}— manage →
+                {(() => { const n = status.matched_count ?? 0; return t`${n} synced` })()}
+                {(status.unmatched_count ?? 0) > 0 && (() => { const n = status.unmatched_count ?? 0; return t` · ${n} not matched` })()}
+                {(status.error_count ?? 0) > 0 && (() => { const n = status.error_count ?? 0; return t` · ${n} errors` })()}
+                {' '}<Trans>— manage →</Trans>
               </Link>
             </div>
           </div>

--- a/frontend/src/components/ImpersonationBanner.tsx
+++ b/frontend/src/components/ImpersonationBanner.tsx
@@ -1,5 +1,6 @@
 import { UserX } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
+import { Trans } from '@lingui/react/macro'
 
 export function ImpersonationBanner() {
   const { isImpersonating, impersonatedUsername, exitImpersonation } = useAuth()
@@ -9,12 +10,12 @@ export function ImpersonationBanner() {
   return (
     <div className="fixed bottom-0 inset-x-0 z-50 flex items-center justify-center gap-3 px-4 py-2.5 bg-amber-500 text-amber-950 text-sm font-medium shadow-lg">
       <UserX className="w-4 h-4 shrink-0" />
-      <span>Viewing as <strong>{impersonatedUsername}</strong></span>
+      <span><Trans>Viewing as <strong>{impersonatedUsername}</strong></Trans></span>
       <button
         onClick={exitImpersonation}
         className="ml-2 px-3 py-1 rounded-md bg-amber-950/15 hover:bg-amber-950/25 transition-colors text-xs font-semibold"
       >
-        Exit impersonation
+        <Trans>Exit impersonation</Trans>
       </button>
     </div>
   )

--- a/frontend/src/components/InfoHint.tsx
+++ b/frontend/src/components/InfoHint.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { Info } from 'lucide-react'
+import { useLingui } from '@lingui/react/macro'
 
 // A small "i" that explains a chart or control on hover or tap. Tap-toggle so
 // it works on touch (native title tooltips don't). Reserved for the non-obvious.
 // Pass `text` for a plain sentence, or `children` for structured content (a
 // legend, a definition list); `wide` widens the popover for the latter.
 export function InfoHint({ text, children, wide }: { text?: string; children?: ReactNode; wide?: boolean }) {
+  const { t } = useLingui()
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLSpanElement>(null)
   // iOS Safari doesn't focus buttons on tap, so onBlur alone never closes the
@@ -22,7 +24,7 @@ export function InfoHint({ text, children, wide }: { text?: string; children?: R
     <span ref={rootRef} className="relative inline-flex leading-none">
       <button
         type="button"
-        aria-label="What is this?"
+        aria-label={t`What is this?`}
         onClick={() => setOpen(o => !o)}
         onMouseEnter={() => setOpen(true)}
         onMouseLeave={() => setOpen(false)}

--- a/frontend/src/components/InstanceBackup.tsx
+++ b/frontend/src/components/InstanceBackup.tsx
@@ -4,6 +4,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { Archive, Download, Loader2, RotateCcw, X } from 'lucide-react'
 import { api } from '@/lib/api'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 interface RestoreStatus {
   staged: boolean
@@ -37,12 +39,13 @@ export function InstanceBackup() {
       const url = URL.createObjectURL(blob)
       const a = document.createElement('a')
       a.href = url
+      // eslint-disable-next-line lingui/no-unlocalized-strings -- filename
       a.download = resp.headers.get('Content-Disposition')?.match(/filename="?([^";]+)/)?.[1]
         ?? 'tome-backup.tar.gz'
       a.click()
       URL.revokeObjectURL(url)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Backup failed')
+      setError(e instanceof Error ? e.message : t`Backup failed`)
     } finally {
       setDownloading(false)
     }
@@ -61,7 +64,7 @@ export function InstanceBackup() {
       setConfirmText('')
       loadStatus()
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'That file was rejected')
+      setError(e instanceof Error ? e.message : t`That file was rejected`)
     } finally {
       setStaging(false)
     }
@@ -71,14 +74,14 @@ export function InstanceBackup() {
     <div className="rounded-xl border border-border bg-card p-5">
       <div className="mb-2 flex items-center gap-2">
         <Archive className="h-4 w-4 text-muted-foreground" />
-        <h3 className="text-sm font-semibold text-foreground">Instance backup</h3>
+        <h3 className="text-sm font-semibold text-foreground"><Trans>Instance backup</Trans></h3>
       </div>
       <p className="mb-4 text-xs text-muted-foreground">
-        Everything Tome knows in one archive: the database (all users, statuses,
+        <Trans>Everything Tome knows in one archive: the database (all users, statuses,
         sessions, highlights, settings) plus the cover cache. Book files are not
         included — they live on disk and belong to your own backups. Restoring
         stages the archive and applies it at the next server restart; the
-        current database is kept alongside as a safety copy.
+        current database is kept alongside as a safety copy.</Trans>
       </p>
 
       <div className="flex flex-wrap items-center gap-2">
@@ -88,7 +91,7 @@ export function InstanceBackup() {
           className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium transition-all hover:bg-muted disabled:opacity-50"
         >
           {downloading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}
-          {downloading ? 'Preparing…' : 'Download backup'}
+          {downloading ? t`Preparing…` : t`Download backup`}
         </button>
 
         {!status?.staged && (
@@ -105,7 +108,7 @@ export function InstanceBackup() {
               className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium transition-all hover:bg-muted"
             >
               <RotateCcw className="h-3.5 w-3.5" />
-              {pendingFile ? pendingFile.name : 'Restore from backup…'}
+              {pendingFile ? pendingFile.name : t`Restore from backup…`}
             </button>
           </>
         )}
@@ -114,8 +117,8 @@ export function InstanceBackup() {
       {pendingFile && !status?.staged && (
         <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/5 px-3 py-2.5">
           <p className="w-full text-xs text-muted-foreground">
-            This replaces <span className="font-semibold text-foreground">the entire database</span> at
-            the next restart. Type <span className="font-mono font-semibold text-destructive">RESTORE</span> to arm it.
+            <Trans>This replaces <span className="font-semibold text-foreground">the entire database</span> at
+            the next restart. Type <span className="font-mono font-semibold text-destructive">RESTORE</span> to arm it.</Trans>
           </p>
           <input
             value={confirmText}
@@ -129,13 +132,13 @@ export function InstanceBackup() {
             className="flex items-center gap-1.5 rounded-lg bg-destructive px-3 py-1.5 text-xs font-semibold text-white transition-all hover:bg-destructive/90 disabled:opacity-50"
           >
             {staging ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RotateCcw className="h-3.5 w-3.5" />}
-            Stage restore
+            <Trans>Stage restore</Trans>
           </button>
           <button
             onClick={() => { setPendingFile(null); setConfirmText('') }}
             className="rounded-lg border border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
         </div>
       )}
@@ -143,17 +146,17 @@ export function InstanceBackup() {
       {status?.staged && (
         <div className="mt-3 flex flex-wrap items-center gap-2 rounded-lg border border-warning/50 bg-warning/5 px-3 py-2.5">
           <p className="min-w-0 flex-1 text-xs text-foreground">
-            Restore staged
+            <Trans>Restore staged</Trans>
             {status.summary
-              ? ` — backup from ${status.summary.created_at} (v${status.summary.version}, ${status.summary.users} users, ${status.summary.books} books).`
+              ? (() => { const when = status.summary.created_at; const v = status.summary.version; const users = status.summary.users; const books = status.summary.books; return t` — backup from ${when} (v${v}, ${users} users, ${books} books).` })()
               : '.'}{' '}
-            <span className="text-muted-foreground">It applies at the next server restart.</span>
+            <span className="text-muted-foreground"><Trans>It applies at the next server restart.</Trans></span>
           </p>
           <button
             onClick={() => api.delete('/admin/backup/restore').then(loadStatus)}
             className="flex items-center gap-1 rounded-lg border border-border px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
-            <X className="h-3 w-3" /> Cancel restore
+            <X className="h-3 w-3" /> <Trans>Cancel restore</Trans>
           </button>
         </div>
       )}

--- a/frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/KeyboardShortcutsModal.tsx
@@ -65,7 +65,6 @@ const SECTIONS: ShortcutSection[] = [
 ]
 
 function KeyBadge({ label }: { label: string }) {
-  // eslint-disable-next-line lingui/no-unlocalized-strings -- key-cap glyphs, not copy
   const display =
     label === 'ArrowLeft' ? '\u2190'
     : label === 'ArrowRight' ? '\u2192'

--- a/frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/KeyboardShortcutsModal.tsx
@@ -65,6 +65,7 @@ const SECTIONS: ShortcutSection[] = [
 ]
 
 function KeyBadge({ label }: { label: string }) {
+  /* eslint-disable lingui/no-unlocalized-strings -- key-cap glyphs */
   const display =
     label === 'ArrowLeft' ? '\u2190'
     : label === 'ArrowRight' ? '\u2192'
@@ -73,6 +74,7 @@ function KeyBadge({ label }: { label: string }) {
     : label === 'Escape' ? 'Esc'
     : label === 'Enter' ? 'Enter'
     : label
+  /* eslint-enable lingui/no-unlocalized-strings */
   return (
     <kbd className="inline-flex items-center justify-center min-w-[1.75rem] h-7 px-1.5 rounded-md border border-border bg-muted text-xs font-mono font-semibold text-foreground shadow-sm">
       {display}

--- a/frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/KeyboardShortcutsModal.tsx
@@ -1,5 +1,8 @@
 import { useEffect } from 'react'
 import { Keyboard, X } from 'lucide-react'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { msg } from '@lingui/core/macro'
+import type { MessageDescriptor } from '@lingui/core'
 
 interface Props {
   open: boolean
@@ -8,60 +11,61 @@ interface Props {
 
 interface ShortcutRow {
   keys: string[]
-  description: string
+  description: MessageDescriptor
 }
 
 interface ShortcutSection {
-  title: string
+  title: MessageDescriptor
   rows: ShortcutRow[]
 }
 
 const SECTIONS: ShortcutSection[] = [
   {
-    title: 'Everywhere',
+    title: msg`Everywhere`,
     rows: [
-      { keys: ['⌘', 'K'], description: 'Command palette — jump to a book, series, author, or page' },
+      { keys: ['⌘', 'K'], description: msg`Command palette — jump to a book, series, author, or page` },
     ],
   },
   {
-    title: 'Dashboard',
+    title: msg`Dashboard`,
     rows: [
-      { keys: ['/'], description: 'Focus search' },
-      { keys: ['j', 'ArrowDown'], description: 'Next book' },
-      { keys: ['k', 'ArrowUp'], description: 'Previous book' },
-      { keys: ['Enter'], description: 'Open selected book' },
-      { keys: ['Escape'], description: 'Clear selection / blur search' },
-      { keys: ['?'], description: 'Show this help' },
+      { keys: ['/'], description: msg`Focus search` },
+      { keys: ['j', 'ArrowDown'], description: msg`Next book` },
+      { keys: ['k', 'ArrowUp'], description: msg`Previous book` },
+      { keys: ['Enter'], description: msg`Open selected book` },
+      { keys: ['Escape'], description: msg`Clear selection / blur search` },
+      { keys: ['?'], description: msg`Show this help` },
     ],
   },
   {
-    title: 'Book Detail',
+    title: msg`Book Detail`,
     rows: [
-      { keys: ['Escape'], description: 'Go back' },
-      { keys: ['r'], description: 'Open reader' },
-      { keys: ['e'], description: 'Toggle metadata edit' },
+      { keys: ['Escape'], description: msg`Go back` },
+      { keys: ['r'], description: msg`Open reader` },
+      { keys: ['e'], description: msg`Toggle metadata edit` },
     ],
   },
   {
-    title: 'Reader',
+    title: msg`Reader`,
     rows: [
-      { keys: ['ArrowLeft', 'ArrowUp'], description: 'Previous page' },
-      { keys: ['ArrowRight', 'ArrowDown'], description: 'Next page' },
+      { keys: ['ArrowLeft', 'ArrowUp'], description: msg`Previous page` },
+      { keys: ['ArrowRight', 'ArrowDown'], description: msg`Next page` },
     ],
   },
   {
-    title: 'Highlights',
+    title: msg`Highlights`,
     rows: [
-      { keys: ['/'], description: 'Focus search' },
-      { keys: ['Escape'], description: 'Clear search' },
-      { keys: ['c'], description: 'Collapse / expand all books' },
-      { keys: ['n'], description: 'Toggle only-notes filter' },
-      { keys: ['e'], description: 'Download Markdown export' },
+      { keys: ['/'], description: msg`Focus search` },
+      { keys: ['Escape'], description: msg`Clear search` },
+      { keys: ['c'], description: msg`Collapse / expand all books` },
+      { keys: ['n'], description: msg`Toggle only-notes filter` },
+      { keys: ['e'], description: msg`Download Markdown export` },
     ],
   },
 ]
 
 function KeyBadge({ label }: { label: string }) {
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- key-cap glyphs, not copy
   const display =
     label === 'ArrowLeft' ? '\u2190'
     : label === 'ArrowRight' ? '\u2192'
@@ -78,6 +82,7 @@ function KeyBadge({ label }: { label: string }) {
 }
 
 export function KeyboardShortcutsModal({ open, onClose }: Props) {
+  const { i18n } = useLingui()
   useEffect(() => {
     if (!open) return
     function handleKeyDown(e: KeyboardEvent) {
@@ -106,7 +111,7 @@ export function KeyboardShortcutsModal({ open, onClose }: Props) {
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
             <div className="flex items-center gap-2.5">
               <Keyboard className="w-4 h-4 text-primary" />
-              <h2 className="text-sm font-semibold text-foreground">Keyboard Shortcuts</h2>
+              <h2 className="text-sm font-semibold text-foreground"><Trans>Keyboard Shortcuts</Trans></h2>
             </div>
             <button
               onClick={onClose}
@@ -118,15 +123,15 @@ export function KeyboardShortcutsModal({ open, onClose }: Props) {
 
           {/* Body */}
           <div className="px-5 py-4 flex flex-col gap-5 max-h-[70vh] overflow-y-auto">
-            {SECTIONS.map(section => (
-              <div key={section.title}>
+            {SECTIONS.map((section, si) => (
+              <div key={si}>
                 <p className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-2.5">
-                  {section.title}
+                  {i18n._(section.title)}
                 </p>
                 <div className="flex flex-col gap-1.5">
-                  {section.rows.map(row => (
-                    <div key={row.description} className="flex items-center justify-between gap-3">
-                      <span className="text-sm text-foreground">{row.description}</span>
+                  {section.rows.map((row, ri) => (
+                    <div key={ri} className="flex items-center justify-between gap-3">
+                      <span className="text-sm text-foreground">{i18n._(row.description)}</span>
                       <div className="flex items-center gap-1 shrink-0">
                         {row.keys.map((k, i) => (
                           <span key={k} className="flex items-center gap-1">

--- a/frontend/src/components/LibraryHealth.tsx
+++ b/frontend/src/components/LibraryHealth.tsx
@@ -1,4 +1,6 @@
 import { useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 import { useShiftSelect } from '@/lib/useShiftSelect'
 import { FolderOpen, ArrowRight, Loader2, Check, AlertCircle, ChevronDown, ChevronRight, Trash, FileX } from 'lucide-react'
 import { api } from '@/lib/api'
@@ -77,16 +79,16 @@ function groupIssues(issues: HealthIssue[]): Group[] {
 
   for (const [name, items] of [...seriesMap.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
     const dirs = new Set(items.map(i => i.current_path.split('/')[0]))
-    groups.push({ label: `Series: ${name}`, issues: items, folderCount: dirs.size, collapsed: true })
+    groups.push({ label: t`Series: ${name}`, issues: items, folderCount: dirs.size, collapsed: true })
   }
 
   for (const [name, items] of [...authorMap.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
     const dirs = new Set(items.map(i => i.current_path.split('/')[0]))
-    groups.push({ label: `Author: ${name}`, issues: items, folderCount: dirs.size, collapsed: true })
+    groups.push({ label: t`Author: ${name}`, issues: items, folderCount: dirs.size, collapsed: true })
   }
 
   if (ungrouped.length > 0) {
-    groups.push({ label: 'Other', issues: ungrouped, folderCount: 1, collapsed: true })
+    groups.push({ label: t`Other`, issues: ungrouped, folderCount: 1, collapsed: true })
   }
 
   return groups
@@ -115,7 +117,7 @@ export function LibraryHealthTab() {
       const res = await api.post<{ removed: string[] }>('/books/purge-empty-dirs', {})
       setPurgeResult(res.removed)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Purge failed')
+      setError(e instanceof Error ? e.message : t`Purge failed`)
     } finally {
       setPurging(false)
     }
@@ -134,7 +136,7 @@ export function LibraryHealthTab() {
       setHealthData(data)
       setGroups(groupIssues(data.issues))
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Scan failed')
+      setError(e instanceof Error ? e.message : t`Scan failed`)
     } finally {
       setLoading(false)
     }
@@ -160,7 +162,7 @@ export function LibraryHealthTab() {
         setDryRunResult(null)
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Reorganize failed')
+      setError(e instanceof Error ? e.message : t`Reorganize failed`)
     } finally {
       setReorganizing(false)
     }
@@ -181,7 +183,7 @@ export function LibraryHealthTab() {
       setHealthData(data)
       setGroups(groupIssues(data.issues))
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Removing dead entries failed')
+      setError(e instanceof Error ? e.message : t`Removing dead entries failed`)
     } finally {
       setRemovingMissing(false)
     }
@@ -217,19 +219,20 @@ export function LibraryHealthTab() {
       <div className="rounded-xl border border-border bg-card p-4">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <h2 className="text-sm font-semibold">Library Health</h2>
+            <h2 className="text-sm font-semibold"><Trans>Library Health</Trans></h2>
             {healthData && (
               <p className="text-xs text-muted-foreground mt-0.5">
-                {healthData.misplaced_count === 0 && healthData.missing_count === 0
-                  ? `All ${healthData.total_files} files are correctly placed.`
-                  : [
-                      healthData.misplaced_count > 0
-                        ? `${healthData.misplaced_count} of ${healthData.total_files} files need reorganization`
-                        : null,
-                      healthData.missing_count > 0
-                        ? `${healthData.missing_count} ${healthData.missing_count === 1 ? 'entry is' : 'entries are'} missing from disk`
-                        : null,
-                    ].filter(Boolean).join(' · ') + '.'}
+                {(() => {
+                  const total = healthData.total_files
+                  if (healthData.misplaced_count === 0 && healthData.missing_count === 0) return t`All ${total} files are correctly placed.`
+                  const misplaced = healthData.misplaced_count
+                  return [
+                    misplaced > 0 ? t`${misplaced} of ${total} files need reorganization` : null,
+                    healthData.missing_count > 0
+                      ? plural(healthData.missing_count, { one: '# entry is missing from disk', other: '# entries are missing from disk' })
+                      : null,
+                  ].filter(Boolean).join(' · ') + '.'
+                })()}
               </p>
             )}
           </div>
@@ -241,7 +244,7 @@ export function LibraryHealthTab() {
                   disabled={reorganizing}
                   className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-accent transition-colors disabled:opacity-50"
                 >
-                  Dry Run All
+                  <Trans>Dry Run All</Trans>
                 </button>
                 <button
                   onClick={() => selected.size > 0
@@ -254,8 +257,8 @@ export function LibraryHealthTab() {
                   {reorganizing
                     ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
                     : selected.size > 0
-                    ? `Reorganize Selected (${selected.size})`
-                    : 'Reorganize All'
+                    ? (() => { const n = selected.size; return t`Reorganize Selected (${n})` })()
+                    : t`Reorganize All`
                   }
                 </button>
               </>
@@ -264,10 +267,10 @@ export function LibraryHealthTab() {
               onClick={purgeEmpty}
               disabled={purging}
               className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-accent transition-colors disabled:opacity-50 flex items-center gap-1.5"
-              title="Remove folders that contain only hidden files (.DS_Store, etc.)"
+              title={t`Remove folders that contain only hidden files (.DS_Store, etc.)`}
             >
               {purging ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash className="w-3.5 h-3.5" />}
-              {purging ? 'Purging...' : 'Purge Empty Folders'}
+              {purging ? t`Purging...` : t`Purge Empty Folders`}
             </button>
             <button
               onClick={scan}
@@ -275,7 +278,7 @@ export function LibraryHealthTab() {
               className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-accent transition-colors disabled:opacity-50 flex items-center gap-1.5"
             >
               {loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <FolderOpen className="w-3.5 h-3.5" />}
-              {loading ? 'Scanning...' : 'Scan Library'}
+              {loading ? t`Scanning...` : t`Scan Library`}
             </button>
           </div>
         </div>
@@ -292,16 +295,16 @@ export function LibraryHealthTab() {
         <div className="rounded-xl border border-success/20 bg-success/5 p-4 text-xs space-y-1">
           <p className="font-medium text-success flex items-center gap-1.5">
             <Check className="w-3.5 h-3.5" />
-            Reorganization complete
+            <Trans>Reorganization complete</Trans>
           </p>
           <p className="text-muted-foreground">
-            Moved {result.moved.length} files
-            {result.folders_removed.length > 0 && `, removed ${result.folders_removed.length} empty folders`}
-            {result.errors.length > 0 && `, ${result.errors.length} errors`}
+            {(() => { const n = result.moved.length; return <Trans>Moved {n} files</Trans> })()}
+            {result.folders_removed.length > 0 && (() => { const n = result.folders_removed.length; return t`, removed ${n} empty folders` })()}
+            {result.errors.length > 0 && (() => { const n = result.errors.length; return t`, ${n} errors` })()}
           </p>
           {result.errors.length > 0 && (
             <ul className="mt-1 space-y-0.5 text-destructive">
-              {result.errors.map((e, i) => <li key={i}>File {e.file_id}: {e.error}</li>)}
+              {result.errors.map((e, i) => { const id = e.file_id; const err = e.error; return <li key={i}><Trans>File {id}: {err}</Trans></li> })}
             </ul>
           )}
         </div>
@@ -311,7 +314,7 @@ export function LibraryHealthTab() {
         <div className="rounded-xl border border-success/20 bg-success/5 p-4 text-xs space-y-1">
           <p className="font-medium text-success flex items-center gap-1.5">
             <Check className="w-3.5 h-3.5" />
-            {purgeResult.length === 0 ? 'No empty folders found.' : `Removed ${purgeResult.length} empty folder${purgeResult.length !== 1 ? 's' : ''}.`}
+            {purgeResult.length === 0 ? t`No empty folders found.` : plural(purgeResult.length, { one: 'Removed # empty folder.', other: 'Removed # empty folders.' })}
           </p>
           {purgeResult.length > 0 && (
             <ul className="mt-1 space-y-0.5 font-mono text-muted-foreground">
@@ -325,20 +328,20 @@ export function LibraryHealthTab() {
         <div className="rounded-xl border border-success/20 bg-success/5 p-4 text-xs space-y-1">
           <p className="font-medium text-success flex items-center gap-1.5">
             <Check className="w-3.5 h-3.5" />
-            Dead entries removed
+            <Trans>Dead entries removed</Trans>
           </p>
           <p className="text-muted-foreground">
             {[
               missingResult.removed_books.length > 0
-                ? `${missingResult.removed_books.length} book ${missingResult.removed_books.length === 1 ? 'entry' : 'entries'} removed`
+                ? plural(missingResult.removed_books.length, { one: '# book entry removed', other: '# book entries removed' })
                 : null,
               missingResult.removed_file_rows > 0
-                ? `${missingResult.removed_file_rows} file ${missingResult.removed_file_rows === 1 ? 'entry' : 'entries'} removed`
+                ? plural(missingResult.removed_file_rows, { one: '# file entry removed', other: '# file entries removed' })
                 : null,
               missingResult.skipped.length > 0
-                ? `${missingResult.skipped.length} skipped (file exists on disk)`
+                ? (() => { const n = missingResult.skipped.length; return t`${n} skipped (file exists on disk)` })()
                 : null,
-            ].filter(Boolean).join(' · ') || 'Nothing to remove.'}
+            ].filter(Boolean).join(' · ') || t`Nothing to remove.`}
           </p>
           {missingResult.removed_books.length > 0 && (
             <ul className="mt-1 space-y-0.5 text-muted-foreground">
@@ -353,9 +356,9 @@ export function LibraryHealthTab() {
           <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-3 border-b border-border bg-destructive/5">
             <div className="flex items-center gap-2 min-w-0">
               <FileX className="w-4 h-4 text-destructive shrink-0" />
-              <span className="text-xs font-medium whitespace-nowrap">Orphaned entries</span>
+              <span className="text-xs font-medium whitespace-nowrap"><Trans>Orphaned entries</Trans></span>
               <span className="text-xs text-muted-foreground truncate">
-                {healthData.missing.length} file{healthData.missing.length !== 1 ? 's' : ''} in the database but missing from disk
+                {plural(healthData.missing.length, { one: '# file in the database but missing from disk', other: '# files in the database but missing from disk' })}
               </span>
             </div>
             <div className="flex items-center gap-2 shrink-0 ml-auto">
@@ -365,21 +368,21 @@ export function LibraryHealthTab() {
                   disabled={removingMissing}
                   className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-accent transition-colors disabled:opacity-50"
                 >
-                  Cancel
+                  <Trans>Cancel</Trans>
                 </button>
               )}
               <button
                 onClick={() => confirmRemoveMissing ? removeMissing() : setConfirmRemoveMissing(true)}
                 disabled={removingMissing}
                 className="px-3 py-1.5 text-xs rounded-lg bg-destructive text-destructive-foreground hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center gap-1.5"
-                title="Removes the database entries only — no files are touched"
+                title={t`Removes the database entries only — no files are touched`}
               >
                 {removingMissing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash className="w-3.5 h-3.5" />}
                 {removingMissing
-                  ? 'Removing...'
+                  ? t`Removing...`
                   : confirmRemoveMissing
-                  ? `Confirm — remove ${healthData.missing.length} ${healthData.missing.length === 1 ? 'entry' : 'entries'}`
-                  : 'Remove Dead Entries'}
+                  ? plural(healthData.missing.length, { one: 'Confirm — remove # entry', other: 'Confirm — remove # entries' })
+                  : t`Remove Dead Entries`}
               </button>
             </div>
           </div>
@@ -403,7 +406,7 @@ export function LibraryHealthTab() {
                       ? 'border-destructive/30 text-destructive bg-destructive/10'
                       : 'border-border text-muted-foreground bg-muted',
                   )}>
-                    {wholeBook ? 'book entry will be removed' : 'file entry only'}
+                    {wholeBook ? t`book entry will be removed` : t`file entry only`}
                   </span>
                 </li>
               )
@@ -415,14 +418,16 @@ export function LibraryHealthTab() {
       {dryRunResult && (
         <div className="rounded-xl border border-border bg-card p-4 space-y-3">
           <div className="flex items-center justify-between">
+            {(() => { const n = dryRunResult.moved.length; return (
             <p className="text-xs font-semibold">
-              Dry Run Preview — {dryRunResult.moved.length} files would be moved
+              <Trans>Dry Run Preview — {n} files would be moved</Trans>
             </p>
+            ) })()}
             <button
               onClick={() => setDryRunResult(null)}
               className="text-xs text-muted-foreground hover:text-foreground"
             >
-              Dismiss
+              <Trans>Dismiss</Trans>
             </button>
           </div>
           <ul className="space-y-2 max-h-60 overflow-y-auto text-xs font-mono">
@@ -441,14 +446,14 @@ export function LibraryHealthTab() {
               onClick={() => setDryRunResult(null)}
               className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-accent transition-colors"
             >
-              Cancel
+              <Trans>Cancel</Trans>
             </button>
             <button
               onClick={() => runReorganize(dryRunResult.moved.map(m => m.file_id), false)}
               disabled={reorganizing}
               className="px-3 py-1.5 text-xs rounded-lg bg-primary text-primary-foreground hover:opacity-90 transition-opacity disabled:opacity-50"
             >
-              Confirm & Reorganize
+              <Trans>Confirm & Reorganize</Trans>
             </button>
           </div>
         </div>
@@ -483,8 +488,8 @@ export function LibraryHealthTab() {
                     </div>
                     <span className="text-xs font-medium">{group.label}</span>
                     <span className="text-xs text-muted-foreground">
-                      {group.issues.length} file{group.issues.length !== 1 ? 's' : ''}
-                      {group.folderCount > 1 && ` in ${group.folderCount} folders`}
+                      {plural(group.issues.length, { one: '# file', other: '# files' })}
+                      {group.folderCount > 1 && (() => { const n = group.folderCount; return t` in ${n} folders` })()}
                     </span>
                   </div>
                   {group.collapsed
@@ -527,7 +532,7 @@ export function LibraryHealthTab() {
       {healthData && healthData.misplaced_count === 0 && healthData.missing_count === 0 && (
         <div className="flex flex-col items-center justify-center py-12 text-muted-foreground gap-2">
           <Check className="w-8 h-8 text-success" />
-          <p className="text-sm">All files are correctly placed.</p>
+          <p className="text-sm"><Trans>All files are correctly placed.</Trans></p>
         </div>
       )}
     </div>

--- a/frontend/src/components/LibraryHealth.tsx
+++ b/frontend/src/components/LibraryHealth.tsx
@@ -278,7 +278,7 @@ export function LibraryHealthTab() {
               className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-accent transition-colors disabled:opacity-50 flex items-center gap-1.5"
             >
               {loading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <FolderOpen className="w-3.5 h-3.5" />}
-              {loading ? t`Scanning...` : t`Scan Library`}
+              {loading ? t`Scanning…` : t`Scan Library`}
             </button>
           </div>
         </div>

--- a/frontend/src/components/ManageSeriesModal.tsx
+++ b/frontend/src/components/ManageSeriesModal.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 import { X, Plus, Trash2, Loader2, Save } from 'lucide-react'
 import { api } from '@/lib/api'
 import type { Arc, SeriesMeta, SeriesStatus } from '@/lib/books'
@@ -23,11 +27,11 @@ interface ArcRow {
   description: string
 }
 
-const STATUS_OPTIONS: { value: SeriesStatus; label: string }[] = [
-  { value: 'ongoing', label: 'Ongoing' },
-  { value: 'finished', label: 'Finished' },
-  { value: 'hiatus', label: 'Hiatus' },
-  { value: 'unknown', label: 'Unknown' },
+const STATUS_OPTIONS: { value: SeriesStatus; label: MessageDescriptor }[] = [
+  { value: 'ongoing', label: msg`Ongoing` },
+  { value: 'finished', label: msg`Finished` },
+  { value: 'hiatus', label: msg`Hiatus` },
+  { value: 'unknown', label: msg`Unknown` },
 ]
 
 function hasOverlap(rows: ArcRow[], idx: number): boolean {
@@ -129,7 +133,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
       onSaved()
       onClose()
     } catch (e: unknown) {
-      setSaveError(e instanceof Error ? e.message : 'Save failed')
+      setSaveError(e instanceof Error ? e.message : t`Save failed`)
     } finally {
       setStatusSaving(false)
     }
@@ -151,7 +155,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
       onSaved()
       onClose()
     } catch (e: unknown) {
-      setSaveError(e instanceof Error ? e.message : 'Save failed')
+      setSaveError(e instanceof Error ? e.message : t`Save failed`)
     } finally {
       setArcsSaving(false)
     }
@@ -165,13 +169,13 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
           <div>
-            <h2 className="text-base font-semibold text-foreground">Manage Series</h2>
+            <h2 className="text-base font-semibold text-foreground"><Trans>Manage Series</Trans></h2>
             <p className="text-xs text-muted-foreground mt-0.5 truncate max-w-sm">{seriesName}</p>
           </div>
           <button
             onClick={onClose}
             className="p-1.5 rounded-lg hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-            aria-label="Close"
+            aria-label={t`Close`}
           >
             <X className="w-4 h-4" />
           </button>
@@ -179,18 +183,18 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
 
         {/* Tabs */}
         <div className="flex gap-1 px-5 pt-3 shrink-0">
-          {(['series', 'arcs'] as TabId[]).map(t => (
+          {(['series', 'arcs'] as TabId[]).map(tb => (
             <button
-              key={t}
-              onClick={() => { setActiveTab(t); setSaveError(null) }}
+              key={tb}
+              onClick={() => { setActiveTab(tb); setSaveError(null) }}
               className={cn(
                 'px-3 py-1.5 rounded-md text-sm font-medium transition-colors capitalize',
-                activeTab === t
+                activeTab === tb
                   ? 'bg-primary text-primary-foreground'
                   : 'text-muted-foreground hover:text-foreground hover:bg-muted'
               )}
             >
-              {t === 'series' ? 'Series' : 'Arcs'}
+              {tb === 'series' ? t`Series` : t`Arcs`}
             </button>
           ))}
         </div>
@@ -206,7 +210,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
               <div className="flex flex-col gap-4">
                 <div className="flex flex-col gap-1.5">
                   <label className="text-sm font-medium text-foreground" htmlFor="series-status">
-                    Publication status
+                    <Trans>Publication status</Trans>
                   </label>
                   <select
                     id="series-status"
@@ -215,7 +219,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
                     className="w-full px-3 py-2 rounded-lg border border-border bg-background text-foreground text-sm focus:outline-none focus:ring-2 focus:ring-primary"
                   >
                     {STATUS_OPTIONS.map(o => (
-                      <option key={o.value} value={o.value}>{o.label}</option>
+                      <option key={o.value} value={o.value}>{i18n._(o.label)}</option>
                     ))}
                   </select>
                 </div>
@@ -232,13 +236,13 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
               <div className="flex flex-col gap-3">
                 {sortedRows.length === 0 && volumes.length > 0 && (
                   <p className="text-sm text-muted-foreground text-center py-4">
-                    No arcs defined yet. Click &ldquo;Add arc&rdquo; to create one.
+                    <Trans>No arcs defined yet. Click &ldquo;Add arc&rdquo; to create one.</Trans>
                   </p>
                 )}
                 {volumes.length === 0 && (
                   <p className="text-sm text-muted-foreground text-center py-4">
-                    This series has no volumes with a numeric index yet. Add
-                    volumes before defining arcs.
+                    <Trans>This series has no volumes with a numeric index yet. Add
+                    volumes before defining arcs.</Trans>
                   </p>
                 )}
                 {sortedRows.length > 0 && (
@@ -246,10 +250,10 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
                     <table className="w-full text-sm">
                       <thead>
                         <tr className="text-left text-xs text-muted-foreground border-b border-border">
-                          <th className="pb-2 font-medium pr-3 min-w-[140px]">Name</th>
-                          <th className="pb-2 font-medium pr-3 w-20">Start</th>
-                          <th className="pb-2 font-medium pr-3 w-20">End</th>
-                          <th className="pb-2 font-medium pr-3">Description</th>
+                          <th className="pb-2 font-medium pr-3 min-w-[140px]"><Trans>Name</Trans></th>
+                          <th className="pb-2 font-medium pr-3 w-20"><Trans>Start</Trans></th>
+                          <th className="pb-2 font-medium pr-3 w-20"><Trans>End</Trans></th>
+                          <th className="pb-2 font-medium pr-3"><Trans>Description</Trans></th>
                           <th className="pb-2 w-8" />
                         </tr>
                       </thead>
@@ -266,7 +270,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
                                   type="text"
                                   value={row.name}
                                   onChange={e => updateRow(originalIdx, { name: e.target.value })}
-                                  placeholder="Arc name"
+                                  placeholder={t`Arc name`}
                                   className="w-full px-2 py-1 rounded border border-border bg-background text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-inset focus:ring-primary"
                                 />
                               </td>
@@ -297,7 +301,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
                                   type="text"
                                   value={row.description}
                                   onChange={e => updateRow(originalIdx, { description: e.target.value })}
-                                  placeholder="Optional"
+                                  placeholder={t`Optional`}
                                   className="w-full px-2 py-1 rounded border border-border bg-background text-foreground text-xs focus:outline-none focus:ring-1 focus:ring-inset focus:ring-primary"
                                 />
                               </td>
@@ -305,7 +309,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
                                 <button
                                   onClick={() => deleteRow(originalIdx)}
                                   className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors opacity-0 group-hover:opacity-100"
-                                  aria-label="Delete arc"
+                                  aria-label={t`Delete arc`}
                                 >
                                   <Trash2 className="w-3.5 h-3.5" />
                                 </button>
@@ -323,7 +327,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
                   className="flex items-center gap-1.5 text-xs text-primary hover:text-primary/80 transition-colors self-start disabled:opacity-40 disabled:cursor-not-allowed"
                 >
                   <Plus className="w-3.5 h-3.5" />
-                  Add arc
+                  <Trans>Add arc</Trans>
                 </button>
               </div>
             )
@@ -343,7 +347,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
               disabled={isBusy}
               className="px-4 py-2 rounded-lg border border-border bg-background text-sm font-medium text-foreground hover:bg-muted disabled:opacity-50 transition-colors"
             >
-              Cancel
+              <Trans>Cancel</Trans>
             </button>
             <button
               onClick={activeTab === 'series' ? saveStatus : saveArcs}
@@ -351,7 +355,7 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
               className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
             >
               {isBusy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Save className="w-3.5 h-3.5" />}
-              Save
+              <Trans>Save</Trans>
             </button>
           </div>
         </div>

--- a/frontend/src/components/MetadataFetchModal.tsx
+++ b/frontend/src/components/MetadataFetchModal.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useState, useRef } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t, msg, plural } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 import { Loader2, Sparkles, BookOpen, ExternalLink, Check, X } from 'lucide-react'
 import { BookAnimation } from '@/components/BookAnimation'
 import type { BookDetail, MetadataCandidate } from '@/lib/books'
@@ -21,7 +25,7 @@ type Step = 'search' | 'diff'
 
 interface FieldRow {
   key: string
-  label: string
+  label: MessageDescriptor
   current: string | null
   incoming: string | null
   checked: boolean
@@ -29,17 +33,17 @@ interface FieldRow {
 
 function candidateToFields(book: BookDetail, c: MetadataCandidate): FieldRow[] {
   return [
-    { key: 'title', label: 'Title', current: book.title, incoming: c.title, checked: true },
-    { key: 'author', label: 'Author', current: book.author, incoming: c.author, checked: true },
-    { key: 'description', label: 'Description', current: book.description, incoming: c.description, checked: true },
-    { key: 'publisher', label: 'Publisher', current: book.publisher, incoming: c.publisher, checked: true },
-    { key: 'year', label: 'Year', current: book.year?.toString() ?? null, incoming: c.year?.toString() ?? null, checked: true },
-    { key: 'language', label: 'Language', current: book.language, incoming: c.language, checked: true },
-    { key: 'isbn', label: 'ISBN', current: book.isbn, incoming: c.isbn, checked: true },
-    { key: 'series', label: 'Series', current: book.series, incoming: c.series, checked: true },
-    { key: 'series_index', label: 'Series #', current: book.series_index?.toString() ?? null, incoming: c.series_index?.toString() ?? null, checked: true },
-    { key: 'tags', label: 'Tags', current: book.tags.map(t => t.tag).join(', ') || null, incoming: c.tags.join(', ') || null, checked: true },
-    { key: 'cover', label: 'Cover', current: null, incoming: c.cover_url, checked: false },
+    { key: 'title', label: msg`Title`, current: book.title, incoming: c.title, checked: true },
+    { key: 'author', label: msg`Author`, current: book.author, incoming: c.author, checked: true },
+    { key: 'description', label: msg`Description`, current: book.description, incoming: c.description, checked: true },
+    { key: 'publisher', label: msg`Publisher`, current: book.publisher, incoming: c.publisher, checked: true },
+    { key: 'year', label: msg`Year`, current: book.year?.toString() ?? null, incoming: c.year?.toString() ?? null, checked: true },
+    { key: 'language', label: msg`Language`, current: book.language, incoming: c.language, checked: true },
+    { key: 'isbn', label: msg`ISBN`, current: book.isbn, incoming: c.isbn, checked: true },
+    { key: 'series', label: msg`Series`, current: book.series, incoming: c.series, checked: true },
+    { key: 'series_index', label: msg`Series #`, current: book.series_index?.toString() ?? null, incoming: c.series_index?.toString() ?? null, checked: true },
+    { key: 'tags', label: msg`Tags`, current: book.tags.map(t => t.tag).join(', ') || null, incoming: c.tags.join(', ') || null, checked: true },
+    { key: 'cover', label: msg`Cover`, current: null, incoming: c.cover_url, checked: false },
   ]
 }
 
@@ -92,23 +96,25 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
       const data: { candidates: MetadataCandidate[]; sources?: Record<string, string> } = await r.json()
 
       // Be honest about degraded sources — "no results" used to swallow 429s.
+      /* eslint-disable lingui/no-unlocalized-strings -- provider names */
       const labels: Record<string, string> = {
         hardcover: 'Hardcover', google_books: 'Google Books', open_library: 'Open Library', anilist: 'AniList',
       }
+      /* eslint-enable lingui/no-unlocalized-strings */
       const degraded = Object.entries(data.sources ?? {})
         .filter(([, s]) => s === 'rate_limited' || s === 'timeout' || s === 'error')
-        .map(([k, s]) => `${labels[k] ?? k} ${s === 'rate_limited' ? 'is rate-limited — try again in a minute' : s === 'timeout' ? 'timed out' : 'errored'}`)
+        .map(([k, s]) => { const name = labels[k] ?? k; return s === 'rate_limited' ? t`${name} is rate-limited — try again in a minute` : s === 'timeout' ? t`${name} timed out` : t`${name} errored` })
       if (degraded.length) setSourceNotice(degraded.join(' · '))
 
       if (data.candidates.length === 0) {
         setError(degraded.length
-          ? 'No results — but some sources were unavailable (see below); retrying may help.'
-          : 'No results found. Try a different search query.')
+          ? t`No results — but some sources were unavailable (see below); retrying may help.`
+          : t`No results found. Try a different search query.`)
       } else {
         setCandidates(data.candidates)
       }
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Search failed')
+      setError(e instanceof Error ? e.message : t`Search failed`)
     } finally {
       setLoading(false)
     }
@@ -164,7 +170,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
       reset()
       onClose()
     } catch (e: unknown) {
-      setError(e instanceof Error ? e.message : 'Apply failed')
+      setError(e instanceof Error ? e.message : t`Apply failed`)
     } finally {
       setApplying(false)
     }
@@ -188,7 +194,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
         <div className="flex items-center justify-between px-6 py-4 border-b border-border sticky top-0 bg-background z-10">
           <div className="flex items-center gap-2 font-semibold text-sm">
             <Sparkles className="h-4 w-4 text-primary" />
-            Fetch Metadata
+            <Trans>Fetch Metadata</Trans>
             <span className="text-muted-foreground font-normal">— {book.title}</span>
           </div>
           <button onClick={handleClose} className="text-muted-foreground hover:text-foreground transition-colors">
@@ -201,7 +207,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
           {step === 'search' && (
             <>
               <p className="text-sm text-muted-foreground">
-                Searching for: <span className="font-medium text-foreground">{book.title}</span>
+                {(() => { const title = book.title; return <Trans>Searching for: <span className="font-medium text-foreground">{title}</span></Trans> })()}
                 {book.author && <> · <span className="font-medium text-foreground">{book.author}</span></>}
               </p>
 
@@ -209,7 +215,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                 <input
                   ref={queryRef}
                   className="flex h-9 w-full rounded-md border border-border bg-transparent px-3 py-1 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-                  placeholder="Override search query (optional)…"
+                  placeholder={t`Override search query (optional)…`}
                   value={query}
                   onChange={e => setQuery(e.target.value)}
                   onKeyDown={e => e.key === 'Enter' && doSearch(query)}
@@ -219,7 +225,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                   disabled={loading}
                   className="shrink-0 flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
                 >
-                  {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : 'Search'}
+                  {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : t`Search`}
                 </button>
               </div>
 
@@ -228,7 +234,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
               {loading && (
                 <div className="flex flex-col items-center justify-center py-8 gap-3">
                   <BookAnimation variant="refresh" className="block w-12 h-12 text-primary" />
-                  <p className="text-sm text-muted-foreground">Searching…</p>
+                  <p className="text-sm text-muted-foreground"><Trans>Searching…</Trans></p>
                 </div>
               )}
 
@@ -239,7 +245,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
               {!loading && candidates.length > 0 && (
                 <div className="space-y-2">
                   <p className="text-xs text-muted-foreground">
-                    {candidates.length} result{candidates.length !== 1 ? 's' : ''} — pick one to review
+                    {plural(candidates.length, { one: '# result — pick one to review', other: '# results — pick one to review' })}
                   </p>
                   {candidates.map((c, i) => (
                     <button
@@ -260,11 +266,12 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                           <span className="flex items-center gap-1 shrink-0">
                             {i === 0 && (
                               <span className="text-[10px] px-1.5 py-0.5 rounded bg-primary/15 text-primary font-medium">
-                                Best match
+                                <Trans>Best match</Trans>
                               </span>
                             )}
                             <span className="text-[10px] px-1.5 py-0.5 rounded border border-border text-muted-foreground bg-muted">
-                              {c.source === 'hardcover' ? 'Hardcover' : c.source === 'google_books' ? 'Google' : c.source === 'anilist' ? 'AniList' : 'OpenLib'}
+                              {/* eslint-disable-next-line lingui/no-unlocalized-strings -- provider names */}
+                          {c.source === 'hardcover' ? 'Hardcover' : c.source === 'google_books' ? 'Google' : c.source === 'anilist' ? 'AniList' : 'OpenLib'}
                             </span>
                           </span>
                         </div>
@@ -299,7 +306,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                   onClick={() => { setStep('search'); setSelected(null); setFields([]) }}
                   className="text-sm text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  ← Back to results
+                  <Trans>← Back to results</Trans>
                 </button>
                 <label className="flex items-center gap-2 text-sm font-medium cursor-pointer select-none">
                   <input
@@ -308,7 +315,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                     onChange={toggleAll}
                     className="rounded border-border"
                   />
-                  Select all
+                  <Trans>Select all</Trans>
                 </label>
               </div>
 
@@ -316,11 +323,12 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                 {/* Header row */}
                 <div className="grid grid-cols-[24px_100px_1fr_1fr] gap-3 items-center bg-muted px-3 py-2 text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
                   <span />
-                  <span>Field</span>
-                  <span>Current</span>
+                  <span><Trans>Field</Trans></span>
+                  <span><Trans>Current</Trans></span>
                   <span>
-                    Incoming
+                    <Trans>Incoming</Trans>
                     <span className="ml-1.5 text-[10px] px-1.5 py-0.5 rounded border border-border bg-background normal-case tracking-normal">
+                      {/* eslint-disable-next-line lingui/no-unlocalized-strings -- provider names */}
                       {selected.source === 'hardcover' ? 'Hardcover' : selected.source === 'google_books' ? 'Google Books' : selected.source === 'anilist' ? 'AniList' : 'Open Library'}
                     </span>
                   </span>
@@ -344,12 +352,12 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                         disabled={!hasChange}
                         className="mt-0.5 rounded border-border"
                       />
-                      <span className="font-medium text-muted-foreground text-xs mt-0.5">{f.label}</span>
+                      <span className="font-medium text-muted-foreground text-xs mt-0.5">{i18n._(f.label)}</span>
 
                       {/* Current value */}
                       {f.key === 'cover' ? (
                         <span className="text-muted-foreground text-xs italic mt-0.5">
-                          {book.cover_path ? 'Has cover' : 'No cover'}
+                          {book.cover_path ? t`Has cover` : t`No cover`}
                         </span>
                       ) : (
                         <span className={`break-words line-clamp-3 text-xs ${hasChange ? 'line-through text-muted-foreground' : 'text-foreground'}`}>
@@ -363,7 +371,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                           <div className="flex items-start gap-2">
                             <img
                               src={f.incoming}
-                              alt="New cover"
+                              alt={t`New cover`}
                               className="h-16 w-12 object-cover rounded border border-border"
                             />
                             <a
@@ -372,11 +380,11 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                               rel="noopener noreferrer"
                               className="text-xs text-primary hover:underline flex items-center gap-1 mt-0.5"
                             >
-                              Preview <ExternalLink className="h-3 w-3" />
+                              <Trans>Preview</Trans> <ExternalLink className="h-3 w-3" />
                             </a>
                           </div>
                         ) : (
-                          <span className="text-muted-foreground/50 italic text-xs mt-0.5">No cover available</span>
+                          <span className="text-muted-foreground/50 italic text-xs mt-0.5"><Trans>No cover available</Trans></span>
                         )
                       ) : (
                         <span className={`break-words line-clamp-3 text-xs ${hasChange ? 'text-primary font-medium' : 'text-foreground'}`}>
@@ -395,7 +403,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                   onClick={handleClose}
                   className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
                 >
-                  <X className="h-3.5 w-3.5" /> Cancel
+                  <X className="h-3.5 w-3.5" /> <Trans>Cancel</Trans>
                 </button>
                 <button
                   onClick={applySelected}
@@ -405,7 +413,7 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
                   {applying
                     ? <Loader2 className="h-3.5 w-3.5 animate-spin" />
                     : <Check className="h-3.5 w-3.5" />}
-                  Apply Selected
+                  <Trans>Apply Selected</Trans>
                 </button>
               </div>
             </>

--- a/frontend/src/components/MetadataManager.tsx
+++ b/frontend/src/components/MetadataManager.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useState, useRef, useCallback } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t, msg, plural } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 import {
   Loader2, Search, X, ChevronUp, ChevronDown, BookOpen,
   Check, ArrowLeft, ArrowRight, SkipForward, RefreshCw,
@@ -49,21 +53,21 @@ type SortCol = 'title' | 'author' | 'series' | 'year' | 'completeness'
 type SortDir = 'asc' | 'desc'
 
 const MISSING_FIELD_OPTIONS = [
-  { key: 'description', label: 'Description' },
-  { key: 'cover', label: 'Cover' },
-  { key: 'isbn', label: 'ISBN' },
-  { key: 'year', label: 'Year' },
-  { key: 'author', label: 'Author' },
-  { key: 'series', label: 'Series' },
-  { key: 'language', label: 'Language' },
-  { key: 'publisher', label: 'Publisher' },
+  { key: 'description', label: msg`Description` },
+  { key: 'cover', label: msg`Cover` },
+  { key: 'isbn', label: msg`ISBN` },
+  { key: 'year', label: msg`Year` },
+  { key: 'author', label: msg`Author` },
+  { key: 'series', label: msg`Series` },
+  { key: 'language', label: msg`Language` },
+  { key: 'publisher', label: msg`Publisher` },
 ]
 
 // ── FieldRow (shared with review flow) ───────────────────────────────────────
 
 interface FieldRow {
   key: string
-  label: string
+  label: MessageDescriptor
   current: string | null
   incoming: string | null
   checked: boolean
@@ -71,17 +75,17 @@ interface FieldRow {
 
 function buildFieldRows(book: BookDetail, c: MetadataCandidate): FieldRow[] {
   return [
-    { key: 'title', label: 'Title', current: book.title, incoming: c.title, checked: true },
-    { key: 'author', label: 'Author', current: book.author, incoming: c.author, checked: true },
-    { key: 'description', label: 'Description', current: book.description, incoming: c.description, checked: true },
-    { key: 'publisher', label: 'Publisher', current: book.publisher, incoming: c.publisher, checked: true },
-    { key: 'year', label: 'Year', current: book.year?.toString() ?? null, incoming: c.year?.toString() ?? null, checked: true },
-    { key: 'language', label: 'Language', current: book.language, incoming: c.language, checked: true },
-    { key: 'isbn', label: 'ISBN', current: book.isbn, incoming: c.isbn, checked: true },
-    { key: 'series', label: 'Series', current: book.series, incoming: c.series, checked: true },
-    { key: 'series_index', label: 'Series #', current: book.series_index?.toString() ?? null, incoming: c.series_index?.toString() ?? null, checked: true },
-    { key: 'tags', label: 'Tags', current: book.tags.map(t => t.tag).join(', ') || null, incoming: c.tags.join(', ') || null, checked: true },
-    { key: 'cover', label: 'Cover', current: null, incoming: c.cover_url, checked: false },
+    { key: 'title', label: msg`Title`, current: book.title, incoming: c.title, checked: true },
+    { key: 'author', label: msg`Author`, current: book.author, incoming: c.author, checked: true },
+    { key: 'description', label: msg`Description`, current: book.description, incoming: c.description, checked: true },
+    { key: 'publisher', label: msg`Publisher`, current: book.publisher, incoming: c.publisher, checked: true },
+    { key: 'year', label: msg`Year`, current: book.year?.toString() ?? null, incoming: c.year?.toString() ?? null, checked: true },
+    { key: 'language', label: msg`Language`, current: book.language, incoming: c.language, checked: true },
+    { key: 'isbn', label: msg`ISBN`, current: book.isbn, incoming: c.isbn, checked: true },
+    { key: 'series', label: msg`Series`, current: book.series, incoming: c.series, checked: true },
+    { key: 'series_index', label: msg`Series #`, current: book.series_index?.toString() ?? null, incoming: c.series_index?.toString() ?? null, checked: true },
+    { key: 'tags', label: msg`Tags`, current: book.tags.map(t => t.tag).join(', ') || null, incoming: c.tags.join(', ') || null, checked: true },
+    { key: 'cover', label: msg`Cover`, current: null, incoming: c.cover_url, checked: false },
   ]
 }
 
@@ -229,10 +233,10 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
         setSelectedCandidate(data[0])
         setFields(buildFieldRows(book, data[0]))
       } else if (data.length === 0) {
-        setCandidateError('No candidates found.')
+        setCandidateError(t`No candidates found.`)
       }
     } catch {
-      setCandidateError('Failed to fetch candidates.')
+      setCandidateError(t`Failed to fetch candidates.`)
     } finally {
       setLoadingCandidates(false)
     }
@@ -312,7 +316,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
       }
       advance()
     } catch {
-      setApplyError('Failed to apply metadata.')
+      setApplyError(t`Failed to apply metadata.`)
     } finally {
       setApplying(false)
     }
@@ -331,15 +335,15 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
     return (
       <div className="flex flex-col items-center justify-center py-24 gap-4 text-center">
         <Check className="w-12 h-12 text-success" />
-        <h2 className="text-lg font-semibold">Review complete</h2>
+        <h2 className="text-lg font-semibold"><Trans>Review complete</Trans></h2>
         <p className="text-sm text-muted-foreground">
-          Reviewed {queue.length} books — applied changes to {summary.applied}, skipped {summary.skipped}.
+          {(() => { const total = queue.length; const applied = summary.applied; const skipped = summary.skipped; return <Trans>Reviewed {total} books — applied changes to {applied}, skipped {skipped}.</Trans> })()}
         </p>
         <button
           onClick={onBack}
           className="mt-4 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-all"
         >
-          Back to Table
+          <Trans>Back to Table</Trans>
         </button>
       </div>
     )
@@ -353,11 +357,11 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
           onClick={onBack}
           className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
         >
-          <ArrowLeft className="w-4 h-4" /> Back to Table
+          <ArrowLeft className="w-4 h-4" /> <Trans>Back to Table</Trans>
         </button>
         <div className="flex items-center gap-3 flex-1 max-w-xs">
           <span className="text-xs text-muted-foreground whitespace-nowrap">
-            Book {idx + 1} of {queue.length}
+            {(() => { const at = idx + 1; const total = queue.length; return <Trans>Book {at} of {total}</Trans> })()}
           </span>
           <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden">
             <div
@@ -389,24 +393,24 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
               </div>
               <div className="min-w-0">
                 <p className="font-semibold text-sm leading-snug">{book.title}</p>
-                <p className="text-xs text-muted-foreground mt-0.5">{book.author || <span className="italic">No author</span>}</p>
+                <p className="text-xs text-muted-foreground mt-0.5">{book.author || <span className="italic"><Trans>No author</Trans></span>}</p>
               </div>
             </div>
 
             <div className="space-y-2">
               {[
-                { field: 'title', label: 'Title', value: book.title },
-                { field: 'subtitle', label: 'Subtitle', value: book.subtitle || '' },
-                { field: 'author', label: 'Author', value: book.author || '' },
-                { field: 'series', label: 'Series', value: book.series || '' },
-                { field: 'series_index', label: 'Series #', value: book.series_index?.toString() || '' },
-                { field: 'year', label: 'Year', value: book.year?.toString() || '' },
-                { field: 'isbn', label: 'ISBN', value: book.isbn || '' },
-                { field: 'language', label: 'Language', value: book.language || '' },
-                { field: 'publisher', label: 'Publisher', value: book.publisher || '' },
+                { field: 'title', label: msg`Title`, value: book.title },
+                { field: 'subtitle', label: msg`Subtitle`, value: book.subtitle || '' },
+                { field: 'author', label: msg`Author`, value: book.author || '' },
+                { field: 'series', label: msg`Series`, value: book.series || '' },
+                { field: 'series_index', label: msg`Series #`, value: book.series_index?.toString() || '' },
+                { field: 'year', label: msg`Year`, value: book.year?.toString() || '' },
+                { field: 'isbn', label: msg`ISBN`, value: book.isbn || '' },
+                { field: 'language', label: msg`Language`, value: book.language || '' },
+                { field: 'publisher', label: msg`Publisher`, value: book.publisher || '' },
               ].map(({ field, label, value }) => (
                 <div key={field} className="grid grid-cols-[80px_1fr] gap-2 items-center">
-                  <span className="text-xs text-muted-foreground">{label}</span>
+                  <span className="text-xs text-muted-foreground">{i18n._(label)}</span>
                   <input
                     value={draft[field as keyof BookDetail] as string ?? value}
                     onChange={e => setDraft(d => ({ ...d, [field]: e.target.value }))}
@@ -415,7 +419,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
                 </div>
               ))}
               <div className="grid grid-cols-[80px_1fr] gap-2">
-                <span className="text-xs text-muted-foreground pt-1">Description</span>
+                <span className="text-xs text-muted-foreground pt-1"><Trans>Description</Trans></span>
                 <textarea
                   value={(draft.description as string | undefined) ?? book.description ?? ''}
                   onChange={e => setDraft(d => ({ ...d, description: e.target.value }))}
@@ -434,7 +438,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
                 value={customQuery}
                 onChange={e => setCustomQuery(e.target.value)}
                 onKeyDown={e => e.key === 'Enter' && fetchCandidates(book.id, customQuery)}
-                placeholder="Override search query…"
+                placeholder={t`Override search query…`}
                 className="flex-1 h-8 text-xs bg-background border border-border rounded px-2 focus:outline-none focus:ring-1 focus:ring-ring"
               />
               <button
@@ -443,7 +447,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
                 className="flex items-center gap-1 px-3 py-1.5 rounded-lg text-xs font-medium bg-muted hover:bg-accent border border-border transition-all disabled:opacity-50"
               >
                 {loadingCandidates ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
-                Fetch
+                <Trans>Fetch</Trans>
               </button>
             </div>
 
@@ -460,7 +464,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
             {/* Candidate list */}
             {candidates.length > 0 && !loadingCandidates && (
               <div className="space-y-2">
-                <p className="text-xs text-muted-foreground">{candidates.length} candidate{candidates.length !== 1 ? 's' : ''} — click to select</p>
+                <p className="text-xs text-muted-foreground">{plural(candidates.length, { one: '# candidate — click to select', other: '# candidates — click to select' })}</p>
                 {candidates.map(c => (
                   <button
                     key={`${c.source}-${c.source_id}`}
@@ -498,7 +502,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
             {selectedCandidate && fields.length > 0 && (
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
-                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Field diff</p>
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide"><Trans>Field diff</Trans></p>
                   <label className="flex items-center gap-1.5 text-xs cursor-pointer select-none">
                     <input
                       type="checkbox"
@@ -506,15 +510,15 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
                       onChange={toggleAll}
                       className="rounded border-border"
                     />
-                    All
+                    <Trans>All</Trans>
                   </label>
                 </div>
                 <div className="rounded-lg border border-border overflow-hidden">
                   <div className="grid grid-cols-[20px_60px_1fr_1fr] sm:grid-cols-[20px_80px_1fr_1fr] gap-2 items-center bg-muted px-3 py-1.5 text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
                     <span />
-                    <span>Field</span>
-                    <span>Current</span>
-                    <span>Incoming</span>
+                    <span><Trans>Field</Trans></span>
+                    <span><Trans>Current</Trans></span>
+                    <span><Trans>Incoming</Trans></span>
                   </div>
                   {fields.map((f, i) => {
                     const hasChange = !!(f.incoming && f.incoming !== f.current)
@@ -534,10 +538,10 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
                           disabled={!hasChange}
                           className="mt-0.5 rounded border-border"
                         />
-                        <span className="text-muted-foreground text-[11px] mt-0.5">{f.label}</span>
+                        <span className="text-muted-foreground text-[11px] mt-0.5">{i18n._(f.label)}</span>
                         {f.key === 'cover' ? (
                           <span className="text-muted-foreground italic text-[11px]">
-                            {book.cover_path ? 'Has cover' : 'No cover'}
+                            {book.cover_path ? t`Has cover` : t`No cover`}
                           </span>
                         ) : (
                           <span className={cn('break-words line-clamp-2 text-[11px]', hasChange ? 'line-through text-muted-foreground' : '')}>
@@ -578,7 +582,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
             disabled={idx === 0}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 transition-all"
           >
-            <ArrowLeft className="w-3.5 h-3.5" /> Previous
+            <ArrowLeft className="w-3.5 h-3.5" /> <Trans>Previous</Trans>
           </button>
           <div className="flex items-center gap-2">
             {applyError && <span className="text-xs text-destructive">{applyError}</span>}
@@ -586,7 +590,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
               onClick={skip}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
             >
-              <SkipForward className="w-3.5 h-3.5" /> Skip
+              <SkipForward className="w-3.5 h-3.5" /> <Trans>Skip</Trans>
             </button>
             <button
               onClick={applyAndNext}
@@ -594,7 +598,7 @@ function ReviewFlow({ queue, onBack, onBookUpdated }: ReviewFlowProps) {
               className="flex items-center gap-1.5 px-4 py-1.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
             >
               {applying ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <ArrowRight className="w-3.5 h-3.5" />}
-              Apply & Next
+              <Trans>Apply & Next</Trans>
             </button>
           </div>
         </div>
@@ -664,7 +668,7 @@ function StandardizeModal({ proposals, onClose, onApplied }: StandardizeModalPro
       onApplied()
       onClose()
     } catch {
-      setError('Some changes failed to apply.')
+      setError(t`Some changes failed to apply.`)
     } finally {
       setApplying(false)
     }
@@ -679,10 +683,10 @@ function StandardizeModal({ proposals, onClose, onApplied }: StandardizeModalPro
           <div>
             <div className="flex items-center gap-2 font-semibold text-sm">
               <Wand2 className="w-4 h-4 text-primary" />
-              Standardize Titles
+              <Trans>Standardize Titles</Trans>
             </div>
             <p className="text-xs text-muted-foreground mt-0.5">
-              {changed.length} of {proposals.length} books would change
+              {(() => { const n = changed.length; const total = proposals.length; return <Trans>{n} of {total} books would change</Trans> })()}
             </p>
           </div>
           <button onClick={onClose} className="text-muted-foreground hover:text-foreground transition-colors">
@@ -694,7 +698,7 @@ function StandardizeModal({ proposals, onClose, onApplied }: StandardizeModalPro
         <div className="overflow-y-auto flex-1 divide-y divide-border/50">
           {changed.length === 0 && (
             <p className="text-sm text-muted-foreground text-center py-12">
-              No titles need standardizing.
+              <Trans>No titles need standardizing.</Trans>
             </p>
           )}
           {changed.length > 0 && (
@@ -705,7 +709,7 @@ function StandardizeModal({ proposals, onClose, onApplied }: StandardizeModalPro
                 onChange={toggleAll}
                 className="rounded border-border"
               />
-              <span className="text-xs text-muted-foreground">Select all ({changed.length})</span>
+              {(() => { const n = changed.length; return <span className="text-xs text-muted-foreground"><Trans>Select all ({n})</Trans></span> })()}
             </div>
           )}
           {changed.map(p => (
@@ -720,16 +724,16 @@ function StandardizeModal({ proposals, onClose, onApplied }: StandardizeModalPro
                 <p className="text-xs text-muted-foreground line-through truncate">{p.current_title}{p.current_subtitle ? ` — ${p.current_subtitle}` : ''}</p>
                 <div className="text-xs space-y-0.5">
                   {p.proposed_title !== p.current_title && (
-                    <p><span className="text-muted-foreground w-16 inline-block">Title</span><span className="font-medium">{p.proposed_title}</span></p>
+                    <p><span className="text-muted-foreground w-16 inline-block"><Trans>Title</Trans></span><span className="font-medium">{p.proposed_title}</span></p>
                   )}
                   {p.proposed_subtitle !== p.current_subtitle && (
-                    <p><span className="text-muted-foreground w-16 inline-block">Subtitle</span><span className="font-medium">{p.proposed_subtitle ?? <span className="italic text-muted-foreground/50">cleared</span>}</span></p>
+                    <p><span className="text-muted-foreground w-16 inline-block"><Trans>Subtitle</Trans></span><span className="font-medium">{p.proposed_subtitle ?? <span className="italic text-muted-foreground/50"><Trans>cleared</Trans></span>}</span></p>
                   )}
                   {p.proposed_series !== p.current_series && (
-                    <p><span className="text-muted-foreground w-16 inline-block">Series</span><span className="font-medium">{p.proposed_series ?? <span className="italic text-muted-foreground/50">cleared</span>}</span></p>
+                    <p><span className="text-muted-foreground w-16 inline-block"><Trans>Series</Trans></span><span className="font-medium">{p.proposed_series ?? <span className="italic text-muted-foreground/50"><Trans>cleared</Trans></span>}</span></p>
                   )}
                   {p.proposed_series_index !== p.current_series_index && (
-                    <p><span className="text-muted-foreground w-16 inline-block">Index</span><span className="font-medium">{p.proposed_series_index ?? <span className="italic text-muted-foreground/50">cleared</span>}</span></p>
+                    <p><span className="text-muted-foreground w-16 inline-block"><Trans>Index</Trans></span><span className="font-medium">{p.proposed_series_index ?? <span className="italic text-muted-foreground/50"><Trans>cleared</Trans></span>}</span></p>
                   )}
                 </div>
               </div>
@@ -751,7 +755,7 @@ function StandardizeModal({ proposals, onClose, onApplied }: StandardizeModalPro
             disabled={applying}
             className="px-3 py-1.5 rounded-lg text-sm font-medium border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-50 transition-all"
           >
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
           <button
             onClick={apply}
@@ -759,7 +763,7 @@ function StandardizeModal({ proposals, onClose, onApplied }: StandardizeModalPro
             className="flex items-center gap-1.5 px-4 py-1.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
           >
             {applying ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
-            Apply {checked.size > 0 ? `${checked.size} ` : ''}Changes
+            {(() => { const n = checked.size; return n > 0 ? <Trans>Apply {n} Changes</Trans> : <Trans>Apply Changes</Trans> })()}
           </button>
         </div>
       </div>
@@ -817,7 +821,7 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
 
   function buildCleanTitle(title: string, seriesName: string): string {
     const num = extractChapterNum(title)
-    if (num !== null) return `${seriesName} Chapter ${num}`
+    if (num !== null) return t`${seriesName} Chapter ${num}`
     return title
   }
 
@@ -873,7 +877,7 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
       <div className="relative z-10 bg-background border border-border rounded-2xl shadow-xl shadow-accent-soft w-full max-w-md mx-4 flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border">
-          <h2 className="text-sm font-semibold">Assign Chapter Metadata</h2>
+          <h2 className="text-sm font-semibold"><Trans>Assign Chapter Metadata</Trans></h2>
           <button onClick={handleClose} disabled={applying} className="text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50">
             <X className="h-4 w-4" />
           </button>
@@ -882,17 +886,17 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
         {/* Body */}
         <div className="px-6 py-5 space-y-4">
           <p className="text-xs text-muted-foreground">
-            {bookIds.length} chapters uploaded{detected > 0 ? ` — ${detected} chapter numbers detected` : ''}
+            {(() => { const n = bookIds.length; return t`${n} chapters uploaded` })()}{detected > 0 ? t` — ${detected} chapter numbers detected` : ''}
           </p>
 
           {/* Series picker */}
           <div className="space-y-1.5">
-            <label className="text-xs font-medium text-muted-foreground">Series</label>
+            <label className="text-xs font-medium text-muted-foreground"><Trans>Series</Trans></label>
             <input
               list="chapter-series-list"
               value={series}
               onChange={e => setSeries(e.target.value)}
-              placeholder="Start typing to search..."
+              placeholder={t`Start typing to search...`}
               className="w-full text-sm rounded-lg border border-border bg-background px-3 py-2 focus:outline-none focus:ring-1 focus:ring-ring"
             />
             <datalist id="chapter-series-list">
@@ -902,12 +906,12 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
 
           {/* Author */}
           <div className="space-y-1.5">
-            <label className="text-xs font-medium text-muted-foreground">Author</label>
+            <label className="text-xs font-medium text-muted-foreground"><Trans>Author</Trans></label>
             <input
               list="chapter-author-list"
               value={author}
               onChange={e => setAuthor(e.target.value)}
-              placeholder="Auto-filled from series"
+              placeholder={t`Auto-filled from series`}
               className="w-full text-sm rounded-lg border border-border bg-background px-3 py-2 focus:outline-none focus:ring-1 focus:ring-ring"
             />
             <datalist id="chapter-author-list">
@@ -917,13 +921,13 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
 
           {/* Book type */}
           <div className="space-y-1.5">
-            <label className="text-xs font-medium text-muted-foreground">Book Type</label>
+            <label className="text-xs font-medium text-muted-foreground"><Trans>Book Type</Trans></label>
             <select
               value={bookTypeId}
               onChange={e => setBookTypeId(e.target.value)}
               className="w-full text-sm rounded-lg border border-border bg-background px-3 py-2 focus:outline-none focus:ring-1 focus:ring-ring"
             >
-              <option value="">None</option>
+              <option value="">{t`None`}</option>
               {bookTypes.map(bt => <option key={bt.id} value={String(bt.id)}>{bt.label}</option>)}
             </select>
           </div>
@@ -938,7 +942,7 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
                     <div key={b.id} className="flex items-center gap-2 px-3 py-1.5 text-xs">
                       <span className="text-muted-foreground truncate flex-1">{b.title}</span>
                       <span className="shrink-0 font-medium">
-                        {num !== null ? `Ch. ${num}` : <span className="text-warning">?</span>}
+                        {num !== null ? t`Ch. ${num}` : <span className="text-warning">?</span>}
                       </span>
                     </div>
                   )
@@ -950,9 +954,10 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
 
         {/* Footer */}
         <div className="px-6 py-4 border-t border-border flex items-center justify-between">
-          {applying && progress ? (
-            <span className="text-xs text-muted-foreground">Applying {progress.done}/{progress.total}...</span>
-          ) : (
+          {applying && progress ? (() => {
+            const done = progress.done, total = progress.total
+            return <span className="text-xs text-muted-foreground"><Trans>Applying {done}/{total}...</Trans></span>
+          })() : (
             <span />
           )}
           <div className="flex items-center gap-2">
@@ -961,7 +966,7 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
               disabled={applying}
               className="px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50"
             >
-              Cancel
+              <Trans>Cancel</Trans>
             </button>
             <button
               onClick={apply}
@@ -969,7 +974,7 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
             >
               {applying ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
-              Apply to {bookIds.length} Chapters
+              {(() => { const n = bookIds.length; return <Trans>Apply to {n} Chapters</Trans> })()}
             </button>
           </div>
         </div>
@@ -1036,7 +1041,7 @@ export function MetadataManager() {
       setBookTypes(btData)
       setLibraries(libData)
     } catch {
-      setError('Failed to load metadata audit data.')
+      setError(t`Failed to load metadata audit data.`)
     } finally {
       setLoading(false)
     }
@@ -1216,7 +1221,10 @@ export function MetadataManager() {
         }}
         onWishMatches={(wishIds) => {
           const n = wishIds.length
-          toast.info(`This upload satisfies ${n} wish${n !== 1 ? 'es' : ''} — review in Admin > Wishlist`)
+          toast.info(plural(n, {
+            one: 'This upload satisfies # wish — review in Admin > Wishlist',
+            other: 'This upload satisfies # wishes — review in Admin > Wishlist',
+          }))
         }}
       />
 
@@ -1236,7 +1244,7 @@ export function MetadataManager() {
           <input
             value={search}
             onChange={e => handleSearchChange(e.target.value)}
-            placeholder="Search title, author…"
+            placeholder={t`Search title, author…`}
             className="pl-8 pr-3 h-8 w-52 text-xs bg-background border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-ring"
           />
           {search && (
@@ -1252,7 +1260,7 @@ export function MetadataManager() {
           onChange={e => setFilterSeries(e.target.value)}
           className="h-8 px-2 text-xs bg-background border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-ring"
         >
-          <option value="">All series</option>
+          <option value="">{t`All series`}</option>
           {allSeries.map(s => <option key={s} value={s}>{s}</option>)}
         </select>
 
@@ -1262,7 +1270,7 @@ export function MetadataManager() {
           onChange={e => setFilterTypeId(e.target.value)}
           className="h-8 px-2 text-xs bg-background border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-ring"
         >
-          <option value="">All types</option>
+          <option value="">{t`All types`}</option>
           {bookTypes.map(t => <option key={t.id} value={t.id}>{t.label}</option>)}
         </select>
 
@@ -1272,7 +1280,7 @@ export function MetadataManager() {
           onChange={e => setFilterLibId(e.target.value)}
           className="h-8 px-2 text-xs bg-background border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-ring"
         >
-          <option value="">All libraries</option>
+          <option value="">{t`All libraries`}</option>
           {libraries.map(l => <option key={l.id} value={l.id}>{l.name}</option>)}
         </select>
 
@@ -1286,7 +1294,7 @@ export function MetadataManager() {
             )}
           >
             <Filter className="w-3 h-3" />
-            Missing
+            <Trans>Missing</Trans>
             {missingFields.length > 0 && <span className="font-medium">({missingFields.length})</span>}
             <ChevronDown className="w-3 h-3" />
           </button>
@@ -1302,7 +1310,7 @@ export function MetadataManager() {
                       onChange={() => toggleMissingField(opt.key)}
                       className="rounded border-border"
                     />
-                    {opt.label}
+                    {i18n._(opt.label)}
                   </label>
                 ))}
               </div>
@@ -1312,7 +1320,7 @@ export function MetadataManager() {
 
         {hasFilters && (
           <button onClick={clearFilters} className="h-8 px-2.5 text-xs text-muted-foreground hover:text-foreground border border-border rounded-lg hover:bg-muted transition-colors">
-            Clear
+            <Trans>Clear</Trans>
           </button>
         )}
 
@@ -1328,14 +1336,14 @@ export function MetadataManager() {
           className="flex items-center gap-1.5 h-8 px-3 text-xs font-medium rounded-lg border border-border bg-card text-foreground hover:bg-muted transition-all"
         >
           <Upload className="w-3.5 h-3.5" />
-          Upload
+          <Trans>Upload</Trans>
         </button>
         <button
           onClick={() => { setChapterMode(true); setUploadModalOpen(true) }}
           className="flex items-center gap-1.5 h-8 px-3 text-xs font-medium rounded-lg border border-border bg-card text-foreground hover:bg-muted transition-all"
         >
           <BookMarked className="w-3.5 h-3.5" />
-          Upload Chapters
+          <Trans>Upload Chapters</Trans>
         </button>
 
         {/* Batch Fetch */}
@@ -1345,7 +1353,7 @@ export function MetadataManager() {
           className="flex items-center gap-1.5 h-8 px-3 text-xs font-medium rounded-lg border border-border bg-card text-foreground hover:bg-muted disabled:opacity-40 transition-all"
         >
           <Sparkles className="w-3.5 h-3.5" />
-          Batch Fetch ({Math.min(sorted.length, 100)})
+          {(() => { const n = Math.min(sorted.length, 100); return <Trans>Batch Fetch ({n})</Trans> })()}
         </button>
 
         {/* Review all filtered */}
@@ -1355,7 +1363,7 @@ export function MetadataManager() {
           className="flex items-center gap-1.5 h-8 px-3 text-xs font-medium rounded-lg bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-40 transition-all"
         >
           <Sparkles className="w-3.5 h-3.5" />
-          Review All Filtered ({sorted.length})
+          {(() => { const n = sorted.length; return <Trans>Review All Filtered ({n})</Trans> })()}
         </button>
         <button
           onClick={() => startStandardize(sorted.map(b => b.id))}
@@ -1363,28 +1371,28 @@ export function MetadataManager() {
           className="flex items-center gap-1.5 h-8 px-3 text-xs font-medium rounded-lg border border-border bg-card text-foreground hover:bg-muted disabled:opacity-40 transition-all"
         >
           {standardizeLoading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Wand2 className="w-3.5 h-3.5" />}
-          Standardize Titles
+          <Trans>Standardize Titles</Trans>
         </button>
       </div>
 
       {/* Bulk bar */}
       {selected.size > 0 && (
         <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-primary/5 border border-primary/20">
-          <span className="text-xs font-medium text-primary">{selected.size} selected</span>
+          {(() => { const n = selected.size; return <span className="text-xs font-medium text-primary">{t`${n} selected`}</span> })()}
           <div className="flex-1" />
           <button
             onClick={() => startBatchFetch([...selected])}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted transition-all"
           >
             <Sparkles className="w-3.5 h-3.5" />
-            Batch Fetch
+            <Trans>Batch Fetch</Trans>
           </button>
           <button
             onClick={() => startReview([...selected])}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
           >
             <Sparkles className="w-3.5 h-3.5" />
-            Review Selected
+            <Trans>Review Selected</Trans>
           </button>
           <button
             onClick={() => startStandardize([...selected])}
@@ -1392,7 +1400,7 @@ export function MetadataManager() {
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted disabled:opacity-50 transition-all"
           >
             {standardizeLoading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Wand2 className="w-3.5 h-3.5" />}
-            Standardize
+            <Trans>Standardize</Trans>
           </button>
           <button
             onClick={() => setSelected(new Set())}
@@ -1426,17 +1434,17 @@ export function MetadataManager() {
                   />
                 </th>
                 <th className="w-10 px-2 py-2" />
-                <th className="px-2 py-2 text-left"><SortHeader col="title" label="Title" /></th>
-                <th className="w-28 px-2 py-2 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Subtitle</th>
-                <th className="w-36 px-2 py-2 text-left"><SortHeader col="author" label="Author" /></th>
-                <th className="w-36 px-2 py-2 text-left"><SortHeader col="series" label="Series" /></th>
+                <th className="px-2 py-2 text-left"><SortHeader col="title" label={t`Title`} /></th>
+                <th className="w-28 px-2 py-2 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide"><Trans>Subtitle</Trans></th>
+                <th className="w-36 px-2 py-2 text-left"><SortHeader col="author" label={t`Author`} /></th>
+                <th className="w-36 px-2 py-2 text-left"><SortHeader col="series" label={t`Series`} /></th>
                 <th className="w-10 px-2 py-2 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide">#</th>
-                <th className="w-16 px-2 py-2 text-left"><SortHeader col="year" label="Year" /></th>
-                <th className="w-12 px-2 py-2 text-center text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Desc</th>
-                <th className="w-12 px-2 py-2 text-center text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Cover</th>
+                <th className="w-16 px-2 py-2 text-left"><SortHeader col="year" label={t`Year`} /></th>
+                <th className="w-12 px-2 py-2 text-center text-[11px] font-medium text-muted-foreground uppercase tracking-wide"><Trans>Desc</Trans></th>
+                <th className="w-12 px-2 py-2 text-center text-[11px] font-medium text-muted-foreground uppercase tracking-wide"><Trans>Cover</Trans></th>
                 <th className="w-24 px-2 py-2 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide">ISBN</th>
-                <th className="w-12 px-2 py-2 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Lang</th>
-                <th className="w-14 px-2 py-2 text-left"><SortHeader col="completeness" label="Score" /></th>
+                <th className="w-12 px-2 py-2 text-left text-[11px] font-medium text-muted-foreground uppercase tracking-wide"><Trans>Lang</Trans></th>
+                <th className="w-14 px-2 py-2 text-left"><SortHeader col="completeness" label={t`Score`} /></th>
               </tr>
             </thead>
             <tbody>
@@ -1504,7 +1512,7 @@ export function MetadataManager() {
               {sorted.length === 0 && (
                 <tr>
                   <td colSpan={13} className="px-4 py-12 text-center text-muted-foreground text-sm">
-                    No books match the current filters.
+                    <Trans>No books match the current filters.</Trans>
                   </td>
                 </tr>
               )}

--- a/frontend/src/components/MetadataManager.tsx
+++ b/frontend/src/components/MetadataManager.tsx
@@ -956,7 +956,7 @@ function ChapterAssignModal({ bookIds, open, bookTypes, onClose, onDone }: Chapt
         <div className="px-6 py-4 border-t border-border flex items-center justify-between">
           {applying && progress ? (() => {
             const done = progress.done, total = progress.total
-            return <span className="text-xs text-muted-foreground"><Trans>Applying {done}/{total}...</Trans></span>
+            return <span className="text-xs text-muted-foreground"><Trans>Applying {done}/{total}…</Trans></span>
           })() : (
             <span />
           )}

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -8,20 +8,26 @@ import {
   markAllRead,
   type NotificationOut,
 } from '@/lib/notifications'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 const POLL_INTERVAL_MS = 60_000 // 1 minute
 
+// Uses the core t macro (global i18n) — called during render, so a locale
+// switch re-renders it through I18nProvider like everything else.
 function relativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
   const mins = Math.floor(diff / 60_000)
-  if (mins < 1) return 'just now'
-  if (mins < 60) return `${mins}m ago`
+  if (mins < 1) return t`just now`
+  if (mins < 60) return t`${mins}m ago`
   const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
-  return `${Math.floor(hrs / 24)}d ago`
+  if (hrs < 24) return t`${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  return t`${days}d ago`
 }
 
 export function NotificationBell() {
+  const { t } = useLingui()
   const [open, setOpen] = useState(false)
   const [notifications, setNotifications] = useState<NotificationOut[]>([])
   const [unreadCount, setUnreadCount] = useState(0)
@@ -111,8 +117,8 @@ export function NotificationBell() {
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen(o => !o)}
-        title="Notifications"
-        aria-label="Notifications"
+        title={t`Notifications`}
+        aria-label={t`Notifications`}
         className={cn(
           'relative flex items-center justify-center w-8 h-8 rounded-lg transition-colors',
           open
@@ -132,7 +138,7 @@ export function NotificationBell() {
         <div className="absolute right-0 top-full mt-1.5 z-50 w-80 max-h-96 flex flex-col bg-card border border-border rounded-xl shadow-xl shadow-accent-soft overflow-hidden">
           {/* Header */}
           <div className="flex items-center justify-between px-3 py-2.5 border-b border-border shrink-0">
-            <span className="text-xs font-semibold text-foreground">Notifications</span>
+            <span className="text-xs font-semibold text-foreground"><Trans>Notifications</Trans></span>
             {unreadCount > 0 && (
               <button
                 onClick={handleMarkAll}
@@ -140,7 +146,7 @@ export function NotificationBell() {
                 className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
               >
                 <Check className="w-3 h-3" />
-                Mark all read
+                <Trans>Mark all read</Trans>
               </button>
             )}
           </div>
@@ -150,7 +156,7 @@ export function NotificationBell() {
             {notifications.length === 0 ? (
               <div className="flex flex-col items-center gap-2 py-8 text-center">
                 <Bell className="w-8 h-8 text-muted-foreground/30" />
-                <p className="text-xs text-muted-foreground">No notifications yet</p>
+                <p className="text-xs text-muted-foreground"><Trans>No notifications yet</Trans></p>
               </div>
             ) : (
               notifications.map(n => (

--- a/frontend/src/components/NotificationChannels.tsx
+++ b/frontend/src/components/NotificationChannels.tsx
@@ -125,7 +125,6 @@ export function NotificationChannels() {
           onChange={e => setKind(e.target.value as Channel['kind'])}
           className="rounded-md border border-border bg-background px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
         >
-          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product names */}
           <option value="ntfy">ntfy</option>
           {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product names */}
           <option value="gotify">Gotify</option>

--- a/frontend/src/components/NotificationChannels.tsx
+++ b/frontend/src/components/NotificationChannels.tsx
@@ -5,6 +5,10 @@ import { useEffect, useState } from 'react'
 import { CheckCircle, Loader2, Plus, Send, Trash2, XCircle } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 
 interface Channel {
   id: number
@@ -14,16 +18,17 @@ interface Channel {
   enabled: boolean
 }
 
+// eslint-disable-next-line lingui/no-unlocalized-strings -- product names
 const KIND_LABEL = { ntfy: 'ntfy', gotify: 'Gotify', webhook: 'Webhook' } as const
 const URL_HINT: Record<Channel['kind'], string> = {
   ntfy: 'https://ntfy.sh/your-topic',
   gotify: 'https://gotify.example.org',
   webhook: 'https://example.org/hook',
 }
-const TOKEN_HINT: Record<Channel['kind'], string> = {
-  ntfy: 'Access token (only for protected topics)',
-  gotify: 'Application token (required)',
-  webhook: 'Not used',
+const TOKEN_HINT: Record<Channel['kind'], MessageDescriptor> = {
+  ntfy: msg`Access token (only for protected topics)`,
+  gotify: msg`Application token (required)`,
+  webhook: msg`Not used`,
 }
 
 export function NotificationChannels() {
@@ -58,52 +63,52 @@ export function NotificationChannels() {
     setTestState(prev => ({ ...prev, [c.id]: 'testing' }))
     try {
       const r = await api.post<{ ok: boolean; error?: string }>(`/notification-channels/${c.id}/test`)
-      setTestState(prev => ({ ...prev, [c.id]: r.ok ? 'ok' : (r.error || 'failed') }))
+      setTestState(prev => ({ ...prev, [c.id]: r.ok ? 'ok' : (r.error || t`failed`) }))
     } catch {
-      setTestState(prev => ({ ...prev, [c.id]: 'request failed' }))
+      setTestState(prev => ({ ...prev, [c.id]: t`request failed` }))
     }
   }
 
   return (
     <div className="mt-3 rounded-xl border border-border/60 bg-card/50 p-5">
       <p className="text-xs text-muted-foreground mb-4">
-        Push Tome&apos;s notifications (wish fulfilled, new volume detected, reading
+        <Trans>Push Tome&apos;s notifications (wish fulfilled, new volume detected, reading
         goals) to ntfy, Gotify, or any webhook the moment they happen — the bell
         above only rings when you visit. Each channel can be tested, paused, or
-        removed; tokens are stored server-side and never shown again.
+        removed; tokens are stored server-side and never shown again.</Trans>
       </p>
 
       {channels.length > 0 && (
         <ul className="mb-4 flex flex-col gap-2">
           {channels.map(c => {
-            const t = testState[c.id]
+            const testResult = testState[c.id]
             return (
               <li key={c.id} className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2">
                 <span className="w-16 shrink-0 text-xs font-semibold text-foreground">{KIND_LABEL[c.kind]}</span>
                 <span className={cn('min-w-0 flex-1 truncate text-xs', c.enabled ? 'text-muted-foreground' : 'text-muted-foreground/50 line-through')}>
                   {c.url}
                 </span>
-                {t === 'ok' && <CheckCircle className="h-3.5 w-3.5 shrink-0 text-success" />}
-                {t && t !== 'ok' && t !== 'testing' && (
-                  <span title={t}><XCircle className="h-3.5 w-3.5 shrink-0 text-destructive" /></span>
+                {testResult === 'ok' && <CheckCircle className="h-3.5 w-3.5 shrink-0 text-success" />}
+                {testResult && testResult !== 'ok' && testResult !== 'testing' && (
+                  <span title={testResult}><XCircle className="h-3.5 w-3.5 shrink-0 text-destructive" /></span>
                 )}
                 <button
                   onClick={() => test(c)}
-                  disabled={t === 'testing'}
-                  title="Send a test notification"
+                  disabled={testResult === 'testing'}
+                  title={t`Send a test notification`}
                   className="rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-50"
                 >
-                  {t === 'testing' ? <Loader2 className="h-3 w-3 animate-spin" /> : <Send className="h-3 w-3" />}
+                  {testResult === 'testing' ? <Loader2 className="h-3 w-3 animate-spin" /> : <Send className="h-3 w-3" />}
                 </button>
                 <button
                   onClick={() => api.post(`/notification-channels/${c.id}/toggle`).then(load)}
                   className="rounded-md border border-border px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
                 >
-                  {c.enabled ? 'Pause' : 'Resume'}
+                  {c.enabled ? t`Pause` : t`Resume`}
                 </button>
                 <button
                   onClick={() => api.delete(`/notification-channels/${c.id}`).then(load)}
-                  title="Remove channel"
+                  title={t`Remove channel`}
                   className="rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-destructive"
                 >
                   <Trash2 className="h-3 w-3" />
@@ -120,8 +125,11 @@ export function NotificationChannels() {
           onChange={e => setKind(e.target.value as Channel['kind'])}
           className="rounded-md border border-border bg-background px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
         >
+          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product names */}
           <option value="ntfy">ntfy</option>
+          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product names */}
           <option value="gotify">Gotify</option>
+          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product names */}
           <option value="webhook">Webhook</option>
         </select>
         <input
@@ -134,7 +142,7 @@ export function NotificationChannels() {
           <input
             value={token}
             onChange={e => setToken(e.target.value)}
-            placeholder={TOKEN_HINT[kind]}
+            placeholder={i18n._(TOKEN_HINT[kind])}
             className="min-w-[180px] rounded-md border border-border bg-background px-2.5 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring"
           />
         )}
@@ -144,7 +152,7 @@ export function NotificationChannels() {
           className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-all hover:bg-primary/90 disabled:opacity-50"
         >
           {adding ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Plus className="h-3.5 w-3.5" />}
-          Add channel
+          <Trans>Add channel</Trans>
         </button>
       </div>
     </div>

--- a/frontend/src/components/PositionHistoryModal.tsx
+++ b/frontend/src/components/PositionHistoryModal.tsx
@@ -7,6 +7,8 @@ import { createPortal } from 'react-dom'
 import { History, Loader2, RotateCcw, X } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 interface HistoryEntry {
   id: number
@@ -23,8 +25,8 @@ interface HistoryResponse {
 function fmtWhen(iso: string): string {
   const d = new Date(iso)
   const diff = Date.now() - d.getTime()
-  if (diff < 3600_000) return `${Math.max(1, Math.floor(diff / 60_000))} min ago`
-  if (diff < 86400_000) return `${Math.floor(diff / 3600_000)}h ago`
+  if (diff < 3600_000) { const m = Math.max(1, Math.floor(diff / 60_000)); return t`${m} min ago` }
+  if (diff < 86400_000) { const h = Math.floor(diff / 3600_000); return t`${h}h ago` }
   return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short' }) +
     ' ' + d.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
 }
@@ -61,10 +63,10 @@ export function PositionHistoryModal({ bookId, onClose, onRestored }: {
         <div className="pointer-events-auto flex max-h-[70vh] w-full max-w-md flex-col rounded-xl border border-border bg-card shadow-xl">
           <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
             <History className="h-4 w-4 text-primary" />
-            <h2 className="font-display text-base text-foreground">Position history</h2>
+            <h2 className="font-display text-base text-foreground"><Trans>Position history</Trans></h2>
             <button
               onClick={onClose}
-              aria-label="Close"
+              aria-label={t`Close`}
               className="ml-auto rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
               <X className="h-4 w-4" />
@@ -73,11 +75,11 @@ export function PositionHistoryModal({ bookId, onClose, onRestored }: {
           <div className="min-h-0 overflow-y-auto overscroll-contain px-5 py-3">
             {!data ? (
               <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+                <Loader2 className="h-4 w-4 animate-spin" /> <Trans>Loading…</Trans>
               </div>
             ) : data.history.length === 0 ? (
               <p className="py-6 text-center text-sm text-muted-foreground">
-                No position changes recorded yet — history starts with the next sync.
+                <Trans>No position changes recorded yet — history starts with the next sync.</Trans>
               </p>
             ) : (
               <ul className="flex flex-col">
@@ -96,10 +98,10 @@ export function PositionHistoryModal({ bookId, onClose, onRestored }: {
                         {Math.round(h.percentage * 1000) / 10}%
                       </span>
                       <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
-                        {h.device || 'unknown device'} · {fmtWhen(h.created_at)}
+                        {h.device || t`unknown device`} · {fmtWhen(h.created_at)}
                         {isCurrent && (
                           <span className="ml-1.5 rounded bg-muted px-1.5 py-0.5 text-[10px] text-foreground">
-                            current
+                            <Trans>current</Trans>
                           </span>
                         )}
                       </span>
@@ -112,7 +114,7 @@ export function PositionHistoryModal({ bookId, onClose, onRestored }: {
                           {restoring === h.id
                             ? <Loader2 className="h-3 w-3 animate-spin" />
                             : <RotateCcw className="h-3 w-3" />}
-                          Restore
+                          <Trans>Restore</Trans>
                         </button>
                       )}
                     </li>
@@ -121,9 +123,9 @@ export function PositionHistoryModal({ bookId, onClose, onRestored }: {
               </ul>
             )}
             <p className="pb-1 pt-3 text-[11px] leading-relaxed text-muted-foreground">
-              Restoring sets the live position (and read status) back to that
+              <Trans>Restoring sets the live position (and read status) back to that
               point; devices pick it up on their next sync. Restoring below
-              100% un-finishes a falsely completed book.
+              100% un-finishes a falsely completed book.</Trans>
             </p>
           </div>
         </div>

--- a/frontend/src/components/ReadingImport.tsx
+++ b/frontend/src/components/ReadingImport.tsx
@@ -5,6 +5,10 @@ import { useRef, useState } from 'react'
 import { CheckCircle2, FileUp, Loader2, Upload } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 
 interface MatchedRow {
   title: string
@@ -26,7 +30,7 @@ interface Preview {
   skipped_unread: number
 }
 
-const VIA_LABEL = { isbn: 'ISBN', title: 'title', fuzzy: 'fuzzy' } as const
+const VIA_LABEL: Record<string, MessageDescriptor> = { isbn: msg`ISBN`, title: msg`title`, fuzzy: msg`fuzzy` }
 
 export function ReadingImport() {
   const [preview, setPreview] = useState<Preview | null>(null)
@@ -48,7 +52,7 @@ export function ReadingImport() {
       setChecked(new Set(p.matched.map((_, i) => i)))
       setPhase('idle')
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Could not read that file')
+      setError(e instanceof Error ? e.message : t`Could not read that file`)
       setPhase('idle')
     }
   }
@@ -67,13 +71,14 @@ export function ReadingImport() {
         '/import/reading-csv/apply', { items },
       )
       const a = r.applied
-      setSummary(
-        `Applied: ${a.status} statuses, ${a.rating} ratings, ${a.finished_on} finish dates, ${a.review} reviews.`,
-      )
+      {
+        const statuses = a.status, ratings = a.rating, finishes = a.finished_on, reviews = a.review
+        setSummary(t`Applied: ${statuses} statuses, ${ratings} ratings, ${finishes} finish dates, ${reviews} reviews.`)
+      }
       setPreview(null)
       setPhase('done')
     } catch {
-      setError('Applying failed — nothing was changed.')
+      setError(t`Applying failed — nothing was changed.`)
       setPhase('idle')
     }
   }
@@ -81,11 +86,11 @@ export function ReadingImport() {
   return (
     <div className="mt-3 rounded-xl border border-border/60 bg-card/50 p-5">
       <p className="text-xs text-muted-foreground mb-4">
-        Bring your reading history from Goodreads or StoryGraph: upload their CSV
+        <Trans>Bring your reading history from Goodreads or StoryGraph: upload their CSV
         export, review what matches your library, apply. Importing only fills
         gaps — it never overwrites a status, rating, review, or finish date you
         already have. &quot;To read&quot; shelves are skipped (that&apos;s what the wishlist
-        is for).
+        is for).</Trans>
       </p>
 
       <input
@@ -104,7 +109,7 @@ export function ReadingImport() {
             className="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-1.5 text-xs font-medium transition-all hover:bg-muted disabled:opacity-50"
           >
             {phase === 'previewing' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <FileUp className="h-3.5 w-3.5" />}
-            Choose CSV export
+            <Trans>Choose CSV export</Trans>
           </button>
           {summary && (
             <span className="flex items-center gap-1.5 text-xs text-success">
@@ -117,11 +122,13 @@ export function ReadingImport() {
 
       {preview && (
         <div className="space-y-3">
+          {(() => { const dialect = preview.dialect; const matched = preview.matched.length; const unmatched = preview.unmatched.length; const skipped = preview.skipped_unread; return (
           <p className="text-xs text-muted-foreground">
-            Recognized a <span className="font-semibold text-foreground">{preview.dialect}</span> export:{' '}
-            {preview.matched.length} matched, {preview.unmatched.length} not in your library,{' '}
-            {preview.skipped_unread} to-read rows skipped.
+            <Trans>Recognized a <span className="font-semibold text-foreground">{dialect}</span> export:{' '}
+            {matched} matched, {unmatched} not in your library,{' '}
+            {skipped} to-read rows skipped.</Trans>
           </p>
+          ) })()}
 
           {preview.matched.length > 0 && (
             <div className="max-h-72 overflow-y-auto overscroll-contain rounded-lg border border-border">
@@ -151,10 +158,10 @@ export function ReadingImport() {
                       <span className="block truncate text-xs text-foreground">{m.matched_title}</span>
                       <span className="block truncate text-[11px] text-muted-foreground">
                         {m.status}
-                        {m.rating != null ? ` · ${m.rating} stars` : ''}
-                        {m.finished_on ? ` · finished ${m.finished_on}` : ''}
-                        {' · matched by '}{VIA_LABEL[m.match_via]}
-                        {noop ? ' · nothing to fill (already tracked)' : ''}
+                        {m.rating != null ? (() => { const r = m.rating; return t` · ${r} stars` })() : ''}
+                        {m.finished_on ? (() => { const d = m.finished_on; return t` · finished ${d}` })() : ''}
+                        {(() => { const via = i18n._(VIA_LABEL[m.match_via]); return t` · matched by ${via}` })()}
+                        {noop ? t` · nothing to fill (already tracked)` : ''}
                       </span>
                     </span>
                   </label>
@@ -165,7 +172,7 @@ export function ReadingImport() {
 
           {preview.unmatched.length > 0 && (
             <details className="text-xs text-muted-foreground">
-              <summary className="cursor-pointer">Not in your library ({preview.unmatched.length})</summary>
+              {(() => { const n = preview.unmatched.length; return <summary className="cursor-pointer"><Trans>Not in your library ({n})</Trans></summary> })()}
               <ul className="mt-1 max-h-32 overflow-y-auto pl-4">
                 {preview.unmatched.map((u, i) => (
                   <li key={i} className="truncate">{u.title} — {u.author}</li>
@@ -181,13 +188,13 @@ export function ReadingImport() {
               className="flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-all hover:bg-primary/90 disabled:opacity-50"
             >
               {phase === 'applying' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Upload className="h-3.5 w-3.5" />}
-              Apply {checked.size} selected
+              {(() => { const n = checked.size; return t`Apply ${n} selected` })()}
             </button>
             <button
               onClick={() => { setPreview(null); setError(null) }}
               className="rounded-lg border border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
             >
-              Cancel
+              <Trans>Cancel</Trans>
             </button>
           </div>
         </div>

--- a/frontend/src/components/SaveFilterButton.tsx
+++ b/frontend/src/components/SaveFilterButton.tsx
@@ -34,7 +34,7 @@ export function SaveFilterButton({ params, onSaved }: Props) {
       <button
         onClick={() => setModalOpen(true)}
         className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-muted-foreground hover:text-primary hover:border-primary/30 transition-all"
-        title="Save current filters as a shelf"
+        title={t`Save current filters as a shelf`}
       >
         <Bookmark className="w-3.5 h-3.5" />
         <span className="hidden sm:inline"><Trans>Add shelf</Trans></span>

--- a/frontend/src/components/SaveFilterButton.tsx
+++ b/frontend/src/components/SaveFilterButton.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react'
 import { Bookmark } from 'lucide-react'
 import { api } from '@/lib/api'
 import { EntityModal } from '@/components/EntityModal'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 interface Props {
   params: Record<string, string>
@@ -23,7 +25,7 @@ export function SaveFilterButton({ params, onSaved }: Props) {
     <>
       {modalOpen && (
         <EntityModal
-          title="Add Shelf"
+          title={t`Add Shelf`}
           defaultIcon="Bookmark"
           onSave={handleSave}
           onClose={() => setModalOpen(false)}
@@ -35,7 +37,7 @@ export function SaveFilterButton({ params, onSaved }: Props) {
         title="Save current filters as a shelf"
       >
         <Bookmark className="w-3.5 h-3.5" />
-        <span className="hidden sm:inline">Add shelf</span>
+        <span className="hidden sm:inline"><Trans>Add shelf</Trans></span>
       </button>
     </>
   )

--- a/frontend/src/components/SendButton.tsx
+++ b/frontend/src/components/SendButton.tsx
@@ -4,6 +4,8 @@ import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
 import type { BookFile } from '@/lib/books'
 import { SendToDeviceModal } from '@/components/SendToDeviceModal'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 interface SendStatus {
   configured: boolean
@@ -56,14 +58,15 @@ export function SendButton({ books, variant = 'rail', disabled }: SendButtonProp
         { book_ids: books.map(b => b.id) },
       )
       if (res.queued > 0) {
-        toast.success(
-          `Queued ${res.queued} to KOReader — arrives next time KOReader syncs`,
-        )
+        {
+          const n = res.queued
+          toast.success(t`Queued ${n} to KOReader — arrives next time KOReader syncs`)
+        }
       } else {
-        toast.info('Already in your KOReader inbox')
+        toast.info(t`Already in your KOReader inbox`)
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to queue for KOReader')
+      toast.error(err instanceof Error ? err.message : t`Failed to queue for KOReader`)
     } finally {
       setSending(false)
     }
@@ -73,9 +76,11 @@ export function SendButton({ books, variant = 'rail', disabled }: SendButtonProp
   // button it would lift each half independently and break the seam. The plain
   // (non-split) rail button adds the lift back below for parity with the old
   // Send-to-Device button.
+  /* eslint-disable lingui/no-unlocalized-strings -- Tailwind classes */
   const btn = variant === 'bulk'
     ? 'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted disabled:opacity-50 transition-all'
     : 'flex items-center justify-center gap-2 px-3 py-2 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted disabled:opacity-50 transition-all duration-200'
+  /* eslint-enable lingui/no-unlocalized-strings */
 
   // Feature off (or unknown) → plain email button, current behaviour.
   if (!status?.koreader) {
@@ -87,7 +92,7 @@ export function SendButton({ books, variant = 'rail', disabled }: SendButtonProp
           className={variant === 'rail' ? `mt-2 w-full ${btn} hover:-translate-y-0.5 hover:shadow-sm` : btn}
         >
           <Send className="w-3.5 h-3.5 text-muted-foreground" />
-          Send to Device
+          <Trans>Send to Device</Trans>
         </button>
         <SendToDeviceModal open={modalOpen} onClose={() => setModalOpen(false)} books={books} />
       </>
@@ -106,15 +111,15 @@ export function SendButton({ books, variant = 'rail', disabled }: SendButtonProp
           {sending
             ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
             : <Send className="w-3.5 h-3.5 text-muted-foreground" />}
-          Send to KOReader
+          <Trans>Send to KOReader</Trans>
           <span className="ml-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground border border-border rounded px-1 leading-tight">
-            Beta
+            <Trans>Beta</Trans>
           </span>
         </button>
         <button
           onClick={() => setMenuOpen(o => !o)}
           disabled={disabled}
-          aria-label="More send options"
+          aria-label={t`More send options`}
           className={`${btn} rounded-l-none border-l-0 px-2`}
         >
           <ChevronDown className="w-3.5 h-3.5" />
@@ -126,7 +131,7 @@ export function SendButton({ books, variant = 'rail', disabled }: SendButtonProp
               className="w-full flex items-center gap-2 px-3 py-2 text-xs text-foreground hover:bg-muted transition-colors"
             >
               <Mail className="w-3.5 h-3.5 text-muted-foreground" />
-              Send via email…
+              <Trans>Send via email…</Trans>
             </button>
           </div>
         )}

--- a/frontend/src/components/SendToDeviceModal.tsx
+++ b/frontend/src/components/SendToDeviceModal.tsx
@@ -225,7 +225,7 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
                   {sending ? (
                     <>
                       <Loader2 className="w-4 h-4 animate-spin" />
-                      <Trans>Sending...</Trans>
+                      <Trans>Sending…</Trans>
                     </>
                   ) : (
                     <>

--- a/frontend/src/components/SendToDeviceModal.tsx
+++ b/frontend/src/components/SendToDeviceModal.tsx
@@ -6,6 +6,8 @@ import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
 import type { BookFile } from '@/lib/books'
 import { formatBytes } from '@/lib/books'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 
 interface Device {
   id: number
@@ -74,9 +76,9 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
           { book_ids: books.map(b => b.id), device_id: selectedDevice },
         )
         if (res.failed === 0) {
-          toast.success(`Sent ${res.sent} book${res.sent !== 1 ? 's' : ''} to device`)
+          toast.success(plural(res.sent, { one: 'Sent # book to device', other: 'Sent # books to device' }))
         } else {
-          toast.info(`Sent ${res.sent}/${res.sent + res.failed}. ${res.failed} failed.`)
+          { const sent = res.sent, total = res.sent + res.failed, failedN = res.failed; toast.info(t`Sent ${sent}/${total}. ${failedN} failed.`) }
         }
         onClose()
       } else if (singleBook && selectedFileId) {
@@ -84,11 +86,11 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
           device_id: selectedDevice,
           file_id: selectedFileId,
         })
-        toast.success(`Sent "${singleBook.title}" to device`)
+        { const title = singleBook.title; toast.success(t`Sent "${title}" to device`) }
         onClose()
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to send')
+      toast.error(err instanceof Error ? err.message : t`Failed to send`)
     } finally {
       setSending(false)
     }
@@ -105,7 +107,7 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
             <div className="flex items-center gap-2">
               <Send className="w-4 h-4 text-primary" />
-              <h2 className="text-sm font-semibold text-foreground">Send to Device</h2>
+              <h2 className="text-sm font-semibold text-foreground"><Trans>Send to Device</Trans></h2>
             </div>
             <button
               onClick={onClose}
@@ -125,35 +127,35 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
               <div className="flex flex-col items-center justify-center py-6 gap-3">
                 <BookAnimation variant="send" className="block w-16 h-16 text-primary" />
                 <p className="text-sm font-medium text-foreground">
-                  Sending<span className="dots-anim"><span>.</span><span>.</span><span>.</span></span>
+                  <Trans>Sending</Trans><span className="dots-anim"><span>.</span><span>.</span><span>.</span></span>
                 </p>
               </div>
             ) : smtpConfigured === false ? (
               <div className="text-center py-4 space-y-2">
                 <AlertTriangle className="w-8 h-8 text-warning mx-auto" />
-                <p className="text-sm font-medium text-foreground">Email delivery is not set up yet</p>
+                <p className="text-sm font-medium text-foreground"><Trans>Email delivery is not set up yet</Trans></p>
                 <p className="text-xs text-muted-foreground">
-                  See Settings for setup instructions.
+                  <Trans>See Settings for setup instructions.</Trans>
                 </p>
                 <button
                   onClick={() => { onClose(); navigate('/settings') }}
                   className="mt-2 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
                 >
-                  Go to Settings
+                  <Trans>Go to Settings</Trans>
                 </button>
               </div>
             ) : devices.length === 0 ? (
               <div className="text-center py-4 space-y-2">
                 <Send className="w-8 h-8 text-muted-foreground mx-auto" />
-                <p className="text-sm font-medium text-foreground">No devices configured</p>
+                <p className="text-sm font-medium text-foreground"><Trans>No devices configured</Trans></p>
                 <p className="text-xs text-muted-foreground">
-                  Add a device in Settings to start sending books.
+                  <Trans>Add a device in Settings to start sending books.</Trans>
                 </p>
                 <button
                   onClick={() => { onClose(); navigate('/settings') }}
                   className="mt-2 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
                 >
-                  Go to Settings
+                  <Trans>Go to Settings</Trans>
                 </button>
               </div>
             ) : (
@@ -161,20 +163,20 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
                 {/* Book info */}
                 {singleBook && (
                   <div>
-                    <p className="text-xs font-medium text-muted-foreground mb-1">Book</p>
+                    <p className="text-xs font-medium text-muted-foreground mb-1"><Trans>Book</Trans></p>
                     <p className="text-sm text-foreground truncate">{singleBook.title}</p>
                   </div>
                 )}
                 {isBulk && (
                   <div>
-                    <p className="text-xs font-medium text-muted-foreground mb-1">Books</p>
+                    <p className="text-xs font-medium text-muted-foreground mb-1"><Trans>Books</Trans></p>
                     <p className="text-sm text-foreground">{books.length} book{books.length !== 1 ? 's' : ''} selected</p>
                   </div>
                 )}
 
                 {/* Device selector */}
                 <div>
-                  <label className="block text-xs font-medium text-muted-foreground mb-1">Device</label>
+                  <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Device</Trans></label>
                   <select
                     value={selectedDevice ?? ''}
                     onChange={e => setSelectedDevice(Number(e.target.value))}
@@ -189,7 +191,7 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
                 {/* Format selector (single book with multiple files) */}
                 {singleBook && singleBook.files.length > 1 && (
                   <div>
-                    <label className="block text-xs font-medium text-muted-foreground mb-1">Format</label>
+                    <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Format</Trans></label>
                     <select
                       value={selectedFileId ?? ''}
                       onChange={e => setSelectedFileId(Number(e.target.value))}
@@ -207,9 +209,9 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
                 {/* File size info */}
                 {selectedFile?.file_size && (
                   <p className="text-xs text-muted-foreground">
-                    File size: {formatBytes(selectedFile.file_size)}
+                    {(() => { const size = formatBytes(selectedFile.file_size); return <Trans>File size: {size}</Trans> })()}
                     {selectedFile.file_size > 25 * 1024 * 1024 && (
-                      <span className="text-warning ml-1">(exceeds 25 MB email limit)</span>
+                      <span className="text-warning ml-1"><Trans>(exceeds 25 MB email limit)</Trans></span>
                     )}
                   </p>
                 )}
@@ -223,12 +225,12 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
                   {sending ? (
                     <>
                       <Loader2 className="w-4 h-4 animate-spin" />
-                      Sending...
+                      <Trans>Sending...</Trans>
                     </>
                   ) : (
                     <>
                       <Send className="w-4 h-4" />
-                      {isBulk ? `Send ${books.length} books` : 'Send'}
+                      {isBulk ? plural(books.length, { one: 'Send # book', other: 'Send # books' }) : t`Send`}
                     </>
                   )}
                 </button>

--- a/frontend/src/components/SeriesCoverageStrip.tsx
+++ b/frontend/src/components/SeriesCoverageStrip.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { t } from '@lingui/core/macro'
 import type { WishCoverageVolume } from '@/lib/wishlist'
 
 const PILL_BASE = 'inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium border transition-all'
@@ -42,7 +43,7 @@ export function SeriesCoverageStrip({ coverage, total }: { coverage: WishCoverag
               #{n}
             </Link>
           ) : (
-            <span key={n} title={`Volume ${n} — not in the library`} className={`${PILL_BASE} ${PILL_MISSING}`}>
+            <span key={n} title={t`Volume ${n} — not in the library`} className={`${PILL_BASE} ${PILL_MISSING}`}>
               #{n}
             </span>
           )

--- a/frontend/src/components/SeriesFollowButton.tsx
+++ b/frontend/src/components/SeriesFollowButton.tsx
@@ -4,6 +4,7 @@ import { api } from '@/lib/api'
 import { getFollows, invalidateFollows, type FollowOut } from '@/lib/follows'
 import { useToast } from '@/contexts/ToastContext'
 import { cn, formatDate } from '@/lib/utils'
+import { t } from '@lingui/core/macro'
 
 /**
  * Follow/unfollow a series from its detail page (release detection). Renders
@@ -33,12 +34,12 @@ export function SeriesFollowButton({ seriesName }: { seriesName: string }) {
         await api.delete(`/wishlist/${follow.id}`)
       } else {
         await api.post('/wishlist/follow', { name: seriesName })
-        toast.success(`Following "${seriesName}" — you'll hear when a new volume is out`)
+        toast.success(t`Following "${seriesName}" — you'll hear when a new volume is out`)
       }
       invalidateFollows()
       getFollows().then(setRows)
     } catch (e) {
-      toast.error((e as Error).message ?? 'Could not resolve this series on Hardcover')
+      toast.error((e as Error).message ?? t`Could not resolve this series on Hardcover`)
     } finally {
       setBusy(false)
     }
@@ -59,16 +60,16 @@ export function SeriesFollowButton({ seriesName }: { seriesName: string }) {
             ? 'border-primary/40 bg-primary/10 text-foreground hover:bg-primary/15'
             : 'border-border bg-card text-foreground hover:bg-muted',
         )}
-        title={follow ? 'Stop following this series' : 'Get notified when a new volume is released'}
+        title={follow ? t`Stop following this series` : t`Get notified when a new volume is released`}
       >
         {busy
           ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
           : follow ? <BellRing className="w-3.5 h-3.5 text-primary" /> : <BellPlus className="w-3.5 h-3.5" />}
-        {follow ? 'Following' : 'Follow'}
+        {follow ? t`Following` : t`Follow`}
       </button>
       {follow && vol != null && date && (
         <p className="absolute top-full left-1/2 -translate-x-1/2 mt-1 whitespace-nowrap text-[10px] text-muted-foreground text-center">
-          {upcoming ? 'Next' : 'Latest'}: Vol {Number.isInteger(vol) ? vol : vol.toFixed(1)} · {formatDate(date)}
+          {(() => { const v = Number.isInteger(vol) ? vol : vol.toFixed(1); const d = formatDate(date); return upcoming ? t`Next: Vol ${v} · ${d}` : t`Latest: Vol ${v} · ${d}` })()}
         </p>
       )}
     </div>

--- a/frontend/src/components/SeriesRating.tsx
+++ b/frontend/src/components/SeriesRating.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
 import { StarRating } from '@/components/StarRating'
+import { t } from '@lingui/core/macro'
 
 interface SeriesRatingData {
   series_name: string
@@ -41,15 +42,15 @@ export function SeriesRating({ seriesName, isUnserialized }: { seriesName: strin
       setData(updated)
     } catch {
       setData(prev)
-      toast.error('Failed to save series rating')
+      toast.error(t`Failed to save series rating`)
     }
   }
 
   const hint = rating != null
-    ? 'Applied to volumes you haven’t rated'
+    ? t`Applied to volumes you haven’t rated`
     : data.volume_average != null
-      ? `Your volumes average ${data.volume_average} (${data.rated_volumes} rated)`
-      : 'Rate the whole series'
+      ? (() => { const avg = data.volume_average, rated = data.rated_volumes; return t`Your volumes average ${avg} (${rated} rated)` })()
+      : t`Rate the whole series`
 
   return (
     <div className="mt-2 flex items-center gap-2.5">

--- a/frontend/src/components/SeriesReadingStats.tsx
+++ b/frontend/src/components/SeriesReadingStats.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn, formatDuration, formatDate } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -60,7 +62,7 @@ function VolumeChart({ volumes }: { volumes: PerVolume[] }) {
 
   return (
     <div className="flex flex-col">
-      <p className="text-xs text-muted-foreground/70 mb-1.5 shrink-0">Time per volume</p>
+      <p className="text-xs text-muted-foreground/70 mb-1.5 shrink-0"><Trans>Time per volume</Trans></p>
       <div className="relative h-24">
         {/* faint baseline rule */}
         <div className="absolute bottom-0 left-0 right-0 h-px bg-border/40" />
@@ -69,7 +71,8 @@ function VolumeChart({ volumes }: { volumes: PerVolume[] }) {
             const isRead = v.seconds > 0
             const pct = isRead ? Math.max(v.seconds / max, 0.1) : 0
             const mins = Math.round(v.seconds / 60)
-            const label = v.series_index != null ? `Vol ${v.series_index}` : v.title
+            const idx = v.series_index
+            const label = idx != null ? t`Vol ${idx}` : v.title
             const tip = `${label}: ${mins > 0 ? `${mins}m` : 'unread'}`
             return (
               <div
@@ -91,8 +94,8 @@ function VolumeChart({ volumes }: { volumes: PerVolume[] }) {
         </div>
       </div>
       <div className="flex justify-between text-xs text-muted-foreground/50 mt-1 shrink-0">
-        <span>{firstIdx != null ? `Vol ${firstIdx}` : ''}</span>
-        <span>{lastIdx != null ? `Vol ${lastIdx}` : ''}</span>
+        <span>{firstIdx != null ? t`Vol ${firstIdx}` : ''}</span>
+        <span>{lastIdx != null ? t`Vol ${lastIdx}` : ''}</span>
       </div>
     </div>
   )
@@ -122,10 +125,10 @@ export function SeriesReadingStats({ seriesName }: SeriesReadingStatsProps) {
 
   const supporting: { label: string; value: string }[] = [
     { label: 'finished', value: `${own.books_finished}/${own.books_total} (${own.completion_pct}%)` },
-    { label: 'sessions', value: String(own.sessions) },
-    { label: 'pages', value: own.pages_turned > 0 ? String(own.pages_turned) : '—' },
+    { label: t`sessions`, value: String(own.sessions) },
+    { label: t`pages`, value: own.pages_turned > 0 ? String(own.pages_turned) : '—' },
     ...(own.avg_volume_seconds > 0
-      ? [{ label: 'avg / volume', value: formatDuration(own.avg_volume_seconds) }] : []),
+      ? [{ label: t`avg / volume`, value: formatDuration(own.avg_volume_seconds) }] : []),
   ]
 
   // "Est. remaining" used to live here (avg finished volume × unfinished). The
@@ -133,17 +136,19 @@ export function SeriesReadingStats({ seriesName }: SeriesReadingStatsProps) {
   const bottomStats: { label: string; value: string }[] = []
   if (own.longest_volume != null) {
     bottomStats.push({
-      label: 'Longest volume',
-      value: own.longest_volume.series_index != null
-        ? `Vol ${own.longest_volume.series_index} · ${formatDuration(own.longest_volume.seconds)}`
-        : formatDuration(own.longest_volume.seconds),
+      label: t`Longest volume`,
+      value: (() => {
+        const idx = own.longest_volume.series_index
+        const dur = formatDuration(own.longest_volume.seconds)
+        return idx != null ? t`Vol ${idx} · ${dur}` : dur
+      })(),
     })
   }
   if (own.first_read) {
-    bottomStats.push({ label: 'First read', value: formatDate(own.first_read.slice(0, 10)) })
+    bottomStats.push({ label: t`First read`, value: formatDate(own.first_read.slice(0, 10)) })
   }
   if (own.last_read) {
-    bottomStats.push({ label: 'Last read', value: formatDate(own.last_read.slice(0, 10)) })
+    bottomStats.push({ label: t`Last read`, value: formatDate(own.last_read.slice(0, 10)) })
   }
 
   return (
@@ -156,7 +161,7 @@ export function SeriesReadingStats({ seriesName }: SeriesReadingStatsProps) {
           aria-expanded={open}
           className="flex items-center gap-1.5 font-display text-base text-foreground hover:text-primary transition-colors"
         >
-          Reading Stats
+          <Trans>Reading Stats</Trans>
           <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', !open && '-rotate-90')} />
         </button>
       </div>
@@ -205,7 +210,12 @@ export function SeriesReadingStats({ seriesName }: SeriesReadingStatsProps) {
           {/* Admin aggregate footer */}
           {aggregate && (
             <p className="text-xs text-muted-foreground/60 mt-3">
-              All readers: {formatDuration(aggregate.total_seconds)} · {aggregate.total_sessions} session{aggregate.total_sessions !== 1 ? 's' : ''} · {aggregate.distinct_readers} reader{aggregate.distinct_readers !== 1 ? 's' : ''}
+              {(() => {
+                const dur = formatDuration(aggregate.total_seconds)
+                const sess = plural(aggregate.total_sessions, { one: '# session', other: '# sessions' })
+                const readers = plural(aggregate.distinct_readers, { one: '# reader', other: '# readers' })
+                return t`All readers: ${dur} · ${sess} · ${readers}`
+              })()}
             </p>
           )}
         </div>

--- a/frontend/src/components/SeriesStackCard.tsx
+++ b/frontend/src/components/SeriesStackCard.tsx
@@ -75,6 +75,7 @@ export function SeriesStackCard({ book, count, view, focused, index = 0, onOpen 
   // overlapping neighbouring cards. Small view halves the offsets — its grid
   // gap is tighter.
   const lg = view === 'large'
+  /* eslint-disable lingui/no-unlocalized-strings -- Tailwind classes */
   const deepLayerCls = lg
     ? 'translate-x-2 -translate-y-2 group-hover:translate-x-3 group-hover:-translate-y-3.5 group-hover:rotate-2'
     : 'translate-x-1 -translate-y-1 group-hover:translate-x-1.5 group-hover:-translate-y-2 group-hover:rotate-2'
@@ -82,6 +83,7 @@ export function SeriesStackCard({ book, count, view, focused, index = 0, onOpen 
     ? 'translate-x-1 -translate-y-1 group-hover:translate-x-1.5 group-hover:-translate-y-2 group-hover:rotate-1'
     : 'translate-x-0.5 -translate-y-0.5 group-hover:translate-x-1 group-hover:-translate-y-1 group-hover:rotate-1'
   const layerBaseCls = 'absolute inset-0 rounded-xl overflow-hidden border border-border bg-muted transition-transform duration-300 ease-out'
+  /* eslint-enable lingui/no-unlocalized-strings */
 
   return (
     <div

--- a/frontend/src/components/ShareLinksOverview.tsx
+++ b/frontend/src/components/ShareLinksOverview.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react'
 import { Book, Bookmark, Check, Copy, Layers, Trash2 } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn, copyToClipboard } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 interface ShareLinkRow {
   id: number
@@ -34,23 +36,23 @@ export function ShareLinksOverview() {
   }
 
   function fmtExpiry(row: ShareLinkRow): string {
-    if (row.expired) return 'expired'
-    if (!row.expires_at) return 'never expires'
-    return `expires ${new Date(row.expires_at).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}`
+    if (row.expired) return t`expired`
+    if (!row.expires_at) return t`never expires`
+    { const d = new Date(row.expires_at).toLocaleDateString(undefined, { day: 'numeric', month: 'short' }); return t`expires ${d}` }
   }
 
   return (
     <div className="mt-3 rounded-xl border border-border/60 bg-card/50 p-5">
       <p className="mb-4 text-xs text-muted-foreground">
-        Every public link you&apos;ve shared — shelves, series, and books. Links show
+        <Trans>Every public link you&apos;ve shared — shelves, series, and books. Links show
         metadata, your ratings, highlights, and reading stats; never files. Revoking
-        kills a link instantly.
+        kills a link instantly.</Trans>
       </p>
       {rows === null ? (
-        <p className="animate-pulse text-xs text-muted-foreground">Loading…</p>
+        <p className="animate-pulse text-xs text-muted-foreground"><Trans>Loading…</Trans></p>
       ) : rows.length === 0 ? (
         <p className="text-xs text-muted-foreground">
-          Nothing shared yet. Use the share icon on a shelf, a series page, or a book page.
+          <Trans>Nothing shared yet. Use the share icon on a shelf, a series page, or a book page.</Trans>
         </p>
       ) : (
         <ul className="flex flex-col gap-2">
@@ -78,7 +80,7 @@ export function ShareLinksOverview() {
                     rel="noopener noreferrer"
                     className="shrink-0 text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
                   >
-                    Open
+                    <Trans>Open</Trans>
                   </a>
                 )}
                 <button

--- a/frontend/src/components/ShareLinksOverview.tsx
+++ b/frontend/src/components/ShareLinksOverview.tsx
@@ -85,14 +85,14 @@ export function ShareLinksOverview() {
                 )}
                 <button
                   onClick={() => copy(row)}
-                  title="Copy link"
+                  title={t`Copy link`}
                   className="shrink-0 rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground"
                 >
                   {copiedId === row.id ? <Check className="h-3 w-3 text-success" /> : <Copy className="h-3 w-3" />}
                 </button>
                 <button
                   onClick={() => api.delete(`/share-links/${row.id}`).then(load)}
-                  title="Revoke link"
+                  title={t`Revoke link`}
                   className="shrink-0 rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-destructive"
                 >
                   <Trash2 className="h-3 w-3" />

--- a/frontend/src/components/ShareShelfModal.tsx
+++ b/frontend/src/components/ShareShelfModal.tsx
@@ -7,6 +7,8 @@ import { createPortal } from 'react-dom'
 import { Check, Copy, Link2, Loader2, Share2, Trash2, X } from 'lucide-react'
 import { api } from '@/lib/api'
 import { copyToClipboard } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
   title: string
@@ -76,10 +78,10 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
         <div className="pointer-events-auto w-full max-w-md rounded-xl border border-border bg-card shadow-xl">
           <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
             <Share2 className="h-4 w-4 text-primary" />
-            <h2 className="font-display text-base text-foreground">Share &quot;{title}&quot;</h2>
+            <h2 className="font-display text-base text-foreground"><Trans>Share &quot;{title}&quot;</Trans></h2>
             <button
               onClick={onClose}
-              aria-label="Close"
+              aria-label={t`Close`}
               className="ml-auto rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
             >
               <X className="h-4 w-4" />
@@ -87,25 +89,25 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
           </div>
           <div className="px-5 py-4">
             <p className="text-xs leading-relaxed text-muted-foreground">
-              A share link is a read-only page anyone with the link can open — no account
-              needed. It shows covers, titles, tags, descriptions, and your ratings and
-              highlights for {noun === 'book' ? 'this book' : noun === 'series' ? 'the books in this series' : 'the books on this shelf'}.
-              It never exposes files: no downloads, no reading, no way in. Revoke it any
-              time and the link dies instantly.
+              {noun === 'book'
+                ? <Trans>A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for this book. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly.</Trans>
+                : noun === 'series'
+                ? <Trans>A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for the books in this series. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly.</Trans>
+                : <Trans>A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for the books on this shelf. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly.</Trans>}
             </p>
 
             {token === undefined ? (
               <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
-                <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+                <Loader2 className="h-4 w-4 animate-spin" /> <Trans>Loading…</Trans>
               </div>
             ) : token === null ? (
               <div className="mt-4 flex flex-wrap items-center gap-2">
                 <div className="flex items-center gap-1 rounded-lg bg-muted p-0.5">
                   {[
-                    { d: null, label: 'Never expires' },
-                    { d: 1, label: '1 day' },
-                    { d: 7, label: '7 days' },
-                    { d: 30, label: '30 days' },
+                    { d: null, label: t`Never expires` },
+                    { d: 1, label: t`1 day` },
+                    { d: 7, label: t`7 days` },
+                    { d: 30, label: t`30 days` },
                   ].map(o => (
                     <button
                       key={String(o.d)}
@@ -127,7 +129,7 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
                   className="flex items-center gap-2 rounded-lg bg-primary px-3.5 py-2 text-xs font-semibold text-primary-foreground transition-all hover:bg-primary/90 disabled:opacity-50"
                 >
                   {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Link2 className="h-3.5 w-3.5" />}
-                  Create share link
+                  <Trans>Create share link</Trans>
                 </button>
               </div>
             ) : (
@@ -136,7 +138,7 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
                   <code data-share-url className="min-w-0 flex-1 truncate text-xs text-foreground">{url}</code>
                   <button
                     onClick={copy}
-                    title="Copy link"
+                    title={t`Copy link`}
                     className="shrink-0 rounded-md border border-border p-1.5 text-muted-foreground transition-colors hover:text-foreground"
                   >
                     {copied ? <Check className="h-3.5 w-3.5 text-success" /> : <Copy className="h-3.5 w-3.5" />}
@@ -149,13 +151,13 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
                     className="flex w-fit items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
                   >
                     {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Trash2 className="h-3.5 w-3.5" />}
-                    Revoke link
+                    <Trans>Revoke link</Trans>
                   </button>
                   <span className="text-[11px] text-muted-foreground">
                     {expiresAt
-                      ? `Expires ${new Date(expiresAt).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })}`
-                      : 'Never expires'}
-                    {' · to change expiry, revoke and re-create'}
+                      ? (() => { const d = new Date(expiresAt).toLocaleDateString(undefined, { day: 'numeric', month: 'short' }); return t`Expires ${d}` })()
+                      : t`Never expires`}
+                    {t` · to change expiry, revoke and re-create`}
                   </span>
                 </div>
               </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -17,6 +17,9 @@ import { TomeMark } from '@/components/TomeMark'
 import { useAuth, isAdmin, isMember } from '@/contexts/AuthContext'
 import { applyTheme, getStoredTheme, type ThemeId } from '@/lib/theme'
 import { DOCS, docsLink } from '@/lib/docs'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { msg } from '@lingui/core/macro'
+import type { MessageDescriptor } from '@lingui/core'
 
 const SIDEBAR_KEY = 'tome_sidebar'
 
@@ -40,6 +43,7 @@ const ALL_ICONS: [string, LucideIcon][] = Object.entries(LucideIcons).filter(
 ) as [string, LucideIcon][]
 
 export function IconPicker({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const { t } = useLingui()
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState('')
   const ref = useRef<HTMLDivElement>(null)
@@ -68,8 +72,8 @@ export function IconPicker({ value, onChange }: { value: string; onChange: (v: s
         type="button"
         onClick={() => { setOpen(o => !o); setSearch('') }}
         className="flex items-center justify-center w-7 h-7 rounded-md border border-border bg-muted hover:bg-muted/80 text-muted-foreground hover:text-foreground transition-colors"
-        title="Choose icon"
-        aria-label="Choose icon"
+        title={t`Choose icon`}
+        aria-label={t`Choose icon`}
       >
         <Curr className="w-3.5 h-3.5" />
       </button>
@@ -79,7 +83,7 @@ export function IconPicker({ value, onChange }: { value: string; onChange: (v: s
             ref={searchRef}
             value={search}
             onChange={e => setSearch(e.target.value)}
-            placeholder="Search icons…"
+            placeholder={t`Search icons…`}
             className="w-full mb-2 px-2 py-1 text-xs rounded-md border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring"
           />
           <div className="grid grid-cols-8 gap-1 max-h-[300px] overflow-y-auto">
@@ -98,7 +102,7 @@ export function IconPicker({ value, onChange }: { value: string; onChange: (v: s
               </button>
             ))}
           </div>
-          {!search && <p className="text-[10px] text-muted-foreground text-center mt-1.5">Search to find more icons</p>}
+          {!search && <p className="text-[10px] text-muted-foreground text-center mt-1.5"><Trans>Search to find more icons</Trans></p>}
         </div>
       )}
     </div>
@@ -120,6 +124,7 @@ interface Props {
 }
 
 export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange, onSavedFiltersChange, onOpenSeriesView, onOpenHomeView, mobileOpen, onMobileClose }: Props) {
+  const { t } = useLingui()
   const [open, setOpen] = useState(() => localStorage.getItem(SIDEBAR_KEY) !== 'closed')
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
@@ -209,7 +214,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
   }
 
   function openCreateLibModal() {
-    setLibModalTitle('New Library')
+    setLibModalTitle(t`New Library`)
     setLibModalInitialName('')
     setLibModalInitialIcon('Library')
     setLibModalInitialPublic(true)
@@ -223,7 +228,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
   }
 
   function openEditLibModal(lib: Library) {
-    setLibModalTitle('Edit Library')
+    setLibModalTitle(t`Edit Library`)
     setLibModalInitialName(lib.name)
     setLibModalInitialIcon(lib.icon ?? 'Library')
     setLibModalInitialPublic(lib.is_public ?? true)
@@ -239,7 +244,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
   const [shareShelf, setShareShelf] = useState<SavedFilter | null>(null)
 
   function openEditFilterModal(sf: SavedFilter) {
-    setModalTitle('Edit Shelf')
+    setModalTitle(t`Edit Shelf`)
     setModalInitialName(sf.name)
     setModalInitialIcon(sf.icon ?? 'Bookmark')
     setModalDefaultIcon('Bookmark')
@@ -253,6 +258,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
 
   return (
     <>
+      {/* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS, not copy */}
       <style>{`
         @keyframes sidebar-jiggle {
           0%, 100% { transform: rotate(0deg); }
@@ -311,8 +317,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
           <div className="flex flex-col items-center flex-1 overflow-y-auto py-2 space-y-0.5 overscroll-contain">
             <button
               onClick={onOpenHomeView}
-              title="Home"
-              aria-label="Home"
+              title={t`Home`}
+              aria-label={t`Home`}
               className={cn(
                 'group relative flex items-center justify-center w-9 h-9 rounded-lg transition-all',
                 isHomeTab
@@ -324,8 +330,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
             </button>
             <button
               onClick={selectAllBooks}
-              title="All Books"
-              aria-label="All Books"
+              title={t`All Books`}
+              aria-label={t`All Books`}
               className={cn(
                 'group relative flex items-center justify-center w-9 h-9 rounded-lg transition-all',
                 isAllBooks
@@ -337,8 +343,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
             </button>
             <button
               onClick={onOpenSeriesView}
-              title="Series"
-              aria-label="Series"
+              title={t`Series`}
+              aria-label={t`Series`}
               className={cn(
                 'group relative flex items-center justify-center w-9 h-9 rounded-lg transition-all',
                 isSeriesTab
@@ -350,8 +356,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
             </button>
             <Link
               to="/stats"
-              title="Stats"
-              aria-label="Stats"
+              title={t`Stats`}
+              aria-label={t`Stats`}
               className={cn(
                 'group relative flex items-center justify-center w-9 h-9 rounded-lg transition-all',
                 location.pathname === '/stats'
@@ -363,8 +369,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
             </Link>
             <Link
               to="/highlights"
-              title="Highlights"
-              aria-label="Highlights"
+              title={t`Highlights`}
+              aria-label={t`Highlights`}
               className={cn(
                 'group relative flex items-center justify-center w-9 h-9 rounded-lg transition-all',
                 location.pathname === '/highlights'
@@ -377,8 +383,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
             {isMember(user) && (
               <Link
                 to="/wishlist"
-                title="Wishlist"
-                aria-label="Wishlist"
+                title={t`Wishlist`}
+                aria-label={t`Wishlist`}
                 className={cn(
                   'group relative flex items-center justify-center w-9 h-9 rounded-lg transition-all',
                   location.pathname === '/wishlist'
@@ -392,8 +398,8 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
             {isAdmin(user) && (
               <Link
                 to="/bindery"
-                title="Bindery"
-                aria-label="Bindery"
+                title={t`Bindery`}
+                aria-label={t`Bindery`}
                 className={cn(
                   'group relative flex items-center justify-center w-9 h-9 rounded-lg transition-all',
                   location.pathname === '/bindery'
@@ -465,7 +471,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                 )}
               >
                 <Home className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                <span className="truncate">Home</span>
+                <span className="truncate"><Trans>Home</Trans></span>
               </button>
               <button
                 onClick={selectAllBooks}
@@ -477,7 +483,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                 )}
               >
                 <BookOpen className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                <span className="truncate">All Books</span>
+                <span className="truncate"><Trans>All Books</Trans></span>
               </button>
               <button
                 onClick={onOpenSeriesView}
@@ -489,7 +495,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                 )}
               >
                 <Layers className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                <span className="truncate">Series</span>
+                <span className="truncate"><Trans>Series</Trans></span>
               </button>
               <Link
                 to="/stats"
@@ -501,7 +507,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                 )}
               >
                 <BarChart3 className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                <span className="truncate">Stats</span>
+                <span className="truncate"><Trans>Stats</Trans></span>
               </Link>
               <Link
                 to="/highlights"
@@ -513,7 +519,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                 )}
               >
                 <Quote className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                <span className="truncate">Highlights</span>
+                <span className="truncate"><Trans>Highlights</Trans></span>
               </Link>
               {isMember(user) && (
                 <Link
@@ -526,7 +532,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   )}
                 >
                   <Sparkles className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                  <span className="truncate">Wishlist</span>
+                  <span className="truncate"><Trans>Wishlist</Trans></span>
                 </Link>
               )}
               {isMember(user) && (
@@ -540,7 +546,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   )}
                 >
                   <BookMarked className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                  <span className="truncate">Hardcover</span>
+                  <span className="truncate"><Trans>Hardcover</Trans></span>
                 </Link>
               )}
               {isAdmin(user) && (
@@ -554,7 +560,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   )}
                 >
                   <BookPlus className="w-4 h-4 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                  <span className="truncate">Bindery</span>
+                  <span className="truncate"><Trans>Bindery</Trans></span>
                   {binderyCount > 0 && (
                     <span
                       className="ml-auto text-[10px] font-medium bg-primary/15 text-primary px-1.5 py-0.5 rounded-full"
@@ -568,9 +574,9 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
             </div>
 
             <Section
-              title="Libraries"
+              title={t`Libraries`}
               icon={<LibraryIcon className="w-3 h-3" />}
-              onAdd={openCreateLibModal}
+              onAdd={openCreateLibModal} addLabel={t`New library`}
             >
               {libraries.map(lib => (
                 <SidebarItem
@@ -593,7 +599,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
 
             {savedFilters.length > 0 && (
               <Section
-                title="Shelves"
+                title={t`Shelves`}
                 icon={<Bookmark className="w-3 h-3" />}
               >
                 {savedFilters.map(sf => (
@@ -653,7 +659,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
               <button
                 onClick={onMobileClose}
                 className="flex items-center justify-center w-8 h-8 text-muted-foreground hover:text-foreground transition-colors rounded-lg hover:bg-muted"
-                aria-label="Close navigation"
+                aria-label={t`Close navigation`}
               >
                 <X className="w-4 h-4" />
               </button>
@@ -671,7 +677,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   )}
                 >
                   <Home className="w-5 h-5 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                  <span className="truncate">Home</span>
+                  <span className="truncate"><Trans>Home</Trans></span>
                 </button>
                 <button
                   onClick={() => { selectAllBooks(); onMobileClose() }}
@@ -683,7 +689,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   )}
                 >
                   <BookOpen className="w-5 h-5 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                  <span className="truncate">All Books</span>
+                  <span className="truncate"><Trans>All Books</Trans></span>
                 </button>
                 <button
                   onClick={() => { onOpenSeriesView(); onMobileClose() }}
@@ -695,7 +701,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   )}
                 >
                   <Layers className="w-5 h-5 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                  <span className="truncate">Series</span>
+                  <span className="truncate"><Trans>Series</Trans></span>
                 </button>
                 <Link
                   to="/stats"
@@ -708,7 +714,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   )}
                 >
                   <BarChart3 className="w-5 h-5 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                  <span className="truncate">Stats</span>
+                  <span className="truncate"><Trans>Stats</Trans></span>
                 </Link>
                 <Link
                   to="/highlights"
@@ -721,7 +727,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   )}
                 >
                   <Quote className="w-5 h-5 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                  <span className="truncate">Highlights</span>
+                  <span className="truncate"><Trans>Highlights</Trans></span>
                 </Link>
                 {isMember(user) && (
                   <Link
@@ -735,7 +741,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                     )}
                   >
                     <Sparkles className="w-5 h-5 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                    <span className="truncate">Wishlist</span>
+                    <span className="truncate"><Trans>Wishlist</Trans></span>
                   </Link>
                 )}
                 {isAdmin(user) && (
@@ -750,7 +756,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                     )}
                   >
                     <BookPlus className="w-5 h-5 shrink-0 group-hover:animate-[wiggle_0.4s_ease-in-out]" />
-                    <span className="truncate flex-1">Bindery</span>
+                    <span className="truncate flex-1"><Trans>Bindery</Trans></span>
                     {binderyCount > 0 && (
                       <span className="text-xs font-medium text-primary tabular-nums">{binderyCount}</span>
                     )}
@@ -759,9 +765,9 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
               </div>
 
               <Section
-                title="Libraries"
+                title={t`Libraries`}
                 icon={<LibraryIcon className="w-3 h-3" />}
-                onAdd={openCreateLibModal}
+                onAdd={openCreateLibModal} addLabel={t`New library`}
               >
                 {libraries.map(lib => (
                   <SidebarItem
@@ -784,7 +790,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
 
               {savedFilters.length > 0 && (
                 <Section
-                  title="Shelves"
+                  title={t`Shelves`}
                   icon={<Bookmark className="w-3 h-3" />}
                 >
                   {savedFilters.map(sf => (
@@ -816,7 +822,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                 </div>
                 <div className="flex-1 min-w-0">
                   <p className="text-sm font-medium truncate">{user?.username}</p>
-                  {isAdmin(user) && <p className="text-[11px] text-muted-foreground">Admin</p>}
+                  {isAdmin(user) && <p className="text-[11px] text-muted-foreground"><Trans>Admin</Trans></p>}
                 </div>
               </div>
               {/* Actions */}
@@ -828,7 +834,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                 >
                   <Settings className="w-5 h-5 shrink-0" />
-                  Settings
+                  <Trans>Settings</Trans>
                 </Link>
                 {isAdmin(user) && (
                   <Link
@@ -837,7 +843,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                     className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                   >
                     <Shield className="w-5 h-5 shrink-0" />
-                    Admin
+                    <Trans>Admin</Trans>
                   </Link>
                 )}
                 <a
@@ -848,7 +854,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                 >
                   <BookOpen className="w-5 h-5 shrink-0" />
-                  <span className="flex-1">Docs</span>
+                  <span className="flex-1"><Trans>Docs</Trans></span>
                   <ExternalLink className="w-3.5 h-3.5 shrink-0 opacity-60" />
                 </a>
                 <button
@@ -856,7 +862,7 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
                   className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-sm text-destructive/80 hover:text-destructive hover:bg-destructive/10 transition-colors"
                 >
                   <LogOut className="w-5 h-5 shrink-0" />
-                  Log out
+                  <Trans>Log out</Trans>
                 </button>
               </div>
             </div>
@@ -867,15 +873,16 @@ export function Sidebar({ libraries, savedFilters, activeTab, onLibrariesChange,
 }
 
 
-const THEME_OPTIONS: { id: ThemeId; icon: typeof Sun; label: string }[] = [
-  { id: 'light', icon: Sun, label: 'Light' },
-  { id: 'dark', icon: Moon, label: 'Dark' },
-  { id: 'black', icon: MoonStar, label: 'Black' },
-  { id: 'amber', icon: Flame, label: 'Amber' },
-  { id: 'ember', icon: Coffee, label: 'Ember' },
+const THEME_OPTIONS: { id: ThemeId; icon: typeof Sun; label: MessageDescriptor }[] = [
+  { id: 'light', icon: Sun, label: msg`Light` },
+  { id: 'dark', icon: Moon, label: msg`Dark` },
+  { id: 'black', icon: MoonStar, label: msg`Black` },
+  { id: 'amber', icon: Flame, label: msg`Amber` },
+  { id: 'ember', icon: Coffee, label: msg`Ember` },
 ]
 
 function ThemeMenuItems({ itemClass }: { itemClass: string }) {
+  const { i18n } = useLingui()
   const [current, setCurrent] = useState(getStoredTheme)
   return (
     <>
@@ -888,7 +895,7 @@ function ThemeMenuItems({ itemClass }: { itemClass: string }) {
             className={itemClass}
           >
             <Icon className="w-4 h-4 shrink-0" />
-            {label}
+            {i18n._(label)}
             {current === id && <Check className="w-3.5 h-3.5 shrink-0 text-primary ml-auto" />}
           </button>
         </Fragment>
@@ -898,16 +905,19 @@ function ThemeMenuItems({ itemClass }: { itemClass: string }) {
 }
 
 function MobileThemeRow() {
+  const { t, i18n } = useLingui()
   const [current, setCurrent] = useState(getStoredTheme)
   return (
     <div className="flex items-center gap-1 px-3 py-1.5">
-      <span className="flex-1 text-sm text-muted-foreground">Theme</span>
-      {THEME_OPTIONS.map(({ id, icon: Icon, label }) => (
+      <span className="flex-1 text-sm text-muted-foreground"><Trans>Theme</Trans></span>
+      {THEME_OPTIONS.map(({ id, icon: Icon, label }) => {
+        const themeName = i18n._(label)
+        return (
         <button
           key={id}
           onClick={() => { applyTheme(id); setCurrent(id) }}
-          title={label}
-          aria-label={`${label} theme`}
+          title={themeName}
+          aria-label={t`${themeName} theme`}
           className={cn(
             'flex items-center justify-center w-9 h-9 rounded-lg transition-colors',
             current === id
@@ -917,12 +927,14 @@ function MobileThemeRow() {
         >
           <Icon className="w-4 h-4" />
         </button>
-      ))}
+        )
+      })}
     </div>
   )
 }
 
 function CollapsedUserMenu({ user, logout, onExpand }: { user: { username: string; is_admin?: boolean; role?: string } | null; logout: () => void; onExpand: () => void }) {
+  const { t } = useLingui()
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
@@ -941,16 +953,16 @@ function CollapsedUserMenu({ user, logout, onExpand }: { user: { username: strin
     <div ref={ref} className="relative shrink-0 border-t border-border flex flex-col items-center gap-0.5 py-2">
       <button
         onClick={onExpand}
-        title="Expand sidebar"
-        aria-label="Expand sidebar"
+        title={t`Expand sidebar`}
+        aria-label={t`Expand sidebar`}
         className="flex items-center justify-center w-9 h-7 rounded-lg text-muted-foreground/60 hover:text-foreground hover:bg-accent/60 transition-colors"
       >
         <ChevronRight className="w-4 h-4" />
       </button>
       <button
         onClick={() => setOpen(o => !o)}
-        title={user?.username ?? 'User menu'}
-        aria-label={user?.username ?? 'User menu'}
+        title={user?.username ?? t`User menu`}
+        aria-label={user?.username ?? t`User menu`}
         className="flex items-center justify-center w-9 h-9 rounded-lg hover:bg-accent/60 transition-colors"
       >
         <div className="flex w-6 h-6 items-center justify-center rounded-full bg-primary/10 text-[10px] font-bold text-primary ring-2 ring-primary/20">
@@ -961,17 +973,17 @@ function CollapsedUserMenu({ user, logout, onExpand }: { user: { username: strin
         <div className="absolute bottom-full left-1 right-1 mb-1 bg-card border border-border rounded-xl shadow-lg shadow-accent-soft py-1.5 z-50 w-40">
           <Link to="/settings" onClick={() => setOpen(false)} className={menuItem}>
             <Settings className="w-4 h-4 shrink-0" />
-            Settings
+            <Trans>Settings</Trans>
           </Link>
           {(user?.is_admin || user?.role === 'admin') && (
             <Link to="/admin" onClick={() => setOpen(false)} className={menuItem}>
               <Shield className="w-4 h-4 shrink-0" />
-              Admin
+              <Trans>Admin</Trans>
             </Link>
           )}
           <a href={docsLink(DOCS.home)} target="_blank" rel="noopener noreferrer" onClick={() => setOpen(false)} className={menuItem}>
             <BookOpen className="w-4 h-4 shrink-0" />
-            <span className="flex-1">Docs</span>
+            <span className="flex-1"><Trans>Docs</Trans></span>
             <ExternalLink className="w-3 h-3 shrink-0 opacity-60" />
           </a>
           <div className="my-1 h-px bg-border mx-2" />
@@ -979,7 +991,7 @@ function CollapsedUserMenu({ user, logout, onExpand }: { user: { username: strin
           <div className="my-1 h-px bg-border mx-2" />
           <button onClick={logout} className={destructive}>
             <LogOut className="w-4 h-4 shrink-0" />
-            Log out
+            <Trans>Log out</Trans>
           </button>
         </div>
       )}
@@ -988,6 +1000,7 @@ function CollapsedUserMenu({ user, logout, onExpand }: { user: { username: strin
 }
 
 function UserMenu({ user, logout, onCollapse }: { user: { username: string; is_admin?: boolean; role?: string } | null; logout: () => void; onCollapse: () => void }) {
+  const { t } = useLingui()
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
 
@@ -1016,8 +1029,8 @@ function UserMenu({ user, logout, onCollapse }: { user: { username: string; is_a
       </button>
       <button
         onClick={onCollapse}
-        title="Collapse sidebar"
-        aria-label="Collapse sidebar"
+        title={t`Collapse sidebar`}
+        aria-label={t`Collapse sidebar`}
         className="flex items-center justify-center w-7 h-8 rounded-lg shrink-0 text-muted-foreground/60 hover:text-foreground hover:bg-accent/60 transition-colors"
       >
         <ChevronLeft className="w-4 h-4" />
@@ -1027,17 +1040,17 @@ function UserMenu({ user, logout, onCollapse }: { user: { username: string; is_a
         <div className="absolute bottom-full left-2 right-2 mb-1 bg-card border border-border rounded-xl shadow-lg shadow-accent-soft py-1.5 z-50">
           <Link to="/settings" onClick={() => setOpen(false)} className={menuItem}>
             <Settings className="w-4 h-4 shrink-0" />
-            Settings
+            <Trans>Settings</Trans>
           </Link>
           {(user?.is_admin || user?.role === 'admin') && (
             <Link to="/admin" onClick={() => setOpen(false)} className={menuItem}>
               <Shield className="w-4 h-4 shrink-0" />
-              Admin
+              <Trans>Admin</Trans>
             </Link>
           )}
           <a href={docsLink(DOCS.home)} target="_blank" rel="noopener noreferrer" onClick={() => setOpen(false)} className={menuItem}>
             <BookOpen className="w-4 h-4 shrink-0" />
-            <span className="flex-1">Docs</span>
+            <span className="flex-1"><Trans>Docs</Trans></span>
             <ExternalLink className="w-3 h-3 shrink-0 opacity-60" />
           </a>
           <div className="my-1 h-px bg-border mx-2" />
@@ -1045,7 +1058,7 @@ function UserMenu({ user, logout, onCollapse }: { user: { username: string; is_a
           <div className="my-1 h-px bg-border mx-2" />
           <button onClick={logout} className={destructive}>
             <LogOut className="w-4 h-4 shrink-0" />
-            Log out
+            <Trans>Log out</Trans>
           </button>
         </div>
       )}
@@ -1053,10 +1066,12 @@ function UserMenu({ user, logout, onCollapse }: { user: { username: string; is_a
   )
 }
 
-function Section({ title, icon, onAdd, onTitleClick, children }: {
+function Section({ title, icon, onAdd, addLabel, onTitleClick, children }: {
   title: string
   icon: React.ReactNode
   onAdd?: () => void
+  /** Accessible label for the add button, e.g. "New library". */
+  addLabel?: string
   onTitleClick?: () => void
   children: React.ReactNode
 }) {
@@ -1076,8 +1091,8 @@ function Section({ title, icon, onAdd, onTitleClick, children }: {
           <button
             onClick={onAdd}
             className="p-2.5 -m-2 text-muted-foreground hover:text-foreground transition-colors"
-            title={`New ${title.toLowerCase().replace(/s$/, '')}`}
-            aria-label={`New ${title.toLowerCase().replace(/s$/, '')}`}
+            title={addLabel}
+            aria-label={addLabel}
           >
             <Plus className="w-3.5 h-3.5" />
           </button>
@@ -1099,6 +1114,7 @@ function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdi
   onShare?: () => void
   onDelete?: () => Promise<void>
 }) {
+  const { t } = useLingui()
   return (
     <div
       className={cn(
@@ -1112,7 +1128,7 @@ function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdi
       <span className="shrink-0 sidebar-item-icon">{getIcon(iconName)}</span>
       <span className="truncate flex-1">{label}</span>
       {isPrivate && (
-        <span title="Private library" className="shrink-0 flex items-center group-hover:hidden group-focus-within:hidden">
+        <span title={t`Private library`} className="shrink-0 flex items-center group-hover:hidden group-focus-within:hidden">
           <Lock className="w-3 h-3 text-muted-foreground/50" />
         </span>
       )}
@@ -1127,8 +1143,8 @@ function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdi
           <button
             onClick={e => { e.stopPropagation(); onEdit() }}
             className="p-0.5 rounded hover:text-foreground transition-colors"
-            title="Edit"
-            aria-label="Edit"
+            title={t`Edit`}
+            aria-label={t`Edit`}
           >
             <Pencil className="w-3 h-3" />
           </button>
@@ -1137,8 +1153,8 @@ function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdi
           <button
             onClick={e => { e.stopPropagation(); onShare() }}
             className="p-0.5 rounded hover:text-foreground transition-colors"
-            title="Share"
-            aria-label="Share"
+            title={t`Share`}
+            aria-label={t`Share`}
           >
             <Share2 className="w-3 h-3" />
           </button>
@@ -1147,8 +1163,8 @@ function SidebarItem({ label, iconName, count, active, isPrivate, onClick, onEdi
           <button
             onClick={async e => { e.stopPropagation(); await onDelete() }}
             className="p-0.5 rounded hover:text-destructive transition-colors"
-            title="Delete"
-            aria-label="Delete"
+            title={t`Delete`}
+            aria-label={t`Delete`}
           >
             <Trash2 className="w-3 h-3" />
           </button>
@@ -1172,6 +1188,7 @@ function LibraryModal({ title, initialName, initialIcon, initialIsPublic, librar
   onChanged?: () => void
   onClose: () => void
 }) {
+  const { t } = useLingui()
   const [name, setName] = useState(initialName ?? '')
   const [icon, setIcon] = useState(initialIcon ?? 'Library')
   const [isPublic, setIsPublic] = useState(initialIsPublic ?? true)
@@ -1206,7 +1223,7 @@ function LibraryModal({ title, initialName, initialIcon, initialIsPublic, librar
       }
       onChanged?.()
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to update sharing')
+      setError(e instanceof Error ? e.message : t`Failed to update sharing`)
     } finally {
       setBusyUserId(null)
     }
@@ -1227,7 +1244,7 @@ function LibraryModal({ title, initialName, initialIcon, initialIsPublic, librar
       await onSave(name.trim(), icon, isPublic)
       onClose()
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save')
+      setError(e instanceof Error ? e.message : t`Failed to save`)
     } finally {
       setSaving(false)
     }
@@ -1245,15 +1262,15 @@ function LibraryModal({ title, initialName, initialIcon, initialIsPublic, librar
           value={name}
           onChange={e => { setName(e.target.value); setError('') }}
           onKeyDown={e => { if (e.key === 'Enter') handleSave() }}
-          placeholder="Name…"
+          placeholder={t`Name…`}
           className="w-full px-3 py-2 rounded-lg border border-border bg-background text-sm focus:outline-none focus:ring-1 focus:ring-ring"
         />
         <div className="flex items-center gap-3">
-          <span className="text-sm text-muted-foreground">Icon</span>
+          <span className="text-sm text-muted-foreground"><Trans>Icon</Trans></span>
           <IconPicker value={icon} onChange={setIcon} />
         </div>
         <div className="flex items-center gap-3">
-          <span className="text-sm text-muted-foreground flex-1">Public library</span>
+          <span className="text-sm text-muted-foreground flex-1"><Trans>Public library</Trans></span>
           <button
             type="button"
             onClick={() => setIsPublic(v => !v)}
@@ -1270,16 +1287,16 @@ function LibraryModal({ title, initialName, initialIcon, initialIsPublic, librar
         </div>
         {!isPublic && (
           <p className="text-xs text-muted-foreground flex items-center gap-1">
-            <Lock className="w-3 h-3" /> Private — only assigned users can access
+            <Lock className="w-3 h-3" /> <Trans>Private — only assigned users can access</Trans>
           </p>
         )}
         {canShare && (
           <div className="space-y-2">
             <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
-              <Users className="w-3.5 h-3.5" /> Share with users
+              <Users className="w-3.5 h-3.5" /> <Trans>Share with users</Trans>
             </div>
             {users.length === 0 ? (
-              <p className="text-xs text-muted-foreground">No other users to share with.</p>
+              <p className="text-xs text-muted-foreground"><Trans>No other users to share with.</Trans></p>
             ) : (
               <div className="max-h-40 overflow-y-auto rounded-lg border border-border divide-y divide-border">
                 {users.map(u => {
@@ -1307,7 +1324,7 @@ function LibraryModal({ title, initialName, initialIcon, initialIsPublic, librar
           </div>
         )}
         {!isPublic && libraryId == null && (
-          <p className="text-xs text-muted-foreground">Save the library first, then reopen it to share with users.</p>
+          <p className="text-xs text-muted-foreground"><Trans>Save the library first, then reopen it to share with users.</Trans></p>
         )}
         {error && <p className="text-xs text-destructive">{error}</p>}
         <div className="flex items-center justify-end gap-2 pt-1">
@@ -1315,14 +1332,14 @@ function LibraryModal({ title, initialName, initialIcon, initialIsPublic, librar
             onClick={onClose}
             className="px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
           <button
             onClick={handleSave}
             disabled={saving || !name.trim()}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
           >
-            Save
+            <Trans>Save</Trans>
           </button>
         </div>
       </div>

--- a/frontend/src/components/StarRating.tsx
+++ b/frontend/src/components/StarRating.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Star } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { t } from '@lingui/core/macro'
 
 interface StarRatingProps {
   /** The fill to display (may be a derived value, e.g. a volume average). */
@@ -64,7 +65,7 @@ export function StarRating({
     return (
       <span
         className={cn('inline-flex items-center gap-px', className)}
-        aria-label={value != null ? `Rated ${value} of 5` : undefined}
+        aria-label={value != null ? t`Rated ${value} of 5` : undefined}
       >
         {[1, 2, 3, 4, 5].map(n => (
           <span key={n} className="relative inline-flex">{star(n)}</span>

--- a/frontend/src/components/SyncStatusBadge.tsx
+++ b/frontend/src/components/SyncStatusBadge.tsx
@@ -2,23 +2,24 @@ import { useEffect, useState } from 'react'
 import { RefreshCw } from 'lucide-react'
 import { useKosyncStatus } from '@/hooks/useKosyncStatus'
 import { cn } from '@/lib/utils'
+import { t, plural } from '@lingui/core/macro'
 
 const FRESH_MS = 5 * 60_000
 const RECENT_MS = 30 * 60_000
 
 function formatRelative(iso: string | null): string {
-  if (!iso) return 'Never'
+  if (!iso) return t`Never`
   const ts = new Date(iso).getTime()
-  if (Number.isNaN(ts)) return 'Never'
+  if (Number.isNaN(ts)) return t`Never`
   const diff = Date.now() - ts
-  if (diff < 60_000) return 'Just synced'
+  if (diff < 60_000) return t`Just synced`
   const mins = Math.floor(diff / 60_000)
-  if (mins < 60) return `${mins}m ago`
+  if (mins < 60) return t`${mins}m ago`
   const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
+  if (hrs < 24) return t`${hrs}h ago`
   const days = Math.floor(hrs / 24)
-  if (days === 1) return 'Yesterday'
-  if (days < 7) return `${days}d ago`
+  if (days === 1) return t`Yesterday`
+  if (days < 7) return t`${days}d ago`
   return new Date(ts).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
 }
 
@@ -45,15 +46,16 @@ export function SyncStatusBadge() {
   const ts = status.lastSync ? new Date(status.lastSync).getTime() : 0
   const diff = ts ? Date.now() - ts : Infinity
   const label = formatRelative(status.lastSync)
-  const tooltip = status.lastDevice
-    ? `Last sync from ${status.lastDevice} · ${status.syncedDocuments} book${status.syncedDocuments === 1 ? '' : 's'} tracked`
-    : `${status.syncedDocuments} book${status.syncedDocuments === 1 ? '' : 's'} tracked`
+  const lastDevice = status.lastDevice
+  const tooltip = lastDevice
+    ? plural(status.syncedDocuments, { one: `Last sync from ${lastDevice} · # book tracked`, other: `Last sync from ${lastDevice} · # books tracked` })
+    : plural(status.syncedDocuments, { one: '# book tracked', other: '# books tracked' })
 
   return (
     <div
       title={`${label} — ${tooltip}`}
       className="inline-flex items-center gap-1.5 h-7 px-1.5 sm:px-2 rounded-md text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors cursor-default select-none"
-      aria-label={`KOReader sync: ${label}. ${tooltip}`}
+      aria-label={t`KOReader sync: ${label}. ${tooltip}`}
     >
       <RefreshCw className={cn('w-3.5 h-3.5 sm:w-3 sm:h-3', iconColor(diff))} />
       <span className="font-medium tabular-nums hidden sm:inline">{label}</span>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -2,6 +2,9 @@ import { Sun, Moon, MoonStar, Flame, Coffee } from 'lucide-react'
 import { Fragment, useState } from 'react'
 import { cn } from '@/lib/utils'
 import { applyTheme, getStoredTheme, THEMES, loadCustomThemes, type ThemeId } from '@/lib/theme'
+import { t, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 
 export function ThemeToggle({ className }: { className?: string }) {
   const [themeId, setThemeId] = useState(getStoredTheme)
@@ -33,19 +36,19 @@ export function ThemeToggle({ className }: { className?: string }) {
         'transition-colors duration-200',
         className
       )}
-      aria-label="Toggle theme"
+      aria-label={t`Toggle theme`}
     >
       {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
     </button>
   )
 }
 
-const BUILT_IN: { id: ThemeId; icon: typeof Sun; label: string }[] = [
-  { id: 'light', icon: Sun, label: 'Light' },
-  { id: 'dark', icon: Moon, label: 'Dark' },
-  { id: 'black', icon: MoonStar, label: 'Black' },
-  { id: 'amber', icon: Flame, label: 'Amber' },
-  { id: 'ember', icon: Coffee, label: 'Ember' },
+const BUILT_IN: { id: ThemeId; icon: typeof Sun; label: MessageDescriptor }[] = [
+  { id: 'light', icon: Sun, label: msg`Light` },
+  { id: 'dark', icon: Moon, label: msg`Dark` },
+  { id: 'black', icon: MoonStar, label: msg`Black` },
+  { id: 'amber', icon: Flame, label: msg`Amber` },
+  { id: 'ember', icon: Coffee, label: msg`Ember` },
 ]
 
 export function ThemePill({ className }: { className?: string }) {
@@ -57,14 +60,14 @@ export function ThemePill({ className }: { className?: string }) {
   }
 
   return (
-    <div className={cn('inline-flex gap-0.5 p-0.5 rounded-full bg-muted/60 border border-border', className)} role="group" aria-label="Theme">
+    <div className={cn('inline-flex gap-0.5 p-0.5 rounded-full bg-muted/60 border border-border', className)} role="group" aria-label={t`Theme`}>
       {BUILT_IN.map(({ id, icon: Icon, label }) => (
         <Fragment key={id}>
           {/* hairline between the neutral core and the warm pair */}
           {id === 'amber' && <span className="w-px self-stretch bg-border mx-0.5" />}
           <button
             onClick={() => pick(id)}
-            aria-label={`${label} theme`}
+            aria-label={(() => { const name = i18n._(label); return t`${name} theme` })()}
             className={cn(
               'w-6 h-6 rounded-full grid place-items-center transition-all duration-200',
               themeId === id

--- a/frontend/src/components/UpcomingReleases.tsx
+++ b/frontend/src/components/UpcomingReleases.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { BookOpen, CalendarClock } from 'lucide-react'
 import { getFollows, type FollowOut } from '@/lib/follows'
 import { formatDate } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
 
 /**
  * Home rail card: upcoming volumes of the series you follow (release
@@ -32,7 +33,7 @@ export function UpcomingReleases() {
     <section className="p-4">
       <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground mb-2.5">
         <CalendarClock className="w-4 h-4 text-primary/60" />
-        Upcoming releases
+        <Trans>Upcoming releases</Trans>
       </h2>
       <div className="flex flex-col gap-2">
         {rows.map(f => (
@@ -49,7 +50,7 @@ export function UpcomingReleases() {
             <div className="min-w-0 flex-1">
               <p className="text-xs font-medium text-foreground truncate">{f.name}</p>
               <p className="text-[11px] text-muted-foreground truncate">
-                {f.latest_known_index != null && <>Vol {Number.isInteger(f.latest_known_index) ? f.latest_known_index : f.latest_known_index.toFixed(1)} · </>}
+                {f.latest_known_index != null && (() => { const v = Number.isInteger(f.latest_known_index) ? f.latest_known_index : f.latest_known_index.toFixed(1); return <Trans>Vol {v} · </Trans> })()}
                 {formatDate(f.latest_release_date!)}
               </p>
             </div>

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -4,6 +4,8 @@ import { api } from '@/lib/api'
 import { useBookTypes } from '@/lib/bookTypes'
 import { useToast } from '@/contexts/ToastContext'
 import { cn } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 
 interface UploadItem {
   id: string
@@ -153,7 +155,7 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
       } catch (err) {
         setItems(prev => prev.map(it =>
           it.id === item.id
-            ? { ...it, status: 'error', errorMsg: err instanceof Error ? err.message : 'Upload failed' }
+            ? { ...it, status: 'error', errorMsg: err instanceof Error ? err.message : t`Upload failed` }
             : it
         ))
         failed++
@@ -170,16 +172,16 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
     }
     if (success > 0) {
       onDone()
-      const skipNote = skipped > 0 ? `, ${skipped} already in library` : ''
+      const skipNote = skipped > 0 ? t`, ${skipped} already in library` : ''
       if (failed === 0) {
-        toast.success(`${success} book${success !== 1 ? 's' : ''} uploaded${skipNote}`)
+        toast.success(plural(success, { one: '# book uploaded', other: '# books uploaded' }) + skipNote)
       } else {
-        toast.info(`${success} uploaded, ${failed} failed${skipNote}`)
+        toast.info(t`${success} uploaded, ${failed} failed` + skipNote)
       }
     } else if (failed > 0) {
-      toast.error(`Upload failed for ${failed} file${failed !== 1 ? 's' : ''}`)
+      toast.error(plural(failed, { one: 'Upload failed for # file', other: 'Upload failed for # files' }))
     } else if (skipped > 0) {
-      toast.info(`Nothing to upload — ${skipped} file${skipped !== 1 ? 's are' : ' is'} already in your library`)
+      toast.info(plural(skipped, { one: 'Nothing to upload — # file is already in your library', other: 'Nothing to upload — # files are already in your library' }))
     }
   }
 
@@ -225,7 +227,7 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
           <h2 className="text-base font-semibold flex items-center gap-2">
-            <Upload className="w-4 h-4 text-muted-foreground" /> Upload Books
+            <Upload className="w-4 h-4 text-muted-foreground" /> <Trans>Upload Books</Trans>
           </h2>
           <button
             onClick={handleClose}
@@ -253,8 +255,9 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
           >
             <Upload className="w-6 h-6 text-muted-foreground mx-auto mb-2" />
             <p className="text-sm text-muted-foreground">
-              Drop books here or <span className="text-primary">click to browse</span>
+              <Trans>Drop books here or <span className="text-primary">click to browse</span></Trans>
             </p>
+            {/* eslint-disable-next-line lingui/no-unlocalized-strings -- file extensions */}
             <p className="text-xs text-muted-foreground/60 mt-1">epub, pdf, cbz, cbr, mobi, azw3</p>
           </div>
           <input
@@ -269,13 +272,13 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
           {/* Bulk type selector */}
           {items.length > 1 && (
             <div className="flex items-center gap-2 text-sm">
-              <span className="text-muted-foreground shrink-0">Set all to</span>
+              <span className="text-muted-foreground shrink-0"><Trans>Set all to</Trans></span>
               <select
                 value={bulkType}
                 onChange={e => { setBulkType(e.target.value); setAllTypes(e.target.value) }}
                 className="flex-1 text-sm sm:text-xs rounded-md border border-border bg-background px-1.5 py-2 sm:py-1 focus:outline-none focus:ring-1 focus:ring-ring"
               >
-                <option value="">No type</option>
+                <option value="">{t`No type`}</option>
                 {bookTypes.map(bt => (
                   <option key={bt.id} value={String(bt.id)}>{bt.label}</option>
                 ))}
@@ -300,7 +303,7 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
                     disabled={item.status !== 'pending'}
                     className="shrink-0 text-sm sm:text-xs rounded-md border border-border bg-background px-1.5 py-2 sm:py-1 focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
                   >
-                    <option value="">No type</option>
+                    <option value="">{t`No type`}</option>
                     {bookTypes.map(bt => (
                       <option key={bt.id} value={String(bt.id)}>{bt.label}</option>
                     ))}
@@ -332,14 +335,14 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
                   )}
                   {item.status === 'duplicate' && (
                     <p className="px-2.5 pb-2 text-xs text-warning">
-                      Already in your library — will be skipped.{' '}
+                      <Trans>Already in your library — will be skipped.</Trans>{' '}
                       <a
                         href={`/books/${item.dupBookId}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="underline hover:no-underline"
                       >
-                        View book
+                        <Trans>View book</Trans>
                       </a>
                     </p>
                   )}
@@ -359,7 +362,7 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
               {summary.failed === 0
                 ? <CheckCircle2 className="w-4 h-4 shrink-0" />
                 : <AlertCircle className="w-4 h-4 shrink-0" />}
-              {summary.success} uploaded{summary.failed > 0 ? `, ${summary.failed} failed` : ''}
+              {(() => { const ok = summary.success; const failedN = summary.failed; return t`${ok} uploaded` + (failedN > 0 ? t`, ${failedN} failed` : '') })()}
             </div>
           )}
         </div>
@@ -367,7 +370,7 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
         {/* Footer */}
         <div className="px-5 py-4 border-t border-border flex items-center justify-between gap-3 shrink-0">
           <span className="text-xs text-muted-foreground">
-            {items.length > 0 ? `${items.length} file${items.length !== 1 ? 's' : ''} selected` : ''}
+            {items.length > 0 ? plural(items.length, { one: '# file selected', other: '# files selected' }) : ''}
           </span>
           <div className="flex items-center gap-2">
             <button
@@ -375,7 +378,7 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
               disabled={uploading}
               className="px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50"
             >
-              {summary ? 'Close' : 'Cancel'}
+              {summary ? t`Close` : t`Cancel`}
             </button>
             <button
               onClick={uploadAll}
@@ -383,7 +386,7 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
             >
               {uploading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Upload className="w-3.5 h-3.5" />}
-              Upload All
+              <Trans>Upload All</Trans>
             </button>
           </div>
         </div>

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -314,7 +314,7 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
                       <button
                         onClick={() => removeItem(item.id)}
                         className="text-muted-foreground hover:text-destructive transition-colors"
-                        title="Remove"
+                        title={t`Remove`}
                       >
                         <X className="w-3.5 h-3.5" />
                       </button>

--- a/frontend/src/components/WhatsNewPanel.tsx
+++ b/frontend/src/components/WhatsNewPanel.tsx
@@ -7,6 +7,8 @@ import { useEffect, useState, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { Minus, Plus, RefreshCw, Sparkles, Wrench, X } from 'lucide-react'
 import { api } from '@/lib/api'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 interface WhatsNewEntry {
   kind: string
@@ -22,9 +24,11 @@ const SEEN_KEY = 'tome_seen_version'
 // Once per SPA session is enough — remounts (route changes) must not refetch.
 let checkedThisSession = false
 
+// eslint-disable-next-line lingui/no-unlocalized-strings -- changelog section keys
 const KIND_ORDER = ['Added', 'Changed', 'Fixed', 'Removed']
 
 // Per-kind visual identity — an icon chip per entry beats a wall of gray text.
+/* eslint-disable lingui/no-unlocalized-strings -- Tailwind class map keyed by changelog sections */
 const KIND_META: Record<string, { icon: typeof Plus; chip: string }> = {
   Added: { icon: Plus, chip: 'bg-success/15 text-success' },
   Changed: { icon: RefreshCw, chip: 'bg-primary/15 text-primary' },
@@ -32,6 +36,7 @@ const KIND_META: Record<string, { icon: typeof Plus; chip: string }> = {
   Removed: { icon: Minus, chip: 'bg-destructive/15 text-destructive' },
 }
 const KIND_FALLBACK = { icon: Sparkles, chip: 'bg-muted text-muted-foreground' }
+/* eslint-enable lingui/no-unlocalized-strings */
 
 // Inline `code` spans from the changelog render as code, not literal backticks.
 function renderInline(text: string): ReactNode {
@@ -110,15 +115,15 @@ export function WhatsNewPanel() {
               </span>
               <div className="min-w-0">
                 <p className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-                  Just updated
+                  <Trans>Just updated</Trans>
                 </p>
                 <h2 className="font-display text-xl leading-tight text-foreground">
-                  What&apos;s new in Tome {data.version}
+                  {(() => { const version = data.version; return <Trans>What&apos;s new in Tome {version}</Trans> })()}
                 </h2>
               </div>
               <button
                 onClick={dismiss}
-                aria-label="Dismiss"
+                aria-label={t`Dismiss`}
                 className="ml-auto rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               >
                 <X className="h-4 w-4" />
@@ -167,7 +172,7 @@ export function WhatsNewPanel() {
               onClick={dismiss}
               className="rounded-lg bg-primary px-3.5 py-1.5 text-xs font-semibold text-primary-foreground transition-all hover:bg-primary/90"
             >
-              Got it
+              <Trans>Got it</Trans>
             </button>
           </div>
         </div>

--- a/frontend/src/components/WishlistModal.tsx
+++ b/frontend/src/components/WishlistModal.tsx
@@ -1,4 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 import { X, Search, Loader2, BookOpen, Layers, ChevronLeft } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import {
@@ -143,11 +145,11 @@ export function WishlistModal({ onClose, onCreated }: Props) {
   async function handleSubmit() {
     setError(null)
     if (!manualMode && !selected && !selectedSeries) {
-      setError('Please pick a result or use the manual form.')
+      setError(t`Please pick a result or use the manual form.`)
       return
     }
     if (manualMode && !manualTitle.trim()) {
-      setError('Title is required.')
+      setError(t`Title is required.`)
       return
     }
 
@@ -175,7 +177,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
         })
       } else if (wishWholeSeries) {
         if (!seriesNameDraft.trim()) {
-          setError('Series name is required.')
+          setError(t`Series name is required.`)
           setSubmitting(false)
           return
         }
@@ -204,18 +206,20 @@ export function WishlistModal({ onClose, onCreated }: Props) {
       onCreated()
       handleClose()
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to add wish')
+      setError(e instanceof Error ? e.message : t`Failed to add wish`)
     } finally {
       setSubmitting(false)
     }
   }
 
+  /* eslint-disable lingui/no-unlocalized-strings -- provider names */
   const SOURCE_LABEL: Record<string, string> = {
     hardcover: 'Hardcover',
     google_books: 'Google Books',
     open_library: 'OpenLibrary',
     manual: 'Manual',
   }
+  /* eslint-enable lingui/no-unlocalized-strings */
 
   const inSearchState = !manualMode && !selected && !selectedSeries
 
@@ -233,7 +237,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
       )}>
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
-          <h2 className="text-base font-semibold">Add to Wishlist</h2>
+          <h2 className="text-base font-semibold"><Trans>Add to Wishlist</Trans></h2>
           <button
             onClick={handleClose}
             className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
@@ -258,7 +262,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                   )}
                 >
                   <BookOpen className="w-3 h-3" />
-                  Book
+                  <Trans>Book</Trans>
                 </button>
                 <button
                   type="button"
@@ -269,7 +273,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                   )}
                 >
                   <Layers className="w-3 h-3" />
-                  Series
+                  <Trans>Series</Trans>
                 </button>
               </div>
               )}
@@ -281,7 +285,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                   ref={inputRef}
                   value={query}
                   onChange={e => handleQueryChange(e.target.value)}
-                  placeholder={searchMode === 'series' ? 'Search for a series…' : 'Search for a book…'}
+                  placeholder={searchMode === 'series' ? t`Search for a series…` : t`Search for a book…`}
                   className="w-full h-9 pl-9 pr-4 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                 />
                 {searching && (
@@ -351,7 +355,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
 
               {query && !searching && (
                 (searchMode === 'book' ? candidates.length === 0 : seriesResults.length === 0) && (
-                  <p className="text-sm text-muted-foreground text-center py-4">No results found.</p>
+                  <p className="text-sm text-muted-foreground text-center py-4"><Trans>No results found.</Trans></p>
                 )
               )}
 
@@ -362,7 +366,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                   onClick={() => { setManualMode(true); setSelected(null); setWishWholeSeries(false); setError(null) }}
                   className="text-xs text-muted-foreground hover:text-foreground transition-colors underline-offset-2 hover:underline"
                 >
-                  Can't find it? Add manually
+                  <Trans>Can't find it? Add manually</Trans>
                 </button>
               )}
             </>
@@ -372,40 +376,40 @@ export function WishlistModal({ onClose, onCreated }: Props) {
             <div className="space-y-3">
               <div>
                 <label className="block text-xs font-medium text-muted-foreground mb-1">
-                  Title <span className="text-destructive">*</span>
+                  <Trans>Title <span className="text-destructive">*</span></Trans>
                 </label>
                 <input
                   value={manualTitle}
                   onChange={e => { setManualTitle(e.target.value); setError(null) }}
-                  placeholder="Book title"
+                  placeholder={t`Book title`}
                   autoFocus
                   className="w-full h-9 rounded-lg border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-muted-foreground mb-1">Author</label>
+                <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Author</Trans></label>
                 <input
                   value={manualAuthor}
                   onChange={e => setManualAuthor(e.target.value)}
-                  placeholder="Author name"
+                  placeholder={t`Author name`}
                   className="w-full h-9 rounded-lg border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-muted-foreground mb-1">Series</label>
+                <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Series</Trans></label>
                 <input
                   value={manualSeries}
                   onChange={e => setManualSeries(e.target.value)}
-                  placeholder="Series name — fill this alone to wish for the whole series"
+                  placeholder={t`Series name — fill this alone to wish for the whole series`}
                   className="w-full h-9 rounded-lg border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                 />
               </div>
               <div>
-                <label className="block text-xs font-medium text-muted-foreground mb-1">Note</label>
+                <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Note</Trans></label>
                 <textarea
                   value={manualNote}
                   onChange={e => setManualNote(e.target.value)}
-                  placeholder="Optional note (e.g. 'the new one')"
+                  placeholder={t`Optional note (e.g. 'the new one')`}
                   rows={2}
                   className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring resize-none"
                 />
@@ -415,7 +419,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                 onClick={() => { setManualMode(false); setError(null) }}
                 className="text-xs text-muted-foreground hover:text-foreground transition-colors underline-offset-2 hover:underline"
               >
-                Back to search
+                <Trans>Back to search</Trans>
               </button>
             </div>
           )}
@@ -429,7 +433,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                 className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
                 <ChevronLeft className="w-3.5 h-3.5" />
-                Choose a different book
+                <Trans>Choose a different book</Trans>
               </button>
 
               <div className="border border-primary/30 bg-primary/5 rounded-xl p-3 flex items-start gap-3">
@@ -462,7 +466,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                       : 'bg-muted text-muted-foreground hover:text-foreground'
                   )}
                 >
-                  This volume
+                  <Trans>This volume</Trans>
                 </button>
                 <button
                   type="button"
@@ -478,20 +482,20 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                   )}
                 >
                   <Layers className="w-3 h-3" />
-                  Whole series
+                  <Trans>Whole series</Trans>
                 </button>
               </div>
 
               {wishWholeSeries && (
                 <div>
-                  <label className="block text-xs font-medium text-muted-foreground mb-1">Series name</label>
+                  <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Series name</Trans></label>
                   <input
                     value={seriesNameDraft}
                     onChange={e => { setSeriesNameDraft(e.target.value); setError(null) }}
-                    placeholder="Series name"
+                    placeholder={t`Series name`}
                     className="w-full h-9 rounded-lg border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                   />
-                  <p className="mt-1 text-xs text-muted-foreground">For precise series tracking, use the <strong>Series</strong> tab instead.</p>
+                  <p className="mt-1 text-xs text-muted-foreground"><Trans>For precise series tracking, use the <strong>Series</strong> tab instead.</Trans></p>
                 </div>
               )}
             </>
@@ -506,7 +510,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                 className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
               >
                 <ChevronLeft className="w-3.5 h-3.5" />
-                Choose a different series
+                <Trans>Choose a different series</Trans>
               </button>
 
               <div className="border border-primary/30 bg-primary/5 rounded-xl p-3 flex items-start gap-3">
@@ -515,12 +519,12 @@ export function WishlistModal({ onClose, onCreated }: Props) {
                   <p className="text-sm font-medium text-foreground leading-snug">{selectedSeries.name}</p>
                   {selectedSeries.author && <p className="text-xs text-muted-foreground mt-0.5">{selectedSeries.author}</p>}
                   {selectedSeries.total != null && (
-                    <p className="text-xs text-muted-foreground/70">{selectedSeries.total} volumes</p>
+                    <p className="text-xs text-muted-foreground/70">{(() => { const n = selectedSeries.total; return <Trans>{n} volumes</Trans> })()}</p>
                   )}
                 </div>
               </div>
               <p className="text-xs text-muted-foreground px-1">
-                This wish covers the whole series and stays open as new volumes arrive.
+                <Trans>This wish covers the whole series and stays open as new volumes arrive.</Trans>
               </p>
             </>
           )}
@@ -536,7 +540,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
             onClick={handleClose}
             className="px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
           <button
             onClick={handleSubmit}
@@ -549,7 +553,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
             className="flex items-center gap-1.5 px-4 py-1.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
           >
             {submitting && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-            Add to Wishlist
+            <Trans>Add to Wishlist</Trans>
           </button>
         </div>
       </div>

--- a/frontend/src/components/WordCount.tsx
+++ b/frontend/src/components/WordCount.tsx
@@ -13,6 +13,7 @@ import {
 const POLL_MS = 1000
 
 function formatBytes(n: number): string {
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- unit
   if (!n) return '0 B'
   const units = ['B', 'KB', 'MB', 'GB', 'TB']
   let i = 0
@@ -170,7 +171,7 @@ export function WordCountTab() {
             <div className="flex items-center justify-between mb-2">
               <span className="text-sm font-medium flex items-center gap-2">
                 <Loader2 className="w-4 h-4 animate-spin text-primary" />
-                Counting… {formatCount(state.done_files)} / {formatCount(state.total_files)}
+                {(() => { const done = formatCount(state.done_files); const total = formatCount(state.total_files); return <Trans>Counting… {done} / {total}</Trans> })()}
               </span>
               <span className="text-xs text-muted-foreground tabular-nums">{pct.toFixed(1)}%</span>
             </div>

--- a/frontend/src/components/WordCount.tsx
+++ b/frontend/src/components/WordCount.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 import {
   AlignLeft, Loader2, Check, X, FileWarning, Play, Ban, RotateCcw,
 } from 'lucide-react'
@@ -22,12 +24,13 @@ function formatBytes(n: number): string {
 function formatDuration(secs: number | null): string {
   if (secs == null) return '—'
   const s = Math.max(0, Math.round(secs))
-  if (s < 60) return `${s}s`
+  if (s < 60) return t`${s}s`
   const m = Math.floor(s / 60)
   const rem = s % 60
-  if (m < 60) return `${m}m ${rem}s`
+  if (m < 60) return t`${m}m ${rem}s`
   const h = Math.floor(m / 60)
-  return `${h}h ${m % 60}m`
+  const mm = m % 60
+  return t`${h}h ${mm}m`
 }
 
 function formatCount(n: number): string {
@@ -73,7 +76,7 @@ export function WordCountTab() {
         setState(s)
         if (s.status === 'running') startPolling()
       })
-      .catch(() => { if (alive) setError('Failed to load word-count status') })
+      .catch(() => { if (alive) setError(t`Failed to load word-count status`) })
     return () => { alive = false; stopPolling() }
   }, [startPolling, stopPolling])
 
@@ -85,7 +88,7 @@ export function WordCountTab() {
       setState(s)
       startPolling()
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to start')
+      setError(e instanceof Error ? e.message : t`Failed to start`)
     } finally {
       setBusy(false)
     }
@@ -122,12 +125,12 @@ export function WordCountTab() {
           <AlignLeft className="w-4 h-4" />
         </div>
         <div>
-          <h2 className="text-sm font-semibold">Word counts</h2>
+          <h2 className="text-sm font-semibold"><Trans>Word counts</Trans></h2>
           <p className="text-xs text-muted-foreground mt-0.5 leading-relaxed">
-            Parse each EPUB to store its word count. New uploads get this automatically — this
+            <Trans>Parse each EPUB to store its word count. New uploads get this automatically — this
             backfills books added before the feature. It only reads the files and writes one
             number per book; nothing on disk is modified. Word counts power words-read and
-            reading-speed stats. PDF and CBZ are skipped.
+            reading-speed stats. PDF and CBZ are skipped.</Trans>
           </p>
         </div>
       </div>
@@ -143,9 +146,9 @@ export function WordCountTab() {
       {!running && !terminal && (
         <div className="border border-border rounded-xl bg-card overflow-hidden">
           <div className="px-4 py-3 border-b border-border grid grid-cols-3 gap-2 text-center">
-            <Stat label="EPUBs" value={preflight ? formatCount(preflight.epub_total) : '—'} />
-            <Stat label="Already counted" value={preflight ? formatCount(preflight.already_counted) : '—'} />
-            <Stat label="To count" value={preflight ? formatCount(pending) : '—'} accent={pending > 0}
+            <Stat label={t`EPUBs`} value={preflight ? formatCount(preflight.epub_total) : '—'} />
+            <Stat label={t`Already counted`} value={preflight ? formatCount(preflight.already_counted) : '—'} />
+            <Stat label={t`To count`} value={preflight ? formatCount(pending) : '—'} accent={pending > 0}
               sub={preflight ? formatBytes(preflight.pending_bytes) : undefined} />
           </div>
           <div className="px-4 py-3">
@@ -154,7 +157,7 @@ export function WordCountTab() {
               disabled={busy || pending === 0}
               className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
               {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Play className="w-4 h-4" />}
-              {pending === 0 ? 'Every EPUB is counted' : `Count ${formatCount(pending)} EPUB${pending !== 1 ? 's' : ''}`}
+              {pending === 0 ? t`Every EPUB is counted` : plural(pending, { one: 'Count # EPUB', other: 'Count # EPUBs' })}
             </button>
           </div>
         </div>
@@ -176,22 +179,22 @@ export function WordCountTab() {
             </div>
             <div className="flex items-center justify-between mt-2 text-xs text-muted-foreground">
               <span>{formatBytes(state.done_bytes)} / {formatBytes(state.total_bytes)}</span>
-              <span>Elapsed {formatDuration(state.elapsed_seconds)} · ~{formatDuration(state.eta_seconds)} left</span>
+              {(() => { const el = formatDuration(state.elapsed_seconds); const eta = formatDuration(state.eta_seconds); return <span><Trans>Elapsed {el} · ~{eta} left</Trans></span> })()}
             </div>
           </div>
           <div className="px-4 py-3 flex flex-col gap-3">
             <div className="text-xs text-muted-foreground truncate">
-              <span className="text-foreground/70">Current:</span>{' '}
+              <span className="text-foreground/70"><Trans>Current:</Trans></span>{' '}
               <span className="font-mono">{state.current_file?.split('/').pop() ?? '…'}</span>
             </div>
             <div className="grid grid-cols-3 gap-2 text-center">
-              <Stat label="Counted" value={formatCount(state.counted)} accent />
-              <Stat label="Words found" value={formatCount(state.words_total)} />
-              <Stat label="Failed" value={formatCount(state.failed)} danger={state.failed > 0} />
+              <Stat label={t`Counted`} value={formatCount(state.counted)} accent />
+              <Stat label={t`Words found`} value={formatCount(state.words_total)} />
+              <Stat label={t`Failed`} value={formatCount(state.failed)} danger={state.failed > 0} />
             </div>
             <button onClick={handleCancel} disabled={busy}
               className="self-start flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border border-destructive/40 text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-50">
-              <Ban className="w-3.5 h-3.5" /> Stop
+              <Ban className="w-3.5 h-3.5" /> <Trans>Stop</Trans>
             </button>
           </div>
         </div>
@@ -206,16 +209,16 @@ export function WordCountTab() {
             {state.status === 'cancelled' && <Ban className="w-4 h-4" />}
             {state.status === 'error' && <FileWarning className="w-4 h-4" />}
             <span className="text-sm font-semibold">
-              {state.status === 'done' && 'Word count complete'}
-              {state.status === 'cancelled' && 'Word count stopped'}
-              {state.status === 'error' && 'Word count failed'}
+              {state.status === 'done' && t`Word count complete`}
+              {state.status === 'cancelled' && t`Word count stopped`}
+              {state.status === 'error' && t`Word count failed`}
             </span>
-            <span className="ml-auto text-xs text-muted-foreground">Took {formatDuration(state.elapsed_seconds)}</span>
+            {(() => { const dur = formatDuration(state.elapsed_seconds); return <span className="ml-auto text-xs text-muted-foreground"><Trans>Took {dur}</Trans></span> })()}
           </div>
           <div className="px-4 py-3 grid grid-cols-3 gap-2 text-center border-b border-border">
-            <Stat label="Counted" value={formatCount(state.counted)} accent />
-            <Stat label="Words found" value={formatCount(state.words_total)} />
-            <Stat label="Failed" value={formatCount(state.failed)} danger={state.failed > 0} />
+            <Stat label={t`Counted`} value={formatCount(state.counted)} accent />
+            <Stat label={t`Words found`} value={formatCount(state.words_total)} />
+            <Stat label={t`Failed`} value={formatCount(state.failed)} danger={state.failed > 0} />
           </div>
           {state.error && (
             <div className="px-4 py-2 text-xs text-destructive border-b border-border">{state.error}</div>
@@ -223,7 +226,7 @@ export function WordCountTab() {
           {state.issues.length > 0 && (
             <div className="px-4 py-3 border-b border-border">
               <p className="text-xs font-medium text-muted-foreground mb-1.5 flex items-center gap-1.5">
-                <FileWarning className="w-3.5 h-3.5" /> Could not parse ({state.issues.length})
+                <FileWarning className="w-3.5 h-3.5" /> {(() => { const n = state.issues.length; return <Trans>Could not parse ({n})</Trans> })()}
               </p>
               <div className="max-h-64 overflow-y-auto flex flex-col gap-1">
                 {state.issues.map((it, i) => (
@@ -238,13 +241,13 @@ export function WordCountTab() {
           <div className="px-4 py-3 flex items-center gap-2">
             <button onClick={handleDismiss} disabled={busy}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50">
-              {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />} Done
+              {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Check className="w-4 h-4" />} <Trans>Done</Trans>
             </button>
             {state.failed > 0 && (
               <button onClick={handleStart} disabled={busy}
                 className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border border-border hover:bg-accent transition-colors disabled:opacity-50">
                 {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <RotateCcw className="w-3.5 h-3.5" />}
-                Retry {formatCount(state.failed)} failed
+                {(() => { const n = formatCount(state.failed); return <Trans>Retry {n} failed</Trans> })()}
               </button>
             )}
           </div>

--- a/frontend/src/components/home/FocusMode.tsx
+++ b/frontend/src/components/home/FocusMode.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 import { useNavigate } from 'react-router-dom'
 import { Play, RefreshCw, BookOpen } from 'lucide-react'
 import { api } from '@/lib/api'
@@ -50,26 +52,26 @@ function relativeTime(iso: string | null): string {
   if (!iso) return ''
   const then = new Date(iso)
   const diff = Math.floor((Date.now() - then.getTime()) / 1000)
-  if (diff < 60) return 'just now'
-  if (diff < 3600) return `${Math.floor(diff / 60)} min ago`
-  if (diff < 7200) return '1 hour ago'
-  if (diff < 86400) return `${Math.floor(diff / 3600)} hours ago`
+  if (diff < 60) return t`just now`
+  if (diff < 3600) { const m = Math.floor(diff / 60); return t`${m} min ago` }
+  if (diff < 7200) return t`1 hour ago`
+  if (diff < 86400) { const h = Math.floor(diff / 3600); return t`${h} hours ago` }
   if (diff < 172800) return 'yesterday'
   // Past a month, "412 days ago" reads worse than the date itself.
   if (diff >= 30 * 86400) {
     return `on ${then.toLocaleDateString(undefined, { month: 'short', day: 'numeric' })}`
   }
-  return `${Math.floor(diff / 86400)} days ago`
+  { const d = Math.floor(diff / 86400); return t`${d} days ago` }
 }
 
 function deviceLabel(device: string | null): string {
-  if (!device) return 'Synced'
+  if (!device) return t`Synced`
   const d = device.toLowerCase()
-  if (d === 'web') return 'Read on the web'
-  if (d.includes('kindle')) return 'Synced from Kindle'
-  if (d.includes('kobo')) return 'Synced from Kobo'
-  if (d.includes('koreader')) return 'Synced from KOReader'
-  return `Synced from ${device}`
+  if (d === 'web') return t`Read on the web`
+  if (d.includes('kindle')) return t`Synced from Kindle`
+  if (d.includes('kobo')) return t`Synced from Kobo`
+  if (d.includes('koreader')) return t`Synced from KOReader`
+  return t`Synced from ${device}`
 }
 
 const cover = (id: number) => `/api/books/${id}/cover`
@@ -322,15 +324,15 @@ export function FocusMode() {
           <BookOpen className="w-8 h-8 text-primary/40" />
         </div>
         <div>
-          <p className="text-base font-medium text-foreground">Nothing in progress</p>
-          <p className="text-sm text-muted-foreground mt-1">Start a book and Focus mode will pick up where you left off</p>
+          <p className="text-base font-medium text-foreground"><Trans>Nothing in progress</Trans></p>
+          <p className="text-sm text-muted-foreground mt-1"><Trans>Start a book and Focus mode will pick up where you left off</Trans></p>
         </div>
         <button
           type="button"
           onClick={() => navigate('/?tab=books')}
           className="px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors"
         >
-          Browse library
+          <Trans>Browse library</Trans>
         </button>
       </div>
     )
@@ -367,7 +369,7 @@ export function FocusMode() {
         {/* No series name here — the h1 right below IS the series (same link);
             repeating it 40px apart just duplicated the title. */}
         <div className="flex items-center gap-2 text-[12px] font-bold tracking-[0.12em] uppercase text-muted-foreground">
-          {onCurrent ? 'Continue reading' : 'Up next'}
+          {onCurrent ? t`Continue reading` : t`Up next`}
         </div>
 
         <h1 className="font-display text-3xl sm:text-4xl font-bold leading-[1.05] tracking-tight mt-3 text-foreground">
@@ -378,17 +380,18 @@ export function FocusMode() {
 
         {b.series && sel.series_index != null && (
           <div className="mt-2.5 text-[15px] font-semibold text-foreground">
-            Volume <span className="text-primary">{fmtVol(sel.series_index)}</span>
-            {onCurrent && data.ahead_count > 0 && (
-              <span className="text-muted-foreground font-medium"> · {data.ahead_count} ahead in this series</span>
-            )}
+            {(() => { const v = fmtVol(sel.series_index); return <Trans>Volume <span className="text-primary">{v}</span></Trans> })()}
+            {onCurrent && data.ahead_count > 0 && (() => {
+              const n = data.ahead_count
+              return <span className="text-muted-foreground font-medium"><Trans> · {n} ahead in this series</Trans></span>
+            })()}
           </div>
         )}
         {b.author && <div className="mt-1 text-[15px] text-muted-foreground">{b.author}</div>}
 
         {/* Description swaps with the selected volume. */}
         <p key={sel.book_id} className="mt-5 text-[15px] leading-relaxed text-muted-foreground line-clamp-4 min-h-[6rem] animate-[fadeIn_350ms_ease]">
-          {sel.description || 'No description yet for this volume.'}
+          {sel.description || t`No description yet for this volume.`}
         </p>
 
         {/* Progress — only the in-progress current book has it. A book that's
@@ -397,7 +400,7 @@ export function FocusMode() {
           b.progress > 0 ? (
             <div className="mt-6">
               <div className="flex items-baseline justify-between mb-2">
-                <span className="text-[13px] text-muted-foreground">Progress</span>
+                <span className="text-[13px] text-muted-foreground"><Trans>Progress</Trans></span>
                 <span className="text-base font-bold tabular-nums text-foreground">{Math.round(b.progress)}%</span>
               </div>
               <div className="h-[7px] rounded-full bg-muted overflow-hidden">
@@ -405,10 +408,10 @@ export function FocusMode() {
               </div>
             </div>
           ) : (
-            <div className="mt-6 text-[13px] font-medium text-muted-foreground">Just started</div>
+            <div className="mt-6 text-[13px] font-medium text-muted-foreground"><Trans>Just started</Trans></div>
           )
         ) : (
-          <div className="mt-6 text-[13px] text-muted-foreground">Not started yet</div>
+          <div className="mt-6 text-[13px] text-muted-foreground"><Trans>Not started yet</Trans></div>
         )}
 
         {/* Sync chip — the standout beat, current book only. */}
@@ -428,7 +431,7 @@ export function FocusMode() {
             className="inline-flex items-center gap-2 rounded-xl bg-primary text-primary-foreground px-6 py-3.5 text-[16px] font-bold hover:bg-primary/90 transition-colors"
           >
             <Play className="w-[17px] h-[17px] fill-current" />
-            {onCurrent ? 'Resume reading' : 'Start reading'}
+            {onCurrent ? t`Resume reading` : t`Start reading`}
           </button>
           {onCurrent && items.length > 1 ? (
             <button
@@ -436,7 +439,7 @@ export function FocusMode() {
               onClick={() => setSelected(1)}
               className="text-[14px] font-semibold text-muted-foreground hover:text-foreground transition-colors"
             >
-              Next: Vol {fmtVol(items[1].series_index)} →
+              {(() => { const v = fmtVol(items[1].series_index); return <Trans>Next: Vol {v} →</Trans> })()}
             </button>
           ) : !onCurrent ? (
             <button
@@ -444,7 +447,7 @@ export function FocusMode() {
               onClick={() => setSelected(0)}
               className="text-[14px] font-semibold text-muted-foreground hover:text-foreground transition-colors"
             >
-              ← Back to current
+              <Trans>← Back to current</Trans>
             </button>
           ) : null}
         </div>
@@ -457,7 +460,7 @@ export function FocusMode() {
       {data.reading.length > 1 && (
         <div className="w-full max-w-[1080px] mx-auto pt-8 mt-2 border-t border-border/60">
           <div className="text-[12px] font-bold tracking-[0.12em] uppercase text-muted-foreground mb-3">
-            Currently reading
+            <Trans>Currently reading</Trans>
           </div>
           {/* px/py padding gives the active ring room — overflow-x-auto would
               otherwise clip the ring at the container's edges. */}

--- a/frontend/src/components/home/FocusMode.tsx
+++ b/frontend/src/components/home/FocusMode.tsx
@@ -507,7 +507,7 @@ export function FocusMode() {
                 type="button"
                 onClick={() => navigate('/?tab=books&reading_status=reading')}
                 className="shrink-0 w-[64px] self-stretch"
-                title="See all in-progress books"
+                title={t`See all in-progress books`}
               >
                 <div className="w-[64px] aspect-[2/3] rounded-lg ring-1 ring-border bg-muted/60 grid place-items-center text-xs font-semibold text-muted-foreground hover:text-foreground hover:ring-primary/60 transition">
                   +{(data.reading_total ?? 0) - data.reading.length}

--- a/frontend/src/components/stats/AuthorAffinity.tsx
+++ b/frontend/src/components/stats/AuthorAffinity.tsx
@@ -1,4 +1,6 @@
 import { ProgressRow } from './ProgressRow'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 
 interface AuthorAffinityEntry {
   author: string
@@ -13,13 +15,13 @@ function formatDuration(seconds: number): string {
   const h = Math.floor(seconds / 3600)
   const m = Math.floor((seconds % 3600) / 60)
   if (h === 0) return `${m}m`
-  return `${h}h ${m}m`
+  return t`${h}h ${m}m`
 }
 
 export function AuthorAffinity({ data }: { data: AuthorAffinityEntry[] }) {
   if (!data || data.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-4">No author data.</p>
+      <p className="text-sm text-muted-foreground text-center py-4"><Trans>No author data.</Trans></p>
     )
   }
 
@@ -33,7 +35,7 @@ export function AuthorAffinity({ data }: { data: AuthorAffinityEntry[] }) {
           label={a.author}
           value={formatDuration(a.seconds)}
           pct={(a.seconds / maxSeconds) * 100}
-          sub={`${a.books_finished} finished · ${a.book_count} book${a.book_count !== 1 ? 's' : ''} read`}
+          sub={(() => { const fin = a.books_finished; return plural(a.book_count, { one: `${fin} finished · # book read`, other: `${fin} finished · # books read` }) })()}
         />
       ))}
     </div>

--- a/frontend/src/components/stats/BacklogEstimate.tsx
+++ b/frontend/src/components/stats/BacklogEstimate.tsx
@@ -2,6 +2,8 @@
 // user's pace, by book type. Scope (Want to Read / all unread / a library / a
 // shelf) is tile config, picked in the edit-mode popover.
 import { useEffect, useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 import { api } from '@/lib/api'
 import { describePace, formatEstimateDays, formatEstimateHours, type BacklogSummary } from '@/lib/backlog'
 import { ProgressRow } from './ProgressRow'
@@ -22,20 +24,21 @@ export function BacklogEstimate({ scope = DEFAULT_BACKLOG_SCOPE }: { scope?: str
     return () => { alive = false }
   }, [scope])
 
-  if (error) return <p className="text-sm text-muted-foreground text-center py-4">Could not load this scope.</p>
-  if (!data) return <p className="text-sm text-muted-foreground text-center py-4">Loading…</p>
-  if (data.books === 0) return <p className="text-sm text-muted-foreground text-center py-4">No unstarted books in this scope.</p>
+  if (error) return <p className="text-sm text-muted-foreground text-center py-4"><Trans>Could not load this scope.</Trans></p>
+  if (!data) return <p className="text-sm text-muted-foreground text-center py-4"><Trans>Loading…</Trans></p>
+  if (data.books === 0) return <p className="text-sm text-muted-foreground text-center py-4"><Trans>No unstarted books in this scope.</Trans></p>
 
   const { pace } = data
-  const usesTypeAvg = data.by_type.some(t => t.type_avg > 0)
+  const usesTypeAvg = data.by_type.some(x => x.type_avg > 0)
   const paceNote = pace.minutes_per_day
-    ? `you read ~${Math.round(pace.minutes_per_day)} min a day (last ${pace.window_days} days)`
-    : 'no recent reading, so no day estimate'
+    ? (() => { const mpd = Math.round(pace.minutes_per_day); const win = pace.window_days; return t`you read ~${mpd} min a day (last ${win} days)` })()
+    : t`no recent reading, so no day estimate`
 
   if (data.estimated === 0) {
     return (
       <p className="text-sm text-muted-foreground py-4">
-        {data.books} {data.books === 1 ? 'book' : 'books'}, none estimated yet. Finish a couple of books of each type so Tome can measure your pace.
+        {plural(data.books, { one: '# book, none estimated yet.', other: '# books, none estimated yet.' })}{' '}
+        <Trans>Finish a couple of books of each type so Tome can measure your pace.</Trans>
       </p>
     )
   }
@@ -46,25 +49,31 @@ export function BacklogEstimate({ scope = DEFAULT_BACKLOG_SCOPE }: { scope?: str
         <span className="text-3xl font-semibold tabular-nums text-foreground leading-none">{formatEstimateHours(data.seconds)}</span>
         {data.days != null && (
           <span className="text-sm text-muted-foreground">
-            about <span className="text-foreground font-medium tabular-nums">{formatEstimateDays(data.days).replace(/^~/, '')}</span> at your pace
+            {(() => { const d = formatEstimateDays(data.days).replace(/^~/, ''); return (
+              <Trans>about <span className="text-foreground font-medium tabular-nums">{d}</span> at your pace</Trans>
+            ) })()}
           </span>
         )}
       </div>
       <p className="text-xs text-muted-foreground">
-        {data.books} {data.books === 1 ? 'book' : 'books'} &middot; {paceNote}
-        {usesTypeAvg && <> &middot; books without a word count use your average for that type</>}
-        {data.unestimated > 0 && <> &middot; {data.unestimated} not estimated yet</>}
+        {plural(data.books, { one: '# book', other: '# books' })} &middot; {paceNote}
+        {usesTypeAvg && <Trans> &middot; books without a word count use your average for that type</Trans>}
+        {data.unestimated > 0 && (() => { const n = data.unestimated; return <Trans> &middot; {n} not estimated yet</Trans> })()}
       </p>
       <div className="flex flex-col gap-3">
-        {data.by_type.map(t => (
+        {data.by_type.map(row => (
           <ProgressRow
-            key={t.label}
-            label={t.label}
-            value={t.seconds > 0
-              ? `${formatEstimateHours(t.seconds)}${t.days != null ? ` · ${formatEstimateDays(t.days)}` : ''}`
-              : 'not estimated yet'}
-            pct={data.seconds > 0 ? (t.seconds / data.seconds) * 100 : 0}
-            sub={`${t.books} ${t.books === 1 ? 'book' : 'books'}${t.unestimated > 0 && t.seconds > 0 ? ` · ${t.unestimated} not estimated` : ''}`}
+            key={row.label}
+            label={row.label}
+            value={row.seconds > 0
+              ? `${formatEstimateHours(row.seconds)}${row.days != null ? ` · ${formatEstimateDays(row.days)}` : ''}`
+              : t`not estimated yet`}
+            pct={data.seconds > 0 ? (row.seconds / data.seconds) * 100 : 0}
+            sub={(() => {
+              const booksStr = plural(row.books, { one: '# book', other: '# books' })
+              const extra = row.unestimated > 0 && row.seconds > 0 ? ' · ' + plural(row.unestimated, { one: '# not estimated', other: '# not estimated' }) : ''
+              return booksStr + extra
+            })()}
           />
         ))}
       </div>

--- a/frontend/src/components/stats/CompletionByType.tsx
+++ b/frontend/src/components/stats/CompletionByType.tsx
@@ -1,4 +1,6 @@
 import { ProgressRow } from './ProgressRow'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 interface CompletionByTypeEntry {
   category: string
@@ -10,7 +12,7 @@ interface CompletionByTypeEntry {
 export function CompletionByType({ data }: { data: CompletionByTypeEntry[] }) {
   if (!data || data.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-4">No completion data by type.</p>
+      <p className="text-sm text-muted-foreground text-center py-4"><Trans>No completion data by type.</Trans></p>
     )
   }
 
@@ -22,7 +24,7 @@ export function CompletionByType({ data }: { data: CompletionByTypeEntry[] }) {
           label={c.category}
           value={`${c.pct}%`}
           pct={c.pct}
-          sub={`${c.finished} of ${c.started} finished`}
+          sub={(() => { const fin = c.finished, st = c.started; return t`${fin} of ${st} finished` })()}
         />
       ))}
     </div>

--- a/frontend/src/components/stats/CompletionRateCard.tsx
+++ b/frontend/src/components/stats/CompletionRateCard.tsx
@@ -1,4 +1,5 @@
 import { BookCheck } from 'lucide-react'
+import { Trans } from '@lingui/react/macro'
 
 interface CompletionRate {
   started: number
@@ -12,11 +13,11 @@ export function CompletionRateCard({ data }: { data: CompletionRate | undefined 
     <div className="bg-card border border-border rounded-xl p-4 flex flex-col gap-1">
       <div className="flex items-center gap-1.5 text-muted-foreground">
         <BookCheck className="w-3.5 h-3.5" />
-        <span className="text-xs">Completion Rate</span>
+        <span className="text-xs"><Trans>Completion Rate</Trans></span>
       </div>
       <p className="text-2xl font-bold text-foreground leading-tight">{data.pct}%</p>
       <p className="text-xs text-muted-foreground">
-        {data.finished} of {data.started} started · all time
+        {(() => { const fin = data.finished, st = data.started; return <Trans>{fin} of {st} started · all time</Trans> })()}
       </p>
     </div>
   )

--- a/frontend/src/components/stats/GoalWidget.tsx
+++ b/frontend/src/components/stats/GoalWidget.tsx
@@ -17,6 +17,8 @@ import {
 } from '@/lib/goals'
 import { useBookTypes } from '@/lib/bookTypes'
 import { cn } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 // ── Ring card (shared by the dashboard tile and the Home strip) ───────────────
 
@@ -79,7 +81,7 @@ export function GoalEditorModal({
       onSaved(saved)
       onClose()
     } catch {
-      setError(goal ? 'Could not update the goal.' : 'Could not create the goal — it may already exist.')
+      setError(goal ? t`Could not update the goal.` : t`Could not create the goal — it may already exist.`)
       setSaving(false)
     }
   }
@@ -90,19 +92,19 @@ export function GoalEditorModal({
       <div className="relative z-10 w-full max-w-md rounded-2xl border border-border bg-card p-5 shadow-xl shadow-accent-soft">
         <div className="mb-4 flex items-start justify-between">
           <div>
-            <h2 className="text-base font-semibold">{goal ? 'Edit goal' : 'Set a reading goal'}</h2>
+            <h2 className="text-base font-semibold">{goal ? t`Edit goal` : t`Set a reading goal`}</h2>
             <p className="text-xs text-muted-foreground">
-              {goal ? goalTitle(goal) : 'Pick a rhythm — progress counts automatically.'}
+              {goal ? goalTitle(goal) : t`Pick a rhythm — progress counts automatically.`}
             </p>
           </div>
-          <button type="button" onClick={onClose} aria-label="Close" className="rounded-md p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground">
+          <button type="button" onClick={onClose} aria-label={t`Close`} className="rounded-md p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground">
             <X className="h-4 w-4" />
           </button>
         </div>
 
         {!goal && (
           <>
-            <p className="mb-1.5 text-xs font-medium text-muted-foreground">Goal</p>
+            <p className="mb-1.5 text-xs font-medium text-muted-foreground"><Trans>Goal</Trans></p>
             <div className="mb-4 grid grid-cols-2 gap-1.5">
               {ALLOWED_GOAL_KINDS.map((k) => (
                 <button
@@ -121,16 +123,16 @@ export function GoalEditorModal({
 
             {bookTypes.length > 0 && (
               <>
-                <p className="mb-1.5 text-xs font-medium text-muted-foreground">Counts</p>
+                <p className="mb-1.5 text-xs font-medium text-muted-foreground"><Trans>Counts</Trans></p>
                 <select
                   value={bookTypeId ?? ''}
                   onChange={(e) => setBookTypeId(e.target.value === '' ? null : Number(e.target.value))}
                   className="mb-4 w-full rounded-lg border border-border bg-background px-2.5 py-1.5 text-xs text-foreground focus:border-primary focus:outline-none"
                 >
-                  <option value="">All books</option>
-                  {bookTypes.map((t) => (
-                    <option key={t.id} value={t.id}>
-                      {t.label} only
+                  <option value="">{t`All books`}</option>
+                  {bookTypes.map((bt) => (
+                    <option key={bt.id} value={bt.id}>
+                      {(() => { const label = bt.label; return t`${label} only` })()}
                     </option>
                   ))}
                 </select>
@@ -139,7 +141,7 @@ export function GoalEditorModal({
           </>
         )}
 
-        <p className="mb-1.5 text-xs font-medium text-muted-foreground">Target</p>
+        <p className="mb-1.5 text-xs font-medium text-muted-foreground"><Trans>Target</Trans></p>
         <div className="mb-2 flex gap-1.5">
           {meta.presets.map((p) => (
             <button
@@ -169,13 +171,13 @@ export function GoalEditorModal({
         </div>
 
         {!goal && taken(kind, bookTypeId) && (
-          <p className="mb-3 text-xs text-muted-foreground">You already have this goal — edit it from its tile instead.</p>
+          <p className="mb-3 text-xs text-muted-foreground"><Trans>You already have this goal — edit it from its tile instead.</Trans></p>
         )}
         {error && <p className="mb-3 text-xs text-destructive">{error}</p>}
 
         <div className="flex justify-end gap-2">
           <button type="button" onClick={onClose} className="rounded-lg px-3 py-1.5 text-xs font-medium text-muted-foreground transition hover:bg-muted hover:text-foreground">
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
           <button
             type="button"
@@ -183,7 +185,7 @@ export function GoalEditorModal({
             disabled={!valid || saving}
             className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {goal ? 'Save' : 'Set goal'}
+            {goal ? t`Save` : t`Set goal`}
           </button>
         </div>
       </div>
@@ -210,20 +212,20 @@ export function GoalWidgetBody({
   const [creating, setCreating] = useState(false)
 
   if (goals === null) {
-    return <div className="flex h-full items-center justify-center text-xs text-muted-foreground">Loading…</div>
+    return <div className="flex h-full items-center justify-center text-xs text-muted-foreground"><Trans>Loading…</Trans></div>
   }
 
   if (goals.length === 0) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-2 text-center">
         <Target className="h-6 w-6 text-muted-foreground/40" />
-        <p className="text-xs text-muted-foreground">Set a target and watch the ring fill as you read.</p>
+        <p className="text-xs text-muted-foreground"><Trans>Set a target and watch the ring fill as you read.</Trans></p>
         <button
           type="button"
           onClick={() => setCreating(true)}
           className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition hover:opacity-90"
         >
-          Set a goal
+          <Trans>Set a goal</Trans>
         </button>
         {creating && <GoalEditorModal existing={[]} onSaved={onChanged} onClose={() => setCreating(false)} />}
       </div>
@@ -238,7 +240,7 @@ export function GoalWidgetBody({
       style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(11.5rem, 1fr))' }}
     >
       {goals.map((goal) => {
-        const caption = goal.period === 'year' && goal.year ? `${goal.year} Challenge` : goalMeta(goal.kind).caption
+        const caption = goal.period === 'year' && goal.year ? (() => { const y = goal.year; return t`${y} Challenge` })() : goalMeta(goal.kind).caption
         const sub = goal.book_type_label ? `${goal.book_type_label} · ${goalSubtext(goal)}` : goalSubtext(goal)
         return (
           <div
@@ -280,7 +282,7 @@ export function GoalWidgetBody({
         className="flex min-h-[4.25rem] items-center justify-center gap-1.5 rounded-lg border border-dashed border-border text-xs text-muted-foreground transition hover:border-primary/50 hover:text-foreground"
       >
         <Plus className="h-3.5 w-3.5" />
-        New goal
+        <Trans>New goal</Trans>
       </button>
 
       {editing && (

--- a/frontend/src/components/stats/GoalWidget.tsx
+++ b/frontend/src/components/stats/GoalWidget.tsx
@@ -257,7 +257,7 @@ export function GoalWidgetBody({
               <button
                 type="button"
                 onClick={() => setEditing(goal)}
-                title="Edit goal"
+                title={t`Edit goal`}
                 className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
               >
                 <Pencil className="h-3 w-3" />
@@ -265,7 +265,7 @@ export function GoalWidgetBody({
               <button
                 type="button"
                 onClick={() => deleteGoal(goal.id).then(onChanged).catch(() => {})}
-                title="Delete this goal"
+                title={t`Delete this goal`}
                 className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-destructive/10 hover:text-destructive"
               >
                 <Trash2 className="h-3 w-3" />

--- a/frontend/src/components/stats/HourDowHeatmap.tsx
+++ b/frontend/src/components/stats/HourDowHeatmap.tsx
@@ -1,4 +1,7 @@
 import { useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t, msg, plural } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
 import { createPortal } from 'react-dom'
 import { useChartColors } from '@/lib/useChartAccent'
 import { HScrollRow } from '@/components/HScrollRow'
@@ -10,14 +13,14 @@ interface HourDowCell {
   sessions: number
 }
 
-const DOW_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+const DOW_LABELS = [msg`Sun`, msg`Mon`, msg`Tue`, msg`Wed`, msg`Thu`, msg`Fri`, msg`Sat`]
 
 function formatDuration(seconds: number): string {
   if (seconds === 0) return '0m'
   const h = Math.floor(seconds / 3600)
   const m = Math.floor((seconds % 3600) / 60)
   if (h === 0) return `${m}m`
-  return `${h}h ${m}m`
+  return t`${h}h ${m}m`
 }
 
 export function HourDowHeatmap({ data }: { data: HourDowCell[] }) {
@@ -33,7 +36,7 @@ export function HourDowHeatmap({ data }: { data: HourDowCell[] }) {
 
   if (!data || data.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-8">No session data.</p>
+      <p className="text-sm text-muted-foreground text-center py-8"><Trans>No session data.</Trans></p>
     )
   }
 
@@ -84,7 +87,7 @@ export function HourDowHeatmap({ data }: { data: HourDowCell[] }) {
             fill={tick}
             textAnchor="end"
           >
-            {label}
+            {i18n._(label)}
           </text>
         ))}
 
@@ -127,12 +130,12 @@ export function HourDowHeatmap({ data }: { data: HourDowCell[] }) {
             }}
           >
             <div className="font-medium">
-              {DOW_LABELS[tooltip.dow]} {tooltip.hour}:00
+              {i18n._(DOW_LABELS[tooltip.dow])} {tooltip.hour}:00
             </div>
             <div className="text-muted-foreground">
               {tooltip.seconds > 0
-                ? `${formatDuration(tooltip.seconds)} · ${tooltip.sessions} session${tooltip.sessions !== 1 ? 's' : ''}`
-                : 'No activity'}
+                ? (() => { const dur = formatDuration(tooltip.seconds); return plural(tooltip.sessions, { one: `${dur} · # session`, other: `${dur} · # sessions` }) })()
+                : t`No activity`}
             </div>
           </div>,
           document.body,

--- a/frontend/src/components/stats/LibraryGrowthChart.tsx
+++ b/frontend/src/components/stats/LibraryGrowthChart.tsx
@@ -1,3 +1,4 @@
+import { Trans } from '@lingui/react/macro'
 import {
   ComposedChart,
   Area,
@@ -38,7 +39,7 @@ export function LibraryGrowthChart({ data, height = 280, chartType = 'area' }: {
   const { tick, cursor } = useChartColors()
   if (!data || data.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-8">No library growth data.</p>
+      <p className="text-sm text-muted-foreground text-center py-8"><Trans>No library growth data.</Trans></p>
     )
   }
 
@@ -48,7 +49,7 @@ export function LibraryGrowthChart({ data, height = 280, chartType = 'area' }: {
 
   if (categories.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-8">No library growth data.</p>
+      <p className="text-sm text-muted-foreground text-center py-8"><Trans>No library growth data.</Trans></p>
     )
   }
 
@@ -81,7 +82,7 @@ export function LibraryGrowthChart({ data, height = 280, chartType = 'area' }: {
             return (
               <ChartTooltip>
                 <div className="font-medium mb-1">{formatMonth(month)}</div>
-                <div className="text-muted-foreground mb-1">Total: {total}</div>
+                <div className="text-muted-foreground mb-1"><Trans>Total: {total}</Trans></div>
                 {payload
                   .filter(p => (p.value as number) > 0)
                   .map(p => (

--- a/frontend/src/components/stats/PaceByFormat.tsx
+++ b/frontend/src/components/stats/PaceByFormat.tsx
@@ -1,5 +1,7 @@
 import { ProgressRow } from './ProgressRow'
 import { useChartAccent } from '@/lib/useChartAccent'
+import { Trans } from '@lingui/react/macro'
+import { plural } from '@lingui/core/macro'
 
 interface FormatPace {
   format: string
@@ -13,7 +15,7 @@ export function PaceByFormat({ data }: { data: FormatPace[] }) {
   const accent = useChartAccent()
   if (!data || data.length === 0) {
     return (
-      <p className="text-sm text-muted-foreground text-center py-4">No pace data by format.</p>
+      <p className="text-sm text-muted-foreground text-center py-4"><Trans>No pace data by format.</Trans></p>
     )
   }
 
@@ -27,7 +29,7 @@ export function PaceByFormat({ data }: { data: FormatPace[] }) {
           label={f.format.toUpperCase()}
           value={`${f.pages_per_min} p/min`}
           pct={(f.pages_per_min / maxPpm) * 100}
-          sub={`${f.sessions} session${f.sessions !== 1 ? 's' : ''} · ${f.pages} pages`}
+          sub={(() => { const pages = f.pages; return plural(f.sessions, { one: `# session · ${pages} pages`, other: `# sessions · ${pages} pages` }) })()}
           color={accent}
         />
       ))}

--- a/frontend/src/components/stats/ReadingDNACard.tsx
+++ b/frontend/src/components/stats/ReadingDNACard.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Sparkles, Moon, Sunrise, Zap, BookMarked, Compass, ChevronDown, ChevronUp, type LucideIcon } from 'lucide-react'
 import type { ReadingDNA, ReadingDNATrait } from './shared'
+import { Trans } from '@lingui/react/macro'
 
 const COLLAPSE_KEY = 'tome_dna_collapsed'
 
@@ -73,7 +74,7 @@ export function ReadingDNABody({ dna, showLink = false }: { dna: ReadingDNA; sho
           to="/stats"
           className="mt-3 block text-[11px] text-muted-foreground hover:text-foreground transition-colors text-center"
         >
-          Full breakdown →
+          <Trans>Full breakdown →</Trans>
         </Link>
       )}
     </div>
@@ -103,7 +104,7 @@ export function ReadingDNACard({ dna }: { dna: ReadingDNA }) {
       >
         <span className="flex items-center gap-2 text-sm font-semibold min-w-0">
           <Sparkles className="w-[15px] h-[15px] text-primary/75 shrink-0" />
-          <span className="shrink-0">Reading DNA</span>
+          <span className="shrink-0"><Trans>Reading DNA</Trans></span>
           {collapsed && dna.archetype && (
             <span className="text-[13px] text-muted-foreground truncate">
               · <span className="text-foreground font-semibold">{dna.archetype}</span>

--- a/frontend/src/components/stats/SeriesCompletionGrid.tsx
+++ b/frontend/src/components/stats/SeriesCompletionGrid.tsx
@@ -1,5 +1,7 @@
 import { FileText } from 'lucide-react'
 import { useChartColors } from '@/lib/useChartAccent'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 interface SeriesCompletion {
   series: string
@@ -15,7 +17,7 @@ export function SeriesCompletionGrid({ data }: { data: SeriesCompletion[] }) {
   if (!data || data.length === 0) {
     return (
       <div className="bg-card border border-border rounded-xl p-8 text-center text-muted-foreground text-sm">
-        No series with reading history yet.
+        <Trans>No series with reading history yet.</Trans>
       </div>
     )
   }
@@ -51,7 +53,7 @@ export function SeriesCompletionGrid({ data }: { data: SeriesCompletion[] }) {
             </p>
             <p className="text-xs text-muted-foreground mt-0.5">
               {s.read} of {s.total} read
-              {s.reading > 0 && ` · ${s.reading} in progress`}
+              {s.reading > 0 && (() => { const n = s.reading; return t` · ${n} in progress` })()}
             </p>
             <div className="mt-2 flex items-center gap-2">
               <div className="flex-1 h-1.5 bg-muted rounded-full overflow-hidden">

--- a/frontend/src/components/stats/TimelineRibbon.tsx
+++ b/frontend/src/components/stats/TimelineRibbon.tsx
@@ -11,6 +11,8 @@ import { api } from '@/lib/api'
 import { formatDate, formatDuration } from '@/lib/utils'
 import { useChartColors } from '@/lib/useChartAccent'
 import { useAuth } from '@/contexts/AuthContext'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 
 interface TimelineBook {
   book_id: number
@@ -32,6 +34,7 @@ interface TimelineResponse {
 }
 
 const DAY_MS = 86400000
+// eslint-disable-next-line lingui/no-unlocalized-strings -- ISO suffix
 const dayNum = (d: string) => Math.floor(Date.parse(`${d}T00:00:00Z`) / DAY_MS)
 const dayStr = (n: number) => new Date(n * DAY_MS).toISOString().slice(0, 10)
 
@@ -143,6 +146,7 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
   const navigate = useNavigate()
   // Touch: first tap on a bar shows the tooltip, second tap navigates —
   // tap-navigating instantly made "inspect" impossible on phones.
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- media query
   const coarse = useMemo(() => window.matchMedia('(pointer: coarse)').matches, [])
   const lastTapRef = useRef<number | null>(null)
 
@@ -214,9 +218,9 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
     if (el && model) el.scrollLeft = el.scrollWidth
   }, [model === null]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (failed) return <Empty text="Couldn't load the timeline." />
-  if (!data) return <Empty text="Loading your reading life…" pulse />
-  if (!model || !lanes) return <Empty text="No reading history yet — sessions and imported KOReader history land here." />
+  if (failed) return <Empty text={t`Couldn't load the timeline.`} />
+  if (!data) return <Empty text={t`Loading your reading life…`} pulse />
+  if (!model || !lanes) return <Empty text={t`No reading history yet — sessions and imported KOReader history land here.`} />
 
   const ppd = model.ppd
   const atFitFloor = ppd > ZOOMS[zoom] + 0.001 // preset already below fit — zooming out changes nothing
@@ -242,14 +246,14 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
       <div className="flex items-center justify-end gap-1">
         {standalone && (
           <div className="mr-auto flex items-baseline gap-2">
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Reading Timeline</h3>
-            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">lifetime</span>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground"><Trans>Reading Timeline</Trans></h3>
+            <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"><Trans>lifetime</Trans></span>
           </div>
         )}
         <button
           onClick={() => setZoom((z) => Math.max(0, z - 1))}
           disabled={zoom === 0 || atFitFloor}
-          aria-label="Zoom out"
+          aria-label={t`Zoom out`}
           className="rounded-md border border-border p-1 text-muted-foreground hover:text-foreground disabled:opacity-40"
         >
           <Minus className="h-3.5 w-3.5" />
@@ -257,7 +261,7 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
         <button
           onClick={() => setZoom((z) => Math.min(ZOOMS.length - 1, z + 1))}
           disabled={zoom === ZOOMS.length - 1}
-          aria-label="Zoom in"
+          aria-label={t`Zoom in`}
           className="rounded-md border border-border p-1 text-muted-foreground hover:text-foreground disabled:opacity-40"
         >
           <Plus className="h-3.5 w-3.5" />
@@ -304,7 +308,7 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
                 >
                   <span className="truncate text-[11px] font-medium leading-tight">{lane.label}</span>
                   <span className="truncate text-[10px] leading-tight text-muted-foreground">
-                    {lane.placed.length > 1 ? `${lane.placed.length} vols · ` : ''}
+                    {lane.placed.length > 1 ? (() => { const n = lane.placed.length; return t`${n} vols · ` })() : ''}
                     {formatDuration(lane.totalSeconds)}
                   </span>
                 </div>
@@ -338,7 +342,7 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
                         onMouseLeave={() => {
                           if (!coarse) setHover(null)
                         }}
-                        aria-label={`${b.title} — ${formatDuration(b.total_seconds)} between ${b.first_day} and ${b.last_day}`}
+                        aria-label={(() => { const title = b.title; const dur = formatDuration(b.total_seconds); const from = b.first_day; const to = b.last_day; return t`${title} — ${dur} between ${from} and ${to}` })()}
                         className="group absolute block cursor-pointer overflow-hidden rounded-[4px] border transition-transform hover:-translate-y-px"
                         style={{
                           left: x,
@@ -392,17 +396,16 @@ export function TimelineRibbon({ standalone = false }: { standalone?: boolean } 
               <div className="truncate font-semibold">{hover.b.title}</div>
               {hover.b.author && <div className="truncate text-muted-foreground">{hover.b.author}</div>}
               <div className="mt-1 text-muted-foreground">
-                {formatDate(hover.b.first_day)} – {formatDate(hover.b.last_day)} · {hover.b.days.length}{' '}
-                {hover.b.days.length === 1 ? 'day' : 'days'}
+                {formatDate(hover.b.first_day)} – {formatDate(hover.b.last_day)} · {plural(hover.b.days.length, { one: '# day', other: '# days' })}
               </div>
               <div className="text-muted-foreground">
                 {formatDuration(hover.b.total_seconds)}
-                {hover.b.finished_on ? ` · finished ${formatDate(hover.b.finished_on)}` : ''}
+                {hover.b.finished_on ? (() => { const d = formatDate(hover.b.finished_on); return t` · finished ${d}` })() : ''}
               </div>
               {hover.day && (
                 <div className="mt-1 border-t border-border/60 pt-1" style={{ color: colors.accent }}>
                   {formatDate(hover.day.date)} ·{' '}
-                  {hover.day.seconds > 0 ? formatDuration(hover.day.seconds) : 'no reading'}
+                  {hover.day.seconds > 0 ? formatDuration(hover.day.seconds) : t`no reading`}
                 </div>
               )}
             </div>

--- a/frontend/src/components/stats/widgets/habits.tsx
+++ b/frontend/src/components/stats/widgets/habits.tsx
@@ -76,7 +76,13 @@ export function SessionTimeline({ sessions }: { sessions: StatsResponse['session
                     key={s.id}
                     className="absolute top-0.5 bottom-0.5 rounded-sm transition-colors"
                     style={{ left: `${left}%`, width: `${width}%`, backgroundColor: accent, opacity: 0.7 }}
-                    title={`${s.title} — ${start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} to ${end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} (${formatDuration(s.duration_seconds)})`}
+                    title={(() => {
+                      const st = start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+                      const en = end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+                      const dur = formatDuration(s.duration_seconds)
+                      const bt = s.title
+                      return t`${bt} — ${st} to ${en} (${dur})`
+                    })()}
                   />
                 )
               })}

--- a/frontend/src/components/stats/widgets/habits.tsx
+++ b/frontend/src/components/stats/widgets/habits.tsx
@@ -16,6 +16,9 @@ import {
   Legend,
 } from 'recharts'
 import { type ChartKind } from '@/components/stats/widgets/overview'
+import { Trans } from '@lingui/react/macro'
+import { t, msg, plural } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
 import { TrendingUp, TrendingDown, Zap, Minus, FileText, Loader2 } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { useChartColors } from '@/lib/useChartAccent'
@@ -30,11 +33,11 @@ export function HourDowCard({ data }: { data: StatsResponse['hour_dow_heatmap'] 
     <>
       <HourDowHeatmap data={data} />
       <div className="flex items-center gap-2 justify-end mt-1">
-        <span className="text-[10px] text-muted-foreground">Less</span>
+        <span className="text-[10px] text-muted-foreground"><Trans>Less</Trans></span>
         {[0.15, 0.37, 0.58, 0.79, 1.0].map((o) => (
           <div key={o} className="w-3 h-3 rounded-sm border border-border/30" style={{ backgroundColor: accent, opacity: o }} />
         ))}
-        <span className="text-[10px] text-muted-foreground">More</span>
+        <span className="text-[10px] text-muted-foreground"><Trans>More</Trans></span>
       </div>
     </>
   )
@@ -88,7 +91,7 @@ export function SessionTimeline({ sessions }: { sessions: StatsResponse['session
         ))}
       </div>
       <p className="shrink-0 pt-1 text-center text-[10px] text-muted-foreground">
-        {dayEntries.length} active {dayEntries.length === 1 ? 'day' : 'days'} in this window
+        {plural(dayEntries.length, { one: '# active day in this window', other: '# active days in this window' })}
       </p>
     </div>
   )
@@ -96,7 +99,7 @@ export function SessionTimeline({ sessions }: { sessions: StatsResponse['session
 
 export function ReadingPaceChart({ pace }: { pace: StatsResponse['reading_pace'] }) {
   const { accent, tick, cursor } = useChartColors()
-  if (pace.length === 0) return <p className="text-sm text-muted-foreground text-center py-12">No paced sessions.</p>
+  if (pace.length === 0) return <p className="text-sm text-muted-foreground text-center py-12"><Trans>No paced sessions.</Trans></p>
   const avg = pace.reduce((s, p) => s + p.pages_per_min, 0) / pace.length
   return (
     <div className="flex h-full flex-col">
@@ -114,8 +117,8 @@ export function ReadingPaceChart({ pace }: { pace: StatsResponse['reading_pace']
               return (
                 <ChartTooltip>
                   <div className="font-medium">{d.title}</div>
-                  <div>{d.pages_per_min} pages/min</div>
-                  <div className="text-muted-foreground">{d.pages_turned} pages in {formatDuration(d.duration_seconds)}</div>
+                  {(() => { const ppm = d.pages_per_min; return <div><Trans>{ppm} pages/min</Trans></div> })()}
+                  {(() => { const pages = d.pages_turned; const dur = formatDuration(d.duration_seconds); return <div className="text-muted-foreground"><Trans>{pages} pages in {dur}</Trans></div> })()}
                 </ChartTooltip>
               )
             }}
@@ -123,14 +126,14 @@ export function ReadingPaceChart({ pace }: { pace: StatsResponse['reading_pace']
           <Area dataKey="pages_per_min" fill={accent} fillOpacity={0.15} stroke={accent} strokeWidth={2} />
         </AreaChart>
       </ResponsiveContainer>
-      <p className="text-xs text-muted-foreground text-center shrink-0">avg {avg.toFixed(1)} pages/min</p>
+      {(() => { const a = avg.toFixed(1); return <p className="text-xs text-muted-foreground text-center shrink-0"><Trans>avg {a} pages/min</Trans></p> })()}
     </div>
   )
 }
 
 export function ReadingSpeedTrend({ pace }: { pace: StatsResponse['reading_pace'] }) {
   const { accent, tick, cursor } = useChartColors()
-  if (pace.length < 4) return <p className="text-sm text-muted-foreground text-center py-12">Not enough sessions yet.</p>
+  if (pace.length < 4) return <p className="text-sm text-muted-foreground text-center py-12"><Trans>Not enough sessions yet.</Trans></p>
   const paceData = [...pace].reverse()
   const half = Math.floor(paceData.length / 2)
   const avg = (arr: typeof paceData) => arr.reduce((s, p) => s + p.pages_per_min, 0) / arr.length
@@ -143,9 +146,9 @@ export function ReadingSpeedTrend({ pace }: { pace: StatsResponse['reading_pace'
       <div className="flex items-center gap-2 shrink-0">
         {trending === 'up' ? <TrendingUp className="w-4 h-4 text-success" /> : trending === 'down' ? <TrendingDown className="w-4 h-4 text-destructive" /> : <Zap className="w-4 h-4 text-muted-foreground" />}
         <span className={cn('text-sm font-semibold', trending === 'up' ? 'text-success' : trending === 'down' ? 'text-destructive' : 'text-muted-foreground')}>
-          {trending === 'up' ? `Reading speed up ${pctDiff}%` : trending === 'down' ? `Reading speed down ${Math.abs(pctDiff)}%` : 'Reading speed steady'}
+          {(() => { const up = pctDiff; const down = Math.abs(pctDiff); return trending === 'up' ? t`Reading speed up ${up}%` : trending === 'down' ? t`Reading speed down ${down}%` : t`Reading speed steady` })()}
         </span>
-        <span className="text-xs text-muted-foreground ml-1">({secondAvg.toFixed(1)} vs {firstAvg.toFixed(1)} pages/min)</span>
+        {(() => { const a = secondAvg.toFixed(1); const b = firstAvg.toFixed(1); return <span className="text-xs text-muted-foreground ml-1"><Trans>({a} vs {b} pages/min)</Trans></span> })()}
       </div>
       <ResponsiveContainer initialDimension={{ width: 1, height: 1 }} width="100%" height="100%">
         <AreaChart data={paceData} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
@@ -161,7 +164,7 @@ export function ReadingSpeedTrend({ pace }: { pace: StatsResponse['reading_pace'
               return (
                 <ChartTooltip>
                   <div className="font-medium">{d.title}</div>
-                  <div>{d.pages_per_min} pages/min</div>
+                  {(() => { const ppm = d.pages_per_min; return <div><Trans>{ppm} pages/min</Trans></div> })()}
                 </ChartTooltip>
               )
             }}
@@ -183,7 +186,7 @@ export function CompletionEstimatesList({ estimates }: { estimates: CompletionEs
     )
   }
   if (estimates.length === 0) {
-    return <p className="text-sm text-muted-foreground text-center py-8">No books currently in progress.</p>
+    return <p className="text-sm text-muted-foreground text-center py-8"><Trans>No books currently in progress.</Trans></p>
   }
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
@@ -202,8 +205,8 @@ export function CompletionEstimatesList({ estimates }: { estimates: CompletionEs
               <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">{est.progress}%</span>
             </div>
             <p className={cn('text-xs mt-1.5', est.confidence === 'high' ? 'text-foreground' : est.confidence === 'medium' ? 'text-muted-foreground' : 'text-muted-foreground/60')}>
-              {est.estimated_days != null ? `~${est.estimated_days} day${est.estimated_days !== 1 ? 's' : ''} remaining` : 'Just started'}
-              {est.confidence === 'low' && est.estimated_days != null && <span className="ml-1 text-muted-foreground/50">(low confidence)</span>}
+              {est.estimated_days != null ? plural(est.estimated_days, { one: '~# day remaining', other: '~# days remaining' }) : t`Just started`}
+              {est.confidence === 'low' && est.estimated_days != null && <span className="ml-1 text-muted-foreground/50"><Trans>(low confidence)</Trans></span>}
             </p>
           </div>
         </a>
@@ -222,21 +225,19 @@ export function PeriodComparison({ comparison }: { comparison: NonNullable<Stats
       </div>
       <div className="flex-1 min-w-0">
         <p className={cn('text-lg font-bold', up ? 'text-success' : down ? 'text-destructive' : 'text-muted-foreground')}>
-          {comparison.pct_change === null
-            ? 'No previous data to compare'
-            : comparison.pct_change === 0 && comparison.current_seconds === 0
-            ? 'No reading data'
-            : comparison.pct_change === 0
-            ? 'Same as previous period'
-            : up
-            ? `${comparison.pct_change}% more reading this period`
-            : `${Math.abs(comparison.pct_change!)}% less reading this period`}
+          {(() => {
+            if (comparison.pct_change === null) return t`No previous data to compare`
+            if (comparison.pct_change === 0 && comparison.current_seconds === 0) return t`No reading data`
+            if (comparison.pct_change === 0) return t`Same as previous period`
+            const pct = up ? comparison.pct_change : Math.abs(comparison.pct_change!)
+            return up ? t`${pct}% more reading this period` : t`${pct}% less reading this period`
+          })()}
         </p>
         <p className="text-xs text-muted-foreground mt-1">
-          This period: <span className="text-foreground font-medium">{formatDuration(comparison.current_seconds)}</span>
-          {comparison.pct_change !== null && (
-            <> vs previous: <span className="text-foreground font-medium">{formatDuration(comparison.previous_seconds)}</span></>
-          )}
+          {(() => { const cur = formatDuration(comparison.current_seconds); return <Trans>This period: <span className="text-foreground font-medium">{cur}</span></Trans> })()}
+          {comparison.pct_change !== null && (() => { const prev = formatDuration(comparison.previous_seconds); return (
+            <Trans> vs previous: <span className="text-foreground font-medium">{prev}</span></Trans>
+          ) })()}
         </p>
       </div>
     </div>
@@ -261,9 +262,9 @@ export function MonthlyComparison({ monthly, chartType = 'bar' }: { monthly: Sta
             return (
               <ChartTooltip>
                 <div className="font-medium">{d.month}</div>
-                <div>{d.reading_hours}h reading</div>
-                <div>{d.books_finished} book{d.books_finished !== 1 ? 's' : ''} finished</div>
-                <div className="text-muted-foreground">{d.sessions} session{d.sessions !== 1 ? 's' : ''}</div>
+                {(() => { const h = d.reading_hours; return <div><Trans>{h}h reading</Trans></div> })()}
+                <div>{plural(d.books_finished, { one: '# book finished', other: '# books finished' })}</div>
+                <div className="text-muted-foreground">{plural(d.sessions, { one: '# session', other: '# sessions' })}</div>
               </ChartTooltip>
             )
           }}
@@ -311,13 +312,13 @@ export function DayOfWeekBar({ data }: { data: StatsResponse['hour_dow_heatmap']
     sessions[c.dow] += c.sessions
   }
   // dow 0 = Sunday — rotate to Mon-first
-  const LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+  const LABELS = [msg`Mon`, msg`Tue`, msg`Wed`, msg`Thu`, msg`Fri`, msg`Sat`, msg`Sun`]
   const rows = LABELS.map((label, i) => {
     const dow = (i + 1) % 7
-    return { label, seconds: byDow[dow], sessions: sessions[dow] }
+    return { label: i18n._(label), seconds: byDow[dow], sessions: sessions[dow] }
   })
   if (rows.every((r) => r.seconds === 0)) {
-    return <p className="text-sm text-muted-foreground text-center py-12">No session data.</p>
+    return <p className="text-sm text-muted-foreground text-center py-12"><Trans>No session data.</Trans></p>
   }
   return (
     <ResponsiveContainer initialDimension={{ width: 1, height: 1 }} width="100%" height="100%">
@@ -335,7 +336,7 @@ export function DayOfWeekBar({ data }: { data: StatsResponse['hour_dow_heatmap']
               <ChartTooltip>
                 <div className="font-medium">{d.label}</div>
                 <div>{formatDuration(d.seconds)}</div>
-                <div className="text-muted-foreground">{d.sessions} session{d.sessions !== 1 ? 's' : ''}</div>
+                <div className="text-muted-foreground">{plural(d.sessions, { one: '# session', other: '# sessions' })}</div>
               </ChartTooltip>
             )
           }}
@@ -350,7 +351,7 @@ export function DayOfWeekBar({ data }: { data: StatsResponse['hour_dow_heatmap']
 function SplitDonut({ rows }: { rows: { name: string; seconds: number }[] }) {
   const palette = useChartPalette()
   const data = rows.filter((r) => r.seconds > 0)
-  if (data.length === 0) return <p className="text-sm text-muted-foreground text-center py-12">No session data.</p>
+  if (data.length === 0) return <p className="text-sm text-muted-foreground text-center py-12"><Trans>No session data.</Trans></p>
   const total = data.reduce((s, r) => s + r.seconds, 0)
   return (
     <ResponsiveContainer initialDimension={{ width: 1, height: 1 }} width="100%" height="100%">

--- a/frontend/src/components/stats/widgets/insights.tsx
+++ b/frontend/src/components/stats/widgets/insights.tsx
@@ -1,5 +1,7 @@
 // Batch-2 "insights" stats widgets — lifetime, records, TBR, reading clock, language.
 import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 import { Clock, FileText, BookCheck, Activity, Calendar, Flame, Timer, Sun, type LucideIcon } from 'lucide-react'
 import { formatDuration } from '@/lib/utils'
 import { useChartColors } from '@/lib/useChartAccent'
@@ -9,18 +11,18 @@ import { ChartTooltip, type StatsResponse } from '@/components/stats/shared'
 const fmtDay = (d: string | null) =>
   d ? new Date(d + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' }) : '--'
 
-const Empty = () => <p className="py-10 text-center text-sm text-muted-foreground">No data yet.</p>
+const Empty = () => <p className="py-10 text-center text-sm text-muted-foreground"><Trans>No data yet.</Trans></p>
 
 // ── Lifetime totals (all-time, range-independent) ───────────────────────────────
 export function LifetimeTotals({ data }: { data: StatsResponse['lifetime'] }) {
   if (!data) return <Empty />
   const items: { icon: LucideIcon; label: string; value: string }[] = [
-    { icon: Clock, label: 'Total Time', value: formatDuration(data.seconds) },
-    { icon: FileText, label: 'Pages', value: data.pages.toLocaleString() },
-    { icon: BookCheck, label: 'Books Finished', value: String(data.books_finished) },
-    { icon: Activity, label: 'Sessions', value: String(data.sessions) },
-    { icon: Calendar, label: 'Active Days', value: String(data.active_days) },
-    { icon: Flame, label: 'Longest Streak', value: `${data.longest_streak_days}d` },
+    { icon: Clock, label: t`Total Time`, value: formatDuration(data.seconds) },
+    { icon: FileText, label: t`Pages`, value: data.pages.toLocaleString() },
+    { icon: BookCheck, label: t`Books Finished`, value: String(data.books_finished) },
+    { icon: Activity, label: t`Sessions`, value: String(data.sessions) },
+    { icon: Calendar, label: t`Active Days`, value: String(data.active_days) },
+    { icon: Flame, label: t`Longest Streak`, value: `${data.longest_streak_days}d` },
   ]
   return (
     <div className="grid h-full grid-cols-2 gap-2 sm:grid-cols-3">
@@ -41,9 +43,9 @@ export function LifetimeTotals({ data }: { data: StatsResponse['lifetime'] }) {
 export function PersonalRecords({ data }: { data: StatsResponse['records'] }) {
   if (!data) return <Empty />
   const rows: { icon: LucideIcon; label: string; value: string; sub: string | null }[] = [
-    { icon: Timer, label: 'Longest session', value: formatDuration(data.longest_session_seconds), sub: data.longest_session_title },
-    { icon: Sun, label: 'Biggest reading day', value: formatDuration(data.biggest_day_seconds), sub: fmtDay(data.biggest_day_date) },
-    { icon: FileText, label: 'Most pages in a day', value: data.most_pages_day.toLocaleString(), sub: fmtDay(data.most_pages_date) },
+    { icon: Timer, label: t`Longest session`, value: formatDuration(data.longest_session_seconds), sub: data.longest_session_title },
+    { icon: Sun, label: t`Biggest reading day`, value: formatDuration(data.biggest_day_seconds), sub: fmtDay(data.biggest_day_date) },
+    { icon: FileText, label: t`Most pages in a day`, value: data.most_pages_day.toLocaleString(), sub: fmtDay(data.most_pages_date) },
   ]
   return (
     <div className="flex flex-col gap-2.5">
@@ -69,7 +71,7 @@ export function LibraryCompletion({ data }: { data: StatsResponse['tbr'] }) {
     <div className="flex flex-col gap-3">
       <div className="flex items-baseline gap-2">
         <span className="text-2xl font-bold text-foreground">{data.pct}%</span>
-        <span className="text-xs text-muted-foreground">{data.read} of {data.owned} owned read{data.reading ? ` · ${data.reading} reading` : ''}{data.want_to_read ? ` · ${data.want_to_read} want to read` : ''}</span>
+        <span className="text-xs text-muted-foreground">{(() => { const read = data.read; const owned = data.owned; return <Trans>{read} of {owned} owned read</Trans> })()}{data.reading ? (() => { const n = data.reading; return t` · ${n} reading` })() : ''}{data.want_to_read ? (() => { const n = data.want_to_read; return t` · ${n} want to read` })() : ''}</span>
       </div>
       <div className="flex flex-col gap-2">
         {data.by_type.map((t) => (
@@ -95,7 +97,7 @@ export function ReadingClock({ data }: { data: StatsResponse['hour_dow_heatmap']
   const byHour = Array(24).fill(0) as number[]
   for (const c of data) byHour[c.hour] += c.seconds
   const max = Math.max(...byHour, 1)
-  if (max <= 1) return <p className="py-10 text-center text-sm text-muted-foreground">No session-time data yet.</p>
+  if (max <= 1) return <p className="py-10 text-center text-sm text-muted-foreground"><Trans>No session-time data yet.</Trans></p>
 
   const SIZE = 200, cx = SIZE / 2, cy = SIZE / 2, r0 = 24, rmax = 74
   const total = byHour.reduce((s, v) => s + v, 0)
@@ -120,7 +122,7 @@ export function ReadingClock({ data }: { data: StatsResponse['hour_dow_heatmap']
           return <text key={h} x={cx + lr * Math.cos(a)} y={cy + lr * Math.sin(a) + 3} fontSize={9} fill={tick} textAnchor="middle">{h}h</text>
         })}
       </svg>
-      <p className="text-[11px] text-muted-foreground">Peak hour: <span className="font-medium text-foreground">{peak}:00–{(peak + 1) % 24}:00</span> · {formatDuration(total)} total</p>
+      {(() => { const peakEnd = (peak + 1) % 24; const dur = formatDuration(total); return <p className="text-[11px] text-muted-foreground"><Trans>Peak hour: <span className="font-medium text-foreground">{peak}:00–{peakEnd}:00</span> · {dur} total</Trans></p> })()}
     </div>
   )
 }
@@ -129,12 +131,12 @@ export function ReadingClock({ data }: { data: StatsResponse['hour_dow_heatmap']
 export function ReadingByLanguage({ data }: { data: StatsResponse['language'] }) {
   const palette = useChartPalette()
   const pts = (data ?? []).filter((l) => l.seconds > 0)
-  if (pts.length === 0) return <p className="py-12 text-center text-sm text-muted-foreground">No reading-time data yet.</p>
+  if (pts.length === 0) return <p className="py-12 text-center text-sm text-muted-foreground"><Trans>No reading-time data yet.</Trans></p>
   if (pts.length === 1) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-1">
         <p className="text-xl font-bold text-foreground">{pts[0].language}</p>
-        <p className="text-xs text-muted-foreground">{formatDuration(pts[0].seconds)} · {pts[0].books} books — your only language</p>
+        {(() => { const dur = formatDuration(pts[0].seconds); const books = pts[0].books; return <p className="text-xs text-muted-foreground"><Trans>{dur} · {books} books — your only language</Trans></p> })()}
       </div>
     )
   }

--- a/frontend/src/components/stats/widgets/library.tsx
+++ b/frontend/src/components/stats/widgets/library.tsx
@@ -1,5 +1,7 @@
 // Library-tab stats widgets — chart/content-only, shared by StatsPage and the Lab.
 import { Fragment, useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -24,18 +26,18 @@ export function YearInReview({ summary }: { summary: StatsResponse['year_summary
   if (!summary) {
     return (
       <div className="flex h-full items-center justify-center px-4 text-center text-xs text-muted-foreground">
-        Select <span className="mx-1 font-medium text-foreground">1y</span> or <span className="mx-1 font-medium text-foreground">All</span> to see your year in review.
+        <Trans>Select <span className="mx-1 font-medium text-foreground">1y</span> or <span className="mx-1 font-medium text-foreground">All</span> to see your year in review.</Trans>
       </div>
     )
   }
   // Compact (no nested StatCard frame) so all six fit a 2-row tile without clipping.
   const items: { icon: LucideIcon; label: string; value: string }[] = [
-    { icon: BookCheck, label: 'Books Finished', value: String(summary.books_finished) },
-    { icon: Clock, label: 'Total Hours', value: `${summary.total_hours}h` },
-    { icon: Trophy, label: 'Top Genre', value: summary.top_genre ?? '--' },
-    { icon: Flame, label: 'Longest Streak', value: `${summary.longest_streak_days}d` },
-    { icon: Activity, label: 'Total Sessions', value: String(summary.total_sessions) },
-    { icon: Calendar, label: 'Most Active Month', value: summary.most_active_month ?? '--' },
+    { icon: BookCheck, label: t`Books Finished`, value: String(summary.books_finished) },
+    { icon: Clock, label: t`Total Hours`, value: `${summary.total_hours}h` },
+    { icon: Trophy, label: t`Top Genre`, value: summary.top_genre ?? '--' },
+    { icon: Flame, label: t`Longest Streak`, value: `${summary.longest_streak_days}d` },
+    { icon: Activity, label: t`Total Sessions`, value: String(summary.total_sessions) },
+    { icon: Calendar, label: t`Most Active Month`, value: summary.most_active_month ?? '--' },
   ]
   return (
     <div className="grid h-full grid-cols-2 gap-2 sm:grid-cols-3">
@@ -54,7 +56,7 @@ export function YearInReview({ summary }: { summary: StatsResponse['year_summary
 
 export function CategoryBreakdown({ data }: { data: StatsResponse['by_category'] }) {
   const palette = useChartPalette()
-  if (data.length === 0) return <p className="text-sm text-muted-foreground text-center py-12">No category data.</p>
+  if (data.length === 0) return <p className="text-sm text-muted-foreground text-center py-12"><Trans>No category data.</Trans></p>
   const total = data.reduce((s, c) => s + c.seconds, 0)
   return (
     <ResponsiveContainer initialDimension={{ width: 1, height: 1 }} width="100%" height="100%">
@@ -90,7 +92,7 @@ export function GenreOverTime({ data, chartType = 'area' }: { data: StatsRespons
   const palette = useChartPalette()
   const { tick, cursor } = useChartColors()
   const categories = Array.from(new Set(data.flatMap((d) => Object.keys(d).filter((k) => k !== 'month')))).sort()
-  if (categories.length === 0) return <p className="text-sm text-muted-foreground text-center py-12">No category data.</p>
+  if (categories.length === 0) return <p className="text-sm text-muted-foreground text-center py-12"><Trans>No category data.</Trans></p>
 
   const chartData = data.map((d) => {
     const entry: Record<string, number | string> = { month: d.month as string }
@@ -125,7 +127,7 @@ export function GenreOverTime({ data, chartType = 'area' }: { data: StatsRespons
                   .map((p) => (
                     <div key={p.dataKey as string} className="flex items-center gap-1.5">
                       <div className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: p.color }} />
-                      <span>{p.dataKey as string}: {(p.value as number) >= 60 ? `${Math.round((p.value as number) / 60)}h ${(p.value as number) % 60}m` : `${p.value}m`}</span>
+                      <span>{p.dataKey as string}: {(() => { const v = p.value as number; if (v >= 60) { const h = Math.round(v / 60); const m = v % 60; return t`${h}h ${m}m` } return t`${v}m` })()}</span>
                     </div>
                   ))}
               </ChartTooltip>
@@ -149,7 +151,7 @@ export function GenreOverTime({ data, chartType = 'area' }: { data: StatsRespons
 export function SeriesSpotlight({ data, series }: { data: StatsResponse['series_completion']; series?: string }) {
   const { accent } = useChartColors()
   const entry = (series ? data.find((s) => s.series === series) : undefined) ?? data[0]
-  if (!entry) return <p className="text-sm text-muted-foreground text-center py-8">No series read yet.</p>
+  if (!entry) return <p className="text-sm text-muted-foreground text-center py-8"><Trans>No series read yet.</Trans></p>
   return (
     <div className="flex h-full items-center gap-3">
       <img
@@ -161,7 +163,7 @@ export function SeriesSpotlight({ data, series }: { data: StatsResponse['series_
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-semibold text-foreground">{entry.series}</p>
         <p className="mt-0.5 text-xs text-muted-foreground">
-          {entry.read} of {entry.total} read{entry.reading > 0 ? ` · ${entry.reading} reading` : ''}
+          {(() => { const read = entry.read; const total = entry.total; return <Trans>{read} of {total} read</Trans> })()}{entry.reading > 0 ? (() => { const n = entry.reading; return t` · ${n} reading` })() : ''}
         </p>
         <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted">
           <div className="h-full rounded-full" style={{ width: `${Math.min(entry.pct, 100)}%`, backgroundColor: accent }} />
@@ -208,16 +210,16 @@ export function PerBookTimeTable({ data }: { data: StatsResponse['per_book_time'
         <thead>
           <tr className="border-b border-border text-[11px] font-medium text-muted-foreground">
             <th className="text-left py-2 px-2 w-10" />
-            <th className="text-left py-2 px-2">Title</th>
-            <th className="text-left py-2 px-2 hidden sm:table-cell">Author</th>
+            <th className="text-left py-2 px-2"><Trans>Title</Trans></th>
+            <th className="text-left py-2 px-2 hidden sm:table-cell"><Trans>Author</Trans></th>
             <th className="text-right py-2 px-2 cursor-pointer select-none whitespace-nowrap" onClick={() => handleSort('seconds')}>
-              <span className="inline-flex items-center gap-1">Time <SortIcon col="seconds" /></span>
+              <span className="inline-flex items-center gap-1"><Trans>Time</Trans> <SortIcon col="seconds" /></span>
             </th>
             <th className="text-right py-2 px-2 cursor-pointer select-none whitespace-nowrap" onClick={() => handleSort('sessions')}>
-              <span className="inline-flex items-center gap-1">Sessions <SortIcon col="sessions" /></span>
+              <span className="inline-flex items-center gap-1"><Trans>Sessions</Trans> <SortIcon col="sessions" /></span>
             </th>
             <th className="text-right py-2 px-2 cursor-pointer select-none whitespace-nowrap" onClick={() => handleSort('pages_turned')}>
-              <span className="inline-flex items-center gap-1">Pages <SortIcon col="pages_turned" /></span>
+              <span className="inline-flex items-center gap-1"><Trans>Pages</Trans> <SortIcon col="pages_turned" /></span>
             </th>
             <th className="w-8 py-2 px-2" />
           </tr>
@@ -262,7 +264,7 @@ export function PerBookTimeTable({ data }: { data: StatsResponse['per_book_time'
       {hasMore && (
         <button onClick={() => setExpanded(!expanded)} className="flex items-center justify-center gap-1.5 py-2 text-xs text-primary hover:text-primary/80 transition-colors w-full">
           <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', expanded && 'rotate-180')} />
-          <span>{expanded ? 'Show less' : `Show all (${sorted.length} books)`}</span>
+          <span>{expanded ? t`Show less` : (() => { const n = sorted.length; return t`Show all (${n} books)` })()}</span>
         </button>
       )}
     </div>

--- a/frontend/src/components/stats/widgets/library.tsx
+++ b/frontend/src/components/stats/widgets/library.tsx
@@ -244,7 +244,7 @@ export function PerBookTimeTable({ data }: { data: StatsResponse['per_book_time'
                   <button
                     onClick={() => setOpenBook(openBook === b.book_id ? null : b.book_id)}
                     className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
-                    title={openBook === b.book_id ? 'Hide sessions' : 'Show sessions'}
+                    title={openBook === b.book_id ? t`Hide sessions` : t`Show sessions`}
                   >
                     <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', openBook === b.book_id && 'rotate-180')} />
                   </button>

--- a/frontend/src/components/stats/widgets/overview.tsx
+++ b/frontend/src/components/stats/widgets/overview.tsx
@@ -426,7 +426,7 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
                 <button
                   onClick={() => (trimId === s.id ? setTrimId(null) : openTrim(s))}
                   className="p-1 rounded hover:bg-accent text-muted-foreground hover:text-foreground transition-colors"
-                  title="Trim session"
+                  title={t`Trim session`}
                 >
                   <Scissors className="w-3.5 h-3.5" />
                 </button>
@@ -435,7 +435,7 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
                 onClick={() => deleteSession(s)}
                 disabled={deleting.has(s.id)}
                 className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors disabled:opacity-40"
-                title={s.kind === 'imported' ? 'Delete this imported sitting' : 'Delete session'}
+                title={s.kind === 'imported' ? t`Delete this imported sitting` : t`Delete session`}
               >
                 <Trash2 className="w-3.5 h-3.5" />
               </button>

--- a/frontend/src/components/stats/widgets/overview.tsx
+++ b/frontend/src/components/stats/widgets/overview.tsx
@@ -1,6 +1,8 @@
 // Overview-tab stats widgets — chart-only (no card frame, no fixed height), so the
 // same component renders inside a StatsPage ChartCard and inside a resizable Lab tile.
 import { useEffect, useState } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -43,8 +45,8 @@ export function CurrentlyReading({ books }: { books: StatsResponse['books_in_pro
     return (
       <div className="flex h-full min-h-[3.5rem] flex-col items-center justify-center gap-1 py-3 text-center">
         <BookOpen className="h-5 w-5 text-muted-foreground/40" />
-        <p className="text-sm text-muted-foreground">No books in progress</p>
-        <p className="text-xs text-muted-foreground/60">Start reading one and it'll show up here</p>
+        <p className="text-sm text-muted-foreground"><Trans>No books in progress</Trans></p>
+        <p className="text-xs text-muted-foreground/60"><Trans>Start reading one and it'll show up here</Trans></p>
       </div>
     )
   }
@@ -107,7 +109,7 @@ export function ReadingTimePerDay({ daily, chartType = 'bar' }: { daily: StatsRe
                 <div>{formatDuration(d.seconds)}</div>
                 <div className="text-muted-foreground">
                   {d.sessions} session{d.sessions !== 1 ? 's' : ''}
-                  {d.pages > 0 ? ` · ${d.pages.toLocaleString()} pages` : ''}
+                  {d.pages > 0 ? (() => { const pages = d.pages.toLocaleString(); return t` · ${pages} pages` })() : ''}
                 </div>
               </ChartTooltip>
             )
@@ -136,7 +138,7 @@ function TitleTick({ x, y, payload, fill }: { x?: number; y?: number; payload?: 
 export function TopBooksByTime({ topBooks }: { topBooks: StatsResponse['top_books'] }) {
   const { accent, tick, cursor } = useChartColors()
   if (topBooks.length === 0) {
-    return <p className="text-sm text-muted-foreground text-center py-12">No reading sessions recorded.</p>
+    return <p className="text-sm text-muted-foreground text-center py-12"><Trans>No reading sessions recorded.</Trans></p>
   }
   return (
     <ResponsiveContainer initialDimension={{ width: 1, height: 1 }} width="100%" height="100%">
@@ -156,7 +158,7 @@ export function TopBooksByTime({ topBooks }: { topBooks: StatsResponse['top_book
                 <div>{formatDuration(d.seconds)}</div>
                 <div className="text-muted-foreground">
                   {d.sessions} session{d.sessions !== 1 ? 's' : ''}
-                  {d.sessions > 0 ? ` · avg ${formatDuration(Math.round(d.seconds / d.sessions))}` : ''}
+                  {d.sessions > 0 ? (() => { const avg = formatDuration(Math.round(d.seconds / d.sessions)); return t` · avg ${avg}` })() : ''}
                 </div>
               </ChartTooltip>
             )
@@ -174,7 +176,7 @@ export function ReadingActivity365({ heatmap }: { heatmap: StatsResponse['heatma
     <>
       <HeatmapChart data={heatmap} />
       <div className="flex items-center gap-2 justify-end mt-1">
-        <span className="text-[10px] text-muted-foreground">Less</span>
+        <span className="text-[10px] text-muted-foreground"><Trans>Less</Trans></span>
         {[0.12, 0.25, 0.45, 0.7, 1].map((op, i) => (
           <div
             key={i}
@@ -182,7 +184,7 @@ export function ReadingActivity365({ heatmap }: { heatmap: StatsResponse['heatma
             style={i === 0 ? { backgroundColor: tick, opacity: op } : { backgroundColor: accent, opacity: op }}
           />
         ))}
-        <span className="text-[10px] text-muted-foreground">More</span>
+        <span className="text-[10px] text-muted-foreground"><Trans>More</Trans></span>
       </div>
     </>
   )
@@ -225,7 +227,7 @@ export function BooksFinishedArea({ booksFinished, chartType = 'area' }: { books
                 {d.titles.map((t: string) => (
                   <div key={t} className="font-medium">{t}</div>
                 ))}
-                <div className="text-muted-foreground mt-1">{d.daily} finished &middot; {d.count} total</div>
+                {(() => { const daily = d.daily; const count = d.count; return <div className="text-muted-foreground mt-1"><Trans>{daily} finished &middot; {count} total</Trans></div> })()}
               </ChartTooltip>
             )
           }}
@@ -246,25 +248,25 @@ export function SessionLogHint() {
   return (
     <InfoHint wide>
       <span className="flex flex-col gap-1.5 text-left font-normal normal-case">
-        <span>Each row is one reading session.</span>
+        <span><Trans>Each row is one reading session.</Trans></span>
         <span>
-          <span className="font-medium text-foreground">Device name</span> (e.g. Kindle) — recorded
+          <Trans><span className="font-medium text-foreground">Device name</span> (e.g. Kindle) — recorded
           live by the KOReader plugin. <span className="font-medium text-foreground">web</span> /{' '}
           <span className="font-medium text-foreground">manual</span> — the web reader, or logged by
-          hand.
+          hand.</Trans>
         </span>
         <span>
-          <span className="font-medium text-foreground">imported</span> — from KOReader&apos;s synced
-          reading history. Delete only: KOReader already caps idle time, so there is nothing to trim.
+          <Trans><span className="font-medium text-foreground">imported</span> — from KOReader&apos;s synced
+          reading history. Delete only: KOReader already caps idle time, so there is nothing to trim.</Trans>
         </span>
         <span>
-          <span className="font-medium text-foreground">not counted</span> — a live device session
+          <Trans><span className="font-medium text-foreground">not counted</span> — a live device session
           whose sitting is also described by imported history. Listed for completeness,
-          excluded from the totals so nothing is counted twice.
+          excluded from the totals so nothing is counted twice.</Trans>
         </span>
         <span>
-          The triangle marks an implausibly long session. Scissors shorten a session, the bin
-          deletes it.
+          <Trans>The triangle marks an implausibly long session. Scissors shorten a session, the bin
+          deletes it.</Trans>
         </span>
       </span>
     </InfoHint>
@@ -354,7 +356,7 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
   }
 
   if (sessions.length === 0 && !loading) {
-    return <p className="text-sm text-muted-foreground text-center py-8">No sessions recorded.</p>
+    return <p className="text-sm text-muted-foreground text-center py-8"><Trans>No sessions recorded.</Trans></p>
   }
   return (
     <div className="flex flex-col gap-0">
@@ -362,17 +364,17 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
         <button
           onClick={() => setSort(sort === 'recent' ? 'longest' : 'recent')}
           className="inline-flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
-          title="Toggle sort order"
+          title={t`Toggle sort order`}
         >
           <ArrowUpDown className="w-3 h-3" />
-          {sort === 'recent' ? 'Newest first' : 'Longest first'}
+          {sort === 'recent' ? t`Newest first` : t`Longest first`}
         </button>
       </div>
       <div className="hidden sm:grid grid-cols-[1fr_120px_90px_80px_60px] gap-2 px-2 pb-2 text-[11px] font-medium text-muted-foreground border-b border-border">
-        <span>Book</span>
-        <span>Date</span>
-        <span>Duration</span>
-        <span>Device</span>
+        <span><Trans>Book</Trans></span>
+        <span><Trans>Date</Trans></span>
+        <span><Trans>Duration</Trans></span>
+        <span><Trans>Device</Trans></span>
         <span />
       </div>
       {sessions.map((s, idx) => (
@@ -398,7 +400,7 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
               {s.suspect && (
                 <TriangleAlert
                   className="w-3 h-3 text-warning shrink-0"
-                  aria-label="Unusually long session"
+                  aria-label={t`Unusually long session`}
                 />
               )}
             </div>
@@ -416,7 +418,7 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
               {s.kind === 'imported' ? (
                 <span className="block text-[10px] text-muted-foreground/70">imported</span>
               ) : !s.counted ? (
-                <span className="block text-[10px] text-muted-foreground/70">not counted</span>
+                <span className="block text-[10px] text-muted-foreground/70"><Trans>not counted</Trans></span>
               ) : null}
             </div>
             <div className="flex justify-end gap-0.5">
@@ -441,8 +443,8 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
           </div>
           {trimId === s.id && (
             <div className="flex flex-wrap items-center gap-2 rounded bg-muted/40 px-2 py-2 text-xs">
-              <span className="text-muted-foreground">New duration</span>
-              <InfoHint text="Trimming only shortens this session's length and end time — page turns, progress and every other session stay untouched, and the previous duration is kept in the audit log. The suggestion re-prices this session's page turns at your usual reading pace." />
+              <span className="text-muted-foreground"><Trans>New duration</Trans></span>
+              <InfoHint text={t`Trimming only shortens this session's length and end time — page turns, progress and every other session stay untouched, and the previous duration is kept in the audit log. The suggestion re-prices this session's page turns at your usual reading pace.`} />
               <input
                 type="number"
                 min={1}
@@ -450,14 +452,14 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
                 onChange={(e) => setTrimMinutes(e.target.value)}
                 className="w-16 rounded border border-border bg-background px-1.5 py-0.5 text-right tabular-nums"
               />
-              <span className="text-muted-foreground">min</span>
+              <span className="text-muted-foreground"><Trans>min</Trans></span>
               {s.suggested_seconds != null && (
                 <button
                   onClick={() => setTrimMinutes(String(Math.max(1, Math.round(s.suggested_seconds! / 60))))}
                   className="text-primary hover:text-primary/80 transition-colors"
-                  title="Your page turns at your usual reading pace"
+                  title={t`Your page turns at your usual reading pace`}
                 >
-                  Suggested: {formatDuration(s.suggested_seconds)}
+                  {(() => { const dur = formatDuration(s.suggested_seconds); return t`Suggested: ${dur}` })()}
                 </button>
               )}
               <div className="ml-auto flex gap-1.5">
@@ -466,13 +468,13 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
                   disabled={trimBusy}
                   className="rounded bg-primary px-2 py-0.5 font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
                 >
-                  Trim
+                  <Trans>Trim</Trans>
                 </button>
                 <button
                   onClick={() => setTrimId(null)}
                   className="rounded border border-border px-2 py-0.5 text-muted-foreground hover:text-foreground transition-colors"
                 >
-                  Cancel
+                  <Trans>Cancel</Trans>
                 </button>
               </div>
             </div>
@@ -490,7 +492,7 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
           ) : (
             <>
               <ChevronDown className="w-3.5 h-3.5" />
-              <span>Show more ({total - loaded} remaining)</span>
+              {(() => { const left = total - loaded; return <span><Trans>Show more ({left} remaining)</Trans></span> })()}
             </>
           )}
         </button>
@@ -503,7 +505,7 @@ export function SessionLog({ bookId, day, onChange }: { bookId?: number; day?: s
 export function RecentlyFinished({ booksFinished }: { booksFinished: StatsResponse['books_finished'] }) {
   const rows = [...booksFinished].sort((a, b) => b.date.localeCompare(a.date)).slice(0, 12)
   if (rows.length === 0) {
-    return <p className="text-sm text-muted-foreground text-center py-8">Nothing finished in this range.</p>
+    return <p className="text-sm text-muted-foreground text-center py-8"><Trans>Nothing finished in this range.</Trans></p>
   }
   return (
     <div className="flex flex-col gap-1">

--- a/frontend/src/components/stats/widgets/taste.tsx
+++ b/frontend/src/components/stats/widgets/taste.tsx
@@ -22,11 +22,13 @@ import { formatDuration } from '@/lib/utils'
 import { StarRating } from '@/components/StarRating'
 import { useChartColors } from '@/lib/useChartAccent'
 import { ChartTooltip, type StatsResponse } from '@/components/stats/shared'
+import { Trans } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 type Ratings = StatsResponse['ratings']
 
-function Empty({ text = 'No ratings yet.' }: { text?: string }) {
-  return <p className="text-sm text-muted-foreground text-center py-10">{text}</p>
+function Empty({ text }: { text?: string }) {
+  return <p className="text-sm text-muted-foreground text-center py-10">{text ?? t`No ratings yet.`}</p>
 }
 
 function Stars({ value }: { value: number }) {
@@ -76,7 +78,7 @@ export function RatingDistribution({ data }: { data: Ratings['distribution'] }) 
 // 2 ── Taste by genre: avg rating per book-type (radar, bars fallback) ──────────
 export function TasteByGenre({ data }: { data: Ratings['by_category'] }) {
   const { accent, tick } = useChartColors()
-  if (data.length === 0) return <Empty text="No rated books yet." />
+  if (data.length === 0) return <Empty text={t`No rated books yet.`} />
   if (data.length < 3) {
     return (
       <div className="flex h-full flex-col justify-center gap-3">
@@ -135,12 +137,12 @@ export function TopRatedBooks({ books }: { books: Ratings['books'] }) {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2.5">
-        {low.length > 0 && <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Highest</p>}
+        {low.length > 0 && <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"><Trans>Highest</Trans></p>}
         {top.map((b) => <RatedRow key={b.book_id} b={b} />)}
       </div>
       {low.length > 0 && (
         <div className="flex flex-col gap-2.5">
-          <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Lowest</p>
+          <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"><Trans>Lowest</Trans></p>
           {low.map((b) => <RatedRow key={b.book_id} b={b} />)}
         </div>
       )}
@@ -152,7 +154,7 @@ export function TopRatedBooks({ books }: { books: Ratings['books'] }) {
 export function RatingVsTime({ books }: { books: Ratings['books'] }) {
   const { accent, tick, cursor } = useChartColors()
   const pts = books.filter((b) => b.seconds > 0).map((b) => ({ hours: +(b.seconds / 3600).toFixed(1), rating: b.rating, title: b.title }))
-  if (pts.length === 0) return <Empty text="No rated books with reading time yet." />
+  if (pts.length === 0) return <Empty text={t`No rated books with reading time yet.`} />
   return (
     <ResponsiveContainer initialDimension={{ width: 1, height: 1 }} width="100%" height="100%">
       <ScatterChart margin={{ top: 8, right: 12, bottom: 4, left: 0 }}>
@@ -175,7 +177,7 @@ export function RatingVsTime({ books }: { books: Ratings['books'] }) {
 
 // 5 ── Best-rated series ─────────────────────────────────────────────────────────
 export function BestRatedSeries({ series }: { series: Ratings['series'] }) {
-  if (series.length === 0) return <Empty text="No rated series yet." />
+  if (series.length === 0) return <Empty text={t`No rated series yet.`} />
   return (
     <div className="flex flex-col gap-2.5">
       {series.slice(0, 12).map((s) => (
@@ -192,7 +194,7 @@ export function BestRatedSeries({ series }: { series: Ratings['series'] }) {
 // 6 ── Rating trend over time ────────────────────────────────────────────────────
 export function RatingTrend({ trend }: { trend: Ratings['trend'] }) {
   const { accent, tick, cursor } = useChartColors()
-  if (trend.length < 2) return <Empty text="Rate a few books to see a trend." />
+  if (trend.length < 2) return <Empty text={t`Rate a few books to see a trend.`} />
   const fmt = (d: string) => {
     try { return new Date(d + 'T00:00:00').toLocaleDateString(undefined, { month: 'short', year: '2-digit' }) } catch { return d }
   }

--- a/frontend/src/components/stats/widgets/wordstats.tsx
+++ b/frontend/src/components/stats/widgets/wordstats.tsx
@@ -6,9 +6,11 @@ import {
 import { FileText } from 'lucide-react'
 import { useChartColors } from '@/lib/useChartAccent'
 import { ChartTooltip, type StatsResponse } from '@/components/stats/shared'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 
-function Empty({ text = 'No word counts yet.' }: { text?: string }) {
-  return <p className="py-10 text-center text-sm text-muted-foreground">{text}</p>
+function Empty({ text }: { text?: string }) {
+  return <p className="py-10 text-center text-sm text-muted-foreground">{text ?? t`No word counts yet.`}</p>
 }
 
 // Compact number: 1_240_000 -> "1.2M", 84_300 -> "84k", 932 -> "932".
@@ -42,7 +44,7 @@ export function WordsRead({ data }: { data: StatsResponse['words'] }) {
     <div className="flex flex-col gap-3">
       <div className="flex items-baseline gap-2">
         <span className="text-3xl font-bold leading-none text-foreground">{compact(data.total_words)}</span>
-        <span className="text-xs text-muted-foreground">words read · {data.books_counted} book{data.books_counted !== 1 ? 's' : ''}</span>
+        <span className="text-xs text-muted-foreground">{plural(data.books_counted, { one: 'words read · # book', other: 'words read · # books' })}</span>
       </div>
       {years.length >= 2 && (
         <div className="flex flex-col gap-1.5">
@@ -59,7 +61,9 @@ export function WordsRead({ data }: { data: StatsResponse['words'] }) {
           ))}
         </div>
       )}
-      <p className="text-xs text-muted-foreground">avg <span className="font-medium text-foreground">{compact(avgPerBook)}</span> words per book</p>
+      {(() => { const avg = compact(avgPerBook); return (
+      <p className="text-xs text-muted-foreground"><Trans>avg <span className="font-medium text-foreground">{avg}</span> words per book</Trans></p>
+      ) })()}
     </div>
   )
 }
@@ -82,23 +86,23 @@ function WpmRow({ b }: { b: StatsResponse['wpm']['books'][number] }) {
 // (container query, not viewport) — so a wide tile fills with two columns
 // instead of one tall list with dead space on the right.
 export function TrueWpm({ data }: { data: StatsResponse['wpm'] }) {
-  if (!data || data.books_counted === 0) return <Empty text="No timed reading with word counts yet." />
+  if (!data || data.books_counted === 0) return <Empty text={t`No timed reading with word counts yet.`} />
   const fast = data.books.slice(0, 3)
   const slow = data.books.length > 6 ? data.books.slice(-3).reverse() : []
   return (
     <div className="@container flex flex-col gap-3">
       <div className="flex items-baseline gap-2">
         <span className="text-3xl font-bold leading-none text-foreground">{data.overall.toLocaleString()}</span>
-        <span className="text-xs text-muted-foreground">words/min · across {data.books_counted} book{data.books_counted !== 1 ? 's' : ''}</span>
+        <span className="text-xs text-muted-foreground">{plural(data.books_counted, { one: 'words/min · across # book', other: 'words/min · across # books' })}</span>
       </div>
       <div className="grid grid-cols-1 gap-x-8 gap-y-2.5 @md:grid-cols-2">
         <div className="flex flex-col gap-2.5">
-          {fast.length > 0 && slow.length > 0 && <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Fastest</p>}
+          {fast.length > 0 && slow.length > 0 && <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"><Trans>Fastest</Trans></p>}
           {fast.map((b) => <WpmRow key={b.book_id} b={b} />)}
         </div>
         {slow.length > 0 && (
           <div className="flex flex-col gap-2.5">
-            <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Slowest</p>
+            <p className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"><Trans>Slowest</Trans></p>
             {slow.map((b) => <WpmRow key={b.book_id} b={b} />)}
           </div>
         )}
@@ -109,7 +113,7 @@ export function TrueWpm({ data }: { data: StatsResponse['wpm'] }) {
 
 // 4 ── Re-reads: books whose pages you've revisited on a later day ──────────────
 export function ReReads({ data }: { data: StatsResponse['rereads'] }) {
-  if (!data || data.books.length === 0) return <Empty text="No re-reads yet — pages you revisit on a later day show up here." />
+  if (!data || data.books.length === 0) return <Empty text={t`No re-reads yet — pages you revisit on a later day show up here.`} />
   return (
     <div className="flex flex-col gap-2.5">
       {data.books.slice(0, 8).map((b) => (
@@ -153,8 +157,12 @@ export function BookLength({ data }: { data: StatsResponse['book_lengths'] }) {
         </ResponsiveContainer>
       </div>
       <p className="truncate text-[11px] text-muted-foreground">
-        avg <span className="font-medium text-foreground">{compact(data.avg_words)}</span> · median {compact(data.median_words)}
-        {data.longest && <> · longest <span className="text-foreground">{data.longest.title}</span> ({compact(data.longest.words)})</>}
+        {(() => { const avg = compact(data.avg_words); const median = compact(data.median_words); return (
+          <Trans>avg <span className="font-medium text-foreground">{avg}</span> · median {median}</Trans>
+        ) })()}
+        {data.longest && (() => { const title = data.longest.title; const words = compact(data.longest.words); return (
+          <Trans> · longest <span className="text-foreground">{title}</span> ({words})</Trans>
+        ) })()}
       </p>
     </div>
   )

--- a/frontend/src/lib/backlog.ts
+++ b/frontend/src/lib/backlog.ts
@@ -1,3 +1,5 @@
+import { t } from '@lingui/core/macro'
+
 // Backlog completion estimates (#187) — shared types + formatting for the
 // book page cell, the series header line and the Stats "Backlog" tile.
 
@@ -44,26 +46,28 @@ export interface BacklogScope {
 
 /** "~45 min" / "~11 h" — coarse on purpose, these are estimates. */
 export function formatEstimateHours(seconds: number): string {
-  if (seconds < 3600) return `~${Math.max(1, Math.round(seconds / 60))} min`
-  return `~${Math.round(seconds / 3600)} h`
+  if (seconds < 3600) { const m = Math.max(1, Math.round(seconds / 60)); return t`~${m} min` }
+  const h = Math.round(seconds / 3600)
+  return t`~${h} h`
 }
 
 /** "~13 days" / "~4 weeks" / "~3.7 months" at the user's daily pace. */
 export function formatEstimateDays(days: number): string {
   const d = Math.round(days)
-  if (d < 1) return 'under a day'
-  if (d < 14) return `~${d} day${d === 1 ? '' : 's'}`
-  if (d < 60) return `~${Math.round(d / 7)} weeks`
-  return `~${(d / 30).toFixed(1).replace(/\.0$/, '')} months`
+  if (d < 1) return t`under a day`
+  if (d < 14) return d === 1 ? t`~1 day` : t`~${d} days`
+  if (d < 60) { const w = Math.round(d / 7); return t`~${w} weeks` }
+  const mo = (d / 30).toFixed(1).replace(/\.0$/, '')
+  return t`~${mo} months`
 }
 
 /** One-line explanation of where a figure came from, for tooltips. */
 export function describePace(pace: EstimatePace, method: EstimateMethod | null): string {
   const parts: string[] = []
-  if (method === 'words') parts.push(`Word count at your measured ${Math.round(pace.wpm ?? 0)} wpm`)
-  else if (method === 'default') parts.push(`Word count at a default ${pace.default_wpm} wpm (no finished books to measure your pace yet)`)
-  else if (method === 'type_avg') parts.push('Your average time per finished book of this type (no word count)')
-  if (pace.minutes_per_day) parts.push(`days at ~${Math.round(pace.minutes_per_day)} min a day (last ${pace.window_days} days)`)
-  else parts.push('no recent reading, so no day estimate')
+  if (method === 'words') { const wpm = Math.round(pace.wpm ?? 0); parts.push(t`Word count at your measured ${wpm} wpm`) }
+  else if (method === 'default') { const wpm = pace.default_wpm; parts.push(t`Word count at a default ${wpm} wpm (no finished books to measure your pace yet)`) }
+  else if (method === 'type_avg') parts.push(t`Your average time per finished book of this type (no word count)`)
+  if (pace.minutes_per_day) { const mpd = Math.round(pace.minutes_per_day); const win = pace.window_days; parts.push(t`days at ~${mpd} min a day (last ${win} days)`) }
+  else parts.push(t`no recent reading, so no day estimate`)
   return parts.join(' · ')
 }

--- a/frontend/src/lib/goals.ts
+++ b/frontend/src/lib/goals.ts
@@ -4,6 +4,10 @@
  * chips are the curated on-ramp shown in the goal editor.
  */
 import { api } from '@/lib/api'
+import { t } from '@lingui/core/macro'
+import { msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 
 export type GoalKind =
   | 'books_per_year'
@@ -35,73 +39,80 @@ export interface Goal {
   year?: number
 }
 
-interface GoalMeta {
-  label: string          // "Books this year"
-  caption: string        // ring caption below the number
-  unit: string           // suffix shown in ring center bottom ('' | 'm' | 'p')
-  inputUnit: string      // written-out unit for the input row (e.g. "books", "min", "pages")
+interface GoalMetaDef {
+  label: MessageDescriptor
+  caption: MessageDescriptor
+  unit: string
+  inputUnit: MessageDescriptor
   placeholder: number    // default placeholder for the numeric input
   presets: number[]      // quick-pick chips
   metric: GoalMetric
   period: GoalPeriod
 }
 
-const GOAL_META: Record<GoalKind, GoalMeta> = {
+// Resolved (translated) shape handed to callers.
+interface GoalMeta extends Omit<GoalMetaDef, 'label' | 'caption' | 'inputUnit'> {
+  label: string
+  caption: string
+  inputUnit: string
+}
+
+const GOAL_META: Record<GoalKind, GoalMetaDef> = {
   books_per_year: {
-    label: 'Books this year',
-    caption: 'Year Challenge',
+    label: msg`Books this year`,
+    caption: msg`Year Challenge`,
     unit: '',
-    inputUnit: 'books',
+    inputUnit: msg`books`,
     placeholder: 24,
     presets: [12, 24, 52],
     metric: 'books',
     period: 'year',
   },
   books_per_month: {
-    label: 'Books this month',
-    caption: 'Monthly goal',
+    label: msg`Books this month`,
+    caption: msg`Monthly goal`,
     unit: '',
-    inputUnit: 'books',
+    inputUnit: msg`books`,
     placeholder: 2,
     presets: [1, 2, 4],
     metric: 'books',
     period: 'month',
   },
   minutes_per_day: {
-    label: 'Minutes per day',
-    caption: 'Daily minutes',
+    label: msg`Minutes per day`,
+    caption: msg`Daily minutes`,
     unit: 'm',
-    inputUnit: 'min',
+    inputUnit: msg`min`,
     placeholder: 30,
     presets: [15, 30, 60],
     metric: 'minutes',
     period: 'day',
   },
   minutes_per_week: {
-    label: 'Minutes per week',
-    caption: 'Weekly minutes',
+    label: msg`Minutes per week`,
+    caption: msg`Weekly minutes`,
     unit: 'm',
-    inputUnit: 'min',
+    inputUnit: msg`min`,
     placeholder: 300,
     presets: [120, 300, 600],
     metric: 'minutes',
     period: 'week',
   },
   pages_per_day: {
-    label: 'Pages per day',
-    caption: 'Daily pages',
+    label: msg`Pages per day`,
+    caption: msg`Daily pages`,
     unit: 'p',
-    inputUnit: 'pages',
+    inputUnit: msg`pages`,
     placeholder: 50,
     presets: [20, 50, 100],
     metric: 'pages',
     period: 'day',
   },
   pages_per_week: {
-    label: 'Pages per week',
-    caption: 'Weekly pages',
+    label: msg`Pages per week`,
+    caption: msg`Weekly pages`,
     unit: 'p',
-    inputUnit: 'pages',
+    inputUnit: msg`pages`,
     placeholder: 350,
     presets: [150, 350, 700],
     metric: 'pages',
@@ -110,16 +121,14 @@ const GOAL_META: Record<GoalKind, GoalMeta> = {
 }
 
 export function goalMeta(kind: string): GoalMeta {
-  return GOAL_META[kind as GoalKind] ?? {
-    label: kind,
-    caption: kind,
-    unit: '',
-    inputUnit: '',
-    placeholder: 10,
-    presets: [],
-    metric: 'books' as GoalMetric,
-    period: 'year' as GoalPeriod,
+  const def = GOAL_META[kind as GoalKind]
+  if (!def) {
+    return {
+      label: kind, caption: kind, unit: '', inputUnit: '',
+      placeholder: 10, presets: [], metric: 'books' as GoalMetric, period: 'year' as GoalPeriod,
+    }
   }
+  return { ...def, label: i18n._(def.label), caption: i18n._(def.caption), inputUnit: i18n._(def.inputUnit) }
 }
 
 /** All 6 allowed kinds in display order */
@@ -144,22 +153,23 @@ export function goalSubtext(goal: Goal): string {
   const reached = goal.current >= goal.target
 
   if (period === 'day') {
-    if (reached) return 'Goal reached today'
-    return `${goal.days_hit_this_week ?? 0}/7 days this week`
+    if (reached) return t`Goal reached today`
+    const hit = goal.days_hit_this_week ?? 0
+    return t`${hit}/7 days this week`
   }
   if (period === 'week') {
-    return reached ? 'Goal reached' : 'this week'
+    return reached ? t`Goal reached` : t`this week`
   }
   // month/year: pace against the prorated target
-  if (reached) return 'Goal reached'
+  if (reached) return t`Goal reached`
   if (goal.expected != null) {
     const diff = Math.round(goal.current - goal.expected)
-    if (diff >= 1) return `${diff} ahead of pace`
-    if (diff <= -1) return `${Math.abs(diff)} behind pace`
-    return 'on pace'
+    if (diff >= 1) return t`${diff} ahead of pace`
+    if (diff <= -1) { const behind = Math.abs(diff); return t`${behind} behind pace` }
+    return t`on pace`
   }
   const toGo = Math.max(goal.target - Math.floor(goal.current), 0)
-  return `${toGo} to go`
+  return t`${toGo} to go`
 }
 
 // ── API ───────────────────────────────────────────────────────────────────────

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -1,0 +1,78 @@
+import { i18n } from '@lingui/core'
+
+// UI language. Mirrors theme.ts: the preference is client-side (localStorage),
+// resolved once at boot and switchable from Settings without a reload.
+//
+// Adding a language: create src/locales/<code>/messages.po (see docs/translating.md),
+// then add it to LOCALES below. Codes are BCP-47 (`zh-CN`, not `zh_CN`).
+
+export interface LocaleDefinition {
+  code: string
+  /** Native name, shown untranslated in the picker. */
+  label: string
+}
+
+export const LOCALES: LocaleDefinition[] = [
+  { code: 'en', label: 'English' },
+  { code: 'zh-CN', label: '简体中文' },
+]
+
+export const DEFAULT_LOCALE = 'en'
+const STORAGE_KEY = 'tome_locale'
+
+function isSupported(code: string | null | undefined): code is string {
+  return !!code && LOCALES.some(l => l.code === code)
+}
+
+export function getStoredLocale(): string | null {
+  const stored = localStorage.getItem(STORAGE_KEY)
+  return isSupported(stored) ? stored : null
+}
+
+/** Match a browser language tag against LOCALES: exact first, then by primary subtag. */
+function matchBrowserLocale(tags: readonly string[]): string | null {
+  for (const tag of tags) {
+    if (isSupported(tag)) return tag
+  }
+  for (const tag of tags) {
+    const primary = tag.split('-')[0]
+    const hit = LOCALES.find(l => l.code.split('-')[0] === primary)
+    if (hit) return hit.code
+  }
+  return null
+}
+
+/** Stored preference → browser language → English. */
+export function detectLocale(): string {
+  return getStoredLocale() ?? matchBrowserLocale(navigator.languages ?? [navigator.language]) ?? DEFAULT_LOCALE
+}
+
+/**
+ * Load a catalog and make it the active language. Safe to call repeatedly.
+ * Never rejects: a catalog that fails to load activates with no messages, so the
+ * UI renders the source (English) strings instead of a blank page.
+ */
+export async function activateLocale(code: string): Promise<void> {
+  const locale = isSupported(code) ? code : DEFAULT_LOCALE
+  let messages = {}
+  try {
+    ;({ messages } = await import(`../locales/${locale}/messages.po`))
+  } catch (err) {
+    console.error(`[i18n] failed to load catalog for ${locale}`, err)
+  }
+  i18n.load(locale, messages)
+  i18n.activate(locale)
+  document.documentElement.lang = locale
+}
+
+/** Persist the choice and switch immediately. */
+export function setLocale(code: string): Promise<void> {
+  localStorage.setItem(STORAGE_KEY, code)
+  return activateLocale(code)
+}
+
+export function getActiveLocale(): string {
+  return i18n.locale || DEFAULT_LOCALE
+}
+
+export { i18n }

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -49,6 +49,10 @@ msgstr " · {prog}% in"
 msgid " · finished {d}"
 msgstr " · finished {d}"
 
+#: src/pages/HardcoverPage.tsx
+msgid " · last synced {when}"
+msgstr " · last synced {when}"
+
 #: src/pages/BinderyPage.tsx
 msgid " · reviewed"
 msgstr " · reviewed"
@@ -136,7 +140,9 @@ msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups foun
 msgstr "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
 
 #. placeholder {0}: aggregate.distinct_readers
+#. placeholder {0}: c.users_count
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "{0, plural, one {# reader} other {# readers}}"
 msgstr "{0, plural, one {# reader} other {# readers}}"
 
@@ -249,6 +255,10 @@ msgstr "{0, plural, one {Updated metadata for # book} other {Updated metadata fo
 #: src/pages/AdminPage.tsx
 msgid "{added} added · {skipped} skipped"
 msgstr "{added} added · {skipped} skipped"
+
+#: src/pages/HardcoverPage.tsx
+msgid "{base} · Vol. {idx}"
+msgstr "{base} · Vol. {idx}"
 
 #: src/pages/HighlightsPage.tsx
 msgid "{books, plural, one {{total} from # book} other {{total} from # books}}"
@@ -489,6 +499,10 @@ msgstr "~{at}% in · not read"
 msgid "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
 msgstr "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
 
+#: src/pages/HardcoverPage.tsx
+msgid "A sync is already running"
+msgstr "A sync is already running"
+
 #: src/pages/DashboardPage.tsx
 msgid "A while ago"
 msgstr "A while ago"
@@ -516,6 +530,10 @@ msgstr "Accepted: {title}"
 #: src/pages/SettingsPage.tsx
 msgid "Account & Security"
 msgstr "Account & Security"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Action failed"
+msgstr "Action failed"
 
 #: src/pages/AdminPage.tsx
 msgid "Active"
@@ -610,6 +628,7 @@ msgid "Admin access required."
 msgstr "Admin access required."
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "All"
 msgstr "All"
 
@@ -624,6 +643,10 @@ msgstr "All →"
 #: src/pages/AdminPage.tsx
 msgid "All actions"
 msgstr "All actions"
+
+#: src/pages/HardcoverPage.tsx
+msgid "All books"
+msgstr "All books"
 
 #: src/components/Sidebar.tsx
 msgid "All Books"
@@ -918,6 +941,7 @@ msgid "Click for details"
 msgstr "Click for details"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "Close"
 msgstr "Close"
 
@@ -1047,9 +1071,17 @@ msgstr "Core"
 msgid "Could not link SSO. Please try again."
 msgstr "Could not link SSO. Please try again."
 
+#: src/pages/HardcoverPage.tsx
+msgid "Could not set match"
+msgstr "Could not set match"
+
 #: src/pages/SettingsPage.tsx
 msgid "Could not start SSO linking."
 msgstr "Could not start SSO linking."
+
+#: src/pages/HardcoverPage.tsx
+msgid "Could not start sync"
+msgstr "Could not start sync"
 
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
@@ -1365,6 +1397,14 @@ msgstr "Email delivery is not set up yet."
 msgid "Ember"
 msgstr "Ember"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Error"
+msgstr "Error"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Errors"
+msgstr "Errors"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
 msgstr "Est. remaining"
@@ -1376,6 +1416,18 @@ msgstr "Everywhere"
 #: src/pages/AdminPage.tsx
 msgid "Exact Match"
 msgstr "Exact Match"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Exclude"
+msgstr "Exclude"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Excluded"
+msgstr "Excluded"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Excluded from Hardcover sync"
+msgstr "Excluded from Hardcover sync"
 
 #: src/components/ImpersonationBanner.tsx
 msgid "Exit impersonation"
@@ -1572,6 +1624,10 @@ msgstr "Fetching metadata..."
 msgid "File is missing from disk"
 msgstr "File is missing from disk"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Filter…"
+msgstr "Filter…"
+
 #: src/pages/DashboardPage.tsx
 msgid "Filters"
 msgstr "Filters"
@@ -1679,10 +1735,12 @@ msgid "Group by series"
 msgstr "Group by series"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "Group series"
 msgstr "Group series"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "Group volumes by series"
 msgstr "Group volumes by series"
 
@@ -1693,6 +1751,10 @@ msgstr "Guest"
 #: src/components/Sidebar.tsx
 msgid "Hardcover"
 msgstr "Hardcover"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Hardcover sync is disabled on this server."
+msgstr "Hardcover sync is disabled on this server."
 
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
@@ -1803,6 +1865,10 @@ msgstr "In KOReader: Tools → Progress sync → Custom sync server."
 #: src/pages/AdminPage.tsx
 msgid "Inactive"
 msgstr "Inactive"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Include"
+msgstr "Include"
 
 #: src/pages/AdminPage.tsx
 msgid "Incoming"
@@ -1953,6 +2019,10 @@ msgstr "Link your identity provider to this account so you can sign in with SSO.
 msgid "Link your identity provider to this account so you can sign in with SSO. Your existing login keeps working."
 msgstr "Link your identity provider to this account so you can sign in with SSO. Your existing login keeps working."
 
+#: src/pages/HardcoverPage.tsx
+msgid "Link your personal API token in <0>Settings → Hardcover</0> — syncing starts right after."
+msgstr "Link your personal API token in <0>Settings → Hardcover</0> — syncing starts right after."
+
 #: src/pages/SettingsPage.tsx
 msgid "Linked"
 msgstr "Linked"
@@ -1969,11 +2039,16 @@ msgstr "List view"
 msgid "Load more ({left} left)"
 msgstr "Load more ({left} left)"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Loading books…"
+msgstr "Loading books…"
+
 #: src/pages/BinderyPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Loading..."
 msgstr "Loading..."
 
+#: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
 msgid "Loading…"
 msgstr "Loading…"
@@ -2035,9 +2110,21 @@ msgstr "Marked as reading"
 msgid "Marked unread — reading progress cleared"
 msgstr "Marked unread — reading progress cleared"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Match “{title}” to…"
+msgstr "Match “{title}” to…"
+
 #: src/pages/BinderyPage.tsx
 msgid "Match all"
 msgstr "Match all"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Match cleared — re-matching on the next sync"
+msgstr "Match cleared — re-matching on the next sync"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Matched to “{title}”"
+msgstr "Matched to “{title}”"
 
 #: src/pages/BinderyPage.tsx
 msgid "Matches \"{name}\" already in your library — name, author, type and libraries adopted from it"
@@ -2123,6 +2210,10 @@ msgstr "Native KOReader plugin — tracks reading sessions and syncs by book ID.
 msgid "Never"
 msgstr "Never"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Never sync this book"
+msgstr "Never sync this book"
+
 #: src/pages/SettingsPage.tsx
 msgid "never used"
 msgstr "never used"
@@ -2199,6 +2290,10 @@ msgstr "No books found. Upload the book first, then fulfill."
 msgid "No books have been sent yet."
 msgstr "No books have been sent yet."
 
+#: src/pages/HardcoverPage.tsx
+msgid "No books in this view."
+msgstr "No books in this view."
+
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
 msgstr "No description"
@@ -2223,6 +2318,10 @@ msgstr "No files in the bindery"
 msgid "No fulfilled wishes."
 msgstr "No fulfilled wishes."
 
+#: src/pages/HardcoverPage.tsx
+msgid "No Hardcover account linked yet."
+msgstr "No Hardcover account linked yet."
+
 #: src/pages/HighlightsPage.tsx
 msgid "No highlights match your search."
 msgstr "No highlights match your search."
@@ -2230,6 +2329,10 @@ msgstr "No highlights match your search."
 #: src/pages/HighlightsPage.tsx
 msgid "No highlights yet"
 msgstr "No highlights yet"
+
+#: src/pages/HardcoverPage.tsx
+msgid "no ISBN"
+msgstr "no ISBN"
 
 #: src/pages/BinderyPage.tsx
 msgid "No libraries"
@@ -2270,6 +2373,10 @@ msgstr "No reading activity yet. Records appear when users start reading books."
 #: src/pages/BookDetailPage.tsx
 msgid "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
 msgstr "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
+
+#: src/pages/HardcoverPage.tsx
+msgid "No results — try a different query."
+msgstr "No results — try a different query."
 
 #: src/pages/DashboardPage.tsx
 msgid "No results for \"{search}\""
@@ -2321,9 +2428,21 @@ msgstr "Not configured"
 msgid "Not found"
 msgstr "Not found"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Not matched"
+msgstr "Not matched"
+
 #: src/pages/BookDetailPage.tsx
 msgid "not read"
 msgstr "not read"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Not synced yet"
+msgstr "Not synced yet"
+
+#: src/pages/HardcoverPage.tsx
+msgid "not syncing"
+msgstr "not syncing"
 
 #: src/pages/SettingsPage.tsx
 msgid "Note on KOSync coexistence"
@@ -2480,6 +2599,10 @@ msgstr "Passwords do not match"
 msgid "Per-file details"
 msgstr "Per-file details"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Pick"
+msgstr "Pick"
+
 #: src/pages/DashboardPage.tsx
 msgid "Pick up where you left off"
 msgstr "Pick up where you left off"
@@ -2619,6 +2742,10 @@ msgstr "Rated: 5 stars"
 msgid "Rating"
 msgstr "Rating"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Re-match"
+msgstr "Re-match"
+
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "read"
@@ -2742,6 +2869,10 @@ msgstr "Remove device"
 #: src/pages/BookDetailPage.tsx
 msgid "Remove from library"
 msgstr "Remove from library"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Remove our entry from Hardcover and re-match automatically"
+msgstr "Remove our entry from Hardcover and re-match automatically"
 
 #: src/pages/WishlistPage.tsx
 msgid "Remove wish"
@@ -2867,6 +2998,10 @@ msgstr "Scanning…"
 msgid "Scope"
 msgstr "Scope"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Search"
+msgstr "Search"
+
 #: src/components/AppHeader.tsx
 msgid "Search books"
 msgstr "Search books"
@@ -2875,6 +3010,10 @@ msgstr "Search books"
 msgid "Search books… (/)"
 msgstr "Search books… (/)"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Search failed"
+msgstr "Search failed"
+
 #: src/pages/AdminPage.tsx
 msgid "Search for a book in the library…"
 msgstr "Search for a book in the library…"
@@ -2882,6 +3021,14 @@ msgstr "Search for a book in the library…"
 #: src/pages/AdminPage.tsx
 msgid "Search for a different book…"
 msgstr "Search for a different book…"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Search Hardcover and pick the record yourself"
+msgstr "Search Hardcover and pick the record yourself"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Search Hardcover…"
+msgstr "Search Hardcover…"
 
 #: src/components/Sidebar.tsx
 msgid "Search icons…"
@@ -2898,6 +3045,10 @@ msgstr "Search to find more icons"
 #: src/pages/HighlightsPage.tsx
 msgid "Search your highlights…"
 msgstr "Search your highlights…"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Searching…"
+msgstr "Searching…"
 
 #: src/components/AppShell.tsx
 msgid "See all results for \"{searchQuery}\""
@@ -3087,6 +3238,7 @@ msgid "Show details"
 msgstr "Show details"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "Show individual volumes"
 msgstr "Show individual volumes"
 
@@ -3184,6 +3336,10 @@ msgstr "start"
 msgid "Start {volLabel}"
 msgstr "Start {volLabel}"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Start matching this book again"
+msgstr "Start matching this book again"
+
 #: src/pages/DashboardPage.tsx
 msgid "Start reading and your progress will show up here"
 msgstr "Start reading and your progress will show up here"
@@ -3209,13 +3365,25 @@ msgstr "Strong enough"
 msgid "Subtitle (optional)"
 msgstr "Subtitle (optional)"
 
+#: src/pages/HardcoverPage.tsx
+msgid "Sync now"
+msgstr "Sync now"
+
 #: src/pages/SettingsPage.tsx
 msgid "Sync reading position between KOReader and Tome."
 msgstr "Sync reading position between KOReader and Tome."
 
+#: src/pages/HardcoverPage.tsx
+msgid "Sync started"
+msgstr "Sync started"
+
 #: src/pages/AdminPage.tsx
 msgid "Sync Status"
 msgstr "Sync Status"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Synced"
+msgstr "Synced"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Synced document"
@@ -3224,6 +3392,10 @@ msgstr "Synced document"
 #: src/pages/HighlightsPage.tsx
 msgid "Synced to Tome {when}"
 msgstr "Synced to Tome {when}"
+
+#: src/pages/HardcoverPage.tsx
+msgid "Syncing…"
+msgstr "Syncing…"
 
 #: src/pages/BinderyPage.tsx
 msgid "Synopsis or description"
@@ -3387,6 +3559,10 @@ msgstr "Unfollow {name}"
 #: src/pages/BinderyPage.tsx
 msgid "Ungrouped files"
 msgstr "Ungrouped files"
+
+#: src/pages/HardcoverPage.tsx
+msgid "unknown author"
+msgstr "unknown author"
 
 #: src/pages/WishlistPage.tsx
 msgid "Unknown author"
@@ -3570,6 +3746,10 @@ msgstr "Welcome to Tome"
 #: src/pages/BookDetailPage.tsx
 msgid "What did you think? (optional, saved automatically)"
 msgstr "What did you think? (optional, saved automatically)"
+
+#: src/pages/HardcoverPage.tsx
+msgid "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
+msgstr "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
 
 #: src/pages/BookDetailPage.tsx
 msgid "Where in the book your time went — taller means more time spent on those pages."

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -17,6 +17,18 @@ msgstr ""
 msgid " — click for sessions"
 msgstr " — click for sessions"
 
+#: src/pages/AdminPage.tsx
+msgid " — MISSING"
+msgstr " — MISSING"
+
+#: src/pages/AdminPage.tsx
+msgid " · {dups} duplicates"
+msgstr " · {dups} duplicates"
+
+#: src/pages/AdminPage.tsx
+msgid " · {errs} error(s)"
+msgstr " · {errs} error(s)"
+
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
 msgstr " · {prog}% in"
@@ -24,6 +36,10 @@ msgstr " · {prog}% in"
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
 msgstr "— keep existing —"
+
+#: src/pages/AdminPage.tsx
+msgid ", {n} failed"
+msgstr ", {n} failed"
 
 #: src/pages/BookDetailPage.tsx
 msgid ", {pages} pages"
@@ -45,10 +61,32 @@ msgstr "· p. {page} of {totalPages}"
 msgid "(enables dark: variants)"
 msgstr "(enables dark: variants)"
 
+#: src/pages/AdminPage.tsx
+msgid "(last 100)"
+msgstr "(last 100)"
+
+#: src/pages/AdminPage.tsx
+msgid "(leave blank to keep)"
+msgstr "(leave blank to keep)"
+
+#: src/pages/AdminPage.tsx
+msgid "(not set)"
+msgstr "(not set)"
+
+#. placeholder {0}: res.errors.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+msgstr "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+
 #. placeholder {0}: s.book_count
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
 msgstr "{0, plural, one {# book} other {# books}}"
+
+#. placeholder {0}: groups.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
+msgstr "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
 
 #. placeholder {0}: aggregate.distinct_readers
 #: src/pages/BookDetailPage.tsx
@@ -60,15 +98,35 @@ msgstr "{0, plural, one {# reader} other {# readers}}"
 msgid "{0, plural, one {# reading day} other {# reading days}}"
 msgstr "{0, plural, one {# reading day} other {# reading days}}"
 
+#. placeholder {0}: records.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# record} other {# records}}"
+msgstr "{0, plural, one {# record} other {# records}}"
+
 #. placeholder {0}: data.reread_bins
 #: src/pages/BookDetailPage.tsx
 msgid "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
 msgstr "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
 
+#. placeholder {0}: wish.suggested_book_ids.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# suggested match} other {# suggested matches}}"
+msgstr "{0, plural, one {# suggested match} other {# suggested matches}}"
+
+#. placeholder {0}: users.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# user} other {# users}}"
+msgstr "{0, plural, one {# user} other {# users}}"
+
 #. placeholder {0}: selected.size
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Added # book to library} other {Added # books to library}}"
 msgstr "{0, plural, one {Added # book to library} other {Added # books to library}}"
+
+#. placeholder {0}: applyResult.applied
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {Applied # group} other {Applied # groups}}"
+msgstr "{0, plural, one {Applied # group} other {Applied # groups}}"
 
 #. placeholder {0}: selectedIds.size
 #: src/pages/DashboardPage.tsx
@@ -85,10 +143,23 @@ msgstr "{0, plural, one {Deleting # book...} other {Deleting # books...}}"
 msgid "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Books}}"
 msgstr "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Books}}"
 
+#. placeholder {0}: suggestedBooks.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {Suggested match:} other {Suggested matches:}}"
+msgstr "{0, plural, one {Suggested match:} other {Suggested matches:}}"
+
 #. placeholder {0}: selected.size
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
 msgstr "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
+
+#: src/pages/AdminPage.tsx
+msgid "{added} added · {skipped} skipped"
+msgstr "{added} added · {skipped} skipped"
+
+#: src/pages/AdminPage.tsx
+msgid "{clearResult} covers deleted."
+msgstr "{clearResult} covers deleted."
 
 #: src/pages/BookDetailPage.tsx
 msgid "{count} sittings · {from} – {to}"
@@ -99,6 +170,7 @@ msgid "{d}d ago"
 msgstr "{d}d ago"
 
 #: src/components/NotificationBell.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "{days}d ago"
 msgstr "{days}d ago"
@@ -107,6 +179,10 @@ msgstr "{days}d ago"
 msgid "{dayStr}: {mins}m"
 msgstr "{dayStr}: {mins}m"
 
+#: src/pages/AdminPage.tsx
+msgid "{deleteBookCount, plural, one {delete # book (removes files)} other {delete # books (removes files)}}"
+msgstr "{deleteBookCount, plural, one {delete # book (removes files)} other {delete # books (removes files)}}"
+
 #: src/pages/DashboardPage.tsx
 msgid "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
 msgstr "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
@@ -114,6 +190,10 @@ msgstr "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
 #: src/pages/BookDetailPage.tsx
 msgid "{deltaStr}% vs last week"
 msgstr "{deltaStr}% vs last week"
+
+#: src/pages/AdminPage.tsx
+msgid "{dismissCount, plural, one {dismiss # group} other {dismiss # groups}}"
+msgstr "{dismissCount, plural, one {dismiss # group} other {dismiss # groups}}"
 
 #: src/pages/BookDetailPage.tsx
 msgid "{dur} across {n} chapters"
@@ -140,6 +220,7 @@ msgid "{hours}h ago"
 msgstr "{hours}h ago"
 
 #: src/components/NotificationBell.tsx
+#: src/pages/AdminPage.tsx
 msgid "{hrs}h ago"
 msgstr "{hrs}h ago"
 
@@ -147,13 +228,30 @@ msgstr "{hrs}h ago"
 msgid "{m}m"
 msgstr "{m}m"
 
+#: src/pages/AdminPage.tsx
+msgid "{mergeCount, plural, one {merge # group} other {merge # groups}}"
+msgstr "{mergeCount, plural, one {merge # group} other {merge # groups}}"
+
 #: src/components/NotificationBell.tsx
+#: src/pages/AdminPage.tsx
 msgid "{mins}m ago"
 msgstr "{mins}m ago"
 
 #: src/pages/SettingsPage.tsx
 msgid "{minutes}m ago"
 msgstr "{minutes}m ago"
+
+#: src/pages/AdminPage.tsx
+msgid "{months}mo ago"
+msgstr "{months}mo ago"
+
+#: src/pages/AdminPage.tsx
+msgid "{n, plural, one {# matching volume currently in the library.} other {# matching volumes currently in the library.}}"
+msgstr "{n, plural, one {# matching volume currently in the library.} other {# matching volumes currently in the library.}}"
+
+#: src/pages/AdminPage.tsx
+msgid "{n, plural, one {Confirm — apply # decision} other {Confirm — apply # decisions}}"
+msgstr "{n, plural, one {Confirm — apply # decision} other {Confirm — apply # decisions}}"
 
 #: src/components/AppShell.tsx
 #: src/pages/DashboardPage.tsx
@@ -167,6 +265,10 @@ msgstr "{n} selected"
 #: src/pages/DashboardPage.tsx
 msgid "{name} · Vol. {start_index}–{end_index}"
 msgstr "{name} · Vol. {start_index}–{end_index}"
+
+#: src/pages/AdminPage.tsx
+msgid "{othersCount, plural, one {Delete # other} other {Delete # others}}"
+msgstr "{othersCount, plural, one {Delete # other} other {Delete # others}}"
 
 #: src/pages/BookDetailPage.tsx
 msgid "{pacePerMin} pg/min"
@@ -220,6 +322,10 @@ msgstr "{totalCount, plural, one {# result for \"{search}\"} other {# results fo
 msgid "{words} words"
 msgstr "{words} words"
 
+#: src/pages/AdminPage.tsx
+msgid "{years}y ago"
+msgstr "{years}y ago"
+
 #: src/pages/BookDetailPage.tsx
 msgid "← Back to library"
 msgstr "← Back to library"
@@ -247,6 +353,10 @@ msgstr "About"
 #: src/pages/SettingsPage.tsx
 msgid "Account & Security"
 msgstr "Account & Security"
+
+#: src/pages/AdminPage.tsx
+msgid "Active"
+msgstr "Active"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Activity"
@@ -290,6 +400,10 @@ msgstr "Add to library"
 msgid "Add to Library"
 msgstr "Add to Library"
 
+#: src/pages/AdminPage.tsx
+msgid "Add Type"
+msgstr "Add Type"
+
 #: src/pages/SettingsPage.tsx
 msgid "Add your e-reader or personal email. Books are sent as attachments — works with Kindle, Kobo, or any email address."
 msgstr "Add your e-reader or personal email. Books are sent as attachments — works with Kindle, Kobo, or any email address."
@@ -298,13 +412,22 @@ msgstr "Add your e-reader or personal email. Books are sent as attachments — w
 msgid "Add your SMTP sender address to Amazon's <0>Approved Personal Document E-mail List</0>, or emails will be silently dropped."
 msgstr "Add your SMTP sender address to Amazon's <0>Approved Personal Document E-mail List</0>, or emails will be silently dropped."
 
+#: src/pages/AdminPage.tsx
+msgid "Added"
+msgstr "Added"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Added to Want to Read"
 msgstr "Added to Want to Read"
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 msgid "Admin"
 msgstr "Admin"
+
+#: src/pages/AdminPage.tsx
+msgid "Admin access required."
+msgstr "Admin access required."
 
 #: src/pages/DashboardPage.tsx
 msgid "All"
@@ -318,9 +441,17 @@ msgstr "All {loadedCount} books loaded"
 msgid "All →"
 msgstr "All →"
 
+#: src/pages/AdminPage.tsx
+msgid "All actions"
+msgstr "All actions"
+
 #: src/components/Sidebar.tsx
 msgid "All Books"
 msgstr "All Books"
+
+#: src/pages/AdminPage.tsx
+msgid "All Devices"
+msgstr "All Devices"
 
 #: src/pages/BookDetailPage.tsx
 msgid "All readers: {dur} · {days} · {readers}"
@@ -355,13 +486,33 @@ msgstr "App-specific PINs"
 msgid "Appearance"
 msgstr "Appearance"
 
+#: src/pages/AdminPage.tsx
+msgid "Apply All ({n})"
+msgstr "Apply All ({n})"
+
+#: src/pages/AdminPage.tsx
+msgid "Applying {done}/{total}…"
+msgstr "Applying {done}/{total}…"
+
 #: src/pages/SettingsPage.tsx
 msgid "Ask your server admin if you don't manage the Tome installation yourself."
 msgstr "Ask your server admin if you don't manage the Tome installation yourself."
 
+#: src/pages/AdminPage.tsx
+msgid "Assign type to new books"
+msgstr "Assign type to new books"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Attach progress synced from a KOReader-compatible app to this book"
 msgstr "Attach progress synced from a KOReader-compatible app to this book"
+
+#: src/pages/AdminPage.tsx
+msgid "Audit Log"
+msgstr "Audit Log"
+
+#: src/pages/AdminPage.tsx
+msgid "Auth"
+msgstr "Auth"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -396,6 +547,10 @@ msgstr "Bindery"
 msgid "Black"
 msgstr "Black"
 
+#: src/pages/AdminPage.tsx
+msgid "Book"
+msgstr "Book"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Book deleted"
 msgstr "Book deleted"
@@ -408,6 +563,11 @@ msgstr "Book Detail"
 msgid "Book not found"
 msgstr "Book not found"
 
+#: src/pages/AdminPage.tsx
+msgid "Book Types"
+msgstr "Book Types"
+
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Books"
 msgstr "Books"
@@ -429,6 +589,7 @@ msgid "Browse your library"
 msgstr "Browse your library"
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -459,6 +620,7 @@ msgstr "Chapters"
 msgid "Choose icon"
 msgstr "Choose icon"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Clear"
 msgstr "Clear"
@@ -470,6 +632,10 @@ msgstr "Clear all"
 #: src/pages/DashboardPage.tsx
 msgid "Clear all filters"
 msgstr "Clear all filters"
+
+#: src/pages/AdminPage.tsx
+msgid "Clear cover cache"
+msgstr "Clear cover cache"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Clear imported history — remove this book's KOReader page data"
@@ -529,6 +695,10 @@ msgstr "Collapse / expand all books"
 msgid "Collapse sidebar"
 msgstr "Collapse sidebar"
 
+#: src/pages/AdminPage.tsx
+msgid "Color"
+msgstr "Color"
+
 #: src/pages/SettingsPage.tsx
 msgid "Colors <0>(10 hex values, comma-separated)</0>"
 msgstr "Colors <0>(10 hex values, comma-separated)</0>"
@@ -537,6 +707,19 @@ msgstr "Colors <0>(10 hex values, comma-separated)</0>"
 msgid "Command palette — jump to a book, series, author, or page"
 msgstr "Command palette — jump to a book, series, author, or page"
 
+#: src/pages/AdminPage.tsx
+msgid "Complete"
+msgstr "Complete"
+
+#: src/pages/AdminPage.tsx
+msgid "Complete series: {title}"
+msgstr "Complete series: {title}"
+
+#: src/pages/AdminPage.tsx
+msgid "Configured"
+msgstr "Configured"
+
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Confirm"
 msgstr "Confirm"
@@ -581,6 +764,11 @@ msgstr "Cover"
 msgid "Cover size"
 msgstr "Cover size"
 
+#: src/pages/AdminPage.tsx
+msgid "Covers"
+msgstr "Covers"
+
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Create"
 msgstr "Create"
@@ -597,6 +785,10 @@ msgstr "Creating..."
 msgid "Current password"
 msgstr "Current password"
 
+#: src/pages/AdminPage.tsx
+msgid "Danger Zone"
+msgstr "Danger Zone"
+
 #: src/components/Sidebar.tsx
 msgid "Dark"
 msgstr "Dark"
@@ -610,6 +802,14 @@ msgstr "Dark theme"
 msgid "Dashboard"
 msgstr "Dashboard"
 
+#: src/pages/AdminPage.tsx
+msgid "Data"
+msgstr "Data"
+
+#: src/pages/AdminPage.tsx
+msgid "Database"
+msgstr "Database"
+
 #: src/pages/DashboardPage.tsx
 msgid "Date Added"
 msgstr "Date Added"
@@ -619,6 +819,7 @@ msgid "Day streak"
 msgstr "Day streak"
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete"
@@ -628,10 +829,19 @@ msgstr "Delete"
 msgid "Delete \"{title}\"?"
 msgstr "Delete \"{title}\"?"
 
+#: src/pages/AdminPage.tsx
+msgid "Delete all {count} cached cover files ({mb} MB). Covers will be re-extracted on next access."
+msgstr "Delete all {count} cached cover files ({mb} MB). Covers will be re-extracted on next access."
+
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete failed"
 msgstr "Delete failed"
+
+#: src/pages/AdminPage.tsx
+msgid "Delete Others"
+msgstr "Delete Others"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Delete this highlight"
@@ -654,6 +864,14 @@ msgstr "Deselect all"
 msgid "Details"
 msgstr "Details"
 
+#: src/pages/AdminPage.tsx
+msgid "Details:"
+msgstr "Details:"
+
+#: src/pages/AdminPage.tsx
+msgid "Device"
+msgstr "Device"
+
 #: src/pages/SettingsPage.tsx
 msgid "Device authorized — the new device is now signed in."
 msgstr "Device authorized — the new device is now signed in."
@@ -666,9 +884,26 @@ msgstr "Device name"
 msgid "Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device."
 msgstr "Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device."
 
+#: src/pages/AdminPage.tsx
+msgid "Directories"
+msgstr "Directories"
+
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Dismiss"
 msgstr "Dismiss"
+
+#: src/pages/AdminPage.tsx
+msgid "Dismiss failed"
+msgstr "Dismiss failed"
+
+#: src/pages/AdminPage.tsx
+msgid "Dismiss wish"
+msgstr "Dismiss wish"
+
+#: src/pages/AdminPage.tsx
+msgid "Dismissed"
+msgstr "Dismissed"
 
 #: src/components/Sidebar.tsx
 msgid "Docs"
@@ -712,15 +947,28 @@ msgstr "Download your entire library catalog — all titles, authors, series, ta
 msgid "Download ZIP"
 msgstr "Download ZIP"
 
+#: src/pages/AdminPage.tsx
+msgid "Duplicate Detection"
+msgstr "Duplicate Detection"
+
+#: src/pages/AdminPage.tsx
+msgid "Duplicates"
+msgstr "Duplicates"
+
 #: src/pages/SettingsPage.tsx
 msgid "E-Reader Devices"
 msgstr "E-Reader Devices"
+
+#: src/pages/AdminPage.tsx
+msgid "e.g. Novel"
+msgstr "e.g. Novel"
 
 #: src/pages/SettingsPage.tsx
 msgid "e.g. scribe-laptop"
 msgstr "e.g. scribe-laptop"
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Edit"
 msgstr "Edit"
@@ -745,6 +993,11 @@ msgstr "Edit review"
 msgid "Edit Shelf"
 msgstr "Edit Shelf"
 
+#: src/pages/AdminPage.tsx
+msgid "Edit User"
+msgstr "Edit User"
+
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Email"
 msgstr "Email"
@@ -768,6 +1021,10 @@ msgstr "Est. remaining"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Everywhere"
 msgstr "Everywhere"
+
+#: src/pages/AdminPage.tsx
+msgid "Exact Match"
+msgstr "Exact Match"
 
 #: src/components/ImpersonationBanner.tsx
 msgid "Exit impersonation"
@@ -793,6 +1050,7 @@ msgstr "Export {label}"
 msgid "Exporting..."
 msgstr "Exporting..."
 
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Failed"
 msgstr "Failed"
@@ -808,6 +1066,14 @@ msgstr "Failed to authorize"
 #: src/pages/SettingsPage.tsx
 msgid "Failed to change password"
 msgstr "Failed to change password"
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to clear covers"
+msgstr "Failed to clear covers"
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to complete series"
+msgstr "Failed to complete series"
 
 #: src/pages/SettingsPage.tsx
 msgid "Failed to create token"
@@ -825,6 +1091,10 @@ msgstr "Failed to link sync document"
 msgid "Failed to load books"
 msgstr "Failed to load books"
 
+#: src/pages/AdminPage.tsx
+msgid "Failed to load duplicates"
+msgstr "Failed to load duplicates"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to load facets"
 msgstr "Failed to load facets"
@@ -832,6 +1102,22 @@ msgstr "Failed to load facets"
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to load libraries"
 msgstr "Failed to load libraries"
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to load server stats"
+msgstr "Failed to load server stats"
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to load sync status"
+msgstr "Failed to load sync status"
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to load users"
+msgstr "Failed to load users"
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to load wishlist"
+msgstr "Failed to load wishlist"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to log session"
@@ -842,6 +1128,7 @@ msgid "Failed to register"
 msgstr "Failed to register"
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Failed to save"
 msgstr "Failed to save"
@@ -857,6 +1144,10 @@ msgstr "Failed to save rating"
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to save review"
 msgstr "Failed to save review"
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to save role"
+msgstr "Failed to save role"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to undo"
@@ -877,6 +1168,10 @@ msgstr "Failed to update sharing"
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
 msgstr "Fetch Metadata"
+
+#: src/pages/AdminPage.tsx
+msgid "File is missing from disk"
+msgstr "File is missing from disk"
 
 #: src/pages/DashboardPage.tsx
 msgid "Filters"
@@ -915,9 +1210,29 @@ msgstr "Format"
 msgid "Format: {filterFormatUpper}"
 msgstr "Format: {filterFormatUpper}"
 
+#: src/pages/AdminPage.tsx
+msgid "From"
+msgstr "From"
+
 #: src/pages/DashboardPage.tsx
 msgid "From your highlights"
 msgstr "From your highlights"
+
+#: src/pages/AdminPage.tsx
+msgid "Fulfill"
+msgstr "Fulfill"
+
+#: src/pages/AdminPage.tsx
+msgid "Fulfill failed"
+msgstr "Fulfill failed"
+
+#: src/pages/AdminPage.tsx
+msgid "Fulfill: {title}"
+msgstr "Fulfill: {title}"
+
+#: src/pages/AdminPage.tsx
+msgid "Fulfilled"
+msgstr "Fulfilled"
 
 #: src/pages/SettingsPage.tsx
 msgid "Full access"
@@ -932,6 +1247,7 @@ msgid "Genres"
 msgstr "Genres"
 
 #: src/components/KeyboardShortcutsModal.tsx
+#: src/pages/AdminPage.tsx
 msgid "Go back"
 msgstr "Go back"
 
@@ -950,6 +1266,10 @@ msgstr "Group series"
 #: src/pages/DashboardPage.tsx
 msgid "Group volumes by series"
 msgstr "Group volumes by series"
+
+#: src/pages/AdminPage.tsx
+msgid "Guest"
+msgstr "Guest"
 
 #: src/components/Sidebar.tsx
 msgid "Hardcover"
@@ -981,6 +1301,10 @@ msgstr "Highlights & Notes"
 msgid "Home"
 msgstr "Home"
 
+#: src/pages/AdminPage.tsx
+msgid "Host"
+msgstr "Host"
+
 #: src/pages/BookDetailPage.tsx
 msgid "How far through the book you'd read by each date."
 msgstr "How far through the book you'd read by each date."
@@ -990,12 +1314,33 @@ msgid "How to set it up"
 msgstr "How to set it up"
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 msgid "Icon"
 msgstr "Icon"
+
+#: src/pages/AdminPage.tsx
+msgid "Impersonation failed"
+msgstr "Impersonation failed"
+
+#: src/pages/AdminPage.tsx
+msgid "Import complete"
+msgstr "Import complete"
+
+#: src/pages/AdminPage.tsx
+msgid "Import from Incoming"
+msgstr "Import from Incoming"
+
+#: src/pages/AdminPage.tsx
+msgid "Import Now"
+msgstr "Import Now"
 
 #: src/pages/SettingsPage.tsx
 msgid "Import reading history"
 msgstr "Import reading history"
+
+#: src/pages/AdminPage.tsx
+msgid "Importing…"
+msgstr "Importing…"
 
 #: src/pages/SettingsPage.tsx
 msgid "In KOReader: main menu -> TomeSync -> \"Test connection\" to confirm the plugin can reach your Tome server."
@@ -1013,17 +1358,34 @@ msgstr "In KOReader: Settings > Device > Restart KOReader. The plugin loads auto
 msgid "In KOReader: Tools → Progress sync → Custom sync server."
 msgstr "In KOReader: Tools → Progress sync → Custom sync server."
 
+#: src/pages/AdminPage.tsx
+msgid "Inactive"
+msgstr "Inactive"
+
+#: src/pages/AdminPage.tsx
+msgid "Incoming"
+msgstr "Incoming"
+
+#: src/pages/AdminPage.tsx
+msgid "IP:"
+msgstr "IP:"
+
 #: src/pages/BookDetailPage.tsx
 msgid "ISBN"
 msgstr "ISBN"
 
 #: src/components/NotificationBell.tsx
+#: src/pages/AdminPage.tsx
 msgid "just now"
 msgstr "just now"
 
 #: src/pages/SettingsPage.tsx
 msgid "Just now"
 msgstr "Just now"
+
+#: src/pages/AdminPage.tsx
+msgid "Keep this one"
+msgstr "Keep this one"
 
 #: src/pages/SettingsPage.tsx
 msgid "Key created — copy it now, it won't be shown again."
@@ -1044,6 +1406,10 @@ msgstr "KOReader sync linked"
 #: src/pages/SettingsPage.tsx
 msgid "KOSync registered successfully"
 msgstr "KOSync registered successfully"
+
+#: src/pages/AdminPage.tsx
+msgid "Label"
+msgstr "Label"
 
 #: src/pages/SettingsPage.tsx
 msgid "Label (e.g. KOReader)"
@@ -1067,19 +1433,26 @@ msgstr "Last read"
 msgid "Last sync: {d}"
 msgstr "Last sync: {d}"
 
+#: src/pages/AdminPage.tsx
+msgid "Last Synced"
+msgstr "Last Synced"
+
 #: src/pages/SettingsPage.tsx
 msgid "Last used"
 msgstr "Last used"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Learn more"
 msgstr "Learn more"
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Libraries"
 msgstr "Libraries"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -1130,6 +1503,10 @@ msgstr "List view"
 msgid "Loading..."
 msgstr "Loading..."
 
+#: src/pages/AdminPage.tsx
+msgid "Log in as this user"
+msgstr "Log in as this user"
+
 #: src/components/Sidebar.tsx
 msgid "Log out"
 msgstr "Log out"
@@ -1159,6 +1536,14 @@ msgstr "Manual"
 msgid "Mark all read"
 msgstr "Mark all read"
 
+#: src/pages/AdminPage.tsx
+msgid "Mark complete"
+msgstr "Mark complete"
+
+#: src/pages/AdminPage.tsx
+msgid "Mark it complete when you consider the series fully available; the requester will be notified."
+msgstr "Mark it complete when you consider the series fully available; the requester will be notified."
+
 #: src/pages/BookDetailPage.tsx
 msgid "Marked as read"
 msgstr "Marked as read"
@@ -1170,6 +1555,18 @@ msgstr "Marked as reading"
 #: src/pages/BookDetailPage.tsx
 msgid "Marked unread — reading progress cleared"
 msgstr "Marked unread — reading progress cleared"
+
+#: src/pages/AdminPage.tsx
+msgid "Member"
+msgstr "Member"
+
+#: src/pages/AdminPage.tsx
+msgid "Merge"
+msgstr "Merge"
+
+#: src/pages/AdminPage.tsx
+msgid "Metadata"
+msgstr "Metadata"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Metadata saved"
@@ -1251,6 +1648,18 @@ msgstr "new this week"
 msgid "New Token"
 msgstr "New Token"
 
+#: src/pages/AdminPage.tsx
+msgid "New Type"
+msgstr "New Type"
+
+#: src/pages/AdminPage.tsx
+msgid "New User"
+msgstr "New User"
+
+#: src/pages/AdminPage.tsx
+msgid "Next"
+msgstr "Next"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next book"
 msgstr "Next book"
@@ -1267,6 +1676,22 @@ msgstr "No API keys. Download the plugin to auto-create one."
 msgid "No API tokens yet. Create one to use Scribe or scripts against Tome."
 msgstr "No API tokens yet. Create one to use Scribe or scripts against Tome."
 
+#: src/pages/AdminPage.tsx
+msgid "No audit entries yet."
+msgstr "No audit entries yet."
+
+#: src/pages/AdminPage.tsx
+msgid "No book types yet."
+msgstr "No book types yet."
+
+#: src/pages/AdminPage.tsx
+msgid "No books found. Upload the book first, then fulfill."
+msgstr "No books found. Upload the book first, then fulfill."
+
+#: src/pages/AdminPage.tsx
+msgid "No books have been sent yet."
+msgstr "No books have been sent yet."
+
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
 msgstr "No description"
@@ -1275,13 +1700,33 @@ msgstr "No description"
 msgid "No devices yet. Add one to start sending books."
 msgstr "No devices yet. Add one to start sending books."
 
+#: src/pages/AdminPage.tsx
+msgid "No dismissed wishes."
+msgstr "No dismissed wishes."
+
+#: src/pages/AdminPage.tsx
+msgid "No duplicates found. Your library looks clean."
+msgstr "No duplicates found. Your library looks clean."
+
+#: src/pages/AdminPage.tsx
+msgid "No fulfilled wishes."
+msgstr "No fulfilled wishes."
+
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
 msgstr "No matches"
 
+#: src/pages/AdminPage.tsx
+msgid "No matching volumes in the library yet."
+msgstr "No matching volumes in the library yet."
+
 #: src/components/NotificationBell.tsx
 msgid "No notifications yet"
 msgstr "No notifications yet"
+
+#: src/pages/AdminPage.tsx
+msgid "No open wishes."
+msgstr "No open wishes."
 
 #: src/components/Sidebar.tsx
 msgid "No other users to share with."
@@ -1290,6 +1735,10 @@ msgstr "No other users to share with."
 #: src/pages/SettingsPage.tsx
 msgid "No PINs yet. Generate one to use with OPDS clients."
 msgstr "No PINs yet. Generate one to use with OPDS clients."
+
+#: src/pages/AdminPage.tsx
+msgid "No reading activity yet. Records appear when users start reading books."
+msgstr "No reading activity yet. Records appear when users start reading books."
 
 #: src/pages/BookDetailPage.tsx
 msgid "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
@@ -1311,14 +1760,30 @@ msgstr "No Series"
 msgid "No series found — add series metadata to your books."
 msgstr "No series found — add series metadata to your books."
 
+#: src/pages/AdminPage.tsx
+msgid "No suggested match yet — search for the book to link, or upload it first."
+msgstr "No suggested match yet — search for the book to link, or upload it first."
+
 #: src/pages/BookDetailPage.tsx
 msgid "No type"
 msgstr "No type"
+
+#: src/pages/AdminPage.tsx
+msgid "No type (staging / admin only)"
+msgstr "No type (staging / admin only)"
+
+#: src/pages/AdminPage.tsx
+msgid "No users have added devices yet."
+msgstr "No users have added devices yet."
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "None"
 msgstr "None"
+
+#: src/pages/AdminPage.tsx
+msgid "Not configured"
+msgstr "Not configured"
 
 #: src/pages/BookDetailPage.tsx
 msgid "not read"
@@ -1369,6 +1834,10 @@ msgstr "Only filled fields will be updated. Leave blank to keep existing values.
 msgid "OPDS Catalog"
 msgstr "OPDS Catalog"
 
+#: src/pages/AdminPage.tsx
+msgid "Open"
+msgstr "Open"
+
 #: src/pages/SettingsPage.tsx
 msgid "Open a book downloaded via OPDS"
 msgstr "Open a book downloaded via OPDS"
@@ -1409,6 +1878,11 @@ msgstr "pages"
 msgid "Pages · 30d"
 msgstr "Pages · 30d"
 
+#: src/pages/AdminPage.tsx
+msgid "password"
+msgstr "password"
+
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Password"
 msgstr "Password"
@@ -1429,9 +1903,17 @@ msgstr "Passwords do not match"
 msgid "Pick up where you left off"
 msgstr "Pick up where you left off"
 
+#: src/pages/AdminPage.tsx
+msgid "Pick which book to keep and an action per group — Merge, Delete Others, or Dismiss — then apply everything at once."
+msgstr "Pick which book to keep and an action per group — Merge, Delete Others, or Dismiss — then apply everything at once."
+
 #: src/pages/SettingsPage.tsx
 msgid "PIN created — copy it now, it won't be shown again."
 msgstr "PIN created — copy it now, it won't be shown again."
+
+#: src/pages/AdminPage.tsx
+msgid "Port"
+msgstr "Port"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Position history — restore a bad sync"
@@ -1457,6 +1939,10 @@ msgstr "Preview"
 msgid "Preview:"
 msgstr "Preview:"
 
+#: src/pages/AdminPage.tsx
+msgid "Previous"
+msgstr "Previous"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Previous book"
 msgstr "Previous book"
@@ -1473,10 +1959,15 @@ msgstr "Private — only assigned users can access"
 msgid "Private library"
 msgstr "Private library"
 
+#: src/pages/AdminPage.tsx
+msgid "Process files dropped into the <0>incoming/</0> directory and move them into the library."
+msgstr "Process files dropped into the <0>incoming/</0> directory and move them into the library."
+
 #: src/pages/SettingsPage.tsx
 msgid "Profile updated"
 msgstr "Profile updated"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Progress"
 msgstr "Progress"
@@ -1496,6 +1987,14 @@ msgstr "Public library"
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
 msgstr "Publisher"
+
+#: src/pages/AdminPage.tsx
+msgid "Queue: fold the other copies into the kept book"
+msgstr "Queue: fold the other copies into the kept book"
+
+#: src/pages/AdminPage.tsx
+msgid "Queue: not a duplicate — never show this group again"
+msgstr "Queue: not a duplicate — never show this group again"
 
 #: src/pages/SettingsPage.tsx
 msgid "Quick Connect"
@@ -1525,6 +2024,7 @@ msgstr "Rated: 5 stars"
 msgid "Rating"
 msgstr "Rating"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "read"
 msgstr "read"
@@ -1567,6 +2067,7 @@ msgstr "Read-only"
 msgid "Reader"
 msgstr "Reader"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "reading"
 msgstr "reading"
@@ -1599,6 +2100,10 @@ msgstr "Recently Added"
 msgid "Recently Finished"
 msgstr "Recently Finished"
 
+#: src/pages/AdminPage.tsx
+msgid "Refresh"
+msgstr "Refresh"
+
 #: src/pages/SettingsPage.tsx
 msgid "Register"
 msgstr "Register"
@@ -1614,6 +2119,10 @@ msgstr "Remove device"
 #: src/pages/BookDetailPage.tsx
 msgid "Remove from library"
 msgstr "Remove from library"
+
+#: src/pages/AdminPage.tsx
+msgid "Resource:"
+msgstr "Resource:"
 
 #: src/pages/SettingsPage.tsx
 msgid "Restart KOReader"
@@ -1639,7 +2148,24 @@ msgstr "Revoke token"
 msgid "Revoked"
 msgstr "Revoked"
 
+#: src/pages/AdminPage.tsx
+msgid "Role"
+msgstr "Role"
+
+#: src/pages/AdminPage.tsx
+msgid "Roles guide"
+msgstr "Roles guide"
+
+#: src/pages/AdminPage.tsx
+msgid "Same ISBN"
+msgstr "Same ISBN"
+
+#: src/pages/AdminPage.tsx
+msgid "Same Series Volume"
+msgstr "Same Series Volume"
+
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Save"
 msgstr "Save"
@@ -1672,6 +2198,26 @@ msgstr "Saving..."
 msgid "Saving…"
 msgstr "Saving…"
 
+#: src/pages/AdminPage.tsx
+msgid "Scan complete"
+msgstr "Scan complete"
+
+#: src/pages/AdminPage.tsx
+msgid "Scan Library"
+msgstr "Scan Library"
+
+#: src/pages/AdminPage.tsx
+msgid "Scan Now"
+msgstr "Scan Now"
+
+#: src/pages/AdminPage.tsx
+msgid "Scanner"
+msgstr "Scanner"
+
+#: src/pages/AdminPage.tsx
+msgid "Scanning…"
+msgstr "Scanning…"
+
 #: src/pages/SettingsPage.tsx
 msgid "Scope"
 msgstr "Scope"
@@ -1683,6 +2229,14 @@ msgstr "Search books"
 #: src/components/AppHeader.tsx
 msgid "Search books… (/)"
 msgstr "Search books… (/)"
+
+#: src/pages/AdminPage.tsx
+msgid "Search for a book in the library…"
+msgstr "Search for a book in the library…"
+
+#: src/pages/AdminPage.tsx
+msgid "Search for a different book…"
+msgstr "Search for a different book…"
 
 #: src/components/Sidebar.tsx
 msgid "Search icons…"
@@ -1700,13 +2254,37 @@ msgstr "See all results for \"{searchQuery}\""
 msgid "Select"
 msgstr "Select"
 
+#: src/pages/AdminPage.tsx
+msgid "Select a book first."
+msgstr "Select a book first."
+
 #: src/pages/DashboardPage.tsx
 msgid "Select all"
 msgstr "Select all"
 
+#: src/pages/AdminPage.tsx
+msgid "Send failed"
+msgstr "Send failed"
+
+#: src/pages/AdminPage.tsx
+msgid "Send History"
+msgstr "Send History"
+
+#: src/pages/AdminPage.tsx
+msgid "Send test email"
+msgstr "Send test email"
+
 #: src/pages/SettingsPage.tsx
 msgid "Send to Device"
 msgstr "Send to Device"
+
+#: src/pages/AdminPage.tsx
+msgid "Sending..."
+msgstr "Sending..."
+
+#: src/pages/AdminPage.tsx
+msgid "Sent"
+msgstr "Sent"
 
 #: src/components/Sidebar.tsx
 #: src/pages/DashboardPage.tsx
@@ -1725,6 +2303,10 @@ msgstr "Series Progress"
 #: src/pages/DashboardPage.tsx
 msgid "Series: {filterSeries}"
 msgstr "Series: {filterSeries}"
+
+#: src/pages/AdminPage.tsx
+msgid "Server"
+msgstr "Server"
 
 #: src/pages/BookDetailPage.tsx
 msgid "sessions"
@@ -1745,6 +2327,10 @@ msgstr "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>,
 #: src/pages/SettingsPage.tsx
 msgid "Set sync password"
 msgstr "Set sync password"
+
+#: src/pages/AdminPage.tsx
+msgid "Set the following environment variables to enable Send to Device:"
+msgstr "Set the following environment variables to enable Send to Device:"
 
 #: src/components/Sidebar.tsx
 #: src/pages/SettingsPage.tsx
@@ -1779,6 +2365,10 @@ msgstr "Share with users"
 #: src/pages/DashboardPage.tsx
 msgid "Shared Library"
 msgstr "Shared Library"
+
+#: src/pages/AdminPage.tsx
+msgid "shelved"
+msgstr "shelved"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -1831,9 +2421,25 @@ msgstr "Show this help"
 msgid "Sign in on a new device without entering your password. On the new device, tap \"Quick Connect\" on the login screen to get a 6-character code, then enter it here."
 msgstr "Sign in on a new device without entering your password. On the new device, tap \"Quick Connect\" on the login screen to get a 6-character code, then enter it here."
 
+#: src/pages/AdminPage.tsx
+msgid "Similar Title"
+msgstr "Similar Title"
+
 #: src/pages/SettingsPage.tsx
 msgid "Single Sign-On"
 msgstr "Single Sign-On"
+
+#: src/pages/AdminPage.tsx
+msgid "SMTP Status"
+msgstr "SMTP Status"
+
+#: src/pages/AdminPage.tsx
+msgid "Sort Order"
+msgstr "Sort Order"
+
+#: src/pages/AdminPage.tsx
+msgid "Source"
+msgstr "Source"
 
 #: src/pages/SettingsPage.tsx
 msgid "SSO sign-in linked to your account."
@@ -1855,6 +2461,7 @@ msgstr "Start reading and your progress will show up here"
 msgid "Stats"
 msgstr "Stats"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Status"
 msgstr "Status"
@@ -1871,6 +2478,10 @@ msgstr "Subtitle (optional)"
 msgid "Sync reading position between KOReader and Tome."
 msgstr "Sync reading position between KOReader and Tome."
 
+#: src/pages/AdminPage.tsx
+msgid "Sync Status"
+msgstr "Sync Status"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Synced document"
 msgstr "Synced document"
@@ -1882,6 +2493,14 @@ msgstr "Tag"
 #: src/pages/DashboardPage.tsx
 msgid "Tag: {filterTag}"
 msgstr "Tag: {filterTag}"
+
+#: src/pages/AdminPage.tsx
+msgid "Test"
+msgstr "Test"
+
+#: src/pages/AdminPage.tsx
+msgid "Test email sent successfully."
+msgstr "Test email sent successfully."
 
 #: src/pages/SettingsPage.tsx
 msgid "That SSO identity is already linked to another account."
@@ -1903,6 +2522,10 @@ msgstr "Theme name"
 msgid "Theme name is required"
 msgstr "Theme name is required"
 
+#: src/pages/AdminPage.tsx
+msgid "This is a whole-series wish — it stays open as volumes arrive."
+msgstr "This is a whole-series wish — it stays open as volumes arrive."
+
 #: src/pages/SettingsPage.tsx
 msgid "This is the only time you will see this token. Store it somewhere safe — it cannot be recovered."
 msgstr "This is the only time you will see this token. Store it somewhere safe — it cannot be recovered."
@@ -1910,6 +2533,10 @@ msgstr "This is the only time you will see this token. Store it somewhere safe �
 #: src/pages/DashboardPage.tsx
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
 msgstr "This permanently removes the selected books and their files from disk. This cannot be undone."
+
+#: src/pages/AdminPage.tsx
+msgid "Time"
+msgstr "Time"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Time per chapter"
@@ -1924,6 +2551,7 @@ msgstr "Time per chapter, line view"
 msgid "Title"
 msgstr "Title"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Today"
 msgstr "Today"
@@ -1961,6 +2589,10 @@ msgstr "Try adjusting your filters"
 msgid "Type"
 msgstr "Type"
 
+#: src/pages/AdminPage.tsx
+msgid "Types"
+msgstr "Types"
+
 #: src/pages/DashboardPage.tsx
 msgid "Unassigned"
 msgstr "Unassigned"
@@ -1973,6 +2605,7 @@ msgstr "Undo"
 msgid "unknown device"
 msgstr "unknown device"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "unread"
 msgstr "unread"
@@ -2037,17 +2670,30 @@ msgstr "Use this as the OPDS password in KOReader (username stays the same)."
 msgid "used {d}"
 msgstr "used {d}"
 
+#: src/pages/AdminPage.tsx
+msgid "User"
+msgstr "User"
+
 #: src/components/Sidebar.tsx
 msgid "User menu"
 msgstr "User menu"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Username"
 msgstr "Username"
 
+#: src/pages/AdminPage.tsx
+msgid "Users"
+msgstr "Users"
+
 #: src/pages/SettingsPage.tsx
 msgid "Verify it's working"
 msgstr "Verify it's working"
+
+#: src/pages/AdminPage.tsx
+msgid "View book"
+msgstr "View book"
 
 #: src/components/ImpersonationBanner.tsx
 msgid "Viewing as <0>{impersonatedUsername}</0>"
@@ -2070,6 +2716,14 @@ msgstr "Volume"
 msgid "Volumes"
 msgstr "Volumes"
 
+#: src/pages/AdminPage.tsx
+msgid "Walk the library directory and add any new book files found."
+msgstr "Walk the library directory and add any new book files found."
+
+#: src/pages/AdminPage.tsx
+msgid "want to read"
+msgstr "want to read"
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Want to Read"
@@ -2082,6 +2736,10 @@ msgstr "Want to Read — queue this book up next"
 #: src/pages/SettingsPage.tsx
 msgid "Warm"
 msgstr "Warm"
+
+#: src/pages/AdminPage.tsx
+msgid "Web"
+msgstr "Web"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Web reader"
@@ -2099,9 +2757,22 @@ msgstr "Where in the book your time went — taller means more time spent on tho
 msgid "Where you read"
 msgstr "Where you read"
 
+#: src/pages/AdminPage.tsx
+msgid "Whole series"
+msgstr "Whole series"
+
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 msgid "Wishlist"
 msgstr "Wishlist"
+
+#: src/pages/AdminPage.tsx
+msgid "Without a type, new books are only visible to admins until assigned."
+msgstr "Without a type, new books are only visible to admins until assigned."
+
+#: src/pages/AdminPage.tsx
+msgid "Word Counts"
+msgstr "Word Counts"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Words"
@@ -2112,9 +2783,14 @@ msgstr "Words"
 msgid "Year"
 msgstr "Year"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Yesterday"
 msgstr "Yesterday"
+
+#: src/pages/AdminPage.tsx
+msgid "You"
+msgstr "You"
 
 #: src/pages/BookDetailPage.tsx
 msgid "You rated this {rating}/5"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -543,6 +543,10 @@ msgstr "{behind} behind pace"
 msgid "{books, plural, one {{total} from # book} other {{total} from # books}}"
 msgstr "{books, plural, one {{total} from # book} other {{total} from # books}}"
 
+#: src/components/stats/widgets/habits.tsx
+msgid "{bt} — {st} to {en} ({dur})"
+msgstr "{bt} — {st} to {en} ({dur})"
+
 #: src/pages/AdminPage.tsx
 msgid "{clearResult} covers deleted."
 msgstr "{clearResult} covers deleted."
@@ -2154,6 +2158,7 @@ msgid "Copied {n} highlights as Markdown"
 msgstr "Copied {n} highlights as Markdown"
 
 #: src/pages/HighlightsPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Copy"
 msgstr "Copy"
 
@@ -2161,9 +2166,14 @@ msgstr "Copy"
 msgid "Copy all as Markdown"
 msgstr "Copy all as Markdown"
 
+#: src/components/ShareLinksOverview.tsx
 #: src/components/ShareShelfModal.tsx
 msgid "Copy link"
 msgstr "Copy link"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copy this book’s highlights as Markdown"
+msgstr "Copy this book’s highlights as Markdown"
 
 #: src/pages/SettingsPage.tsx
 msgid "Copy to KOReader"
@@ -2450,14 +2460,34 @@ msgstr "Delete failed"
 msgid "Delete Others"
 msgstr "Delete Others"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Delete session"
+msgstr "Delete session"
+
+#: src/pages/AdminPage.tsx
+msgid "Delete sync record"
+msgstr "Delete sync record"
+
+#: src/pages/SettingsPage.tsx
+msgid "Delete theme"
+msgstr "Delete theme"
+
 #: src/pages/BinderyPage.tsx
 msgid "Delete this book from the library? The file will be removed and this cannot be undone."
 msgstr "Delete this book from the library? The file will be removed and this cannot be undone."
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Delete this goal"
+msgstr "Delete this goal"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "Delete this highlight"
 msgstr "Delete this highlight"
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Delete this imported sitting"
+msgstr "Delete this imported sitting"
 
 #: src/pages/StatsPage.tsx
 msgid "Deleted board “{name}”"
@@ -3174,6 +3204,14 @@ msgstr "Finished · 30d"
 msgid "First read"
 msgstr "First read"
 
+#: src/pages/ReaderPage.tsx
+msgid "Fit page height (W)"
+msgstr "Fit page height (W)"
+
+#: src/pages/ReaderPage.tsx
+msgid "Fit page width (W)"
+msgstr "Fit page width (W)"
+
 #: src/components/CoverAudit.tsx
 msgid "Fixed"
 msgstr "Fixed"
@@ -3383,6 +3421,10 @@ msgstr "Hiatus"
 #: src/pages/BookDetailPage.tsx
 msgid "Hide details"
 msgstr "Hide details"
+
+#: src/components/stats/widgets/library.tsx
+msgid "Hide sessions"
+msgstr "Hide sessions"
 
 #: src/components/stats/widgets/taste.tsx
 msgid "Highest"
@@ -4878,6 +4920,10 @@ msgstr "Padding"
 msgid "Page {n}"
 msgstr "Page {n}"
 
+#: src/pages/ReaderPage.tsx
+msgid "Page thumbnails (T)"
+msgstr "Page thumbnails (T)"
+
 #: src/components/SeriesReadingStats.tsx
 #: src/lib/goals.ts
 #: src/pages/BookDetailPage.tsx
@@ -4989,6 +5035,10 @@ msgstr "Pick a rhythm — progress counts automatically."
 #: src/pages/StatsPage.tsx
 msgid "Pick a start & end"
 msgstr "Pick a start & end"
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Pick different candidate"
+msgstr "Pick different candidate"
 
 #: src/pages/DashboardPage.tsx
 msgid "Pick up where you left off"
@@ -5135,6 +5185,10 @@ msgid "Queue: fold the other copies into the kept book"
 msgstr "Queue: fold the other copies into the kept book"
 
 #: src/pages/AdminPage.tsx
+msgid "Queue: keep the selected book and delete the others — their files are removed from disk"
+msgstr "Queue: keep the selected book and delete the others — their files are removed from disk"
+
+#: src/pages/AdminPage.tsx
 msgid "Queue: not a duplicate — never show this group again"
 msgstr "Queue: not a duplicate — never show this group again"
 
@@ -5278,6 +5332,10 @@ msgstr "Read-only"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Reader"
 msgstr "Reader"
+
+#: src/pages/ReaderPage.tsx
+msgid "Reader settings"
+msgstr "Reader settings"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -5440,6 +5498,10 @@ msgstr "Reject files"
 #: src/pages/BinderyPage.tsx
 msgid "Reject imported book"
 msgstr "Reject imported book"
+
+#: src/components/UploadModal.tsx
+msgid "Remove"
+msgstr "Remove"
 
 #: src/pages/StatsPage.tsx
 msgid "Remove {title}"
@@ -5613,6 +5675,7 @@ msgstr "Reviewing {n} files"
 msgid "Revoke"
 msgstr "Revoke"
 
+#: src/components/ShareLinksOverview.tsx
 #: src/components/ShareShelfModal.tsx
 msgid "Revoke link"
 msgstr "Revoke link"
@@ -5683,6 +5746,10 @@ msgstr "Save changes"
 #: src/pages/DashboardPage.tsx
 msgid "Save Changes"
 msgstr "Save Changes"
+
+#: src/components/SaveFilterButton.tsx
+msgid "Save current filters as a shelf"
+msgstr "Save current filters as a shelf"
 
 #: src/components/ManageSeriesModal.tsx
 #: src/pages/BookDetailPage.tsx
@@ -5855,6 +5922,10 @@ msgstr "Searching for: <0>{title}</0>"
 #: src/pages/HardcoverPage.tsx
 msgid "Searching…"
 msgstr "Searching…"
+
+#: src/components/home/FocusMode.tsx
+msgid "See all in-progress books"
+msgstr "See all in-progress books"
 
 #: src/components/AppShell.tsx
 msgid "See all results for \"{searchQuery}\""
@@ -6203,6 +6274,10 @@ msgstr "Show more"
 msgid "Show more ({left} remaining)"
 msgstr "Show more ({left} remaining)"
 
+#: src/components/stats/widgets/library.tsx
+msgid "Show sessions"
+msgstr "Show sessions"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
 msgstr "Show this help"
@@ -6230,6 +6305,10 @@ msgstr "Signing you in…"
 #: src/pages/AdminPage.tsx
 msgid "Similar Title"
 msgstr "Similar Title"
+
+#: src/pages/ReaderPage.tsx
+msgid "Single page (S)"
+msgstr "Single page (S)"
 
 #: src/pages/SettingsPage.tsx
 msgid "Single Sign-On"
@@ -6411,6 +6490,22 @@ msgstr "Suggested: {dur}"
 msgid "Sun"
 msgstr "Sun"
 
+#: src/pages/ReaderPage.tsx
+msgid "Switch to fit height"
+msgstr "Switch to fit height"
+
+#: src/pages/ReaderPage.tsx
+msgid "Switch to fit width"
+msgstr "Switch to fit width"
+
+#: src/pages/ReaderPage.tsx
+msgid "Switch to page mode"
+msgstr "Switch to page mode"
+
+#: src/pages/ReaderPage.tsx
+msgid "Switch to webtoon (scroll) mode"
+msgstr "Switch to webtoon (scroll) mode"
+
 #: src/components/HardcoverSync.tsx
 msgid "Sync automatically"
 msgstr "Sync automatically"
@@ -6474,6 +6569,10 @@ msgstr "Syncing…"
 #: src/pages/BinderyPage.tsx
 msgid "Synopsis or description"
 msgstr "Synopsis or description"
+
+#: src/pages/ReaderPage.tsx
+msgid "Table of contents"
+msgstr "Table of contents"
 
 #: src/pages/DashboardPage.tsx
 msgid "Tag"
@@ -6601,6 +6700,10 @@ msgstr "This replaces <0>the entire database</0> at the next restart. Type <1>RE
 msgid "This series has no volumes with a numeric index yet. Add volumes before defining arcs."
 msgstr "This series has no volumes with a numeric index yet. Add volumes before defining arcs."
 
+#: src/pages/StatsPage.tsx
+msgid "This tile uses a fixed window and ignores the range picker"
+msgstr "This tile uses a fixed window and ignores the range picker"
+
 #: src/components/WishlistModal.tsx
 msgid "This volume"
 msgstr "This volume"
@@ -6710,6 +6813,10 @@ msgstr "Toggle metadata edit"
 msgid "Toggle only-notes filter"
 msgstr "Toggle only-notes filter"
 
+#: src/pages/ReaderPage.tsx
+msgid "Toggle RTL (manga) mode"
+msgstr "Toggle RTL (manga) mode"
+
 #: src/components/stats/widgets/overview.tsx
 msgid "Toggle sort order"
 msgstr "Toggle sort order"
@@ -6784,6 +6891,10 @@ msgid "Trim"
 msgstr "Trim"
 
 #: src/components/stats/widgets/overview.tsx
+msgid "Trim session"
+msgstr "Trim session"
+
+#: src/components/stats/widgets/overview.tsx
 msgid "Trimming only shortens this session's length and end time — page turns, progress and every other session stay untouched, and the previous duration is kept in the audit log. The suggestion re-prices this session's page turns at your usual reading pace."
 msgstr "Trimming only shortens this session's length and end time — page turns, progress and every other session stay untouched, and the previous duration is kept in the audit log. The suggestion re-prices this session's page turns at your usual reading pace."
 
@@ -6807,6 +6918,10 @@ msgstr "Tu"
 #: src/components/stats/widgets/habits.tsx
 msgid "Tue"
 msgstr "Tue"
+
+#: src/pages/ReaderPage.tsx
+msgid "Two-page spread (S)"
+msgstr "Two-page spread (S)"
 
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -7048,6 +7163,10 @@ msgstr "volume"
 #: src/pages/BookDetailPage.tsx
 msgid "Volume"
 msgstr "Volume"
+
+#: src/components/SeriesCoverageStrip.tsx
+msgid "Volume {n} — not in the library"
+msgstr "Volume {n} — not in the library"
 
 #: src/components/home/FocusMode.tsx
 msgid "Volume <0>{v}</0>"
@@ -7345,6 +7464,14 @@ msgstr "Your year, at a glance (1y/All)"
 msgid "Zoom in"
 msgstr "Zoom in"
 
+#: src/pages/ReaderPage.tsx
+msgid "Zoom in (+)"
+msgstr "Zoom in (+)"
+
 #: src/components/stats/TimelineRibbon.tsx
 msgid "Zoom out"
 msgstr "Zoom out"
+
+#: src/pages/ReaderPage.tsx
+msgid "Zoom out (-)"
+msgstr "Zoom out (-)"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -33,9 +33,17 @@ msgstr " · {errs} error(s)"
 msgid " · {prog}% in"
 msgstr " · {prog}% in"
 
+#: src/pages/BinderyPage.tsx
+msgid " · reviewed"
+msgstr " · reviewed"
+
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
 msgstr "— keep existing —"
+
+#: src/pages/BinderyPage.tsx
+msgid ", {errors} failed"
+msgstr ", {errors} failed"
 
 #: src/pages/AdminPage.tsx
 msgid ", {n} failed"
@@ -103,6 +111,11 @@ msgstr "{0, plural, one {# reading day} other {# reading days}}"
 msgid "{0, plural, one {# record} other {# records}}"
 msgstr "{0, plural, one {# record} other {# records}}"
 
+#. placeholder {0}: candidates.length
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {# result — click to fill form} other {# results — click to fill form}}"
+msgstr "{0, plural, one {# result — click to fill form} other {# results — click to fill form}}"
+
 #. placeholder {0}: data.reread_bins
 #: src/pages/BookDetailPage.tsx
 msgid "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
@@ -117,6 +130,17 @@ msgstr "{0, plural, one {# suggested match} other {# suggested matches}}"
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# user} other {# users}}"
 msgstr "{0, plural, one {# user} other {# users}}"
+
+#. placeholder {0}: group.files.length
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {Accept # volume} other {Accept # volumes}}"
+msgstr "{0, plural, one {Accept # volume} other {Accept # volumes}}"
+
+#. placeholder {0}: acceptedPaths.length
+#. placeholder {0}: result.accepted.length
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {Accepted # book} other {Accepted # books}}"
+msgstr "{0, plural, one {Accepted # book} other {Accepted # books}}"
 
 #. placeholder {0}: selected.size
 #: src/pages/DashboardPage.tsx
@@ -142,6 +166,21 @@ msgstr "{0, plural, one {Deleting # book...} other {Deleting # books...}}"
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Books}}"
 msgstr "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Books}}"
+
+#. placeholder {0}: group.library_match.volume_count
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {In library · # vol} other {In library · # vols}}"
+msgstr "{0, plural, one {In library · # vol} other {In library · # vols}}"
+
+#. placeholder {0}: confirmReject?.length ?? 0
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {Permanently delete # file from the bindery? This cannot be undone.} other {Permanently delete # files from the bindery? This cannot be undone.}}"
+msgstr "{0, plural, one {Permanently delete # file from the bindery? This cannot be undone.} other {Permanently delete # files from the bindery? This cannot be undone.}}"
+
+#. placeholder {0}: result.rejected
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {Rejected # file} other {Rejected # files}}"
+msgstr "{0, plural, one {Rejected # file} other {Rejected # files}}"
 
 #. placeholder {0}: suggestedBooks.length
 #: src/pages/AdminPage.tsx
@@ -191,6 +230,18 @@ msgstr "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
 msgid "{deltaStr}% vs last week"
 msgstr "{deltaStr}% vs last week"
 
+#: src/pages/BinderyPage.tsx
+msgid "{diffDays}d ago"
+msgstr "{diffDays}d ago"
+
+#: src/pages/BinderyPage.tsx
+msgid "{diffHrs}h ago"
+msgstr "{diffHrs}h ago"
+
+#: src/pages/BinderyPage.tsx
+msgid "{diffMins}m ago"
+msgstr "{diffMins}m ago"
+
 #: src/pages/AdminPage.tsx
 msgid "{dismissCount, plural, one {dismiss # group} other {dismiss # groups}}"
 msgstr "{dismissCount, plural, one {dismiss # group} other {dismiss # groups}}"
@@ -206,6 +257,10 @@ msgstr "{dur} on device"
 #: src/pages/DashboardPage.tsx
 msgid "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 msgstr "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+
+#: src/pages/BinderyPage.tsx
+msgid "{failedN} of {totalN} failed — {firstErr}"
+msgstr "{failedN} of {totalN} failed — {firstErr}"
 
 #: src/pages/DashboardPage.tsx
 msgid "{h}h"
@@ -223,6 +278,14 @@ msgstr "{hours}h ago"
 #: src/pages/AdminPage.tsx
 msgid "{hrs}h ago"
 msgstr "{hrs}h ago"
+
+#: src/pages/BinderyPage.tsx
+msgid "{imp} imported + {inc} incoming"
+msgstr "{imp} imported + {inc} incoming"
+
+#: src/pages/BinderyPage.tsx
+msgid "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
+msgstr "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
 
 #: src/pages/DashboardPage.tsx
 msgid "{m}m"
@@ -249,6 +312,14 @@ msgstr "{months}mo ago"
 msgid "{n, plural, one {# matching volume currently in the library.} other {# matching volumes currently in the library.}}"
 msgstr "{n, plural, one {# matching volume currently in the library.} other {# matching volumes currently in the library.}}"
 
+#: src/pages/BinderyPage.tsx
+msgid "{n, plural, one {Accepted # volume of {seriesName}} other {Accepted # volumes of {seriesName}}}"
+msgstr "{n, plural, one {Accepted # volume of {seriesName}} other {Accepted # volumes of {seriesName}}}"
+
+#: src/pages/BinderyPage.tsx
+msgid "{n, plural, one {Accepted # volume} other {Accepted # volumes}}"
+msgstr "{n, plural, one {Accepted # volume} other {Accepted # volumes}}"
+
 #: src/pages/AdminPage.tsx
 msgid "{n, plural, one {Confirm — apply # decision} other {Confirm — apply # decisions}}"
 msgstr "{n, plural, one {Confirm — apply # decision} other {Confirm — apply # decisions}}"
@@ -261,6 +332,10 @@ msgstr "{n, plural, one {This upload satisfies # wish — review in Admin > Wish
 #: src/pages/DashboardPage.tsx
 msgid "{n} selected"
 msgstr "{n} selected"
+
+#: src/pages/BinderyPage.tsx
+msgid "{n} selected — Clear"
+msgstr "{n} selected — Clear"
 
 #: src/pages/DashboardPage.tsx
 msgid "{name} · Vol. {start_index}–{end_index}"
@@ -350,6 +425,22 @@ msgstr "A while ago"
 msgid "About"
 msgstr "About"
 
+#: src/pages/BinderyPage.tsx
+msgid "Accept"
+msgstr "Accept"
+
+#: src/pages/BinderyPage.tsx
+msgid "Accept All"
+msgstr "Accept All"
+
+#: src/pages/BinderyPage.tsx
+msgid "Accept failed"
+msgstr "Accept failed"
+
+#: src/pages/BinderyPage.tsx
+msgid "Accepted: {title}"
+msgstr "Accepted: {title}"
+
 #: src/pages/SettingsPage.tsx
 msgid "Account & Security"
 msgstr "Account & Security"
@@ -392,6 +483,10 @@ msgstr "Add Tags"
 msgid "Add Theme"
 msgstr "Add Theme"
 
+#: src/pages/BinderyPage.tsx
+msgid "Add to libraries…"
+msgstr "Add to libraries…"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Add to library"
 msgstr "Add to library"
@@ -415,6 +510,10 @@ msgstr "Add your SMTP sender address to Amazon's <0>Approved Personal Document E
 #: src/pages/AdminPage.tsx
 msgid "Added"
 msgstr "Added"
+
+#: src/pages/BinderyPage.tsx
+msgid "Added {timeAgo}"
+msgstr "Added {timeAgo}"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Added to Want to Read"
@@ -453,6 +552,14 @@ msgstr "All Books"
 msgid "All Devices"
 msgstr "All Devices"
 
+#: src/pages/BinderyPage.tsx
+msgid "All imported books accepted"
+msgstr "All imported books accepted"
+
+#: src/pages/BinderyPage.tsx
+msgid "All items must have a title"
+msgstr "All items must have a title"
+
 #: src/pages/BookDetailPage.tsx
 msgid "All readers: {dur} · {days} · {readers}"
 msgstr "All readers: {dur} · {days} · {readers}"
@@ -490,6 +597,10 @@ msgstr "Appearance"
 msgid "Apply All ({n})"
 msgstr "Apply All ({n})"
 
+#: src/pages/BinderyPage.tsx
+msgid "Apply to all"
+msgstr "Apply to all"
+
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
 msgstr "Applying {done}/{total}…"
@@ -514,10 +625,19 @@ msgstr "Audit Log"
 msgid "Auth"
 msgstr "Auth"
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Author"
 msgstr "Author"
+
+#: src/pages/BinderyPage.tsx
+msgid "Author applied to {n} files"
+msgstr "Author applied to {n} files"
+
+#: src/pages/BinderyPage.tsx
+msgid "Author name"
+msgstr "Author name"
 
 #: src/pages/DashboardPage.tsx
 msgid "Author: {filterAuthor}"
@@ -535,21 +655,46 @@ msgstr "Authorizing..."
 msgid "avg session"
 msgstr "avg session"
 
+#: src/pages/BinderyPage.tsx
+msgid "Back to list"
+msgstr "Back to list"
+
 #: src/pages/SettingsPage.tsx
 msgid "Backup"
 msgstr "Backup"
 
+#: src/pages/BinderyPage.tsx
+msgid "Best match applied to {matched} of {totalN} files — no match for the rest"
+msgstr "Best match applied to {matched} of {totalN} files — no match for the rest"
+
+#: src/pages/BinderyPage.tsx
+msgid "Best match applied to all {matched} files"
+msgstr "Best match applied to all {matched} files"
+
 #: src/components/Sidebar.tsx
+#: src/pages/BinderyPage.tsx
 msgid "Bindery"
 msgstr "Bindery"
+
+#: src/pages/BinderyPage.tsx
+msgid "Bindery flow explained — open docs"
+msgstr "Bindery flow explained — open docs"
 
 #: src/components/Sidebar.tsx
 msgid "Black"
 msgstr "Black"
 
+#: src/pages/BinderyPage.tsx
+msgid "book"
+msgstr "book"
+
 #: src/pages/AdminPage.tsx
 msgid "Book"
 msgstr "Book"
+
+#: src/pages/BinderyPage.tsx
+msgid "Book accepted"
+msgstr "Book accepted"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Book deleted"
@@ -562,6 +707,22 @@ msgstr "Book Detail"
 #: src/pages/BookDetailPage.tsx
 msgid "Book not found"
 msgstr "Book not found"
+
+#: src/pages/BinderyPage.tsx
+msgid "Book rejected and removed"
+msgstr "Book rejected and removed"
+
+#: src/pages/BinderyPage.tsx
+msgid "Book title"
+msgstr "Book title"
+
+#: src/pages/BinderyPage.tsx
+msgid "Book Type"
+msgstr "Book Type"
+
+#: src/pages/BinderyPage.tsx
+msgid "Book type applied to {n} files"
+msgstr "Book type applied to {n} files"
 
 #: src/pages/AdminPage.tsx
 msgid "Book Types"
@@ -590,6 +751,7 @@ msgstr "Browse your library"
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -608,6 +770,11 @@ msgstr "ch. 1"
 msgid "Change Password"
 msgstr "Change Password"
 
+#: src/pages/BinderyPage.tsx
+msgid "chapter"
+msgstr "chapter"
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Chapter"
 msgstr "Chapter"
@@ -658,6 +825,10 @@ msgstr "Clearing…"
 #: src/pages/SettingsPage.tsx
 msgid "Click \"Download plugin ZIP\" above. An API key is automatically created and baked into the plugin — no manual configuration needed."
 msgstr "Click \"Download plugin ZIP\" above. An API key is automatically created and baked into the plugin — no manual configuration needed."
+
+#: src/pages/BinderyPage.tsx
+msgid "Click for details"
+msgstr "Click for details"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Close"
@@ -720,6 +891,7 @@ msgid "Configured"
 msgstr "Configured"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Confirm"
 msgstr "Confirm"
@@ -731,6 +903,10 @@ msgstr "Confirm new password"
 #: src/pages/BookDetailPage.tsx
 msgid "Content"
 msgstr "Content"
+
+#: src/pages/BinderyPage.tsx
+msgid "Content Type"
+msgstr "Content Type"
 
 #: src/pages/DashboardPage.tsx
 msgid "Continue Reading"
@@ -760,9 +936,17 @@ msgstr "Could not start SSO linking."
 msgid "Cover"
 msgstr "Cover"
 
+#: src/pages/BinderyPage.tsx
+msgid "Cover preview"
+msgstr "Cover preview"
+
 #: src/pages/DashboardPage.tsx
 msgid "Cover size"
 msgstr "Cover size"
+
+#: src/pages/BinderyPage.tsx
+msgid "Cover URL"
+msgstr "Cover URL"
 
 #: src/pages/AdminPage.tsx
 msgid "Covers"
@@ -820,6 +1004,7 @@ msgstr "Day streak"
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete"
@@ -843,14 +1028,23 @@ msgstr "Delete failed"
 msgid "Delete Others"
 msgstr "Delete Others"
 
+#: src/pages/BinderyPage.tsx
+msgid "Delete this book from the library? The file will be removed and this cannot be undone."
+msgstr "Delete this book from the library? The file will be removed and this cannot be undone."
+
 #: src/pages/BookDetailPage.tsx
 msgid "Delete this highlight"
 msgstr "Delete this highlight"
+
+#: src/pages/BinderyPage.tsx
+msgid "Deleting..."
+msgstr "Deleting..."
 
 #: src/pages/BookDetailPage.tsx
 msgid "Deleting…"
 msgstr "Deleting…"
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Description"
@@ -889,6 +1083,7 @@ msgid "Directories"
 msgstr "Directories"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Dismiss"
 msgstr "Dismiss"
@@ -947,6 +1142,10 @@ msgstr "Download your entire library catalog — all titles, authors, series, ta
 msgid "Download ZIP"
 msgstr "Download ZIP"
 
+#: src/pages/BinderyPage.tsx
+msgid "Drop files in the incoming folder to get started"
+msgstr "Drop files in the incoming folder to get started"
+
 #: src/pages/AdminPage.tsx
 msgid "Duplicate Detection"
 msgstr "Duplicate Detection"
@@ -958,6 +1157,18 @@ msgstr "Duplicates"
 #: src/pages/SettingsPage.tsx
 msgid "E-Reader Devices"
 msgstr "E-Reader Devices"
+
+#: src/pages/BinderyPage.tsx
+msgid "e.g. 1"
+msgstr "e.g. 1"
+
+#: src/pages/BinderyPage.tsx
+msgid "e.g. 2023"
+msgstr "e.g. 2023"
+
+#: src/pages/BinderyPage.tsx
+msgid "e.g. en"
+msgstr "e.g. en"
 
 #: src/pages/AdminPage.tsx
 msgid "e.g. Novel"
@@ -1051,6 +1262,7 @@ msgid "Exporting..."
 msgstr "Exporting..."
 
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Failed"
 msgstr "Failed"
@@ -1086,6 +1298,10 @@ msgstr "Failed to delete highlight"
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to link sync document"
 msgstr "Failed to link sync document"
+
+#: src/pages/BinderyPage.tsx
+msgid "Failed to load bindery"
+msgstr "Failed to load bindery"
 
 #: src/pages/DashboardPage.tsx
 msgid "Failed to load books"
@@ -1165,9 +1381,17 @@ msgstr "Failed to update reading status"
 msgid "Failed to update sharing"
 msgstr "Failed to update sharing"
 
+#: src/pages/BinderyPage.tsx
+msgid "fantasy, action, romance"
+msgstr "fantasy, action, romance"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
 msgstr "Fetch Metadata"
+
+#: src/pages/BinderyPage.tsx
+msgid "Fetching metadata..."
+msgstr "Fetching metadata..."
 
 #: src/pages/AdminPage.tsx
 msgid "File is missing from disk"
@@ -1201,6 +1425,11 @@ msgstr "Focus"
 msgid "Focus search"
 msgstr "Focus search"
 
+#: src/pages/BinderyPage.tsx
+msgid "for {targetLabel} — click a file to switch"
+msgstr "for {targetLabel} — click a file to switch"
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Format"
@@ -1338,6 +1567,10 @@ msgstr "Import Now"
 msgid "Import reading history"
 msgstr "Import reading history"
 
+#: src/pages/BinderyPage.tsx
+msgid "Importing..."
+msgstr "Importing..."
+
 #: src/pages/AdminPage.tsx
 msgid "Importing…"
 msgstr "Importing…"
@@ -1376,6 +1609,7 @@ msgstr "ISBN"
 
 #: src/components/NotificationBell.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 msgid "just now"
 msgstr "just now"
 
@@ -1415,6 +1649,7 @@ msgstr "Label"
 msgid "Label (e.g. KOReader)"
 msgstr "Label (e.g. KOReader)"
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -1448,9 +1683,14 @@ msgstr "Learn more"
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Libraries"
 msgstr "Libraries"
+
+#: src/pages/BinderyPage.tsx
+msgid "Libraries applied to {n} files"
+msgstr "Libraries applied to {n} files"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -1499,6 +1739,7 @@ msgstr "Linking…"
 msgid "List view"
 msgstr "List view"
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Loading..."
 msgstr "Loading..."
@@ -1556,6 +1797,18 @@ msgstr "Marked as reading"
 msgid "Marked unread — reading progress cleared"
 msgstr "Marked unread — reading progress cleared"
 
+#: src/pages/BinderyPage.tsx
+msgid "Match all"
+msgstr "Match all"
+
+#: src/pages/BinderyPage.tsx
+msgid "Matches \"{name}\" already in your library — name, author, type and libraries adopted from it"
+msgstr "Matches \"{name}\" already in your library — name, author, type and libraries adopted from it"
+
+#: src/pages/BinderyPage.tsx
+msgid "Matching {matchingAll}/{total}…"
+msgstr "Matching {matchingAll}/{total}…"
+
 #: src/pages/AdminPage.tsx
 msgid "Member"
 msgstr "Member"
@@ -1571,6 +1824,10 @@ msgstr "Metadata"
 #: src/pages/BookDetailPage.tsx
 msgid "Metadata saved"
 msgstr "Metadata saved"
+
+#: src/pages/BinderyPage.tsx
+msgid "Metadata Suggestions"
+msgstr "Metadata Suggestions"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Minutes"
@@ -1640,6 +1897,10 @@ msgstr "New Library"
 msgid "New password"
 msgstr "New password"
 
+#: src/pages/BinderyPage.tsx
+msgid "New series"
+msgstr "New series"
+
 #: src/pages/BookDetailPage.tsx
 msgid "new this week"
 msgstr "new this week"
@@ -1708,9 +1969,17 @@ msgstr "No dismissed wishes."
 msgid "No duplicates found. Your library looks clean."
 msgstr "No duplicates found. Your library looks clean."
 
+#: src/pages/BinderyPage.tsx
+msgid "No files in the bindery"
+msgstr "No files in the bindery"
+
 #: src/pages/AdminPage.tsx
 msgid "No fulfilled wishes."
 msgstr "No fulfilled wishes."
+
+#: src/pages/BinderyPage.tsx
+msgid "No libraries"
+msgstr "No libraries"
 
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
@@ -1719,6 +1988,10 @@ msgstr "No matches"
 #: src/pages/AdminPage.tsx
 msgid "No matching volumes in the library yet."
 msgstr "No matching volumes in the library yet."
+
+#: src/pages/BinderyPage.tsx
+msgid "No metadata found"
+msgstr "No metadata found"
 
 #: src/components/NotificationBell.tsx
 msgid "No notifications yet"
@@ -1764,6 +2037,7 @@ msgstr "No series found — add series metadata to your books."
 msgid "No suggested match yet — search for the book to link, or upload it first."
 msgstr "No suggested match yet — search for the book to link, or upload it first."
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "No type"
 msgstr "No type"
@@ -1858,6 +2132,10 @@ msgstr "Open selected book"
 msgid "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
 msgstr "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
 
+#: src/pages/BinderyPage.tsx
+msgid "Other files"
+msgstr "Other files"
+
 #: src/pages/SettingsPage.tsx
 msgid "Other providers"
 msgstr "Other providers"
@@ -1898,6 +2176,10 @@ msgstr "Password updated successfully"
 #: src/pages/SettingsPage.tsx
 msgid "Passwords do not match"
 msgstr "Passwords do not match"
+
+#: src/pages/BinderyPage.tsx
+msgid "Per-file details"
+msgstr "Per-file details"
 
 #: src/pages/DashboardPage.tsx
 msgid "Pick up where you left off"
@@ -1984,6 +2266,7 @@ msgstr "Progress Sync"
 msgid "Public library"
 msgstr "Public library"
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
 msgstr "Publisher"
@@ -1995,6 +2278,18 @@ msgstr "Queue: fold the other copies into the kept book"
 #: src/pages/AdminPage.tsx
 msgid "Queue: not a duplicate — never show this group again"
 msgstr "Queue: not a duplicate — never show this group again"
+
+#: src/pages/BinderyPage.tsx
+msgid "Quick Accept"
+msgstr "Quick Accept"
+
+#: src/pages/BinderyPage.tsx
+msgid "Quick Accept Progress"
+msgstr "Quick Accept Progress"
+
+#: src/pages/BinderyPage.tsx
+msgid "Quick Accept: {done}/{total} done"
+msgstr "Quick Accept: {done}/{total} done"
 
 #: src/pages/SettingsPage.tsx
 msgid "Quick Connect"
@@ -2100,13 +2395,38 @@ msgstr "Recently Added"
 msgid "Recently Finished"
 msgstr "Recently Finished"
 
+#: src/pages/BinderyPage.tsx
+msgid "Recently Imported"
+msgstr "Recently Imported"
+
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 msgid "Refresh"
 msgstr "Refresh"
 
 #: src/pages/SettingsPage.tsx
 msgid "Register"
 msgstr "Register"
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject"
+msgstr "Reject"
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject All"
+msgstr "Reject All"
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject failed"
+msgstr "Reject failed"
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject files"
+msgstr "Reject files"
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject imported book"
+msgstr "Reject imported book"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
@@ -2120,6 +2440,10 @@ msgstr "Remove device"
 msgid "Remove from library"
 msgstr "Remove from library"
 
+#: src/pages/BinderyPage.tsx
+msgid "Rescan the bindery folder"
+msgstr "Rescan the bindery folder"
+
 #: src/pages/AdminPage.tsx
 msgid "Resource:"
 msgstr "Resource:"
@@ -2131,6 +2455,18 @@ msgstr "Restart KOReader"
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
 msgstr "Resume {volLabel}"
+
+#: src/pages/BinderyPage.tsx
+msgid "Review"
+msgstr "Review"
+
+#: src/pages/BinderyPage.tsx
+msgid "Review all failed"
+msgstr "Review all failed"
+
+#: src/pages/BinderyPage.tsx
+msgid "Reviewing {n} files"
+msgstr "Reviewing {n} files"
 
 #: src/pages/SettingsPage.tsx
 msgid "Revoke"
@@ -2242,6 +2578,10 @@ msgstr "Search for a different book…"
 msgid "Search icons…"
 msgstr "Search icons…"
 
+#: src/pages/BinderyPage.tsx
+msgid "Search query..."
+msgstr "Search query..."
+
 #: src/components/Sidebar.tsx
 msgid "Search to find more icons"
 msgstr "Search to find more icons"
@@ -2261,6 +2601,10 @@ msgstr "Select a book first."
 #: src/pages/DashboardPage.tsx
 msgid "Select all"
 msgstr "Select all"
+
+#: src/pages/BinderyPage.tsx
+msgid "Select All"
+msgstr "Select All"
 
 #: src/pages/AdminPage.tsx
 msgid "Send failed"
@@ -2287,10 +2631,24 @@ msgid "Sent"
 msgstr "Sent"
 
 #: src/components/Sidebar.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Series"
 msgstr "Series"
 
+#: src/pages/BinderyPage.tsx
+msgid "Series #"
+msgstr "Series #"
+
+#: src/pages/BinderyPage.tsx
+msgid "Series applied to {n} files"
+msgstr "Series applied to {n} files"
+
+#: src/pages/BinderyPage.tsx
+msgid "Series index"
+msgstr "Series index"
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Series name"
@@ -2299,6 +2657,10 @@ msgstr "Series name"
 #: src/pages/DashboardPage.tsx
 msgid "Series Progress"
 msgstr "Series Progress"
+
+#: src/pages/BinderyPage.tsx
+msgid "Series review"
+msgstr "Series review"
 
 #: src/pages/DashboardPage.tsx
 msgid "Series: {filterSeries}"
@@ -2361,6 +2723,10 @@ msgstr "Share this series — a public metadata-only page"
 #: src/components/Sidebar.tsx
 msgid "Share with users"
 msgstr "Share with users"
+
+#: src/pages/BinderyPage.tsx
+msgid "Shared fields — applies to all {n} items"
+msgstr "Shared fields — applies to all {n} items"
 
 #: src/pages/DashboardPage.tsx
 msgid "Shared Library"
@@ -2429,6 +2795,14 @@ msgstr "Similar Title"
 msgid "Single Sign-On"
 msgstr "Single Sign-On"
 
+#: src/pages/BinderyPage.tsx
+msgid "Size"
+msgstr "Size"
+
+#: src/pages/BinderyPage.tsx
+msgid "Skip"
+msgstr "Skip"
+
 #: src/pages/AdminPage.tsx
 msgid "SMTP Status"
 msgstr "SMTP Status"
@@ -2486,6 +2860,10 @@ msgstr "Sync Status"
 msgid "Synced document"
 msgstr "Synced document"
 
+#: src/pages/BinderyPage.tsx
+msgid "Synopsis or description"
+msgstr "Synopsis or description"
+
 #: src/pages/DashboardPage.tsx
 msgid "Tag"
 msgstr "Tag"
@@ -2493,6 +2871,10 @@ msgstr "Tag"
 #: src/pages/DashboardPage.tsx
 msgid "Tag: {filterTag}"
 msgstr "Tag: {filterTag}"
+
+#: src/pages/BinderyPage.tsx
+msgid "Tags (comma-separated)"
+msgstr "Tags (comma-separated)"
 
 #: src/pages/AdminPage.tsx
 msgid "Test"
@@ -2505,6 +2887,10 @@ msgstr "Test email sent successfully."
 #: src/pages/SettingsPage.tsx
 msgid "That SSO identity is already linked to another account."
 msgstr "That SSO identity is already linked to another account."
+
+#: src/pages/BinderyPage.tsx
+msgid "The book type's own library is always added automatically."
+msgstr "The book type's own library is always added automatically."
 
 #: src/pages/SettingsPage.tsx
 msgid "the sync password set above"
@@ -2546,10 +2932,19 @@ msgstr "Time per chapter"
 msgid "Time per chapter, line view"
 msgstr "Time per chapter, line view"
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Title"
 msgstr "Title"
+
+#: src/pages/BinderyPage.tsx
+msgid "Title *"
+msgstr "Title *"
+
+#: src/pages/BinderyPage.tsx
+msgid "Title is required"
+msgstr "Title is required"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2584,6 +2979,11 @@ msgstr "Translations are community-maintained. Anything not yet translated is sh
 msgid "Try adjusting your filters"
 msgstr "Try adjusting your filters"
 
+#: src/pages/BinderyPage.tsx
+msgid "Try editing the title or series fields"
+msgstr "Try editing the title or series fields"
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Type"
@@ -2600,6 +3000,10 @@ msgstr "Unassigned"
 #: src/pages/BookDetailPage.tsx
 msgid "Undo"
 msgstr "Undo"
+
+#: src/pages/BinderyPage.tsx
+msgid "Ungrouped files"
+msgstr "Ungrouped files"
 
 #: src/pages/BookDetailPage.tsx
 msgid "unknown device"
@@ -2699,6 +3103,10 @@ msgstr "View book"
 msgid "Viewing as <0>{impersonatedUsername}</0>"
 msgstr "Viewing as <0>{impersonatedUsername}</0>"
 
+#: src/pages/BinderyPage.tsx
+msgid "Vol {idx}"
+msgstr "Vol {idx}"
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Vol. {idx}"
@@ -2708,6 +3116,11 @@ msgstr "Vol. {idx}"
 msgid "Vol. {volIdx}"
 msgstr "Vol. {volIdx}"
 
+#: src/pages/BinderyPage.tsx
+msgid "volume"
+msgstr "volume"
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Volume"
 msgstr "Volume"
@@ -2778,6 +3191,7 @@ msgstr "Word Counts"
 msgid "Words"
 msgstr "Words"
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Year"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -21,6 +21,10 @@ msgstr " — click for sessions"
 msgid " — MISSING"
 msgstr " — MISSING"
 
+#: src/pages/DashboardPage.tsx
+msgid " · {d} at your pace"
+msgstr " · {d} at your pace"
+
 #: src/pages/AdminPage.tsx
 msgid " · {dups} duplicates"
 msgstr " · {dups} duplicates"
@@ -37,6 +41,14 @@ msgstr " · {errs} error(s)"
 msgid " · {n} in progress"
 msgstr " · {n} in progress"
 
+#: src/pages/DashboardPage.tsx
+msgid " · {n} not estimated"
+msgstr " · {n} not estimated"
+
+#: src/components/stats/BacklogEstimate.tsx
+msgid " · {n} not estimated yet"
+msgstr " · {n} not estimated yet"
+
 #: src/pages/SharePage.tsx
 msgid " · {n} read"
 msgstr " · {n} read"
@@ -48,6 +60,10 @@ msgstr " · {n} volumes"
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
 msgstr " · {prog}% in"
+
+#: src/components/stats/BacklogEstimate.tsx
+msgid " · books without a word count use your average for that type"
+msgstr " · books without a word count use your average for that type"
 
 #: src/pages/SharePage.tsx
 msgid " · finished {d}"
@@ -146,8 +162,15 @@ msgstr "{0, plural, one {# book could not be deleted} other {# books could not b
 msgid "{0, plural, one {# book tracked} other {# books tracked}}"
 msgstr "{0, plural, one {# book tracked} other {# books tracked}}"
 
+#. placeholder {0}: data.books
+#: src/components/stats/BacklogEstimate.tsx
+msgid "{0, plural, one {# book, none estimated yet.} other {# books, none estimated yet.}}"
+msgstr "{0, plural, one {# book, none estimated yet.} other {# books, none estimated yet.}}"
+
+#. placeholder {0}: data.books
 #. placeholder {0}: data.totals.books
-#. placeholder {0}: s.book_count
+#. placeholder {0}: row.books
+#: src/components/stats/BacklogEstimate.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
@@ -157,6 +180,11 @@ msgstr "{0, plural, one {# book} other {# books}}"
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
 msgstr "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
+
+#. placeholder {0}: row.unestimated
+#: src/components/stats/BacklogEstimate.tsx
+msgid "{0, plural, one {# not estimated} other {# not estimated}}"
+msgstr "{0, plural, one {# not estimated} other {# not estimated}}"
 
 #. placeholder {0}: aggregate.distinct_readers
 #. placeholder {0}: c.users_count
@@ -555,6 +583,10 @@ msgstr "{years}y ago"
 msgid "← Back to library"
 msgstr "← Back to library"
 
+#: src/pages/DashboardPage.tsx
+msgid "<0>{dur}</0> left in this series"
+msgstr "<0>{dur}</0> left in this series"
+
 #: src/pages/BookDetailPage.tsx
 msgid "~{at}% in · {dur}"
 msgstr "~{at}% in · {dur}"
@@ -562,6 +594,30 @@ msgstr "~{at}% in · {dur}"
 #: src/pages/BookDetailPage.tsx
 msgid "~{at}% in · not read"
 msgstr "~{at}% in · not read"
+
+#: src/lib/backlog.ts
+msgid "~{d} days"
+msgstr "~{d} days"
+
+#: src/lib/backlog.ts
+msgid "~{h} h"
+msgstr "~{h} h"
+
+#: src/lib/backlog.ts
+msgid "~{m} min"
+msgstr "~{m} min"
+
+#: src/lib/backlog.ts
+msgid "~{mo} months"
+msgstr "~{mo} months"
+
+#: src/lib/backlog.ts
+msgid "~{w} weeks"
+msgstr "~{w} weeks"
+
+#: src/lib/backlog.ts
+msgid "~1 day"
+msgstr "~1 day"
 
 #: src/pages/StatsPage.tsx
 msgid "12 mo"
@@ -626,6 +682,10 @@ msgstr "A year of reading, heatmap"
 #: src/pages/SettingsPage.tsx
 msgid "About"
 msgstr "About"
+
+#: src/components/stats/BacklogEstimate.tsx
+msgid "about <0>{d}</0> at your pace"
+msgstr "about <0>{d}</0> at your pace"
 
 #: src/pages/BinderyPage.tsx
 msgid "Accept"
@@ -968,6 +1028,14 @@ msgstr "Avg Session"
 #: src/pages/BinderyPage.tsx
 msgid "Back to list"
 msgstr "Back to list"
+
+#: src/pages/StatsPage.tsx
+msgid "Backlog"
+msgstr "Backlog"
+
+#: src/pages/StatsPage.tsx
+msgid "Backlog · {scope}"
+msgstr "Backlog · {scope}"
 
 #: src/pages/SettingsPage.tsx
 msgid "Backup"
@@ -1343,6 +1411,10 @@ msgstr "Core"
 msgid "Could not link SSO. Please try again."
 msgstr "Could not link SSO. Please try again."
 
+#: src/components/stats/BacklogEstimate.tsx
+msgid "Could not load this scope."
+msgstr "Could not load this scope."
+
 #: src/components/SeriesFollowButton.tsx
 msgid "Could not resolve this series on Hardcover"
 msgstr "Could not resolve this series on Hardcover"
@@ -1474,6 +1546,10 @@ msgstr "Date Added"
 #: src/pages/DashboardPage.tsx
 msgid "Day streak"
 msgstr "Day streak"
+
+#: src/lib/backlog.ts
+msgid "days at ~{mpd} min a day (last {win} days)"
+msgstr "days at ~{mpd} min a day (last {win} days)"
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
@@ -1763,7 +1839,10 @@ msgstr "Error"
 msgid "Errors"
 msgstr "Errors"
 
-#: src/components/SeriesReadingStats.tsx
+#: src/pages/BookDetailPage.tsx
+msgid "Est. read time"
+msgstr "Est. read time"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
 msgstr "Est. remaining"
@@ -2029,6 +2108,10 @@ msgstr "Filter…"
 msgid "Filters"
 msgstr "Filters"
 
+#: src/components/stats/BacklogEstimate.tsx
+msgid "Finish a couple of books of each type so Tome can measure your pace."
+msgstr "Finish a couple of books of each type so Tome can measure your pace."
+
 #: src/pages/StatsPage.tsx
 msgid "Finish rate by book type"
 msgstr "Finish rate by book type"
@@ -2279,6 +2362,10 @@ msgid "How long the books you finish are"
 msgstr "How long the books you finish are"
 
 #: src/pages/StatsPage.tsx
+msgid "How long your unread pile would take"
+msgstr "How long your unread pile would take"
+
+#: src/pages/StatsPage.tsx
 msgid "How much of what you own you’ve read"
 msgstr "How much of what you own you’ve read"
 
@@ -2484,6 +2571,7 @@ msgstr "librarian"
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Libraries"
 msgstr "Libraries"
 
@@ -2579,8 +2667,10 @@ msgstr "Loading..."
 
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareLinksOverview.tsx
+#: src/components/stats/BacklogEstimate.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Loading…"
 msgstr "Loading…"
 
@@ -3036,6 +3126,11 @@ msgstr "No reading sessions in this range — session-based tiles will be empty.
 msgid "no reading yet"
 msgstr "no reading yet"
 
+#: src/components/stats/BacklogEstimate.tsx
+#: src/lib/backlog.ts
+msgid "no recent reading, so no day estimate"
+msgstr "no recent reading, so no day estimate"
+
 #: src/pages/HardcoverPage.tsx
 msgid "No results — try a different query."
 msgstr "No results — try a different query."
@@ -3089,6 +3184,10 @@ msgstr "No type"
 msgid "No type (staging / admin only)"
 msgstr "No type (staging / admin only)"
 
+#: src/components/stats/BacklogEstimate.tsx
+msgid "No unstarted books in this scope."
+msgstr "No unstarted books in this scope."
+
 #: src/pages/AdminPage.tsx
 msgid "No users have added devices yet."
 msgstr "No users have added devices yet."
@@ -3114,6 +3213,10 @@ msgstr "Not configured"
 #: src/pages/StatsPage.tsx
 msgid "Not enough reading history yet."
 msgstr "Not enough reading history yet."
+
+#: src/components/stats/BacklogEstimate.tsx
+msgid "not estimated yet"
+msgstr "not estimated yet"
 
 #: src/pages/SharePage.tsx
 msgid "Not found"
@@ -3951,6 +4054,7 @@ msgid "Scanning…"
 msgstr "Scanning…"
 
 #: src/pages/SettingsPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Scope"
 msgstr "Scope"
 
@@ -4229,6 +4333,7 @@ msgid "Shelved — set aside, keeps your progress"
 msgstr "Shelved — set aside, keeps your progress"
 
 #: src/components/Sidebar.tsx
+#: src/pages/StatsPage.tsx
 msgid "Shelves"
 msgstr "Shelves"
 
@@ -4696,6 +4801,10 @@ msgstr "Types"
 msgid "Unassigned"
 msgstr "Unassigned"
 
+#: src/lib/backlog.ts
+msgid "under a day"
+msgstr "under a day"
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Undo"
@@ -4895,6 +5004,7 @@ msgstr "want to read"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Want to Read"
 msgstr "Want to Read"
 
@@ -4989,6 +5099,14 @@ msgstr "Wishlist"
 msgid "Without a type, new books are only visible to admins until assigned."
 msgstr "Without a type, new books are only visible to admins until assigned."
 
+#: src/lib/backlog.ts
+msgid "Word count at a default {wpm} wpm (no finished books to measure your pace yet)"
+msgstr "Word count at a default {wpm} wpm (no finished books to measure your pace yet)"
+
+#: src/lib/backlog.ts
+msgid "Word count at your measured {wpm} wpm"
+msgstr "Word count at your measured {wpm} wpm"
+
 #: src/pages/AdminPage.tsx
 msgid "Word Counts"
 msgstr "Word Counts"
@@ -5026,6 +5144,10 @@ msgstr "You"
 msgid "You rated this {rating}/5"
 msgstr "You rated this {rating}/5"
 
+#: src/components/stats/BacklogEstimate.tsx
+msgid "you read ~{mpd} min a day (last {win} days)"
+msgstr "you read ~{mpd} min a day (last {win} days)"
+
 #: src/pages/SettingsPage.tsx
 msgid "You're signed in via SSO. Manage your credentials at your identity provider — there's no Tome password to change."
 msgstr "You're signed in via SSO. Manage your credentials at your identity provider — there's no Tome password to change."
@@ -5037,6 +5159,10 @@ msgstr "Your account is linked to SSO — you can sign in with your identity pro
 #: src/pages/LoginPage.tsx
 msgid "Your account is not permitted to sign in to Tome."
 msgstr "Your account is not permitted to sign in to Tome."
+
+#: src/lib/backlog.ts
+msgid "Your average time per finished book of this type (no word count)"
+msgstr "Your average time per finished book of this type (no word count)"
 
 #: src/pages/StatsPage.tsx
 msgid "Your highest & lowest rated books"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -370,6 +370,11 @@ msgstr "{0, plural, one {# record} other {# records}}"
 msgid "{0, plural, one {# result — click to fill form} other {# results — click to fill form}}"
 msgstr "{0, plural, one {# result — click to fill form} other {# results — click to fill form}}"
 
+#. placeholder {0}: candidates.length
+#: src/components/MetadataFetchModal.tsx
+msgid "{0, plural, one {# result — pick one to review} other {# results — pick one to review}}"
+msgstr "{0, plural, one {# result — pick one to review} other {# results — pick one to review}}"
+
 #. placeholder {0}: follows.length
 #: src/pages/WishlistPage.tsx
 msgid "{0, plural, one {# series} other {# series}}"
@@ -786,9 +791,21 @@ msgstr "{name} · Vol. {start_index}–{end_index}"
 msgid "{name} copy"
 msgstr "{name} copy"
 
+#: src/components/MetadataFetchModal.tsx
+msgid "{name} errored"
+msgstr "{name} errored"
+
+#: src/components/MetadataFetchModal.tsx
+msgid "{name} is rate-limited — try again in a minute"
+msgstr "{name} is rate-limited — try again in a minute"
+
 #: src/components/ThemeToggle.tsx
 msgid "{name} theme"
 msgstr "{name} theme"
+
+#: src/components/MetadataFetchModal.tsx
+msgid "{name} timed out"
+msgstr "{name} timed out"
 
 #: src/components/BulkMetadataReviewModal.tsx
 msgid "{ok} of {total} approved"
@@ -930,6 +947,10 @@ msgstr "← Back to current"
 #: src/pages/BookDetailPage.tsx
 msgid "← Back to library"
 msgstr "← Back to library"
+
+#: src/components/MetadataFetchModal.tsx
+msgid "← Back to results"
+msgstr "← Back to results"
 
 #: src/pages/DashboardPage.tsx
 msgid "<0>{dur}</0> left in this series"
@@ -1396,6 +1417,14 @@ msgstr "Apply All ({n})"
 msgid "Apply Approved"
 msgstr "Apply Approved"
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Apply failed"
+msgstr "Apply failed"
+
+#: src/components/MetadataFetchModal.tsx
+msgid "Apply Selected"
+msgstr "Apply Selected"
+
 #: src/components/CoverAudit.tsx
 msgid "Apply the first cover-search candidate"
 msgstr "Apply the first cover-search candidate"
@@ -1445,6 +1474,7 @@ msgstr "Audit Log"
 msgid "Auth"
 msgstr "Auth"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/components/stats/widgets/library.tsx
 #: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
@@ -1731,6 +1761,7 @@ msgstr "Can't find it? Add manually"
 #: src/components/InstanceBackup.tsx
 #: src/components/LibraryHealth.tsx
 #: src/components/ManageSeriesModal.tsx
+#: src/components/MetadataFetchModal.tsx
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
@@ -2092,6 +2123,7 @@ msgstr "Counting… {done} / {total}"
 msgid "Counts"
 msgstr "Counts"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr "Cover"
@@ -2149,6 +2181,10 @@ msgstr "Cumulative finishes over time"
 #: src/pages/StatsPage.tsx
 msgid "current"
 msgstr "current"
+
+#: src/components/MetadataFetchModal.tsx
+msgid "Current"
+msgstr "Current"
 
 #: src/pages/StatsPage.tsx
 msgid "Current & longest daily streak"
@@ -2301,6 +2337,7 @@ msgid "Deleting…"
 msgstr "Deleting…"
 
 #: src/components/ManageSeriesModal.tsx
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2885,6 +2922,7 @@ msgid "Fetch failed"
 msgstr "Fetch failed"
 
 #: src/components/BulkMetadataReviewModal.tsx
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
 msgstr "Fetch Metadata"
@@ -2892,6 +2930,10 @@ msgstr "Fetch Metadata"
 #: src/pages/BinderyPage.tsx
 msgid "Fetching metadata..."
 msgstr "Fetching metadata..."
+
+#: src/components/MetadataFetchModal.tsx
+msgid "Field"
+msgstr "Field"
 
 #: src/components/LibraryHealth.tsx
 msgid "File {id}: {err}"
@@ -3127,6 +3169,10 @@ msgstr "Hardcover"
 msgid "Hardcover sync is disabled on this server."
 msgstr "Hardcover sync is disabled on this server."
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Has cover"
+msgstr "Has cover"
+
 #: src/pages/StatsPage.tsx
 msgid "Height auto-fits the content — only width is resizable"
 msgstr "Height auto-fits the content — only width is resizable"
@@ -3305,6 +3351,7 @@ msgstr "Inactive"
 msgid "Include"
 msgstr "Include"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Incoming"
 msgstr "Incoming"
@@ -3317,6 +3364,7 @@ msgstr "Instance backup"
 msgid "IP:"
 msgstr "IP:"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/components/ReadingImport.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "ISBN"
@@ -3394,6 +3442,7 @@ msgstr "Label"
 msgid "Label (e.g. KOReader)"
 msgstr "Label (e.g. KOReader)"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -3874,6 +3923,10 @@ msgstr "never used"
 msgid "New board"
 msgstr "New board"
 
+#: src/components/MetadataFetchModal.tsx
+msgid "New cover"
+msgstr "New cover"
+
 #: src/components/stats/widgets/overview.tsx
 msgid "New duration"
 msgstr "New duration"
@@ -4008,8 +4061,13 @@ msgid "No completion data by type."
 msgstr "No completion data by type."
 
 #: src/components/CoverAudit.tsx
+#: src/components/MetadataFetchModal.tsx
 msgid "No cover"
 msgstr "No cover"
+
+#: src/components/MetadataFetchModal.tsx
+msgid "No cover available"
+msgstr "No cover available"
 
 #: src/components/CoverPickerModal.tsx
 msgid "No cover candidates found."
@@ -4204,6 +4262,10 @@ msgstr "No reading-time data yet."
 msgid "no recent reading, so no day estimate"
 msgstr "no recent reading, so no day estimate"
 
+#: src/components/MetadataFetchModal.tsx
+msgid "No results — but some sources were unavailable (see below); retrying may help."
+msgstr "No results — but some sources were unavailable (see below); retrying may help."
+
 #: src/pages/HardcoverPage.tsx
 msgid "No results — try a different query."
 msgstr "No results — try a different query."
@@ -4219,6 +4281,10 @@ msgstr "No results found"
 #: src/components/WishlistModal.tsx
 msgid "No results found."
 msgstr "No results found."
+
+#: src/components/MetadataFetchModal.tsx
+msgid "No results found. Try a different search query."
+msgstr "No results found. Try a different search query."
 
 #: src/pages/DashboardPage.tsx
 msgid "No Series"
@@ -4541,6 +4607,10 @@ msgstr "Other volumes"
 msgid "over {days} days"
 msgstr "over {days} days"
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Override search query (optional)…"
+msgstr "Override search query (optional)…"
+
 #: src/pages/StatsPage.tsx
 msgid "Overview"
 msgstr "Overview"
@@ -4718,6 +4788,7 @@ msgstr "Preparing..."
 msgid "Preparing…"
 msgstr "Preparing…"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Preview"
 msgstr "Preview"
@@ -4784,6 +4855,7 @@ msgstr "Public library"
 msgid "Publication status"
 msgstr "Publication status"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
@@ -5425,6 +5497,7 @@ msgstr "Scroll left"
 msgid "Scroll right"
 msgstr "Scroll right"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Search"
 msgstr "Search"
@@ -5437,6 +5510,7 @@ msgstr "Search books"
 msgid "Search books… (/)"
 msgstr "Search books… (/)"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Search failed"
 msgstr "Search failed"
@@ -5493,6 +5567,11 @@ msgstr "Search your highlights…"
 msgid "Searching {n} books…"
 msgstr "Searching {n} books…"
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Searching for: <0>{title}</0>"
+msgstr "Searching for: <0>{title}</0>"
+
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Searching…"
 msgstr "Searching…"
@@ -5517,6 +5596,7 @@ msgstr "Select <0>1y</0> or <1>All</1> to see your year in review."
 msgid "Select a book first."
 msgstr "Select a book first."
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Select all"
 msgstr "Select all"
@@ -5582,6 +5662,7 @@ msgstr "Sent {sent}/{total}. {failedN} failed."
 
 #: src/components/CommandPalette.tsx
 #: src/components/ManageSeriesModal.tsx
+#: src/components/MetadataFetchModal.tsx
 #: src/components/Sidebar.tsx
 #: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
@@ -5590,6 +5671,7 @@ msgstr "Sent {sent}/{total}. {failedN} failed."
 msgid "Series"
 msgstr "Series"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Series #"
 msgstr "Series #"
@@ -6079,6 +6161,10 @@ msgstr "Tag"
 msgid "Tag: {filterTag}"
 msgstr "Tag: {filterTag}"
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Tags"
+msgstr "Tags"
+
 #: src/pages/BinderyPage.tsx
 msgid "Tags (comma-separated)"
 msgstr "Tags (comma-separated)"
@@ -6258,6 +6344,7 @@ msgstr "Timeline"
 msgid "title"
 msgstr "title"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/components/stats/widgets/library.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -6805,6 +6892,7 @@ msgstr "Words found"
 msgid "Words Read"
 msgstr "Words Read"
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -121,6 +121,11 @@ msgstr "(leave blank to keep)"
 msgid "(not set)"
 msgstr "(not set)"
 
+#. placeholder {0}: tooltip.sessions
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "{0, plural, one {{dur} · # session} other {{dur} · # sessions}}"
+msgstr "{0, plural, one {{dur} · # session} other {{dur} · # sessions}}"
+
 #. placeholder {0}: b.stats.reading_days
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {{dur} over # day} other {{dur} over # days}}"
@@ -155,6 +160,7 @@ msgstr "{0, plural, one {# duplicate group found.} other {# duplicate groups fou
 
 #. placeholder {0}: aggregate.distinct_readers
 #. placeholder {0}: c.users_count
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "{0, plural, one {# reader} other {# readers}}"
@@ -184,6 +190,11 @@ msgstr "{0, plural, one {# series} other {# series}}"
 #: src/components/stats/PaceByFormat.tsx
 msgid "{0, plural, one {# session · {pages} pages} other {# sessions · {pages} pages}}"
 msgstr "{0, plural, one {# session · {pages} pages} other {# sessions · {pages} pages}}"
+
+#. placeholder {0}: aggregate.total_sessions
+#: src/components/SeriesReadingStats.tsx
+msgid "{0, plural, one {# session} other {# sessions}}"
+msgstr "{0, plural, one {# session} other {# sessions}}"
 
 #. placeholder {0}: data.reread_bins
 #: src/pages/BookDetailPage.tsx
@@ -378,6 +389,7 @@ msgid "{h}h"
 msgstr "{h}h"
 
 #: src/components/stats/AuthorAffinity.tsx
+#: src/components/stats/HourDowHeatmap.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
@@ -801,6 +813,10 @@ msgstr "All items must have a title"
 msgid "All readers: {dur} · {days} · {readers}"
 msgstr "All readers: {dur} · {days} · {readers}"
 
+#: src/components/SeriesReadingStats.tsx
+msgid "All readers: {dur} · {sess} · {readers}"
+msgstr "All readers: {dur} · {sess} · {readers}"
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "All users"
@@ -936,6 +952,10 @@ msgstr "Average rating per book type"
 #: src/pages/StatsPage.tsx
 msgid "avg {avg}"
 msgstr "avg {avg}"
+
+#: src/components/SeriesReadingStats.tsx
+msgid "avg / volume"
+msgstr "avg / volume"
 
 #: src/pages/BookDetailPage.tsx
 msgid "avg session"
@@ -1270,6 +1290,7 @@ msgstr "Configured"
 msgid "Confirm"
 msgstr "Confirm"
 
+#: src/components/ForcePasswordChange.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Confirm new password"
 msgstr "Confirm new password"
@@ -1742,6 +1763,7 @@ msgstr "Error"
 msgid "Errors"
 msgstr "Errors"
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
 msgstr "Est. remaining"
@@ -1971,6 +1993,10 @@ msgstr "Failed to undo"
 msgid "Failed to update metadata"
 msgstr "Failed to update metadata"
 
+#: src/components/ForcePasswordChange.tsx
+msgid "Failed to update password."
+msgstr "Failed to update password."
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to update reading status"
 msgstr "Failed to update reading status"
@@ -2025,6 +2051,7 @@ msgstr "Finished"
 msgid "Finished · 30d"
 msgstr "Finished · 30d"
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "First read"
 msgstr "First read"
@@ -2071,6 +2098,10 @@ msgstr "Format: {filterFormatUpper}"
 #: src/pages/StatsPage.tsx
 msgid "Fr"
 msgstr "Fr"
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Fri"
+msgstr "Fri"
 
 #: src/pages/AdminPage.tsx
 msgid "From"
@@ -2164,6 +2195,15 @@ msgstr "Hardcover sync is disabled on this server."
 #: src/pages/StatsPage.tsx
 msgid "Height auto-fits the content — only width is resizable"
 msgstr "Height auto-fits the content — only width is resizable"
+
+#. placeholder {0}: user?.username
+#: src/components/ForcePasswordChange.tsx
+#~ msgid "Hi <0>{0}</0> — your account was created by an admin. Please set a personal password before continuing."
+#~ msgstr "Hi <0>{0}</0> — your account was created by an admin. Please set a personal password before continuing."
+
+#: src/components/ForcePasswordChange.tsx
+msgid "Hi <0>{username}</0> — your account was created by an admin. Please set a personal password before continuing."
+msgstr "Hi <0>{username}</0> — your account was created by an admin. Please set a personal password before continuing."
 
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
@@ -2397,6 +2437,7 @@ msgstr "Language"
 msgid "Language: {filterLanguageLabel}"
 msgstr "Language: {filterLanguageLabel}"
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Last read"
 msgstr "Last read"
@@ -2575,6 +2616,10 @@ msgstr "Longest session, biggest day, most pages"
 msgid "Longest Streak"
 msgstr "Longest Streak"
 
+#: src/components/SeriesReadingStats.tsx
+msgid "Longest volume"
+msgstr "Longest volume"
+
 #: src/pages/StatsPage.tsx
 msgid "Longest: {d}d"
 msgstr "Longest: {d}d"
@@ -2696,6 +2741,10 @@ msgstr "Missing: {filterMissingLabel}"
 msgid "Mo"
 msgstr "Mo"
 
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Mon"
+msgstr "Mon"
+
 #: src/components/SendButton.tsx
 msgid "More send options"
 msgstr "More send options"
@@ -2778,6 +2827,7 @@ msgstr "New library"
 msgid "New Library"
 msgstr "New Library"
 
+#: src/components/ForcePasswordChange.tsx
 #: src/pages/SettingsPage.tsx
 msgid "New password"
 msgstr "New password"
@@ -2821,6 +2871,10 @@ msgstr "Next page"
 #: src/components/SeriesFollowButton.tsx
 msgid "Next: Vol {v} · {d}"
 msgstr "Next: Vol {v} · {d}"
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "No activity"
+msgstr "No activity"
 
 #: src/pages/SettingsPage.tsx
 msgid "No API keys. Download the plugin to auto-create one."
@@ -3009,6 +3063,10 @@ msgstr "No series with reading history yet."
 #: src/pages/StatsPage.tsx
 msgid "No series with reading progress yet."
 msgstr "No series with reading progress yet."
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "No session data."
+msgstr "No session data."
 
 #: src/pages/StatsPage.tsx
 msgid "no sessions yet"
@@ -3236,6 +3294,7 @@ msgstr "Pace by Format"
 msgid "Padding"
 msgstr "Padding"
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "pages"
 msgstr "pages"
@@ -3276,6 +3335,10 @@ msgstr "Password"
 msgid "Password must be at least 8 characters"
 msgstr "Password must be at least 8 characters"
 
+#: src/components/ForcePasswordChange.tsx
+msgid "Password must be at least 8 characters."
+msgstr "Password must be at least 8 characters."
+
 #: src/pages/SettingsPage.tsx
 msgid "Password updated successfully"
 msgstr "Password updated successfully"
@@ -3284,6 +3347,10 @@ msgstr "Password updated successfully"
 #: src/pages/SetupPage.tsx
 msgid "Passwords do not match"
 msgstr "Passwords do not match"
+
+#: src/components/ForcePasswordChange.tsx
+msgid "Passwords do not match."
+msgstr "Passwords do not match."
 
 #: src/pages/BinderyPage.tsx
 msgid "Per-file details"
@@ -3615,6 +3682,7 @@ msgstr "Reading Speed"
 msgid "Reading Speed Trend"
 msgstr "Reading Speed Trend"
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/SetupPage.tsx
 #: src/pages/StatsPage.tsx
@@ -3803,6 +3871,10 @@ msgstr "Same ISBN"
 msgid "Same Series Volume"
 msgstr "Same Series Volume"
 
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Sat"
+msgstr "Sat"
+
 #: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
@@ -3852,6 +3924,7 @@ msgstr "Saving"
 msgid "Saving..."
 msgstr "Saving..."
 
+#: src/components/ForcePasswordChange.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "Saving…"
@@ -4055,6 +4128,7 @@ msgstr "Server"
 msgid "Session Timeline"
 msgstr "Session Timeline"
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "sessions"
 msgstr "sessions"
@@ -4075,6 +4149,10 @@ msgstr "Sessions ({n})"
 msgid "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
 msgstr "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
 
+#: src/components/ForcePasswordChange.tsx
+msgid "Set password & continue"
+msgstr "Set password & continue"
+
 #: src/pages/SettingsPage.tsx
 msgid "Set sync password"
 msgstr "Set sync password"
@@ -4082,6 +4160,10 @@ msgstr "Set sync password"
 #: src/pages/AdminPage.tsx
 msgid "Set the following environment variables to enable Send to Device:"
 msgstr "Set the following environment variables to enable Send to Device:"
+
+#: src/components/ForcePasswordChange.tsx
+msgid "Set your password"
+msgstr "Set your password"
 
 #: src/components/Sidebar.tsx
 #: src/pages/SettingsPage.tsx
@@ -4322,6 +4404,10 @@ msgstr "Su"
 msgid "Subtitle (optional)"
 msgstr "Subtitle (optional)"
 
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Sun"
+msgstr "Sun"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Sync now"
 msgstr "Sync now"
@@ -4377,6 +4463,10 @@ msgstr "Taste"
 #: src/pages/StatsPage.tsx
 msgid "Taste by Genre"
 msgstr "Taste by Genre"
+
+#: src/components/ForcePasswordChange.tsx
+msgid "Temporary password"
+msgstr "Temporary password"
 
 #: src/pages/AdminPage.tsx
 msgid "Test"
@@ -4451,6 +4541,10 @@ msgstr "This period vs the last"
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
 msgstr "This permanently removes the selected books and their files from disk. This cannot be undone."
 
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Thu"
+msgstr "Thu"
+
 #: src/pages/AdminPage.tsx
 msgid "Time"
 msgstr "Time"
@@ -4478,6 +4572,10 @@ msgstr "Time per chapter"
 #: src/pages/BookDetailPage.tsx
 msgid "Time per chapter, line view"
 msgstr "Time per chapter, line view"
+
+#: src/components/SeriesReadingStats.tsx
+msgid "Time per volume"
+msgstr "Time per volume"
 
 #: src/pages/StatsPage.tsx
 msgid "Time split across categories"
@@ -4579,6 +4677,10 @@ msgstr "Try editing the title or series fields"
 #: src/pages/StatsPage.tsx
 msgid "Tu"
 msgstr "Tu"
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Tue"
+msgstr "Tue"
 
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -4732,9 +4834,22 @@ msgstr "View book"
 msgid "Viewing as <0>{impersonatedUsername}</0>"
 msgstr "Viewing as <0>{impersonatedUsername}</0>"
 
+#: src/components/SeriesReadingStats.tsx
+msgid "Vol {firstIdx}"
+msgstr "Vol {firstIdx}"
+
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Vol {idx}"
 msgstr "Vol {idx}"
+
+#: src/components/SeriesReadingStats.tsx
+msgid "Vol {idx} · {dur}"
+msgstr "Vol {idx} · {dur}"
+
+#: src/components/SeriesReadingStats.tsx
+msgid "Vol {lastIdx}"
+msgstr "Vol {lastIdx}"
 
 #: src/components/UpcomingReleases.tsx
 msgid "Vol {v} · "
@@ -4802,6 +4917,10 @@ msgstr "Web"
 #: src/pages/BookDetailPage.tsx
 msgid "Web reader"
 msgstr "Web reader"
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Wed"
+msgstr "Wed"
 
 #: src/pages/LoginPage.tsx
 msgid "Welcome back"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1,0 +1,22 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-08-19 19:42+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: en\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/pages/SettingsPage.tsx
+msgid "Language"
+msgstr "Language"
+
+#: src/pages/SettingsPage.tsx
+msgid "Translations are community-maintained. Anything not yet translated is shown in English."
+msgstr "Translations are community-maintained. Anything not yet translated is shown in English."

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -37,6 +37,10 @@ msgstr " · {errs} error(s)"
 msgid " · {n} read"
 msgstr " · {n} read"
 
+#: src/pages/WishlistPage.tsx
+msgid " · {n} volumes"
+msgstr " · {n} volumes"
+
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
 msgstr " · {prog}% in"
@@ -48,6 +52,10 @@ msgstr " · finished {d}"
 #: src/pages/BinderyPage.tsx
 msgid " · reviewed"
 msgstr " · reviewed"
+
+#: src/pages/WishlistPage.tsx
+msgid " · you have vol {v}"
+msgstr " · you have vol {v}"
 
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
@@ -147,6 +155,11 @@ msgstr "{0, plural, one {# record} other {# records}}"
 msgid "{0, plural, one {# result — click to fill form} other {# results — click to fill form}}"
 msgstr "{0, plural, one {# result — click to fill form} other {# results — click to fill form}}"
 
+#. placeholder {0}: follows.length
+#: src/pages/WishlistPage.tsx
+msgid "{0, plural, one {# series} other {# series}}"
+msgstr "{0, plural, one {# series} other {# series}}"
+
 #. placeholder {0}: data.reread_bins
 #: src/pages/BookDetailPage.tsx
 msgid "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
@@ -237,9 +250,17 @@ msgstr "{0, plural, one {Updated metadata for # book} other {Updated metadata fo
 msgid "{added} added · {skipped} skipped"
 msgstr "{added} added · {skipped} skipped"
 
+#: src/pages/HighlightsPage.tsx
+msgid "{books, plural, one {{total} from # book} other {{total} from # books}}"
+msgstr "{books, plural, one {{total} from # book} other {{total} from # books}}"
+
 #: src/pages/AdminPage.tsx
 msgid "{clearResult} covers deleted."
 msgstr "{clearResult} covers deleted."
+
+#: src/pages/HighlightsPage.tsx
+msgid "{color} highlight"
+msgstr "{color} highlight"
 
 #: src/pages/BookDetailPage.tsx
 msgid "{count} sittings · {from} – {to}"
@@ -252,6 +273,7 @@ msgstr "{d}d ago"
 #: src/components/NotificationBell.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "{days}d ago"
 msgstr "{days}d ago"
 
@@ -349,6 +371,7 @@ msgid "{minutes}m ago"
 msgstr "{minutes}m ago"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "{months}mo ago"
 msgstr "{months}mo ago"
 
@@ -446,6 +469,7 @@ msgid "{words} words"
 msgstr "{words} words"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "{years}y ago"
 msgstr "{years}y ago"
 
@@ -507,12 +531,21 @@ msgid "Add"
 msgstr "Add"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Add a note"
 msgstr "Add a note"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Add a review"
 msgstr "Add a review"
+
+#: src/pages/WishlistPage.tsx
+msgid "Add a wish"
+msgstr "Add a wish"
+
+#: src/pages/WishlistPage.tsx
+msgid "Add books you'd like to see in the library."
+msgstr "Add books you'd like to see in the library."
 
 #: src/pages/SettingsPage.tsx
 msgid "Add custom theme"
@@ -806,6 +839,7 @@ msgstr "Browse your library"
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/HighlightsPage.tsx
 #: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
@@ -915,9 +949,17 @@ msgstr "Code not found. Check the code and try again."
 msgid "Code was already authorized."
 msgstr "Code was already authorized."
 
+#: src/pages/HighlightsPage.tsx
+msgid "Collapse"
+msgstr "Collapse"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Collapse / expand all books"
 msgstr "Collapse / expand all books"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Collapse all"
+msgstr "Collapse all"
 
 #: src/components/Sidebar.tsx
 msgid "Collapse sidebar"
@@ -972,6 +1014,22 @@ msgstr "Content Type"
 #: src/pages/DashboardPage.tsx
 msgid "Continue Reading"
 msgstr "Continue Reading"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copied {n} from “{title}”"
+msgstr "Copied {n} from “{title}”"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copied {n} highlights as Markdown"
+msgstr "Copied {n} highlights as Markdown"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copy"
+msgstr "Copy"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copy all as Markdown"
+msgstr "Copy all as Markdown"
 
 #: src/pages/SettingsPage.tsx
 msgid "Copy to KOReader"
@@ -1076,6 +1134,7 @@ msgstr "Day streak"
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Delete"
 msgstr "Delete"
 
@@ -1102,6 +1161,7 @@ msgid "Delete this book from the library? The file will be removed and this cann
 msgstr "Delete this book from the library? The file will be removed and this cannot be undone."
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Delete this highlight"
 msgstr "Delete this highlight"
 
@@ -1183,6 +1243,10 @@ msgstr "Done"
 msgid "Download a JSON snapshot of <0>your personal data</0>: reading status, every reading session, sync positions, shelves, and your local preferences. Book files themselves are not included — Tome only references them on disk. API tokens and KOReader keys are also excluded so the file isn't a credential."
 msgstr "Download a JSON snapshot of <0>your personal data</0>: reading status, every reading session, sync positions, shelves, and your local preferences. Book files themselves are not included — Tome only references them on disk. API tokens and KOReader keys are also excluded so the file isn't a credential."
 
+#: src/pages/HighlightsPage.tsx
+msgid "Download as Markdown file"
+msgstr "Download as Markdown file"
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Download failed"
@@ -1211,6 +1275,10 @@ msgstr "Download your entire library catalog — all titles, authors, series, ta
 #: src/pages/DashboardPage.tsx
 msgid "Download ZIP"
 msgstr "Download ZIP"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Downloaded {n} highlights"
+msgstr "Downloaded {n} highlights"
 
 #: src/pages/BinderyPage.tsx
 msgid "Drop files in the incoming folder to get started"
@@ -1263,6 +1331,7 @@ msgid "Edit Metadata"
 msgstr "Edit Metadata"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Edit note"
 msgstr "Edit note"
 
@@ -1316,6 +1385,14 @@ msgstr "Exit impersonation"
 msgid "Exit selection mode"
 msgstr "Exit selection mode"
 
+#: src/pages/HighlightsPage.tsx
+msgid "Expand"
+msgstr "Expand"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Expand all"
+msgstr "Expand all"
+
 #: src/components/Sidebar.tsx
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
@@ -1324,6 +1401,7 @@ msgstr "Expand sidebar"
 msgid "Expires in {timeLeft}"
 msgstr "Expires in {timeLeft}"
 
+#: src/pages/HighlightsPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Export"
 msgstr "Export"
@@ -1331,6 +1409,10 @@ msgstr "Export"
 #: src/pages/SettingsPage.tsx
 msgid "Export {label}"
 msgstr "Export {label}"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Export failed"
+msgstr "Export failed"
 
 #: src/pages/SettingsPage.tsx
 msgid "Exporting..."
@@ -1367,6 +1449,7 @@ msgid "Failed to create token"
 msgstr "Failed to create token"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Failed to delete highlight"
 msgstr "Failed to delete highlight"
 
@@ -1377,6 +1460,10 @@ msgstr "Failed to generate code. Try again."
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to link sync document"
 msgstr "Failed to link sync document"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Failed to load"
+msgstr "Failed to load"
 
 #: src/pages/BinderyPage.tsx
 msgid "Failed to load bindery"
@@ -1398,6 +1485,10 @@ msgstr "Failed to load facets"
 msgid "Failed to load libraries"
 msgstr "Failed to load libraries"
 
+#: src/pages/HighlightsPage.tsx
+msgid "Failed to load more"
+msgstr "Failed to load more"
+
 #: src/pages/AdminPage.tsx
 msgid "Failed to load server stats"
 msgstr "Failed to load server stats"
@@ -1411,6 +1502,7 @@ msgid "Failed to load users"
 msgstr "Failed to load users"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Failed to load wishlist"
 msgstr "Failed to load wishlist"
 
@@ -1421,6 +1513,10 @@ msgstr "Failed to log session"
 #: src/pages/SettingsPage.tsx
 msgid "Failed to register"
 msgstr "Failed to register"
+
+#: src/pages/WishlistPage.tsx
+msgid "Failed to remove wish"
+msgstr "Failed to remove wish"
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
@@ -1505,6 +1601,14 @@ msgstr "Focus"
 msgid "Focus search"
 msgstr "Focus search"
 
+#: src/pages/WishlistPage.tsx
+msgid "Follow a series — search Hardcover…"
+msgstr "Follow a series — search Hardcover…"
+
+#: src/pages/WishlistPage.tsx
+msgid "Following"
+msgstr "Following"
+
 #: src/pages/BinderyPage.tsx
 msgid "for {targetLabel} — click a file to switch"
 msgstr "for {targetLabel} — click a file to switch"
@@ -1540,6 +1644,7 @@ msgid "Fulfill: {title}"
 msgstr "Fulfill: {title}"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Fulfilled"
 msgstr "Fulfilled"
 
@@ -1555,8 +1660,13 @@ msgstr "Generate PIN"
 msgid "Genres"
 msgstr "Genres"
 
+#: src/pages/WishlistPage.tsx
+msgid "Get notified when a new volume of a followed series is released."
+msgstr "Get notified when a new volume of a followed series is released."
+
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Go back"
 msgstr "Go back"
 
@@ -1594,17 +1704,31 @@ msgid "Hide details"
 msgstr "Hide details"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Highlight deleted"
 msgstr "Highlight deleted"
 
+#: src/pages/HighlightsPage.tsx
+msgid "Highlighted {when}"
+msgstr "Highlighted {when}"
+
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/components/Sidebar.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Highlights"
 msgstr "Highlights"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Highlights & Notes"
 msgstr "Highlights & Notes"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Highlights and notes you make in KOReader sync here automatically. Highlight a passage on your device, then sync — it’ll show up in this commonplace book."
+msgstr "Highlights and notes you make in KOReader sync here automatically. Highlight a passage on your device, then sync — it’ll show up in this commonplace book."
+
+#: src/pages/HighlightsPage.tsx
+msgid "Highlights you made on this day in past years"
+msgstr "Highlights you made on this day in past years"
 
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
@@ -1765,8 +1889,13 @@ msgstr "Last Synced"
 msgid "Last used"
 msgstr "Last used"
 
+#: src/pages/WishlistPage.tsx
+msgid "Latest: vol {v}"
+msgstr "Latest: vol {v}"
+
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Learn more"
 msgstr "Learn more"
 
@@ -1835,6 +1964,10 @@ msgstr "Linking…"
 #: src/pages/DashboardPage.tsx
 msgid "List view"
 msgstr "List view"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Load more ({left} left)"
+msgstr "Load more ({left} left)"
 
 #: src/pages/BinderyPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -1917,6 +2050,10 @@ msgstr "Matching {matchingAll}/{total}…"
 #: src/pages/AdminPage.tsx
 msgid "Member"
 msgstr "Member"
+
+#: src/pages/WishlistPage.tsx
+msgid "Members can add books to their wishlist."
+msgstr "Members can add books to their wishlist."
 
 #: src/pages/AdminPage.tsx
 msgid "Merge"
@@ -2086,6 +2223,14 @@ msgstr "No files in the bindery"
 msgid "No fulfilled wishes."
 msgstr "No fulfilled wishes."
 
+#: src/pages/HighlightsPage.tsx
+msgid "No highlights match your search."
+msgstr "No highlights match your search."
+
+#: src/pages/HighlightsPage.tsx
+msgid "No highlights yet"
+msgstr "No highlights yet"
+
 #: src/pages/BinderyPage.tsx
 msgid "No libraries"
 msgstr "No libraries"
@@ -2185,16 +2330,26 @@ msgid "Note on KOSync coexistence"
 msgstr "Note on KOSync coexistence"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Note removed"
 msgstr "Note removed"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Note saved — syncs to your devices"
 msgstr "Note saved — syncs to your devices"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Note: {note}"
+msgstr "Note: {note}"
 
 #: src/pages/SharePage.tsx
 msgid "Nothing here yet."
 msgstr "Nothing here yet."
+
+#: src/pages/HighlightsPage.tsx
+msgid "Nothing highlighted on this day — yet."
+msgstr "Nothing highlighted on this day — yet."
 
 #: src/pages/DashboardPage.tsx
 msgid "Nothing in progress"
@@ -2218,6 +2373,7 @@ msgid "On a device where you're already signed in, go to <0>Settings → Securit
 msgstr "On a device where you're already signed in, go to <0>Settings → Security → Quick Connect</0> and enter this code."
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "On this day"
 msgstr "On this day"
 
@@ -2230,11 +2386,20 @@ msgstr "ongoing"
 msgid "Only filled fields will be updated. Leave blank to keep existing values."
 msgstr "Only filled fields will be updated. Leave blank to keep existing values."
 
+#: src/pages/HighlightsPage.tsx
+msgid "Only highlights that carry one of your notes"
+msgstr "Only highlights that carry one of your notes"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Only notes"
+msgstr "Only notes"
+
 #: src/pages/SettingsPage.tsx
 msgid "OPDS Catalog"
 msgstr "OPDS Catalog"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Open"
 msgstr "Open"
 
@@ -2578,6 +2743,10 @@ msgstr "Remove device"
 msgid "Remove from library"
 msgstr "Remove from library"
 
+#: src/pages/WishlistPage.tsx
+msgid "Remove wish"
+msgstr "Remove wish"
+
 #: src/pages/BinderyPage.tsx
 msgid "Rescan the bindery folder"
 msgstr "Rescan the bindery folder"
@@ -2657,6 +2826,7 @@ msgid "Save failed"
 msgstr "Save failed"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Save note"
 msgstr "Save note"
 
@@ -2669,6 +2839,7 @@ msgid "Saving..."
 msgstr "Saving..."
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -2723,6 +2894,10 @@ msgstr "Search query..."
 #: src/components/Sidebar.tsx
 msgid "Search to find more icons"
 msgstr "Search to find more icons"
+
+#: src/pages/HighlightsPage.tsx
+msgid "Search your highlights…"
+msgstr "Search your highlights…"
 
 #: src/components/AppShell.tsx
 msgid "See all results for \"{searchQuery}\""
@@ -3046,6 +3221,10 @@ msgstr "Sync Status"
 msgid "Synced document"
 msgstr "Synced document"
 
+#: src/pages/HighlightsPage.tsx
+msgid "Synced to Tome {when}"
+msgstr "Synced to Tome {when}"
+
 #: src/pages/BinderyPage.tsx
 msgid "Synopsis or description"
 msgstr "Synopsis or description"
@@ -3134,6 +3313,7 @@ msgstr "Title is required"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Today"
 msgstr "Today"
 
@@ -3196,9 +3376,21 @@ msgstr "Unassigned"
 msgid "Undo"
 msgstr "Undo"
 
+#: src/pages/WishlistPage.tsx
+msgid "Unfollow"
+msgstr "Unfollow"
+
+#: src/pages/WishlistPage.tsx
+msgid "Unfollow {name}"
+msgstr "Unfollow {name}"
+
 #: src/pages/BinderyPage.tsx
 msgid "Ungrouped files"
 msgstr "Ungrouped files"
+
+#: src/pages/WishlistPage.tsx
+msgid "Unknown author"
+msgstr "Unknown author"
 
 #: src/pages/BookDetailPage.tsx
 msgid "unknown device"
@@ -3296,6 +3488,7 @@ msgid "Verify it's working"
 msgstr "Verify it's working"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "View book"
 msgstr "View book"
 
@@ -3387,11 +3580,25 @@ msgid "Where you read"
 msgstr "Where you read"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Whole series"
 msgstr "Whole series"
 
+#: src/pages/WishlistPage.tsx
+msgid "Wish"
+msgstr "Wish"
+
+#: src/pages/WishlistPage.tsx
+msgid "Wish added"
+msgstr "Wish added"
+
+#: src/pages/WishlistPage.tsx
+msgid "Wish removed"
+msgstr "Wish removed"
+
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Wishlist"
 msgstr "Wishlist"
 
@@ -3415,6 +3622,7 @@ msgstr "Year"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Yesterday"
 msgstr "Yesterday"
 
@@ -3451,6 +3659,7 @@ msgid "Your library is empty"
 msgstr "Your library is empty"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Your note — syncs back to KOReader on the next sync"
 msgstr "Your note — syncs back to KOReader on the next sync"
 
@@ -3465,3 +3674,7 @@ msgstr "Your Tome account is disabled."
 #: src/pages/SettingsPage.tsx
 msgid "your Tome password"
 msgstr "your Tome password"
+
+#: src/pages/WishlistPage.tsx
+msgid "Your wishlist is empty"
+msgstr "Your wishlist is empty"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -33,9 +33,17 @@ msgstr ", {pages} pages"
 msgid "…and {more} more not shown"
 msgstr "…and {more} more not shown"
 
+#: src/pages/SettingsPage.tsx
+msgid "· {n} docs"
+msgstr "· {n} docs"
+
 #: src/pages/BookDetailPage.tsx
 msgid "· p. {page} of {totalPages}"
 msgstr "· p. {page} of {totalPages}"
+
+#: src/pages/SettingsPage.tsx
+msgid "(enables dark: variants)"
+msgstr "(enables dark: variants)"
 
 #. placeholder {0}: s.book_count
 #: src/pages/DashboardPage.tsx
@@ -91,6 +99,7 @@ msgid "{d}d ago"
 msgstr "{d}d ago"
 
 #: src/components/NotificationBell.tsx
+#: src/pages/SettingsPage.tsx
 msgid "{days}d ago"
 msgstr "{days}d ago"
 
@@ -126,6 +135,10 @@ msgstr "{h}h"
 msgid "{h}h {m}m"
 msgstr "{h}h {m}m"
 
+#: src/pages/SettingsPage.tsx
+msgid "{hours}h ago"
+msgstr "{hours}h ago"
+
 #: src/components/NotificationBell.tsx
 msgid "{hrs}h ago"
 msgstr "{hrs}h ago"
@@ -137,6 +150,10 @@ msgstr "{m}m"
 #: src/components/NotificationBell.tsx
 msgid "{mins}m ago"
 msgstr "{mins}m ago"
+
+#: src/pages/SettingsPage.tsx
+msgid "{minutes}m ago"
+msgstr "{minutes}m ago"
 
 #: src/components/AppShell.tsx
 #: src/pages/DashboardPage.tsx
@@ -215,15 +232,28 @@ msgstr "~{at}% in · {dur}"
 msgid "~{at}% in · not read"
 msgstr "~{at}% in · not read"
 
+#: src/pages/SettingsPage.tsx
+msgid "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
+msgstr "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
+
 #: src/pages/DashboardPage.tsx
 msgid "A while ago"
 msgstr "A while ago"
+
+#: src/pages/SettingsPage.tsx
+msgid "About"
+msgstr "About"
+
+#: src/pages/SettingsPage.tsx
+msgid "Account & Security"
+msgstr "Account & Security"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Activity"
 msgstr "Activity"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Add"
 msgstr "Add"
 
@@ -235,6 +265,10 @@ msgstr "Add a note"
 msgid "Add a review"
 msgstr "Add a review"
 
+#: src/pages/SettingsPage.tsx
+msgid "Add custom theme"
+msgstr "Add custom theme"
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Add tag…"
@@ -244,6 +278,10 @@ msgstr "Add tag…"
 msgid "Add Tags"
 msgstr "Add Tags"
 
+#: src/pages/SettingsPage.tsx
+msgid "Add Theme"
+msgstr "Add Theme"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Add to library"
 msgstr "Add to library"
@@ -251,6 +289,14 @@ msgstr "Add to library"
 #: src/pages/DashboardPage.tsx
 msgid "Add to Library"
 msgstr "Add to Library"
+
+#: src/pages/SettingsPage.tsx
+msgid "Add your e-reader or personal email. Books are sent as attachments — works with Kindle, Kobo, or any email address."
+msgstr "Add your e-reader or personal email. Books are sent as attachments — works with Kindle, Kobo, or any email address."
+
+#: src/pages/SettingsPage.tsx
+msgid "Add your SMTP sender address to Amazon's <0>Approved Personal Document E-mail List</0>, or emails will be silently dropped."
+msgstr "Add your SMTP sender address to Amazon's <0>Approved Personal Document E-mail List</0>, or emails will be silently dropped."
 
 #: src/pages/BookDetailPage.tsx
 msgid "Added to Want to Read"
@@ -281,6 +327,7 @@ msgid "All readers: {dur} · {days} · {readers}"
 msgstr "All readers: {dur} · {days} · {readers}"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "All users"
 msgstr "All users"
 
@@ -291,6 +338,26 @@ msgstr "Amber"
 #: src/pages/DashboardPage.tsx
 msgid "Any"
 msgstr "Any"
+
+#: src/pages/SettingsPage.tsx
+msgid "API Keys"
+msgstr "API Keys"
+
+#: src/pages/SettingsPage.tsx
+msgid "API Tokens"
+msgstr "API Tokens"
+
+#: src/pages/SettingsPage.tsx
+msgid "App-specific PINs"
+msgstr "App-specific PINs"
+
+#: src/pages/SettingsPage.tsx
+msgid "Appearance"
+msgstr "Appearance"
+
+#: src/pages/SettingsPage.tsx
+msgid "Ask your server admin if you don't manage the Tome installation yourself."
+msgstr "Ask your server admin if you don't manage the Tome installation yourself."
 
 #: src/pages/BookDetailPage.tsx
 msgid "Attach progress synced from a KOReader-compatible app to this book"
@@ -305,9 +372,21 @@ msgstr "Author"
 msgid "Author: {filterAuthor}"
 msgstr "Author: {filterAuthor}"
 
+#: src/pages/SettingsPage.tsx
+msgid "Authorize"
+msgstr "Authorize"
+
+#: src/pages/SettingsPage.tsx
+msgid "Authorizing..."
+msgstr "Authorizing..."
+
 #: src/pages/BookDetailPage.tsx
 msgid "avg session"
 msgstr "avg session"
+
+#: src/pages/SettingsPage.tsx
+msgid "Backup"
+msgstr "Backup"
 
 #: src/components/Sidebar.tsx
 msgid "Bindery"
@@ -333,9 +412,17 @@ msgstr "Book not found"
 msgid "Books"
 msgstr "Books"
 
+#: src/pages/SettingsPage.tsx
+msgid "Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately."
+msgstr "Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately."
+
 #: src/pages/DashboardPage.tsx
 msgid "Books without a series"
 msgstr "Books without a series"
+
+#: src/pages/SettingsPage.tsx
+msgid "Browse and download your library from KOReader or any OPDS client."
+msgstr "Browse and download your library from KOReader or any OPDS client."
 
 #: src/pages/DashboardPage.tsx
 msgid "Browse your library"
@@ -344,6 +431,7 @@ msgstr "Browse your library"
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -354,6 +442,10 @@ msgstr "ch. {n}"
 #: src/pages/BookDetailPage.tsx
 msgid "ch. 1"
 msgstr "ch. 1"
+
+#: src/pages/SettingsPage.tsx
+msgid "Change Password"
+msgstr "Change Password"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Chapter"
@@ -397,6 +489,10 @@ msgstr "Clear selection / blur search"
 msgid "Clearing…"
 msgstr "Clearing…"
 
+#: src/pages/SettingsPage.tsx
+msgid "Click \"Download plugin ZIP\" above. An API key is automatically created and baked into the plugin — no manual configuration needed."
+msgstr "Click \"Download plugin ZIP\" above. An API key is automatically created and baked into the plugin — no manual configuration needed."
+
 #: src/pages/BookDetailPage.tsx
 msgid "Close"
 msgstr "Close"
@@ -404,6 +500,26 @@ msgstr "Close"
 #: src/components/Sidebar.tsx
 msgid "Close navigation"
 msgstr "Close navigation"
+
+#: src/pages/SettingsPage.tsx
+msgid "Code from new device"
+msgstr "Code from new device"
+
+#: src/pages/SettingsPage.tsx
+msgid "Code has expired. Ask the other device to generate a new one."
+msgstr "Code has expired. Ask the other device to generate a new one."
+
+#: src/pages/SettingsPage.tsx
+msgid "Code must be 6 characters"
+msgstr "Code must be 6 characters"
+
+#: src/pages/SettingsPage.tsx
+msgid "Code not found. Check the code and try again."
+msgstr "Code not found. Check the code and try again."
+
+#: src/pages/SettingsPage.tsx
+msgid "Code was already authorized."
+msgstr "Code was already authorized."
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Collapse / expand all books"
@@ -413,6 +529,10 @@ msgstr "Collapse / expand all books"
 msgid "Collapse sidebar"
 msgstr "Collapse sidebar"
 
+#: src/pages/SettingsPage.tsx
+msgid "Colors <0>(10 hex values, comma-separated)</0>"
+msgstr "Colors <0>(10 hex values, comma-separated)</0>"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Command palette — jump to a book, series, author, or page"
 msgstr "Command palette — jump to a book, series, author, or page"
@@ -420,6 +540,10 @@ msgstr "Command palette — jump to a book, series, author, or page"
 #: src/pages/BookDetailPage.tsx
 msgid "Confirm"
 msgstr "Confirm"
+
+#: src/pages/SettingsPage.tsx
+msgid "Confirm new password"
+msgstr "Confirm new password"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Content"
@@ -429,6 +553,26 @@ msgstr "Content"
 msgid "Continue Reading"
 msgstr "Continue Reading"
 
+#: src/pages/SettingsPage.tsx
+msgid "Copy to KOReader"
+msgstr "Copy to KOReader"
+
+#: src/pages/SettingsPage.tsx
+msgid "Copy token"
+msgstr "Copy token"
+
+#: src/pages/SettingsPage.tsx
+msgid "Core"
+msgstr "Core"
+
+#: src/pages/SettingsPage.tsx
+msgid "Could not link SSO. Please try again."
+msgstr "Could not link SSO. Please try again."
+
+#: src/pages/SettingsPage.tsx
+msgid "Could not start SSO linking."
+msgstr "Could not start SSO linking."
+
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr "Cover"
@@ -437,9 +581,29 @@ msgstr "Cover"
 msgid "Cover size"
 msgstr "Cover size"
 
+#: src/pages/SettingsPage.tsx
+msgid "Create"
+msgstr "Create"
+
+#: src/pages/SettingsPage.tsx
+msgid "Created"
+msgstr "Created"
+
+#: src/pages/SettingsPage.tsx
+msgid "Creating..."
+msgstr "Creating..."
+
+#: src/pages/SettingsPage.tsx
+msgid "Current password"
+msgstr "Current password"
+
 #: src/components/Sidebar.tsx
 msgid "Dark"
 msgstr "Dark"
+
+#: src/pages/SettingsPage.tsx
+msgid "Dark theme"
+msgstr "Dark theme"
 
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/pages/DashboardPage.tsx
@@ -490,6 +654,14 @@ msgstr "Deselect all"
 msgid "Details"
 msgstr "Details"
 
+#: src/pages/SettingsPage.tsx
+msgid "Device authorized — the new device is now signed in."
+msgstr "Device authorized — the new device is now signed in."
+
+#: src/pages/SettingsPage.tsx
+msgid "Device name"
+msgstr "Device name"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device."
 msgstr "Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device."
@@ -503,8 +675,13 @@ msgid "Docs"
 msgstr "Docs"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Done"
 msgstr "Done"
+
+#: src/pages/SettingsPage.tsx
+msgid "Download a JSON snapshot of <0>your personal data</0>: reading status, every reading session, sync positions, shelves, and your local preferences. Book files themselves are not included — Tome only references them on disk. API tokens and KOReader keys are also excluded so the file isn't a credential."
+msgstr "Download a JSON snapshot of <0>your personal data</0>: reading status, every reading session, sync positions, shelves, and your local preferences. Book files themselves are not included — Tome only references them on disk. API tokens and KOReader keys are also excluded so the file isn't a credential."
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -515,9 +692,33 @@ msgstr "Download failed"
 msgid "Download Markdown export"
 msgstr "Download Markdown export"
 
+#: src/pages/SettingsPage.tsx
+msgid "Download my data"
+msgstr "Download my data"
+
+#: src/pages/SettingsPage.tsx
+msgid "Download plugin ZIP"
+msgstr "Download plugin ZIP"
+
+#: src/pages/SettingsPage.tsx
+msgid "Download the plugin"
+msgstr "Download the plugin"
+
+#: src/pages/SettingsPage.tsx
+msgid "Download your entire library catalog — all titles, authors, series, tags and formats."
+msgstr "Download your entire library catalog — all titles, authors, series, tags and formats."
+
 #: src/pages/DashboardPage.tsx
 msgid "Download ZIP"
 msgstr "Download ZIP"
+
+#: src/pages/SettingsPage.tsx
+msgid "E-Reader Devices"
+msgstr "E-Reader Devices"
+
+#: src/pages/SettingsPage.tsx
+msgid "e.g. scribe-laptop"
+msgstr "e.g. scribe-laptop"
 
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
@@ -544,6 +745,18 @@ msgstr "Edit review"
 msgid "Edit Shelf"
 msgstr "Edit Shelf"
 
+#: src/pages/SettingsPage.tsx
+msgid "Email"
+msgstr "Email"
+
+#: src/pages/SettingsPage.tsx
+msgid "Email address"
+msgstr "Email address"
+
+#: src/pages/SettingsPage.tsx
+msgid "Email delivery is not set up yet."
+msgstr "Email delivery is not set up yet."
+
 #: src/components/Sidebar.tsx
 msgid "Ember"
 msgstr "Ember"
@@ -568,9 +781,37 @@ msgstr "Exit selection mode"
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
 
+#: src/pages/SettingsPage.tsx
+msgid "Export"
+msgstr "Export"
+
+#: src/pages/SettingsPage.tsx
+msgid "Export {label}"
+msgstr "Export {label}"
+
+#: src/pages/SettingsPage.tsx
+msgid "Exporting..."
+msgstr "Exporting..."
+
 #: src/pages/DashboardPage.tsx
 msgid "Failed"
 msgstr "Failed"
+
+#: src/pages/SettingsPage.tsx
+msgid "Failed to add device"
+msgstr "Failed to add device"
+
+#: src/pages/SettingsPage.tsx
+msgid "Failed to authorize"
+msgstr "Failed to authorize"
+
+#: src/pages/SettingsPage.tsx
+msgid "Failed to change password"
+msgstr "Failed to change password"
+
+#: src/pages/SettingsPage.tsx
+msgid "Failed to create token"
+msgstr "Failed to create token"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to delete highlight"
@@ -596,7 +837,12 @@ msgstr "Failed to load libraries"
 msgid "Failed to log session"
 msgstr "Failed to log session"
 
+#: src/pages/SettingsPage.tsx
+msgid "Failed to register"
+msgstr "Failed to register"
+
 #: src/components/Sidebar.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Failed to save"
 msgstr "Failed to save"
 
@@ -673,6 +919,14 @@ msgstr "Format: {filterFormatUpper}"
 msgid "From your highlights"
 msgstr "From your highlights"
 
+#: src/pages/SettingsPage.tsx
+msgid "Full access"
+msgstr "Full access"
+
+#: src/pages/SettingsPage.tsx
+msgid "Generate PIN"
+msgstr "Generate PIN"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Genres"
 msgstr "Genres"
@@ -731,9 +985,33 @@ msgstr "Home"
 msgid "How far through the book you'd read by each date."
 msgstr "How far through the book you'd read by each date."
 
+#: src/pages/SettingsPage.tsx
+msgid "How to set it up"
+msgstr "How to set it up"
+
 #: src/components/Sidebar.tsx
 msgid "Icon"
 msgstr "Icon"
+
+#: src/pages/SettingsPage.tsx
+msgid "Import reading history"
+msgstr "Import reading history"
+
+#: src/pages/SettingsPage.tsx
+msgid "In KOReader: main menu -> TomeSync -> \"Test connection\" to confirm the plugin can reach your Tome server."
+msgstr "In KOReader: main menu -> TomeSync -> \"Test connection\" to confirm the plugin can reach your Tome server."
+
+#: src/pages/SettingsPage.tsx
+msgid "In KOReader: Search → OPDS catalog → add catalog with the URL above."
+msgstr "In KOReader: Search → OPDS catalog → add catalog with the URL above."
+
+#: src/pages/SettingsPage.tsx
+msgid "In KOReader: Settings > Device > Restart KOReader. The plugin loads automatically."
+msgstr "In KOReader: Settings > Device > Restart KOReader. The plugin loads automatically."
+
+#: src/pages/SettingsPage.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
+msgstr "In KOReader: Tools → Progress sync → Custom sync server."
 
 #: src/pages/BookDetailPage.tsx
 msgid "ISBN"
@@ -743,13 +1021,33 @@ msgstr "ISBN"
 msgid "just now"
 msgstr "just now"
 
+#: src/pages/SettingsPage.tsx
+msgid "Just now"
+msgstr "Just now"
+
+#: src/pages/SettingsPage.tsx
+msgid "Key created — copy it now, it won't be shown again."
+msgstr "Key created — copy it now, it won't be shown again."
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Keyboard Shortcuts"
 msgstr "Keyboard Shortcuts"
 
+#: src/pages/SettingsPage.tsx
+msgid "Kindle users"
+msgstr "Kindle users"
+
 #: src/pages/BookDetailPage.tsx
 msgid "KOReader sync linked"
 msgstr "KOReader sync linked"
+
+#: src/pages/SettingsPage.tsx
+msgid "KOSync registered successfully"
+msgstr "KOSync registered successfully"
+
+#: src/pages/SettingsPage.tsx
+msgid "Label (e.g. KOReader)"
+msgstr "Label (e.g. KOReader)"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -765,6 +1063,18 @@ msgstr "Language: {filterLanguageLabel}"
 msgid "Last read"
 msgstr "Last read"
 
+#: src/pages/SettingsPage.tsx
+msgid "Last sync: {d}"
+msgstr "Last sync: {d}"
+
+#: src/pages/SettingsPage.tsx
+msgid "Last used"
+msgstr "Last used"
+
+#: src/pages/SettingsPage.tsx
+msgid "Learn more"
+msgstr "Learn more"
+
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Libraries"
@@ -772,6 +1082,7 @@ msgstr "Libraries"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Library"
 msgstr "Library"
 
@@ -791,6 +1102,22 @@ msgstr "Link"
 msgid "Link KOReader sync…"
 msgstr "Link KOReader sync…"
 
+#: src/pages/SettingsPage.tsx
+msgid "Link SSO"
+msgstr "Link SSO"
+
+#: src/pages/SettingsPage.tsx
+msgid "Link your identity provider to this account so you can sign in with SSO. Your existing login and password keep working."
+msgstr "Link your identity provider to this account so you can sign in with SSO. Your existing login and password keep working."
+
+#: src/pages/SettingsPage.tsx
+msgid "Link your identity provider to this account so you can sign in with SSO. Your existing login keeps working."
+msgstr "Link your identity provider to this account so you can sign in with SSO. Your existing login keeps working."
+
+#: src/pages/SettingsPage.tsx
+msgid "Linked"
+msgstr "Linked"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Linking…"
 msgstr "Linking…"
@@ -799,6 +1126,10 @@ msgstr "Linking…"
 msgid "List view"
 msgstr "List view"
 
+#: src/pages/SettingsPage.tsx
+msgid "Loading..."
+msgstr "Loading..."
+
 #: src/components/Sidebar.tsx
 msgid "Log out"
 msgstr "Log out"
@@ -806,6 +1137,10 @@ msgstr "Log out"
 #: src/pages/BookDetailPage.tsx
 msgid "Log session"
 msgstr "Log session"
+
+#: src/pages/SettingsPage.tsx
+msgid "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
+msgstr "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
 
 #: src/pages/DashboardPage.tsx
 msgid "Manage"
@@ -852,17 +1187,49 @@ msgstr "Missing"
 msgid "Missing: {filterMissingLabel}"
 msgstr "Missing: {filterMissingLabel}"
 
+#: src/pages/SettingsPage.tsx
+msgid "Must be exactly 10 comma-separated hex values (e.g. #1E1E2E)"
+msgstr "Must be exactly 10 comma-separated hex values (e.g. #1E1E2E)"
+
 #: src/pages/DashboardPage.tsx
 msgid "My Books"
 msgstr "My Books"
+
+#: src/pages/SettingsPage.tsx
+msgid "My Kindle"
+msgstr "My Kindle"
 
 #: src/pages/DashboardPage.tsx
 msgid "My Rating"
 msgstr "My Rating"
 
+#: src/pages/SettingsPage.tsx
+msgid "My Theme"
+msgstr "My Theme"
+
+#: src/pages/SettingsPage.tsx
+msgid "Name"
+msgstr "Name"
+
 #: src/components/Sidebar.tsx
 msgid "Name…"
 msgstr "Name…"
+
+#: src/pages/SettingsPage.tsx
+msgid "Native KOReader plugin — tracks reading sessions and syncs by book ID. More reliable than KOSync."
+msgstr "Native KOReader plugin — tracks reading sessions and syncs by book ID. More reliable than KOSync."
+
+#: src/pages/SettingsPage.tsx
+msgid "Never"
+msgstr "Never"
+
+#: src/pages/SettingsPage.tsx
+msgid "never used"
+msgstr "never used"
+
+#: src/pages/SettingsPage.tsx
+msgid "New key"
+msgstr "New key"
 
 #: src/components/Sidebar.tsx
 msgid "New library"
@@ -872,9 +1239,17 @@ msgstr "New library"
 msgid "New Library"
 msgstr "New Library"
 
+#: src/pages/SettingsPage.tsx
+msgid "New password"
+msgstr "New password"
+
 #: src/pages/BookDetailPage.tsx
 msgid "new this week"
 msgstr "new this week"
+
+#: src/pages/SettingsPage.tsx
+msgid "New Token"
+msgstr "New Token"
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next book"
@@ -884,9 +1259,21 @@ msgstr "Next book"
 msgid "Next page"
 msgstr "Next page"
 
+#: src/pages/SettingsPage.tsx
+msgid "No API keys. Download the plugin to auto-create one."
+msgstr "No API keys. Download the plugin to auto-create one."
+
+#: src/pages/SettingsPage.tsx
+msgid "No API tokens yet. Create one to use Scribe or scripts against Tome."
+msgstr "No API tokens yet. Create one to use Scribe or scripts against Tome."
+
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
 msgstr "No description"
+
+#: src/pages/SettingsPage.tsx
+msgid "No devices yet. Add one to start sending books."
+msgstr "No devices yet. Add one to start sending books."
 
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
@@ -899,6 +1286,10 @@ msgstr "No notifications yet"
 #: src/components/Sidebar.tsx
 msgid "No other users to share with."
 msgstr "No other users to share with."
+
+#: src/pages/SettingsPage.tsx
+msgid "No PINs yet. Generate one to use with OPDS clients."
+msgstr "No PINs yet. Generate one to use with OPDS clients."
 
 #: src/pages/BookDetailPage.tsx
 msgid "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
@@ -933,6 +1324,10 @@ msgstr "None"
 msgid "not read"
 msgstr "not read"
 
+#: src/pages/SettingsPage.tsx
+msgid "Note on KOSync coexistence"
+msgstr "Note on KOSync coexistence"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Note removed"
 msgstr "Note removed"
@@ -950,6 +1345,7 @@ msgid "Nothing matched “{search}”"
 msgstr "Nothing matched “{search}”"
 
 #: src/components/NotificationBell.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Notifications"
 msgstr "Notifications"
 
@@ -969,6 +1365,14 @@ msgstr "ongoing"
 msgid "Only filled fields will be updated. Leave blank to keep existing values."
 msgstr "Only filled fields will be updated. Leave blank to keep existing values."
 
+#: src/pages/SettingsPage.tsx
+msgid "OPDS Catalog"
+msgstr "OPDS Catalog"
+
+#: src/pages/SettingsPage.tsx
+msgid "Open a book downloaded via OPDS"
+msgstr "Open a book downloaded via OPDS"
+
 #: src/components/AppHeader.tsx
 msgid "Open navigation"
 msgstr "Open navigation"
@@ -980,6 +1384,18 @@ msgstr "Open reader"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Open selected book"
 msgstr "Open selected book"
+
+#: src/pages/SettingsPage.tsx
+msgid "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
+msgstr "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
+
+#: src/pages/SettingsPage.tsx
+msgid "Other providers"
+msgstr "Other providers"
+
+#: src/pages/SettingsPage.tsx
+msgid "Owner"
+msgstr "Owner"
 
 #: src/pages/BookDetailPage.tsx
 msgid "pace"
@@ -993,13 +1409,53 @@ msgstr "pages"
 msgid "Pages · 30d"
 msgstr "Pages · 30d"
 
+#: src/pages/SettingsPage.tsx
+msgid "Password"
+msgstr "Password"
+
+#: src/pages/SettingsPage.tsx
+msgid "Password must be at least 8 characters"
+msgstr "Password must be at least 8 characters"
+
+#: src/pages/SettingsPage.tsx
+msgid "Password updated successfully"
+msgstr "Password updated successfully"
+
+#: src/pages/SettingsPage.tsx
+msgid "Passwords do not match"
+msgstr "Passwords do not match"
+
 #: src/pages/DashboardPage.tsx
 msgid "Pick up where you left off"
 msgstr "Pick up where you left off"
 
+#: src/pages/SettingsPage.tsx
+msgid "PIN created — copy it now, it won't be shown again."
+msgstr "PIN created — copy it now, it won't be shown again."
+
 #: src/pages/BookDetailPage.tsx
 msgid "Position history — restore a bad sync"
 msgstr "Position history — restore a bad sync"
+
+#: src/pages/SettingsPage.tsx
+msgid "Prefix"
+msgstr "Prefix"
+
+#: src/pages/SettingsPage.tsx
+msgid "Preparing..."
+msgstr "Preparing..."
+
+#: src/pages/SettingsPage.tsx
+msgid "Preparing…"
+msgstr "Preparing…"
+
+#: src/pages/SettingsPage.tsx
+msgid "Preview"
+msgstr "Preview"
+
+#: src/pages/SettingsPage.tsx
+msgid "Preview:"
+msgstr "Preview:"
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Previous book"
@@ -1017,6 +1473,10 @@ msgstr "Private — only assigned users can access"
 msgid "Private library"
 msgstr "Private library"
 
+#: src/pages/SettingsPage.tsx
+msgid "Profile updated"
+msgstr "Profile updated"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Progress"
 msgstr "Progress"
@@ -1025,6 +1485,10 @@ msgstr "Progress"
 msgid "Progress % <0>(optional)</0>"
 msgstr "Progress % <0>(optional)</0>"
 
+#: src/pages/SettingsPage.tsx
+msgid "Progress Sync"
+msgstr "Progress Sync"
+
 #: src/components/Sidebar.tsx
 msgid "Public library"
 msgstr "Public library"
@@ -1032,6 +1496,10 @@ msgstr "Public library"
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
 msgstr "Publisher"
+
+#: src/pages/SettingsPage.tsx
+msgid "Quick Connect"
+msgstr "Quick Connect"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Rate this book"
@@ -1091,6 +1559,10 @@ msgstr "read {span}"
 msgid "Read book"
 msgstr "Read book"
 
+#: src/pages/SettingsPage.tsx
+msgid "Read-only"
+msgstr "Read-only"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Reader"
 msgstr "Reader"
@@ -1127,22 +1599,54 @@ msgstr "Recently Added"
 msgid "Recently Finished"
 msgstr "Recently Finished"
 
+#: src/pages/SettingsPage.tsx
+msgid "Register"
+msgstr "Register"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
 msgstr "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
+
+#: src/pages/SettingsPage.tsx
+msgid "Remove device"
+msgstr "Remove device"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Remove from library"
 msgstr "Remove from library"
 
+#: src/pages/SettingsPage.tsx
+msgid "Restart KOReader"
+msgstr "Restart KOReader"
+
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
 msgstr "Resume {volLabel}"
+
+#: src/pages/SettingsPage.tsx
+msgid "Revoke"
+msgstr "Revoke"
+
+#: src/pages/SettingsPage.tsx
+msgid "Revoke this token? Any scripts or tools using it will stop working immediately."
+msgstr "Revoke this token? Any scripts or tools using it will stop working immediately."
+
+#: src/pages/SettingsPage.tsx
+msgid "Revoke token"
+msgstr "Revoke token"
+
+#: src/pages/SettingsPage.tsx
+msgid "Revoked"
+msgstr "Revoked"
 
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Save"
 msgstr "Save"
+
+#: src/pages/SettingsPage.tsx
+msgid "Save changes"
+msgstr "Save changes"
 
 #: src/pages/DashboardPage.tsx
 msgid "Save Changes"
@@ -1160,9 +1664,17 @@ msgstr "Save note"
 msgid "Save the library first, then reopen it to share with users."
 msgstr "Save the library first, then reopen it to share with users."
 
+#: src/pages/SettingsPage.tsx
+msgid "Saving..."
+msgstr "Saving..."
+
 #: src/pages/BookDetailPage.tsx
 msgid "Saving…"
 msgstr "Saving…"
+
+#: src/pages/SettingsPage.tsx
+msgid "Scope"
+msgstr "Scope"
 
 #: src/components/AppHeader.tsx
 msgid "Search books"
@@ -1191,6 +1703,10 @@ msgstr "Select"
 #: src/pages/DashboardPage.tsx
 msgid "Select all"
 msgstr "Select all"
+
+#: src/pages/SettingsPage.tsx
+msgid "Send to Device"
+msgstr "Send to Device"
 
 #: src/components/Sidebar.tsx
 #: src/pages/DashboardPage.tsx
@@ -1222,14 +1738,31 @@ msgstr "Sessions · {d}"
 msgid "Sessions ({n})"
 msgstr "Sessions ({n})"
 
+#: src/pages/SettingsPage.tsx
+msgid "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
+msgstr "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
+
+#: src/pages/SettingsPage.tsx
+msgid "Set sync password"
+msgstr "Set sync password"
+
 #: src/components/Sidebar.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Settings"
 msgstr "Settings"
+
+#: src/pages/SettingsPage.tsx
+msgid "Setup instructions"
+msgstr "Setup instructions"
 
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Share"
 msgstr "Share"
+
+#: src/pages/SettingsPage.tsx
+msgid "Share links"
+msgstr "Share links"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Share this book — a public metadata-only page"
@@ -1264,6 +1797,10 @@ msgstr "Shelved — set aside, keeps your progress"
 msgid "Shelves"
 msgstr "Shelves"
 
+#: src/pages/SettingsPage.tsx
+msgid "Short app-specific passwords for OPDS — easier to type on an e-reader than your full password."
+msgstr "Short app-specific passwords for OPDS — easier to type on an e-reader than your full password."
+
 #: src/pages/DashboardPage.tsx
 msgid "Show another highlight"
 msgstr "Show another highlight"
@@ -1289,6 +1826,18 @@ msgstr "Show more"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
 msgstr "Show this help"
+
+#: src/pages/SettingsPage.tsx
+msgid "Sign in on a new device without entering your password. On the new device, tap \"Quick Connect\" on the login screen to get a 6-character code, then enter it here."
+msgstr "Sign in on a new device without entering your password. On the new device, tap \"Quick Connect\" on the login screen to get a 6-character code, then enter it here."
+
+#: src/pages/SettingsPage.tsx
+msgid "Single Sign-On"
+msgstr "Single Sign-On"
+
+#: src/pages/SettingsPage.tsx
+msgid "SSO sign-in linked to your account."
+msgstr "SSO sign-in linked to your account."
 
 #: src/pages/BookDetailPage.tsx
 msgid "start"
@@ -1318,6 +1867,10 @@ msgstr "Status: {filterStatusLabel}"
 msgid "Subtitle (optional)"
 msgstr "Subtitle (optional)"
 
+#: src/pages/SettingsPage.tsx
+msgid "Sync reading position between KOReader and Tome."
+msgstr "Sync reading position between KOReader and Tome."
+
 #: src/pages/BookDetailPage.tsx
 msgid "Synced document"
 msgstr "Synced document"
@@ -1330,9 +1883,29 @@ msgstr "Tag"
 msgid "Tag: {filterTag}"
 msgstr "Tag: {filterTag}"
 
+#: src/pages/SettingsPage.tsx
+msgid "That SSO identity is already linked to another account."
+msgstr "That SSO identity is already linked to another account."
+
+#: src/pages/SettingsPage.tsx
+msgid "the sync password set above"
+msgstr "the sync password set above"
+
 #: src/components/Sidebar.tsx
 msgid "Theme"
 msgstr "Theme"
+
+#: src/pages/SettingsPage.tsx
+msgid "Theme name"
+msgstr "Theme name"
+
+#: src/pages/SettingsPage.tsx
+msgid "Theme name is required"
+msgstr "Theme name is required"
+
+#: src/pages/SettingsPage.tsx
+msgid "This is the only time you will see this token. Store it somewhere safe — it cannot be recovered."
+msgstr "This is the only time you will see this token. Store it somewhere safe — it cannot be recovered."
 
 #: src/pages/DashboardPage.tsx
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
@@ -1362,6 +1935,18 @@ msgstr "Toggle metadata edit"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Toggle only-notes filter"
 msgstr "Toggle only-notes filter"
+
+#: src/pages/SettingsPage.tsx
+msgid "Token name"
+msgstr "Token name"
+
+#: src/pages/SettingsPage.tsx
+msgid "TomeSync and KOSync can both be active. TomeSync tracks full reading sessions; KOSync only stores your last position."
+msgstr "TomeSync and KOSync can both be active. TomeSync tracks full reading sessions; KOSync only stores your last position."
+
+#: src/pages/SettingsPage.tsx
+msgid "TomeSync Plugin"
+msgstr "TomeSync Plugin"
 
 #: src/pages/SettingsPage.tsx
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
@@ -1400,6 +1985,26 @@ msgstr "Unread"
 msgid "Unserialized"
 msgstr "Unserialized"
 
+#: src/pages/SettingsPage.tsx
+msgid "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
+msgstr "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
+
+#: src/pages/SettingsPage.tsx
+msgid "Update"
+msgstr "Update"
+
+#: src/pages/SettingsPage.tsx
+msgid "Update password"
+msgstr "Update password"
+
+#: src/pages/SettingsPage.tsx
+msgid "Update sync password"
+msgstr "Update sync password"
+
+#: src/pages/SettingsPage.tsx
+msgid "Update to v{v}"
+msgstr "Update to v{v}"
+
 #: src/components/AppHeader.tsx
 msgid "Upload"
 msgstr "Upload"
@@ -1416,9 +2021,33 @@ msgstr "Uploader"
 msgid "Uploader: {filterUploaderName}"
 msgstr "Uploader: {filterUploaderName}"
 
+#: src/pages/SettingsPage.tsx
+msgid "URL"
+msgstr "URL"
+
+#: src/pages/SettingsPage.tsx
+msgid "Use a <0>Google App Password</0>, not your regular password."
+msgstr "Use a <0>Google App Password</0>, not your regular password."
+
+#: src/pages/SettingsPage.tsx
+msgid "Use this as the OPDS password in KOReader (username stays the same)."
+msgstr "Use this as the OPDS password in KOReader (username stays the same)."
+
+#: src/pages/SettingsPage.tsx
+msgid "used {d}"
+msgstr "used {d}"
+
 #: src/components/Sidebar.tsx
 msgid "User menu"
 msgstr "User menu"
+
+#: src/pages/SettingsPage.tsx
+msgid "Username"
+msgstr "Username"
+
+#: src/pages/SettingsPage.tsx
+msgid "Verify it's working"
+msgstr "Verify it's working"
 
 #: src/components/ImpersonationBanner.tsx
 msgid "Viewing as <0>{impersonatedUsername}</0>"
@@ -1449,6 +2078,10 @@ msgstr "Want to Read"
 #: src/pages/BookDetailPage.tsx
 msgid "Want to Read — queue this book up next"
 msgstr "Want to Read — queue this book up next"
+
+#: src/pages/SettingsPage.tsx
+msgid "Warm"
+msgstr "Warm"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Web reader"
@@ -1487,6 +2120,14 @@ msgstr "Yesterday"
 msgid "You rated this {rating}/5"
 msgstr "You rated this {rating}/5"
 
+#: src/pages/SettingsPage.tsx
+msgid "You're signed in via SSO. Manage your credentials at your identity provider — there's no Tome password to change."
+msgstr "You're signed in via SSO. Manage your credentials at your identity provider — there's no Tome password to change."
+
+#: src/pages/SettingsPage.tsx
+msgid "Your account is linked to SSO — you can sign in with your identity provider."
+msgstr "Your account is linked to SSO — you can sign in with your identity provider."
+
 #: src/pages/DashboardPage.tsx
 msgid "Your library is empty"
 msgstr "Your library is empty"
@@ -1494,3 +2135,11 @@ msgstr "Your library is empty"
 #: src/pages/BookDetailPage.tsx
 msgid "Your note — syncs back to KOReader on the next sync"
 msgstr "Your note — syncs back to KOReader on the next sync"
+
+#: src/pages/SettingsPage.tsx
+msgid "Your server admin needs to set SMTP environment variables:"
+msgstr "Your server admin needs to set SMTP environment variables:"
+
+#: src/pages/SettingsPage.tsx
+msgid "your Tome password"
+msgstr "your Tome password"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -33,6 +33,10 @@ msgstr " · {dur} read time"
 msgid " · {errs} error(s)"
 msgstr " · {errs} error(s)"
 
+#: src/components/stats/SeriesCompletionGrid.tsx
+msgid " · {n} in progress"
+msgstr " · {n} in progress"
+
 #: src/pages/SharePage.tsx
 msgid " · {n} read"
 msgstr " · {n} read"
@@ -122,6 +126,11 @@ msgstr "(not set)"
 msgid "{0, plural, one {{dur} over # day} other {{dur} over # days}}"
 msgstr "{0, plural, one {{dur} over # day} other {{dur} over # days}}"
 
+#. placeholder {0}: a.book_count
+#: src/components/stats/AuthorAffinity.tsx
+msgid "{0, plural, one {{fin} finished · # book read} other {{fin} finished · # books read}}"
+msgstr "{0, plural, one {{fin} finished · # book read} other {{fin} finished · # books read}}"
+
 #. placeholder {0}: res.errors.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
@@ -165,6 +174,11 @@ msgstr "{0, plural, one {# result — click to fill form} other {# results — c
 #: src/pages/WishlistPage.tsx
 msgid "{0, plural, one {# series} other {# series}}"
 msgstr "{0, plural, one {# series} other {# series}}"
+
+#. placeholder {0}: f.sessions
+#: src/components/stats/PaceByFormat.tsx
+msgid "{0, plural, one {# session · {pages} pages} other {# sessions · {pages} pages}}"
+msgstr "{0, plural, one {# session · {pages} pages} other {# sessions · {pages} pages}}"
 
 #. placeholder {0}: data.reread_bins
 #: src/pages/BookDetailPage.tsx
@@ -335,15 +349,24 @@ msgstr "{failed, plural, one {# book could not be deleted} other {# books could 
 msgid "{failedN} of {totalN} failed — {firstErr}"
 msgstr "{failedN} of {totalN} failed — {firstErr}"
 
+#: src/components/stats/CompletionByType.tsx
+msgid "{fin} of {st} finished"
+msgstr "{fin} of {st} finished"
+
 #: src/pages/StatsPage.tsx
 msgid "{fin} of {st} started"
 msgstr "{fin} of {st} started"
+
+#: src/components/stats/CompletionRateCard.tsx
+msgid "{fin} of {st} started · all time"
+msgstr "{fin} of {st} started · all time"
 
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h"
 msgstr "{h}h"
 
+#: src/components/stats/AuthorAffinity.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
@@ -633,6 +656,14 @@ msgstr "Add books you'd like to see in the library."
 msgid "Add custom theme"
 msgstr "Add custom theme"
 
+#: src/components/SaveFilterButton.tsx
+msgid "Add shelf"
+msgstr "Add shelf"
+
+#: src/components/SaveFilterButton.tsx
+msgid "Add Shelf"
+msgstr "Add Shelf"
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Add tag…"
@@ -781,6 +812,10 @@ msgstr "App-specific PINs"
 #: src/pages/SettingsPage.tsx
 msgid "Appearance"
 msgstr "Appearance"
+
+#: src/components/SeriesRating.tsx
+msgid "Applied to volumes you haven’t rated"
+msgstr "Applied to volumes you haven’t rated"
 
 #: src/pages/StatsPage.tsx
 msgid "Apply"
@@ -1006,6 +1041,7 @@ msgstr "Browse and download your library from KOReader or any OPDS client."
 msgid "Browse your library"
 msgstr "Browse your library"
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -1179,6 +1215,10 @@ msgstr "Completion"
 #: src/pages/StatsPage.tsx
 msgid "Completion Estimates"
 msgstr "Completion Estimates"
+
+#: src/components/stats/CompletionRateCard.tsx
+msgid "Completion Rate"
+msgstr "Completion Rate"
 
 #: src/pages/StatsPage.tsx
 msgid "Configure"
@@ -1663,6 +1703,10 @@ msgstr "Errors"
 msgid "Est. remaining"
 msgstr "Est. remaining"
 
+#: src/components/ShareLinksOverview.tsx
+msgid "Every public link you've shared — shelves, series, and books. Links show metadata, your ratings, highlights, and reading stats; never files. Revoking kills a link instantly."
+msgstr "Every public link you've shared — shelves, series, and books. Links show metadata, your ratings, highlights, and reading stats; never files. Revoking kills a link instantly."
+
 #: src/pages/StatsPage.tsx
 msgid "Every session — paginated, deletable"
 msgstr "Every session — paginated, deletable"
@@ -1710,6 +1754,14 @@ msgstr "Expand all"
 #: src/components/Sidebar.tsx
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
+
+#: src/components/ShareLinksOverview.tsx
+msgid "expired"
+msgstr "expired"
+
+#: src/components/ShareLinksOverview.tsx
+msgid "expires {d}"
+msgstr "expires {d}"
 
 #: src/pages/LoginPage.tsx
 msgid "Expires in {timeLeft}"
@@ -1837,6 +1889,7 @@ msgstr "Failed to register"
 msgid "Failed to remove wish"
 msgstr "Failed to remove wish"
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -1858,6 +1911,10 @@ msgstr "Failed to save review"
 #: src/pages/AdminPage.tsx
 msgid "Failed to save role"
 msgstr "Failed to save role"
+
+#: src/components/SeriesRating.tsx
+msgid "Failed to save series rating"
+msgstr "Failed to save series rating"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to undo"
@@ -1987,6 +2044,10 @@ msgstr "Fulfilled"
 #: src/pages/SettingsPage.tsx
 msgid "Full access"
 msgstr "Full access"
+
+#: src/components/stats/ReadingDNACard.tsx
+msgid "Full breakdown →"
+msgstr "Full breakdown →"
 
 #: src/pages/SettingsPage.tsx
 msgid "Generate PIN"
@@ -2129,6 +2190,7 @@ msgstr "How to set it up"
 msgid "How you spread your 1–5 stars"
 msgstr "How you spread your 1–5 stars"
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 msgid "Icon"
@@ -2397,6 +2459,7 @@ msgstr "Loading books…"
 msgid "Loading..."
 msgstr "Loading..."
 
+#: src/components/ShareLinksOverview.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
 msgid "Loading…"
@@ -2587,6 +2650,7 @@ msgstr "My Theme"
 msgid "Name"
 msgstr "Name"
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 msgid "Name…"
 msgstr "Name…"
@@ -2598,6 +2662,10 @@ msgstr "Native KOReader plugin — tracks reading sessions and syncs by book ID.
 #: src/pages/SettingsPage.tsx
 msgid "Never"
 msgstr "Never"
+
+#: src/components/ShareLinksOverview.tsx
+msgid "never expires"
+msgstr "never expires"
 
 #: src/pages/HardcoverPage.tsx
 msgid "Never sync this book"
@@ -2675,6 +2743,10 @@ msgstr "No API tokens yet. Create one to use Scribe or scripts against Tome."
 msgid "No audit entries yet."
 msgstr "No audit entries yet."
 
+#: src/components/stats/AuthorAffinity.tsx
+msgid "No author data."
+msgstr "No author data."
+
 #: src/pages/AdminPage.tsx
 msgid "No book types yet."
 msgstr "No book types yet."
@@ -2694,6 +2766,10 @@ msgstr "No books in this view."
 #: src/pages/StatsPage.tsx
 msgid "No comparison data."
 msgstr "No comparison data."
+
+#: src/components/stats/CompletionByType.tsx
+msgid "No completion data by type."
+msgstr "No completion data by type."
 
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
@@ -2739,6 +2815,10 @@ msgstr "no ISBN"
 msgid "No libraries"
 msgstr "No libraries"
 
+#: src/components/stats/LibraryGrowthChart.tsx
+msgid "No library growth data."
+msgstr "No library growth data."
+
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
 msgstr "No matches"
@@ -2762,6 +2842,10 @@ msgstr "No open wishes."
 #: src/components/Sidebar.tsx
 msgid "No other users to share with."
 msgstr "No other users to share with."
+
+#: src/components/stats/PaceByFormat.tsx
+msgid "No pace data by format."
+msgstr "No pace data by format."
 
 #: src/pages/SettingsPage.tsx
 msgid "No PINs yet. Generate one to use with OPDS clients."
@@ -2806,6 +2890,10 @@ msgstr "No Series"
 #: src/pages/DashboardPage.tsx
 msgid "No series found — add series metadata to your books."
 msgstr "No series found — add series metadata to your books."
+
+#: src/components/stats/SeriesCompletionGrid.tsx
+msgid "No series with reading history yet."
+msgstr "No series with reading history yet."
 
 #: src/pages/StatsPage.tsx
 msgid "No series with reading progress yet."
@@ -2916,6 +3004,10 @@ msgstr "Nothing in progress"
 msgid "Nothing matched “{search}”"
 msgstr "Nothing matched “{search}”"
 
+#: src/components/ShareLinksOverview.tsx
+msgid "Nothing shared yet. Use the share icon on a shelf, a series page, or a book page."
+msgstr "Nothing shared yet. Use the share icon on a shelf, a series page, or a book page."
+
 #: src/components/NotificationBell.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Notifications"
@@ -2971,6 +3063,7 @@ msgstr "Only notes"
 msgid "OPDS Catalog"
 msgstr "OPDS Catalog"
 
+#: src/components/ShareLinksOverview.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Open"
@@ -3232,6 +3325,10 @@ msgstr "Range"
 msgid "Range follows the page's range picker; days show the newest slice of it."
 msgstr "Range follows the page's range picker; days show the newest slice of it."
 
+#: src/components/SeriesRating.tsx
+msgid "Rate the whole series"
+msgstr "Rate the whole series"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Rate this book"
 msgstr "Rate this book"
@@ -3243,6 +3340,10 @@ msgstr "Rated"
 #: src/components/BookCard.tsx
 msgid "Rated {rating} of 5"
 msgstr "Rated {rating} of 5"
+
+#: src/components/StarRating.tsx
+msgid "Rated {value} of 5"
+msgstr "Rated {value} of 5"
 
 #: src/pages/DashboardPage.tsx
 msgid "Rated: {filterMinRating}+ stars"
@@ -3354,6 +3455,7 @@ msgstr "Reading Clock"
 msgid "Reading days"
 msgstr "Reading days"
 
+#: src/components/stats/ReadingDNACard.tsx
 #: src/pages/StatsPage.tsx
 msgid "Reading DNA"
 msgstr "Reading DNA"
@@ -3570,6 +3672,7 @@ msgstr "Same ISBN"
 msgid "Same Series Volume"
 msgstr "Same Series Volume"
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -3646,6 +3749,14 @@ msgstr "Scanning…"
 #: src/pages/SettingsPage.tsx
 msgid "Scope"
 msgstr "Scope"
+
+#: src/components/HScrollRow.tsx
+msgid "Scroll left"
+msgstr "Scroll left"
+
+#: src/components/HScrollRow.tsx
+msgid "Scroll right"
+msgstr "Scroll right"
 
 #: src/pages/HardcoverPage.tsx
 msgid "Search"
@@ -4296,6 +4407,10 @@ msgstr "Total pages turned"
 msgid "Total time read + avg session"
 msgstr "Total time read + avg session"
 
+#: src/components/stats/LibraryGrowthChart.tsx
+msgid "Total: {total}"
+msgstr "Total: {total}"
+
 #: src/pages/SettingsPage.tsx
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "Translations are community-maintained. Anything not yet translated is shown in English."
@@ -4375,6 +4490,10 @@ msgstr "Unserialized"
 #: src/pages/SettingsPage.tsx
 msgid "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
 msgstr "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
+
+#: src/components/UpcomingReleases.tsx
+msgid "Upcoming releases"
+msgstr "Upcoming releases"
 
 #: src/pages/SettingsPage.tsx
 msgid "Update"
@@ -4467,6 +4586,10 @@ msgstr "Viewing as <0>{impersonatedUsername}</0>"
 msgid "Vol {idx}"
 msgstr "Vol {idx}"
 
+#: src/components/UpcomingReleases.tsx
+msgid "Vol {v} · "
+msgstr "Vol {v} · "
+
 #: src/pages/SharePage.tsx
 msgid "Vol. {a}–{b}"
 msgstr "Vol. {a}–{b}"
@@ -4545,6 +4668,10 @@ msgstr "What did you think? (optional, saved automatically)"
 #: src/pages/StatsPage.tsx
 msgid "What do these mean? — read the stats docs"
 msgstr "What do these mean? — read the stats docs"
+
+#: src/components/InfoHint.tsx
+msgid "What is this?"
+msgstr "What is this?"
 
 #: src/pages/HardcoverPage.tsx
 msgid "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
@@ -4685,6 +4812,10 @@ msgstr "Your Tome account is disabled."
 #: src/pages/SettingsPage.tsx
 msgid "your Tome password"
 msgstr "your Tome password"
+
+#: src/components/SeriesRating.tsx
+msgid "Your volumes average {avg} ({rated} rated)"
+msgstr "Your volumes average {avg} ({rated} rated)"
 
 #: src/pages/WishlistPage.tsx
 msgid "Your wishlist is empty"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -41,6 +41,14 @@ msgstr " · {dur} read time"
 msgid " · {errs} error(s)"
 msgstr " · {errs} error(s)"
 
+#: src/components/home/FocusMode.tsx
+msgid " · {n} ahead in this series"
+msgstr " · {n} ahead in this series"
+
+#: src/components/HardcoverSync.tsx
+msgid " · {n} errors"
+msgstr " · {n} errors"
+
 #: src/components/stats/SeriesCompletionGrid.tsx
 msgid " · {n} in progress"
 msgstr " · {n} in progress"
@@ -52,6 +60,10 @@ msgstr " · {n} not estimated"
 #: src/components/stats/BacklogEstimate.tsx
 msgid " · {n} not estimated yet"
 msgstr " · {n} not estimated yet"
+
+#: src/components/HardcoverSync.tsx
+msgid " · {n} not matched"
+msgstr " · {n} not matched"
 
 #: src/pages/SharePage.tsx
 msgid " · {n} read"
@@ -131,6 +143,10 @@ msgstr " vs previous: <0>{prev}</0>"
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
 msgstr "— keep existing —"
+
+#: src/components/HardcoverSync.tsx
+msgid "— manage →"
+msgstr "— manage →"
 
 #: src/pages/BinderyPage.tsx
 msgid ", {errors} failed"
@@ -462,6 +478,10 @@ msgstr "{color} highlight"
 msgid "{count} sittings · {from} – {to}"
 msgstr "{count} sittings · {from} – {to}"
 
+#: src/components/home/FocusMode.tsx
+msgid "{d} days ago"
+msgstr "{d} days ago"
+
 #: src/pages/DashboardPage.tsx
 msgid "{d}d ago"
 msgstr "{d}d ago"
@@ -554,6 +574,10 @@ msgstr "{fin} of {st} started · all time"
 msgid "{flagged} of {scanned} books flagged (low-res = narrower than {minW}px)."
 msgstr "{flagged} of {scanned} books flagged (low-res = narrower than {minW}px)."
 
+#: src/components/home/FocusMode.tsx
+msgid "{h} hours ago"
+msgstr "{h} hours ago"
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h"
@@ -566,6 +590,10 @@ msgstr "{h}h"
 #: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
 msgstr "{h}h {m}m"
+
+#: src/components/WordCount.tsx
+msgid "{h}h {mm}m"
+msgstr "{h}h {mm}m"
 
 #: src/components/PositionHistoryModal.tsx
 msgid "{h}h ago"
@@ -601,6 +629,7 @@ msgstr "{inc, plural, one {# file waiting for review} other {# files waiting for
 msgid "{label} only"
 msgstr "{label} only"
 
+#: src/components/home/FocusMode.tsx
 #: src/components/PositionHistoryModal.tsx
 msgid "{m} min ago"
 msgstr "{m} min ago"
@@ -609,6 +638,10 @@ msgstr "{m} min ago"
 #: src/pages/SharePage.tsx
 msgid "{m}m"
 msgstr "{m}m"
+
+#: src/components/WordCount.tsx
+msgid "{m}m {rem}s"
+msgstr "{m}m {rem}s"
 
 #: src/pages/AdminPage.tsx
 msgid "{mergeCount, plural, one {merge # group} other {merge # groups}}"
@@ -658,6 +691,10 @@ msgstr "{n} selected"
 msgid "{n} selected — Clear"
 msgstr "{n} selected — Clear"
 
+#: src/components/HardcoverSync.tsx
+msgid "{n} synced"
+msgstr "{n} synced"
+
 #: src/components/stats/TimelineRibbon.tsx
 msgid "{n} vols · "
 msgstr "{n} vols · "
@@ -702,6 +739,10 @@ msgstr "{pct}% less reading this period"
 msgid "{pct}% more reading this period"
 msgstr "{pct}% more reading this period"
 
+#: src/components/WordCount.tsx
+msgid "{pending, plural, one {Count # EPUB} other {Count # EPUBs}}"
+msgstr "{pending, plural, one {Count # EPUB} other {Count # EPUBs}}"
+
 #: src/components/stats/widgets/habits.tsx
 msgid "{ppm} pages/min"
 msgstr "{ppm} pages/min"
@@ -725,6 +766,10 @@ msgstr "{readN} read · {unreadN} unread"
 #: src/pages/BookDetailPage.tsx
 msgid "{recent} in the last 7 days vs {prior} the week before"
 msgstr "{recent} in the last 7 days vs {prior} the week before"
+
+#: src/components/WordCount.tsx
+msgid "{s}s"
+msgstr "{s}s"
 
 #: src/pages/DashboardPage.tsx
 msgid "{seconds}s"
@@ -799,6 +844,10 @@ msgstr "{y} Challenge"
 msgid "{years}y ago"
 msgstr "{years}y ago"
 
+#: src/components/home/FocusMode.tsx
+msgid "← Back to current"
+msgstr "← Back to current"
+
 #: src/pages/BookDetailPage.tsx
 msgid "← Back to library"
 msgstr "← Back to library"
@@ -854,6 +903,10 @@ msgstr "~1 day"
 #: src/components/ShareShelfModal.tsx
 msgid "1 day"
 msgstr "1 day"
+
+#: src/components/home/FocusMode.tsx
+msgid "1 hour ago"
+msgstr "1 hour ago"
 
 #: src/pages/StatsPage.tsx
 msgid "12 mo"
@@ -923,6 +976,7 @@ msgstr "A share link is a read-only page anyone with the link can open — no ac
 msgid "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for this book. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
 msgstr "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for this book. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
 
+#: src/components/HardcoverSync.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "A sync is already running"
 msgstr "A sync is already running"
@@ -1180,6 +1234,10 @@ msgstr "All your reading goals — rings fill as you read, managed in place"
 #: src/pages/StatsPage.tsx
 msgid "All-time hours, pages, books, streak"
 msgstr "All-time hours, pages, books, streak"
+
+#: src/components/WordCount.tsx
+msgid "Already counted"
+msgstr "Already counted"
 
 #: src/components/SendButton.tsx
 msgid "Already in your KOReader inbox"
@@ -1544,6 +1602,10 @@ msgstr "Bring your reading history from Goodreads or StoryGraph: upload their CS
 msgid "Browse and download your library from KOReader or any OPDS client."
 msgstr "Browse and download your library from KOReader or any OPDS client."
 
+#: src/components/home/FocusMode.tsx
+msgid "Browse library"
+msgstr "Browse library"
+
 #: src/pages/DashboardPage.tsx
 msgid "Browse your library"
 msgstr "Browse your library"
@@ -1798,6 +1860,10 @@ msgstr "Content"
 msgid "Content Type"
 msgstr "Content Type"
 
+#: src/components/home/FocusMode.tsx
+msgid "Continue reading"
+msgstr "Continue reading"
+
 #: src/pages/DashboardPage.tsx
 msgid "Continue Reading"
 msgstr "Continue Reading"
@@ -1838,6 +1904,10 @@ msgstr "Core"
 msgid "Could not create the goal — it may already exist."
 msgstr "Could not create the goal — it may already exist."
 
+#: src/components/HardcoverSync.tsx
+msgid "Could not link Hardcover account"
+msgstr "Could not link Hardcover account"
+
 #: src/pages/SettingsPage.tsx
 msgid "Could not link SSO. Please try again."
 msgstr "Could not link SSO. Please try again."
@@ -1845,6 +1915,10 @@ msgstr "Could not link SSO. Please try again."
 #: src/components/stats/BacklogEstimate.tsx
 msgid "Could not load this scope."
 msgstr "Could not load this scope."
+
+#: src/components/WordCount.tsx
+msgid "Could not parse ({n})"
+msgstr "Could not parse ({n})"
 
 #: src/components/ReadingImport.tsx
 msgid "Could not read that file"
@@ -1862,9 +1936,18 @@ msgstr "Could not set match"
 msgid "Could not start SSO linking."
 msgstr "Could not start SSO linking."
 
+#: src/components/HardcoverSync.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Could not start sync"
 msgstr "Could not start sync"
+
+#: src/components/HardcoverSync.tsx
+msgid "Could not unlink"
+msgstr "Could not unlink"
+
+#: src/components/HardcoverSync.tsx
+msgid "Could not update sync setting"
+msgstr "Could not update sync setting"
 
 #: src/components/stats/GoalWidget.tsx
 msgid "Could not update the goal."
@@ -1877,6 +1960,10 @@ msgstr "Couldn’t load stats."
 #: src/components/stats/TimelineRibbon.tsx
 msgid "Couldn't load the timeline."
 msgstr "Couldn't load the timeline."
+
+#: src/components/WordCount.tsx
+msgid "Counted"
+msgstr "Counted"
 
 #: src/components/stats/GoalWidget.tsx
 msgid "Counts"
@@ -1947,6 +2034,14 @@ msgstr "Current & longest daily streak"
 #: src/pages/SettingsPage.tsx
 msgid "Current password"
 msgstr "Current password"
+
+#: src/components/WordCount.tsx
+msgid "Current:"
+msgstr "Current:"
+
+#: src/components/home/FocusMode.tsx
+msgid "Currently reading"
+msgstr "Currently reading"
 
 #: src/pages/StatsPage.tsx
 msgid "Currently Reading"
@@ -2148,6 +2243,7 @@ msgstr "Do you rate books you spend longer on higher?"
 msgid "Docs"
 msgstr "Docs"
 
+#: src/components/WordCount.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
 #: src/pages/StatsPage.tsx
@@ -2299,6 +2395,10 @@ msgstr "Edit Shelf"
 msgid "Edit User"
 msgstr "Edit User"
 
+#: src/components/WordCount.tsx
+msgid "Elapsed {el} · ~{eta} left"
+msgstr "Elapsed {el} · ~{eta} left"
+
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 #: src/pages/SetupPage.tsx
@@ -2334,6 +2434,10 @@ msgstr "End"
 msgid "EPUB vs CBZ time split"
 msgstr "EPUB vs CBZ time split"
 
+#: src/components/WordCount.tsx
+msgid "EPUBs"
+msgstr "EPUBs"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Error"
 msgstr "Error"
@@ -2349,6 +2453,10 @@ msgstr "Est. read time"
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
 msgstr "Est. remaining"
+
+#: src/components/WordCount.tsx
+msgid "Every EPUB is counted"
+msgstr "Every EPUB is counted"
 
 #: src/components/ShareLinksOverview.tsx
 msgid "Every public link you've shared — shelves, series, and books. Links show metadata, your ratings, highlights, and reading stats; never files. Revoking kills a link instantly."
@@ -2448,6 +2556,7 @@ msgstr "Exporting..."
 msgid "failed"
 msgstr "failed"
 
+#: src/components/WordCount.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2548,6 +2657,10 @@ msgstr "Failed to load users"
 msgid "Failed to load wishlist"
 msgstr "Failed to load wishlist"
 
+#: src/components/WordCount.tsx
+msgid "Failed to load word-count status"
+msgstr "Failed to load word-count status"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to log session"
 msgstr "Failed to log session"
@@ -2594,6 +2707,10 @@ msgstr "Failed to save series rating"
 #: src/components/SendToDeviceModal.tsx
 msgid "Failed to send"
 msgstr "Failed to send"
+
+#: src/components/WordCount.tsx
+msgid "Failed to start"
+msgstr "Failed to start"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to undo"
@@ -2792,6 +2909,10 @@ msgstr "Get notified when a new volume is released"
 #: src/pages/WishlistPage.tsx
 msgid "Get notified when a new volume of a followed series is released."
 msgstr "Get notified when a new volume of a followed series is released."
+
+#: src/components/HardcoverSync.tsx
+msgid "Get token"
+msgstr "Get token"
 
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/pages/AdminPage.tsx
@@ -3056,6 +3177,7 @@ msgstr "It applies at the next server restart."
 msgid "Jump to a book, series, author, or page…"
 msgstr "Jump to a book, series, author, or page…"
 
+#: src/components/home/FocusMode.tsx
 #: src/components/NotificationBell.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -3066,6 +3188,7 @@ msgstr "just now"
 msgid "Just now"
 msgstr "Just now"
 
+#: src/components/home/FocusMode.tsx
 #: src/components/stats/widgets/habits.tsx
 msgid "Just started"
 msgstr "Just started"
@@ -3141,6 +3264,10 @@ msgstr "Last sync: {d}"
 #: src/pages/AdminPage.tsx
 msgid "Last Synced"
 msgstr "Last Synced"
+
+#: src/components/HardcoverSync.tsx
+msgid "last synced {when}"
+msgstr "last synced {when}"
 
 #: src/pages/SettingsPage.tsx
 msgid "Last used"
@@ -3228,6 +3355,10 @@ msgstr "Light"
 msgid "Link"
 msgstr "Link"
 
+#: src/components/HardcoverSync.tsx
+msgid "Link account"
+msgstr "Link account"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Link KOReader sync…"
 msgstr "Link KOReader sync…"
@@ -3251,6 +3382,14 @@ msgstr "Link your personal API token in <0>Settings → Hardcover</0> — syncin
 #: src/pages/SettingsPage.tsx
 msgid "Linked"
 msgstr "Linked"
+
+#: src/components/HardcoverSync.tsx
+msgid "Linked as @{username} — initial sync started"
+msgstr "Linked as @{username} — initial sync started"
+
+#: src/components/HardcoverSync.tsx
+msgid "Linked as <0>@{username}</0>"
+msgstr "Linked as <0>@{username}</0>"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Linking…"
@@ -3277,6 +3416,7 @@ msgstr "Loading your reading life…"
 msgid "Loading..."
 msgstr "Loading..."
 
+#: src/components/HardcoverSync.tsx
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareLinksOverview.tsx
 #: src/components/ShareShelfModal.tsx
@@ -3642,6 +3782,10 @@ msgstr "Next page"
 msgid "Next: Vol {v} · {d}"
 msgstr "Next: Vol {v} · {d}"
 
+#: src/components/home/FocusMode.tsx
+msgid "Next: Vol {v} →"
+msgstr "Next: Vol {v} →"
+
 #: src/components/stats/HourDowHeatmap.tsx
 msgid "No activity"
 msgstr "No activity"
@@ -3721,6 +3865,10 @@ msgstr "No data yet."
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
 msgstr "No description"
+
+#: src/components/home/FocusMode.tsx
+msgid "No description yet for this volume."
+msgstr "No description yet for this volume."
 
 #: src/components/SendToDeviceModal.tsx
 msgid "No devices configured"
@@ -4024,6 +4172,10 @@ msgstr "Not on board"
 msgid "not read"
 msgstr "not read"
 
+#: src/components/home/FocusMode.tsx
+msgid "Not started yet"
+msgstr "Not started yet"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Not synced yet"
 msgstr "Not synced yet"
@@ -4070,6 +4222,7 @@ msgstr "Nothing here yet."
 msgid "Nothing highlighted on this day — yet."
 msgstr "Nothing highlighted on this day — yet."
 
+#: src/components/home/FocusMode.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Nothing in progress"
 msgstr "Nothing in progress"
@@ -4262,6 +4415,10 @@ msgstr "Pages per week"
 msgid "Pages Turned"
 msgstr "Pages Turned"
 
+#: src/components/WordCount.tsx
+msgid "Parse each EPUB to store its word count. New uploads get this automatically — this backfills books added before the feature. It only reads the files and writes one number per book; nothing on disk is modified. Word counts power words-read and reading-speed stats. PDF and CBZ are skipped."
+msgstr "Parse each EPUB to store its word count. New uploads get this automatically — this backfills books added before the feature. It only reads the files and writes one number per book; nothing on disk is modified. Word counts power words-read and reading-speed stats. PDF and CBZ are skipped."
+
 #: src/pages/AdminPage.tsx
 msgid "password"
 msgstr "password"
@@ -4294,6 +4451,10 @@ msgstr "Passwords do not match"
 #: src/components/ForcePasswordChange.tsx
 msgid "Passwords do not match."
 msgstr "Passwords do not match."
+
+#: src/components/HardcoverSync.tsx
+msgid "Paste your Hardcover API token"
+msgstr "Paste your Hardcover API token"
 
 #: src/components/NotificationChannels.tsx
 msgid "Pause"
@@ -4416,6 +4577,7 @@ msgstr "Process files dropped into the <0>incoming/</0> directory and move them 
 msgid "Profile updated"
 msgstr "Profile updated"
 
+#: src/components/home/FocusMode.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Progress"
@@ -4445,6 +4607,10 @@ msgstr "Publisher"
 #: src/components/NotificationChannels.tsx
 msgid "Push Tome's notifications (wish fulfilled, new volume detected, reading goals) to ntfy, Gotify, or any webhook the moment they happen — the bell above only rings when you visit. Each channel can be tested, paused, or removed; tokens are stored server-side and never shown again."
 msgstr "Push Tome's notifications (wish fulfilled, new volume detected, reading goals) to ntfy, Gotify, or any webhook the moment they happen — the bell above only rings when you visit. Each channel can be tested, paused, or removed; tokens are stored server-side and never shown again."
+
+#: src/components/HardcoverSync.tsx
+msgid "Push your ratings and reading progress to your Hardcover profile — nothing is ever deleted there. Your Hardcover Want to Read shelf syncs both ways. Needs your personal API token (separate from the server's metadata token)."
+msgstr "Push your ratings and reading progress to your Hardcover profile — nothing is ever deleted there. Your Hardcover Want to Read shelf syncs both ways. Needs your personal API token (separate from the server's metadata token)."
 
 #: src/pages/AdminPage.tsx
 msgid "Queue: fold the other copies into the kept book"
@@ -4531,6 +4697,14 @@ msgstr "Rating Trend"
 msgid "Rating vs Time Spent"
 msgstr "Rating vs Time Spent"
 
+#: src/components/HardcoverSync.tsx
+msgid "Ratings push shortly after you change them; progress goes out in batches."
+msgstr "Ratings push shortly after you change them; progress goes out in batches."
+
+#: src/components/HardcoverSync.tsx
+msgid "Re-link"
+msgstr "Re-link"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Re-match"
 msgstr "Re-match"
@@ -4574,6 +4748,10 @@ msgstr "read {span}"
 #: src/components/BookCard.tsx
 msgid "Read book"
 msgstr "Read book"
+
+#: src/components/home/FocusMode.tsx
+msgid "Read on the web"
+msgstr "Read on the web"
 
 #: src/pages/SettingsPage.tsx
 msgid "Read-only"
@@ -4836,6 +5014,14 @@ msgstr "Resume"
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
 msgstr "Resume {volLabel}"
+
+#: src/components/home/FocusMode.tsx
+msgid "Resume reading"
+msgstr "Resume reading"
+
+#: src/components/WordCount.tsx
+msgid "Retry {n} failed"
+msgstr "Retry {n} failed"
 
 #: src/pages/BinderyPage.tsx
 msgid "Review"
@@ -5490,6 +5676,10 @@ msgstr "Start"
 msgid "Start {volLabel}"
 msgstr "Start {volLabel}"
 
+#: src/components/home/FocusMode.tsx
+msgid "Start a book and Focus mode will pick up where you left off"
+msgstr "Start a book and Focus mode will pick up where you left off"
+
 #: src/pages/StatsPage.tsx
 msgid "Start from default"
 msgstr "Start from default"
@@ -5497,6 +5687,10 @@ msgstr "Start from default"
 #: src/pages/HardcoverPage.tsx
 msgid "Start matching this book again"
 msgstr "Start matching this book again"
+
+#: src/components/home/FocusMode.tsx
+msgid "Start reading"
+msgstr "Start reading"
 
 #: src/pages/DashboardPage.tsx
 msgid "Start reading and your progress will show up here"
@@ -5522,6 +5716,10 @@ msgstr "Status"
 #: src/pages/DashboardPage.tsx
 msgid "Status: {filterStatusLabel}"
 msgstr "Status: {filterStatusLabel}"
+
+#: src/components/WordCount.tsx
+msgid "Stop"
+msgstr "Stop"
 
 #: src/components/SeriesFollowButton.tsx
 msgid "Stop following this series"
@@ -5552,6 +5750,11 @@ msgstr "Suggested: {dur}"
 msgid "Sun"
 msgstr "Sun"
 
+#: src/components/HardcoverSync.tsx
+msgid "Sync automatically"
+msgstr "Sync automatically"
+
+#: src/components/HardcoverSync.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Sync now"
 msgstr "Sync now"
@@ -5564,10 +5767,15 @@ msgstr "Sync reading position between KOReader and Tome."
 msgid "Sync started"
 msgstr "Sync started"
 
+#: src/components/HardcoverSync.tsx
+msgid "Sync started — pushing ratings and progress, syncing Want to Read both ways"
+msgstr "Sync started — pushing ratings and progress, syncing Want to Read both ways"
+
 #: src/pages/AdminPage.tsx
 msgid "Sync Status"
 msgstr "Sync Status"
 
+#: src/components/home/FocusMode.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Synced"
 msgstr "Synced"
@@ -5576,10 +5784,27 @@ msgstr "Synced"
 msgid "Synced document"
 msgstr "Synced document"
 
+#: src/components/home/FocusMode.tsx
+msgid "Synced from {device}"
+msgstr "Synced from {device}"
+
+#: src/components/home/FocusMode.tsx
+msgid "Synced from Kindle"
+msgstr "Synced from Kindle"
+
+#: src/components/home/FocusMode.tsx
+msgid "Synced from Kobo"
+msgstr "Synced from Kobo"
+
+#: src/components/home/FocusMode.tsx
+msgid "Synced from KOReader"
+msgstr "Synced from KOReader"
+
 #: src/pages/HighlightsPage.tsx
 msgid "Synced to Tome {when}"
 msgstr "Synced to Tome {when}"
 
+#: src/components/HardcoverSync.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Syncing…"
 msgstr "Syncing…"
@@ -5798,6 +6023,10 @@ msgstr "Title is required"
 msgid "Title is required."
 msgstr "Title is required."
 
+#: src/components/WordCount.tsx
+msgid "To count"
+msgstr "To count"
+
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/WishlistPage.tsx
@@ -5836,6 +6065,10 @@ msgstr "TomeSync and KOSync can both be active. TomeSync tracks full reading ses
 #: src/pages/SettingsPage.tsx
 msgid "TomeSync Plugin"
 msgstr "TomeSync Plugin"
+
+#: src/components/WordCount.tsx
+msgid "Took {dur}"
+msgstr "Took {dur}"
 
 #: src/pages/StatsPage.tsx
 msgid "Top Authors by Reading Time"
@@ -5958,6 +6191,10 @@ msgstr "Unknown author"
 msgid "unknown device"
 msgstr "unknown device"
 
+#: src/components/HardcoverSync.tsx
+msgid "Unlink"
+msgstr "Unlink"
+
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "unread"
@@ -5982,6 +6219,10 @@ msgstr "Unusually long session"
 #: src/pages/SettingsPage.tsx
 msgid "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
 msgstr "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
+
+#: src/components/home/FocusMode.tsx
+msgid "Up next"
+msgstr "Up next"
 
 #: src/components/UpcomingReleases.tsx
 msgid "Upcoming releases"
@@ -6134,6 +6375,10 @@ msgstr "volume"
 msgid "Volume"
 msgstr "Volume"
 
+#: src/components/home/FocusMode.tsx
+msgid "Volume <0>{v}</0>"
+msgstr "Volume <0>{v}</0>"
+
 #: src/pages/DashboardPage.tsx
 msgid "Volumes"
 msgstr "Volumes"
@@ -6270,6 +6515,22 @@ msgstr "Word count at a default {wpm} wpm (no finished books to measure your pac
 msgid "Word count at your measured {wpm} wpm"
 msgstr "Word count at your measured {wpm} wpm"
 
+#: src/components/WordCount.tsx
+msgid "Word count complete"
+msgstr "Word count complete"
+
+#: src/components/WordCount.tsx
+msgid "Word count failed"
+msgstr "Word count failed"
+
+#: src/components/WordCount.tsx
+msgid "Word count stopped"
+msgstr "Word count stopped"
+
+#: src/components/WordCount.tsx
+msgid "Word counts"
+msgstr "Word counts"
+
 #: src/pages/AdminPage.tsx
 msgid "Word Counts"
 msgstr "Word Counts"
@@ -6277,6 +6538,10 @@ msgstr "Word Counts"
 #: src/pages/BookDetailPage.tsx
 msgid "Words"
 msgstr "Words"
+
+#: src/components/WordCount.tsx
+msgid "Words found"
+msgstr "Words found"
 
 #: src/pages/StatsPage.tsx
 msgid "Words Read"
@@ -6334,6 +6599,10 @@ msgstr "Your account is not permitted to sign in to Tome."
 #: src/lib/backlog.ts
 msgid "Your average time per finished book of this type (no word count)"
 msgstr "Your average time per finished book of this type (no word count)"
+
+#: src/components/HardcoverSync.tsx
+msgid "Your Hardcover token expired (they reset every January 1). Paste a fresh one to resume syncing."
+msgstr "Your Hardcover token expired (they reset every January 1). Paste a fresh one to resume syncing."
 
 #: src/pages/StatsPage.tsx
 msgid "Your highest & lowest rated books"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -57,9 +57,18 @@ msgstr " · {n} not estimated yet"
 msgid " · {n} read"
 msgstr " · {n} read"
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
+msgid " · {n} reading"
+msgstr " · {n} reading"
+
 #: src/pages/WishlistPage.tsx
 msgid " · {n} volumes"
 msgstr " · {n} volumes"
+
+#: src/components/stats/widgets/insights.tsx
+msgid " · {n} want to read"
+msgstr " · {n} want to read"
 
 #: src/components/stats/widgets/overview.tsx
 msgid " · {pages} pages"
@@ -505,6 +514,10 @@ msgstr "{diffMins}m ago"
 msgid "{dismissCount, plural, one {dismiss # group} other {dismiss # groups}}"
 msgstr "{dismissCount, plural, one {dismiss # group} other {dismiss # groups}}"
 
+#: src/components/stats/widgets/insights.tsx
+msgid "{dur} · {books} books — your only language"
+msgstr "{dur} · {books} books — your only language"
+
 #: src/pages/BookDetailPage.tsx
 msgid "{dur} across {n} chapters"
 msgstr "{dur} across {n} chapters"
@@ -548,6 +561,7 @@ msgstr "{h}h"
 
 #: src/components/stats/AuthorAffinity.tsx
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/library.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
@@ -688,6 +702,14 @@ msgstr "{pct}% more reading this period"
 msgid "{ppm} pages/min"
 msgstr "{ppm} pages/min"
 
+#: src/components/stats/widgets/insights.tsx
+msgid "{read} of {owned} owned read"
+msgstr "{read} of {owned} owned read"
+
+#: src/components/stats/widgets/library.tsx
+msgid "{read} of {total} read"
+msgstr "{read} of {total} read"
+
 #: src/pages/DashboardPage.tsx
 msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
 msgstr "{readCount} read · {readingCount} reading · {unreadCount} unread"
@@ -755,6 +777,10 @@ msgstr "{totalCount, plural, one {{shown} of # title} other {{shown} of # titles
 #: src/pages/DashboardPage.tsx
 msgid "{totalCount, plural, one {# result for \"{search}\"} other {# results for \"{search}\"}}"
 msgstr "{totalCount, plural, one {# result for \"{search}\"} other {# results for \"{search}\"}}"
+
+#: src/components/stats/widgets/library.tsx
+msgid "{v}m"
+msgstr "{v}m"
 
 #: src/pages/BookDetailPage.tsx
 msgid "{words} words"
@@ -948,6 +974,10 @@ msgstr "Actions"
 #: src/pages/AdminPage.tsx
 msgid "Active"
 msgstr "Active"
+
+#: src/components/stats/widgets/insights.tsx
+msgid "Active Days"
+msgstr "Active Days"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Activity"
@@ -1237,6 +1267,7 @@ msgstr "Audit Log"
 msgid "Auth"
 msgstr "Auth"
 
+#: src/components/stats/widgets/library.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -1359,6 +1390,10 @@ msgstr "Best-Rated Series"
 msgid "Beta"
 msgstr "Beta"
 
+#: src/components/stats/widgets/insights.tsx
+msgid "Biggest reading day"
+msgstr "Biggest reading day"
+
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Bindery"
@@ -1443,6 +1478,8 @@ msgstr "Books completed"
 msgid "Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately."
 msgstr "Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately."
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
 #: src/pages/StatsPage.tsx
 msgid "Books Finished"
 msgstr "Books Finished"
@@ -3210,6 +3247,10 @@ msgstr "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is sho
 msgid "Longest first"
 msgstr "Longest first"
 
+#: src/components/stats/widgets/insights.tsx
+msgid "Longest session"
+msgstr "Longest session"
+
 #: src/pages/StatsPage.tsx
 msgid "Longest Session"
 msgstr "Longest Session"
@@ -3218,6 +3259,8 @@ msgstr "Longest Session"
 msgid "Longest session, biggest day, most pages"
 msgstr "Longest session, biggest day, most pages"
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
 #: src/pages/StatsPage.tsx
 msgid "Longest Streak"
 msgstr "Longest Streak"
@@ -3385,6 +3428,14 @@ msgstr "More send options"
 #: src/pages/StatsPage.tsx
 msgid "Morning vs evening reader?"
 msgstr "Morning vs evening reader?"
+
+#: src/components/stats/widgets/library.tsx
+msgid "Most Active Month"
+msgstr "Most Active Month"
+
+#: src/components/stats/widgets/insights.tsx
+msgid "Most pages in a day"
+msgstr "Most pages in a day"
 
 #: src/pages/StatsPage.tsx
 msgid "Most-read authors"
@@ -3565,6 +3616,10 @@ msgstr "No books in progress"
 msgid "No books in this view."
 msgstr "No books in this view."
 
+#: src/components/stats/widgets/library.tsx
+msgid "No category data."
+msgstr "No category data."
+
 #: src/pages/StatsPage.tsx
 msgid "No comparison data."
 msgstr "No comparison data."
@@ -3584,6 +3639,10 @@ msgstr "No cover candidates found."
 #: src/components/CoverPickerModal.tsx
 msgid "No covers found — try a different search or use a custom URL below."
 msgstr "No covers found — try a different search or use a custom URL below."
+
+#: src/components/stats/widgets/insights.tsx
+msgid "No data yet."
+msgstr "No data yet."
 
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
@@ -3741,6 +3800,10 @@ msgstr "No reading sessions recorded."
 msgid "no reading yet"
 msgstr "no reading yet"
 
+#: src/components/stats/widgets/insights.tsx
+msgid "No reading-time data yet."
+msgstr "No reading-time data yet."
+
 #: src/components/stats/BacklogEstimate.tsx
 #: src/lib/backlog.ts
 msgid "no recent reading, so no day estimate"
@@ -3766,6 +3829,10 @@ msgstr "No Series"
 msgid "No series found — add series metadata to your books."
 msgstr "No series found — add series metadata to your books."
 
+#: src/components/stats/widgets/library.tsx
+msgid "No series read yet."
+msgstr "No series read yet."
+
 #: src/components/stats/SeriesCompletionGrid.tsx
 msgid "No series with reading history yet."
 msgstr "No series with reading history yet."
@@ -3778,6 +3845,10 @@ msgstr "No series with reading progress yet."
 #: src/components/stats/widgets/habits.tsx
 msgid "No session data."
 msgstr "No session data."
+
+#: src/components/stats/widgets/insights.tsx
+msgid "No session-time data yet."
+msgstr "No session-time data yet."
 
 #: src/components/stats/widgets/overview.tsx
 msgid "No sessions recorded."
@@ -4064,6 +4135,11 @@ msgstr "Padding"
 msgid "pages"
 msgstr "pages"
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
+msgid "Pages"
+msgstr "Pages"
+
 #: src/pages/DashboardPage.tsx
 msgid "Pages · 30d"
 msgstr "Pages · 30d"
@@ -4128,6 +4204,10 @@ msgstr "Passwords do not match."
 #: src/components/NotificationChannels.tsx
 msgid "Pause"
 msgstr "Pause"
+
+#: src/components/stats/widgets/insights.tsx
+msgid "Peak hour: <0>{peak}:00–{peakEnd}:00</0> · {dur} total"
+msgstr "Peak hour: <0>{peak}:00–{peakEnd}:00</0> · {dur} total"
 
 #: src/pages/BinderyPage.tsx
 msgid "Per-file details"
@@ -4877,6 +4957,10 @@ msgstr "See Settings for setup instructions."
 msgid "Select"
 msgstr "Select"
 
+#: src/components/stats/widgets/library.tsx
+msgid "Select <0>1y</0> or <1>All</1> to see your year in review."
+msgstr "Select <0>1y</0> or <1>All</1> to see your year in review."
+
 #: src/pages/AdminPage.tsx
 msgid "Select a book first."
 msgstr "Select a book first."
@@ -5007,6 +5091,8 @@ msgstr "Session Timeline"
 msgid "sessions"
 msgstr "sessions"
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
 #: src/pages/StatsPage.tsx
 msgid "Sessions"
 msgstr "Sessions"
@@ -5136,6 +5222,10 @@ msgstr "Shelves"
 msgid "Short app-specific passwords for OPDS — easier to type on an e-reader than your full password."
 msgstr "Short app-specific passwords for OPDS — easier to type on an e-reader than your full password."
 
+#: src/components/stats/widgets/library.tsx
+msgid "Show all ({n} books)"
+msgstr "Show all ({n} books)"
+
 #: src/pages/DashboardPage.tsx
 msgid "Show another highlight"
 msgstr "Show another highlight"
@@ -5149,6 +5239,7 @@ msgstr "Show details"
 msgid "Show individual volumes"
 msgstr "Show individual volumes"
 
+#: src/components/stats/widgets/library.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Show less"
@@ -5496,6 +5587,7 @@ msgstr "this week"
 msgid "Thu"
 msgstr "Thu"
 
+#: src/components/stats/widgets/library.tsx
 #: src/pages/AdminPage.tsx
 msgid "Time"
 msgstr "Time"
@@ -5544,6 +5636,7 @@ msgstr "Timeline"
 msgid "title"
 msgstr "title"
 
+#: src/components/stats/widgets/library.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -5605,9 +5698,25 @@ msgstr "Top Authors by Reading Time"
 msgid "Top Books by Reading Time"
 msgstr "Top Books by Reading Time"
 
+#: src/components/stats/widgets/library.tsx
+msgid "Top Genre"
+msgstr "Top Genre"
+
+#: src/components/stats/widgets/library.tsx
+msgid "Total Hours"
+msgstr "Total Hours"
+
 #: src/pages/StatsPage.tsx
 msgid "Total pages turned"
 msgstr "Total pages turned"
+
+#: src/components/stats/widgets/library.tsx
+msgid "Total Sessions"
+msgstr "Total Sessions"
+
+#: src/components/stats/widgets/insights.tsx
+msgid "Total Time"
+msgstr "Total Time"
 
 #: src/pages/StatsPage.tsx
 msgid "Total time read + avg session"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -82,6 +82,10 @@ msgstr " · longest <0>{title}</0> ({words})"
 msgid " · reviewed"
 msgstr " · reviewed"
 
+#: src/components/ShareShelfModal.tsx
+msgid " · to change expiry, revoke and re-create"
+msgstr " · to change expiry, revoke and re-create"
+
 #: src/pages/WishlistPage.tsx
 msgid " · you have vol {v}"
 msgstr " · you have vol {v}"
@@ -94,6 +98,10 @@ msgstr "— keep existing —"
 msgid ", {errors} failed"
 msgstr ", {errors} failed"
 
+#: src/components/UploadModal.tsx
+msgid ", {failedN} failed"
+msgstr ", {failedN} failed"
+
 #: src/pages/AdminPage.tsx
 msgid ", {n} failed"
 msgstr ", {n} failed"
@@ -101,6 +109,10 @@ msgstr ", {n} failed"
 #: src/pages/BookDetailPage.tsx
 msgid ", {pages} pages"
 msgstr ", {pages} pages"
+
+#: src/components/UploadModal.tsx
+msgid ", {skipped} already in library"
+msgstr ", {skipped} already in library"
 
 #: src/pages/DashboardPage.tsx
 msgid "…and {more} more not shown"
@@ -129,6 +141,10 @@ msgstr "· p. {page} of {totalPages}"
 #: src/pages/SettingsPage.tsx
 msgid "(enables dark: variants)"
 msgstr "(enables dark: variants)"
+
+#: src/components/SendToDeviceModal.tsx
+msgid "(exceeds 25 MB email limit)"
+msgstr "(exceeds 25 MB email limit)"
 
 #: src/pages/AdminPage.tsx
 msgid "(last 100)"
@@ -190,6 +206,11 @@ msgstr "{0, plural, one {# day} other {# days}}"
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
 msgstr "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
+
+#. placeholder {0}: items.length
+#: src/components/UploadModal.tsx
+msgid "{0, plural, one {# file selected} other {# files selected}}"
+msgstr "{0, plural, one {# file selected} other {# files selected}}"
 
 #. placeholder {0}: row.unestimated
 #: src/components/stats/BacklogEstimate.tsx
@@ -315,6 +336,16 @@ msgstr "{0, plural, one {Permanently delete # file from the bindery? This cannot
 msgid "{0, plural, one {Rejected # file} other {Rejected # files}}"
 msgstr "{0, plural, one {Rejected # file} other {Rejected # files}}"
 
+#. placeholder {0}: books.length
+#: src/components/SendToDeviceModal.tsx
+msgid "{0, plural, one {Send # book} other {Send # books}}"
+msgstr "{0, plural, one {Send # book} other {Send # books}}"
+
+#. placeholder {0}: res.sent
+#: src/components/SendToDeviceModal.tsx
+msgid "{0, plural, one {Sent # book to device} other {Sent # books to device}}"
+msgstr "{0, plural, one {Sent # book to device} other {Sent # books to device}}"
+
 #. placeholder {0}: suggestedBooks.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {Suggested match:} other {Suggested matches:}}"
@@ -414,6 +445,10 @@ msgstr "{dur} on device"
 #: src/pages/DashboardPage.tsx
 msgid "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 msgstr "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+
+#: src/components/UploadModal.tsx
+msgid "{failed, plural, one {Upload failed for # file} other {Upload failed for # files}}"
+msgstr "{failed, plural, one {Upload failed for # file} other {Upload failed for # files}}"
 
 #: src/pages/BinderyPage.tsx
 msgid "{failedN} of {totalN} failed — {firstErr}"
@@ -538,6 +573,10 @@ msgstr "{name} copy"
 msgid "{name} theme"
 msgstr "{name} theme"
 
+#: src/components/UploadModal.tsx
+msgid "{ok} uploaded"
+msgstr "{ok} uploaded"
+
 #: src/pages/AdminPage.tsx
 msgid "{othersCount, plural, one {Delete # other} other {Delete # others}}"
 msgstr "{othersCount, plural, one {Delete # other} other {Delete # others}}"
@@ -573,6 +612,18 @@ msgstr "{shown, plural, one {# book} other {# books}}"
 #: src/pages/DashboardPage.tsx
 msgid "{shown, plural, one {# title} other {# titles}}"
 msgstr "{shown, plural, one {# title} other {# titles}}"
+
+#: src/components/UploadModal.tsx
+msgid "{skipped, plural, one {Nothing to upload — # file is already in your library} other {Nothing to upload — # files are already in your library}}"
+msgstr "{skipped, plural, one {Nothing to upload — # file is already in your library} other {Nothing to upload — # files are already in your library}}"
+
+#: src/components/UploadModal.tsx
+msgid "{success, plural, one {# book uploaded} other {# books uploaded}}"
+msgstr "{success, plural, one {# book uploaded} other {# books uploaded}}"
+
+#: src/components/UploadModal.tsx
+msgid "{success} uploaded, {failed} failed"
+msgstr "{success} uploaded, {failed} failed"
 
 #: src/components/Sidebar.tsx
 msgid "{themeName} theme"
@@ -647,6 +698,10 @@ msgstr "~{w} weeks"
 msgid "~1 day"
 msgstr "~1 day"
 
+#: src/components/ShareShelfModal.tsx
+msgid "1 day"
+msgstr "1 day"
+
 #: src/pages/StatsPage.tsx
 msgid "12 mo"
 msgstr "12 mo"
@@ -663,6 +718,10 @@ msgstr "1y"
 msgid "24 mo"
 msgstr "24 mo"
 
+#: src/components/ShareShelfModal.tsx
+msgid "30 days"
+msgstr "30 days"
+
 #: src/pages/StatsPage.tsx
 msgid "30d"
 msgstr "30d"
@@ -670,6 +729,10 @@ msgstr "30d"
 #: src/pages/StatsPage.tsx
 msgid "365 d"
 msgstr "365 d"
+
+#: src/components/ShareShelfModal.tsx
+msgid "7 days"
+msgstr "7 days"
 
 #: src/pages/StatsPage.tsx
 msgid "7d"
@@ -694,6 +757,18 @@ msgstr "A lot"
 #: src/pages/SettingsPage.tsx
 msgid "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
 msgstr "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
+
+#: src/components/ShareShelfModal.tsx
+msgid "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for the books in this series. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
+msgstr "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for the books in this series. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
+
+#: src/components/ShareShelfModal.tsx
+msgid "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for the books on this shelf. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
+msgstr "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for the books on this shelf. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
+
+#: src/components/ShareShelfModal.tsx
+msgid "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for this book. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
+msgstr "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for this book. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
 
 #: src/pages/HardcoverPage.tsx
 msgid "A sync is already running"
@@ -755,6 +830,10 @@ msgstr "Activity"
 #: src/pages/SettingsPage.tsx
 msgid "Add"
 msgstr "Add"
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Add a device in Settings to start sending books."
+msgstr "Add a device in Settings to start sending books."
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
@@ -929,6 +1008,10 @@ msgstr "All-time hours, pages, books, streak"
 #: src/components/SendButton.tsx
 msgid "Already in your KOReader inbox"
 msgstr "Already in your KOReader inbox"
+
+#: src/components/UploadModal.tsx
+msgid "Already in your library — will be skipped."
+msgstr "Already in your library — will be skipped."
 
 #: src/components/Sidebar.tsx
 #: src/components/ThemeToggle.tsx
@@ -1127,6 +1210,7 @@ msgstr "Black"
 msgid "book"
 msgstr "book"
 
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Book"
 msgstr "Book"
@@ -1171,6 +1255,7 @@ msgstr "Book type applied to {n} files"
 msgid "Book Types"
 msgstr "Book Types"
 
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Books"
@@ -1214,6 +1299,7 @@ msgstr "Browse your library"
 
 #: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
+#: src/components/UploadModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -1310,6 +1396,8 @@ msgid "Click for details"
 msgstr "Click for details"
 
 #: src/components/PositionHistoryModal.tsx
+#: src/components/ShareShelfModal.tsx
+#: src/components/UploadModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/StatsPage.tsx
@@ -1443,6 +1531,10 @@ msgstr "Copy"
 msgid "Copy all as Markdown"
 msgstr "Copy all as Markdown"
 
+#: src/components/ShareShelfModal.tsx
+msgid "Copy link"
+msgstr "Copy link"
+
 #: src/pages/SettingsPage.tsx
 msgid "Copy to KOReader"
 msgstr "Copy to KOReader"
@@ -1515,6 +1607,10 @@ msgstr "Create"
 #: src/pages/SetupPage.tsx
 msgid "Create admin account"
 msgstr "Create admin account"
+
+#: src/components/ShareShelfModal.tsx
+msgid "Create share link"
+msgstr "Create share link"
 
 #: src/pages/SetupPage.tsx
 msgid "Create your admin account to get started"
@@ -1678,6 +1774,7 @@ msgstr "Details"
 msgid "Details:"
 msgstr "Details:"
 
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Device"
 msgstr "Device"
@@ -1777,6 +1874,10 @@ msgstr "Download ZIP"
 msgid "Downloaded {n} highlights"
 msgstr "Downloaded {n} highlights"
 
+#: src/components/UploadModal.tsx
+msgid "Drop books here or <0>click to browse</0>"
+msgstr "Drop books here or <0>click to browse</0>"
+
 #: src/pages/BinderyPage.tsx
 msgid "Drop files in the incoming folder to get started"
 msgstr "Drop files in the incoming folder to get started"
@@ -1866,6 +1967,10 @@ msgstr "Email"
 #: src/pages/SettingsPage.tsx
 msgid "Email address"
 msgstr "Email address"
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Email delivery is not set up yet"
+msgstr "Email delivery is not set up yet"
 
 #: src/pages/SettingsPage.tsx
 msgid "Email delivery is not set up yet."
@@ -1959,6 +2064,10 @@ msgstr "expired"
 #: src/components/ShareLinksOverview.tsx
 msgid "expires {d}"
 msgstr "expires {d}"
+
+#: src/components/ShareShelfModal.tsx
+msgid "Expires {d}"
+msgstr "Expires {d}"
 
 #: src/pages/LoginPage.tsx
 msgid "Expires in {timeLeft}"
@@ -2121,6 +2230,10 @@ msgstr "Failed to save role"
 msgid "Failed to save series rating"
 msgstr "Failed to save series rating"
 
+#: src/components/SendToDeviceModal.tsx
+msgid "Failed to send"
+msgstr "Failed to send"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to undo"
 msgstr "Failed to undo"
@@ -2160,6 +2273,10 @@ msgstr "Fetching metadata..."
 #: src/pages/AdminPage.tsx
 msgid "File is missing from disk"
 msgstr "File is missing from disk"
+
+#: src/components/SendToDeviceModal.tsx
+msgid "File size: {size}"
+msgstr "File size: {size}"
 
 #: src/pages/HardcoverPage.tsx
 msgid "Filter…"
@@ -2229,6 +2346,7 @@ msgstr "Following \"{seriesName}\" — you'll hear when a new volume is out"
 msgid "for {targetLabel} — click a file to switch"
 msgstr "for {targetLabel} — click a file to switch"
 
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2301,6 +2419,10 @@ msgstr "Get notified when a new volume of a followed series is released."
 #: src/pages/WishlistPage.tsx
 msgid "Go back"
 msgstr "Go back"
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Go to Settings"
+msgstr "Go to Settings"
 
 #: src/components/WhatsNewPanel.tsx
 msgid "Got it"
@@ -2741,6 +2863,7 @@ msgstr "Loading..."
 
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareLinksOverview.tsx
+#: src/components/ShareShelfModal.tsx
 #: src/components/stats/BacklogEstimate.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
@@ -2967,6 +3090,10 @@ msgstr "Never"
 msgid "never expires"
 msgstr "never expires"
 
+#: src/components/ShareShelfModal.tsx
+msgid "Never expires"
+msgstr "Never expires"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Never sync this book"
 msgstr "Never sync this book"
@@ -3083,6 +3210,10 @@ msgstr "No completion data by type."
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
 msgstr "No description"
+
+#: src/components/SendToDeviceModal.tsx
+msgid "No devices configured"
+msgstr "No devices configured"
 
 #: src/pages/SettingsPage.tsx
 msgid "No devices yet. Add one to start sending books."
@@ -3265,6 +3396,7 @@ msgstr "No timed reading with word counts yet."
 msgid "No Tome account is linked to this identity, and self-signup is disabled."
 msgstr "No Tome account is linked to this identity, and self-signup is disabled."
 
+#: src/components/UploadModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "No type"
@@ -4061,6 +4193,10 @@ msgstr "Reviewing {n} files"
 msgid "Revoke"
 msgstr "Revoke"
 
+#: src/components/ShareShelfModal.tsx
+msgid "Revoke link"
+msgstr "Revoke link"
+
 #: src/pages/SettingsPage.tsx
 msgid "Revoke this token? Any scripts or tools using it will stop working immediately."
 msgstr "Revoke this token? Any scripts or tools using it will stop working immediately."
@@ -4245,6 +4381,10 @@ msgstr "Searching…"
 msgid "See all results for \"{searchQuery}\""
 msgstr "See all results for \"{searchQuery}\""
 
+#: src/components/SendToDeviceModal.tsx
+msgid "See Settings for setup instructions."
+msgstr "See Settings for setup instructions."
+
 #: src/pages/DashboardPage.tsx
 msgid "Select"
 msgstr "Select"
@@ -4260,6 +4400,10 @@ msgstr "Select all"
 #: src/pages/BinderyPage.tsx
 msgid "Select All"
 msgstr "Select All"
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Send"
+msgstr "Send"
 
 #: src/components/NotificationChannels.tsx
 msgid "Send a test notification"
@@ -4278,6 +4422,7 @@ msgid "Send test email"
 msgstr "Send test email"
 
 #: src/components/SendButton.tsx
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Send to Device"
 msgstr "Send to Device"
@@ -4290,6 +4435,11 @@ msgstr "Send to KOReader"
 msgid "Send via email…"
 msgstr "Send via email…"
 
+#: src/components/SendToDeviceModal.tsx
+msgid "Sending"
+msgstr "Sending"
+
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Sending..."
 msgstr "Sending..."
@@ -4297,6 +4447,14 @@ msgstr "Sending..."
 #: src/pages/AdminPage.tsx
 msgid "Sent"
 msgstr "Sent"
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Sent \"{title}\" to device"
+msgstr "Sent \"{title}\" to device"
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Sent {sent}/{total}. {failedN} failed."
+msgstr "Sent {sent}/{total}. {failedN} failed."
 
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
@@ -4376,6 +4534,10 @@ msgstr "Sessions ({n})"
 msgid "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
 msgstr "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
 
+#: src/components/UploadModal.tsx
+msgid "Set all to"
+msgstr "Set all to"
+
 #: src/components/ForcePasswordChange.tsx
 msgid "Set password & continue"
 msgstr "Set password & continue"
@@ -4409,6 +4571,10 @@ msgstr "Setup instructions"
 #: src/pages/BookDetailPage.tsx
 msgid "Share"
 msgstr "Share"
+
+#: src/components/ShareShelfModal.tsx
+msgid "Share \"{title}\""
+msgstr "Share \"{title}\""
 
 #: src/pages/SettingsPage.tsx
 msgid "Share links"
@@ -5003,6 +5169,18 @@ msgstr "Update to v{v}"
 msgid "Upload"
 msgstr "Upload"
 
+#: src/components/UploadModal.tsx
+msgid "Upload All"
+msgstr "Upload All"
+
+#: src/components/UploadModal.tsx
+msgid "Upload Books"
+msgstr "Upload Books"
+
+#: src/components/UploadModal.tsx
+msgid "Upload failed"
+msgstr "Upload failed"
+
 #: src/pages/DashboardPage.tsx
 msgid "Upload or scan a folder to get started"
 msgstr "Upload or scan a folder to get started"
@@ -5061,6 +5239,7 @@ msgstr "Users"
 msgid "Verify it's working"
 msgstr "Verify it's working"
 
+#: src/components/UploadModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "View book"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/InstanceBackup.tsx
+msgid " — backup from {when} (v{v}, {users} users, {books} books)."
+msgstr " — backup from {when} (v{v}, {users} users, {books} books)."
+
 #: src/pages/BookDetailPage.tsx
 msgid " — click for sessions"
 msgstr " — click for sessions"
@@ -61,10 +65,15 @@ msgstr " · {n} volumes"
 msgid " · {prog}% in"
 msgstr " · {prog}% in"
 
+#: src/components/ReadingImport.tsx
+msgid " · {r} stars"
+msgstr " · {r} stars"
+
 #: src/components/stats/BacklogEstimate.tsx
 msgid " · books without a word count use your average for that type"
 msgstr " · books without a word count use your average for that type"
 
+#: src/components/ReadingImport.tsx
 #: src/components/stats/TimelineRibbon.tsx
 #: src/pages/SharePage.tsx
 msgid " · finished {d}"
@@ -77,6 +86,14 @@ msgstr " · last synced {when}"
 #: src/components/stats/widgets/wordstats.tsx
 msgid " · longest <0>{title}</0> ({words})"
 msgstr " · longest <0>{title}</0> ({words})"
+
+#: src/components/ReadingImport.tsx
+msgid " · matched by {via}"
+msgstr " · matched by {via}"
+
+#: src/components/ReadingImport.tsx
+msgid " · nothing to fill (already tracked)"
+msgstr " · nothing to fill (already tracked)"
 
 #: src/pages/BinderyPage.tsx
 msgid " · reviewed"
@@ -196,6 +213,11 @@ msgstr "{0, plural, one {# book, none estimated yet.} other {# books, none estim
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
 msgstr "{0, plural, one {# book} other {# books}}"
+
+#. placeholder {0}: candidates.length
+#: src/components/CoverPickerModal.tsx
+msgid "{0, plural, one {# cover found — click to apply} other {# covers found — click to apply}}"
+msgstr "{0, plural, one {# cover found — click to apply} other {# covers found — click to apply}}"
 
 #. placeholder {0}: hover.b.days.length
 #: src/components/stats/TimelineRibbon.tsx
@@ -374,6 +396,10 @@ msgstr "{added} added · {skipped} skipped"
 msgid "{base} · Vol. {idx}"
 msgstr "{base} · Vol. {idx}"
 
+#: src/lib/goals.ts
+msgid "{behind} behind pace"
+msgstr "{behind} behind pace"
+
 #: src/pages/HighlightsPage.tsx
 msgid "{books, plural, one {{total} from # book} other {{total} from # books}}"
 msgstr "{books, plural, one {{total} from # book} other {{total} from # books}}"
@@ -417,6 +443,10 @@ msgstr "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
 #: src/pages/BookDetailPage.tsx
 msgid "{deltaStr}% vs last week"
 msgstr "{deltaStr}% vs last week"
+
+#: src/lib/goals.ts
+msgid "{diff} ahead of pace"
+msgstr "{diff} ahead of pace"
 
 #: src/pages/BinderyPage.tsx
 msgid "{diffDays}d ago"
@@ -466,6 +496,10 @@ msgstr "{fin} of {st} started"
 msgid "{fin} of {st} started · all time"
 msgstr "{fin} of {st} started · all time"
 
+#: src/components/CoverAudit.tsx
+msgid "{flagged} of {scanned} books flagged (low-res = narrower than {minW}px)."
+msgstr "{flagged} of {scanned} books flagged (low-res = narrower than {minW}px)."
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h"
@@ -481,6 +515,10 @@ msgstr "{h}h {m}m"
 #: src/components/PositionHistoryModal.tsx
 msgid "{h}h ago"
 msgstr "{h}h ago"
+
+#: src/lib/goals.ts
+msgid "{hit}/7 days this week"
+msgstr "{hit}/7 days this week"
 
 #: src/pages/SettingsPage.tsx
 msgid "{hours}h ago"
@@ -499,6 +537,10 @@ msgstr "{imp} imported + {inc} incoming"
 #: src/pages/BinderyPage.tsx
 msgid "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
 msgstr "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
+
+#: src/components/stats/GoalWidget.tsx
+msgid "{label} only"
+msgstr "{label} only"
 
 #: src/components/PositionHistoryModal.tsx
 msgid "{m} min ago"
@@ -633,6 +675,10 @@ msgstr "{themeName} theme"
 msgid "{title} — {dur} between {from} and {to}"
 msgstr "{title} — {dur} between {from} and {to}"
 
+#: src/lib/goals.ts
+msgid "{toGo} to go"
+msgstr "{toGo} to go"
+
 #: src/pages/DashboardPage.tsx
 msgid "{total, plural, one {# volume} other {# volumes}}"
 msgstr "{total, plural, one {# volume} other {# volumes}}"
@@ -652,6 +698,10 @@ msgstr "{totalCount, plural, one {# result for \"{search}\"} other {# results fo
 #: src/pages/BookDetailPage.tsx
 msgid "{words} words"
 msgstr "{words} words"
+
+#: src/components/stats/GoalWidget.tsx
+msgid "{y} Challenge"
+msgstr "{y} Challenge"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
@@ -818,6 +868,10 @@ msgstr "Account & Security"
 msgid "Action failed"
 msgstr "Action failed"
 
+#: src/components/CommandPalette.tsx
+msgid "Actions"
+msgstr "Actions"
+
 #: src/pages/AdminPage.tsx
 msgid "Active"
 msgstr "Active"
@@ -929,6 +983,7 @@ msgstr "Added {timeAgo}"
 msgid "Added to Want to Read"
 msgstr "Added to Want to Read"
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 msgid "Admin"
@@ -952,6 +1007,10 @@ msgstr "All"
 msgid "All {loadedCount} books loaded"
 msgstr "All {loadedCount} books loaded"
 
+#: src/components/CoverAudit.tsx
+msgid "All {scanned} covers look healthy."
+msgstr "All {scanned} covers look healthy."
+
 #: src/pages/DashboardPage.tsx
 msgid "All →"
 msgstr "All →"
@@ -960,10 +1019,12 @@ msgstr "All →"
 msgid "All actions"
 msgstr "All actions"
 
+#: src/components/stats/GoalWidget.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "All books"
 msgstr "All books"
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 msgid "All Books"
 msgstr "All Books"
@@ -1046,13 +1107,26 @@ msgstr "Application token (required)"
 msgid "Applied to volumes you haven’t rated"
 msgstr "Applied to volumes you haven’t rated"
 
+#: src/components/ReadingImport.tsx
+msgid "Applied: {statuses} statuses, {ratings} ratings, {finishes} finish dates, {reviews} reviews."
+msgstr "Applied: {statuses} statuses, {ratings} ratings, {finishes} finish dates, {reviews} reviews."
+
+#: src/components/CoverPickerModal.tsx
 #: src/pages/StatsPage.tsx
 msgid "Apply"
 msgstr "Apply"
 
+#: src/components/ReadingImport.tsx
+msgid "Apply {n} selected"
+msgstr "Apply {n} selected"
+
 #: src/pages/AdminPage.tsx
 msgid "Apply All ({n})"
 msgstr "Apply All ({n})"
+
+#: src/components/CoverAudit.tsx
+msgid "Apply the first cover-search candidate"
+msgstr "Apply the first cover-search candidate"
 
 #: src/pages/BinderyPage.tsx
 msgid "Apply to all"
@@ -1061,6 +1135,10 @@ msgstr "Apply to all"
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
 msgstr "Applying {done}/{total}…"
+
+#: src/components/ReadingImport.tsx
+msgid "Applying failed — nothing was changed."
+msgstr "Applying failed — nothing was changed."
 
 #: src/pages/StatsPage.tsx
 msgid "Are you getting faster?"
@@ -1116,6 +1194,10 @@ msgstr "Authorize this code from another device"
 msgid "Authorizing..."
 msgstr "Authorizing..."
 
+#: src/components/CommandPalette.tsx
+msgid "Authors"
+msgstr "Authors"
+
 #: src/pages/StatsPage.tsx
 msgid "Auto"
 msgstr "Auto"
@@ -1123,6 +1205,10 @@ msgstr "Auto"
 #: src/pages/StatsPage.tsx
 msgid "Auto-fit height"
 msgstr "Auto-fit height"
+
+#: src/components/CoverAudit.tsx
+msgid "Auto-fix {missingCount} missing"
+msgstr "Auto-fix {missingCount} missing"
 
 #: src/pages/StatsPage.tsx
 msgid "average pace"
@@ -1172,6 +1258,10 @@ msgstr "Backlog · {scope}"
 msgid "Backup"
 msgstr "Backup"
 
+#: src/components/InstanceBackup.tsx
+msgid "Backup failed"
+msgstr "Backup failed"
+
 #: src/pages/StatsPage.tsx
 msgid "Best Day"
 msgstr "Best Day"
@@ -1210,6 +1300,7 @@ msgstr "Black"
 msgid "book"
 msgstr "book"
 
+#: src/components/CoverAudit.tsx
 #: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Book"
@@ -1255,6 +1346,11 @@ msgstr "Book type applied to {n} files"
 msgid "Book Types"
 msgstr "Book Types"
 
+#: src/lib/goals.ts
+msgid "books"
+msgstr "books"
+
+#: src/components/CommandPalette.tsx
 #: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -1281,6 +1377,14 @@ msgstr "Books in progress, with covers"
 msgid "Books Started"
 msgstr "Books Started"
 
+#: src/lib/goals.ts
+msgid "Books this month"
+msgstr "Books this month"
+
+#: src/lib/goals.ts
+msgid "Books this year"
+msgstr "Books this year"
+
 #: src/pages/StatsPage.tsx
 msgid "Books whose pages you revisit"
 msgstr "Books whose pages you revisit"
@@ -1288,6 +1392,10 @@ msgstr "Books whose pages you revisit"
 #: src/pages/DashboardPage.tsx
 msgid "Books without a series"
 msgstr "Books without a series"
+
+#: src/components/ReadingImport.tsx
+msgid "Bring your reading history from Goodreads or StoryGraph: upload their CSV export, review what matches your library, apply. Importing only fills gaps — it never overwrites a status, rating, review, or finish date you already have. \"To read\" shelves are skipped (that's what the wishlist is for)."
+msgstr "Bring your reading history from Goodreads or StoryGraph: upload their CSV export, review what matches your library, apply. Importing only fills gaps — it never overwrites a status, rating, review, or finish date you already have. \"To read\" shelves are skipped (that's what the wishlist is for)."
 
 #: src/pages/SettingsPage.tsx
 msgid "Browse and download your library from KOReader or any OPDS client."
@@ -1298,7 +1406,10 @@ msgid "Browse your library"
 msgstr "Browse your library"
 
 #: src/components/EntityModal.tsx
+#: src/components/InstanceBackup.tsx
+#: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
+#: src/components/stats/GoalWidget.tsx
 #: src/components/UploadModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -1309,6 +1420,10 @@ msgstr "Browse your library"
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
 msgstr "Cancel"
+
+#: src/components/InstanceBackup.tsx
+msgid "Cancel restore"
+msgstr "Cancel restore"
 
 #: src/pages/StatsPage.tsx
 msgid "Category Breakdown"
@@ -1325,6 +1440,10 @@ msgstr "ch. {n}"
 #: src/pages/BookDetailPage.tsx
 msgid "ch. 1"
 msgstr "ch. 1"
+
+#: src/components/CoverPickerModal.tsx
+msgid "Change Cover"
+msgstr "Change Cover"
 
 #: src/pages/SettingsPage.tsx
 msgid "Change Password"
@@ -1346,6 +1465,14 @@ msgstr "Chapters"
 #: src/pages/StatsPage.tsx
 msgid "Chart type"
 msgstr "Chart type"
+
+#: src/components/ReadingImport.tsx
+msgid "Choose CSV export"
+msgstr "Choose CSV export"
+
+#: src/components/CoverPickerModal.tsx
+msgid "Choose file…"
+msgstr "Choose file…"
 
 #: src/components/Sidebar.tsx
 msgid "Choose icon"
@@ -1397,6 +1524,7 @@ msgstr "Click for details"
 
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareShelfModal.tsx
+#: src/components/stats/GoalWidget.tsx
 #: src/components/UploadModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
@@ -1547,6 +1675,10 @@ msgstr "Copy token"
 msgid "Core"
 msgstr "Core"
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Could not create the goal — it may already exist."
+msgstr "Could not create the goal — it may already exist."
+
 #: src/pages/SettingsPage.tsx
 msgid "Could not link SSO. Please try again."
 msgstr "Could not link SSO. Please try again."
@@ -1554,6 +1686,10 @@ msgstr "Could not link SSO. Please try again."
 #: src/components/stats/BacklogEstimate.tsx
 msgid "Could not load this scope."
 msgstr "Could not load this scope."
+
+#: src/components/ReadingImport.tsx
+msgid "Could not read that file"
+msgstr "Could not read that file"
 
 #: src/components/SeriesFollowButton.tsx
 msgid "Could not resolve this series on Hardcover"
@@ -1571,6 +1707,10 @@ msgstr "Could not start SSO linking."
 msgid "Could not start sync"
 msgstr "Could not start sync"
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Could not update the goal."
+msgstr "Could not update the goal."
+
 #: src/pages/StatsPage.tsx
 msgid "Couldn’t load stats."
 msgstr "Couldn’t load stats."
@@ -1578,6 +1718,10 @@ msgstr "Couldn’t load stats."
 #: src/components/stats/TimelineRibbon.tsx
 msgid "Couldn't load the timeline."
 msgstr "Couldn't load the timeline."
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Counts"
+msgstr "Counts"
 
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
@@ -1656,6 +1800,18 @@ msgstr "Custom"
 #: src/pages/StatsPage.tsx
 msgid "Custom Stat"
 msgstr "Custom Stat"
+
+#: src/components/CoverPickerModal.tsx
+msgid "Custom URL"
+msgstr "Custom URL"
+
+#: src/lib/goals.ts
+msgid "Daily minutes"
+msgstr "Daily minutes"
+
+#: src/lib/goals.ts
+msgid "Daily pages"
+msgstr "Daily pages"
 
 #: src/pages/StatsPage.tsx
 msgid "Daily sessions on a 24h track"
@@ -1837,6 +1993,10 @@ msgstr "Download a JSON snapshot of <0>your personal data</0>: reading status, e
 msgid "Download as Markdown file"
 msgstr "Download as Markdown file"
 
+#: src/components/InstanceBackup.tsx
+msgid "Download backup"
+msgstr "Download backup"
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Download failed"
@@ -1933,6 +2093,10 @@ msgstr "e.g. scribe-laptop"
 msgid "Edit"
 msgstr "Edit"
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Edit goal"
+msgstr "Edit goal"
+
 #: src/components/Sidebar.tsx
 msgid "Edit Library"
 msgstr "Edit Library"
@@ -2016,6 +2180,10 @@ msgstr "Every session — paginated, deletable"
 #: src/pages/StatsPage.tsx
 msgid "Every widget is already on this board."
 msgstr "Every widget is already on this board."
+
+#: src/components/InstanceBackup.tsx
+msgid "Everything Tome knows in one archive: the database (all users, statuses, sessions, highlights, settings) plus the cover cache. Book files are not included — they live on disk and belong to your own backups. Restoring stages the archive and applies it at the next server restart; the current database is kept alongside as a safety copy."
+msgstr "Everything Tome knows in one archive: the database (all users, statuses, sessions, highlights, settings) plus the cover cache. Book files are not included — they live on disk and belong to your own backups. Restoring stages the archive and applies it at the next server restart; the current database is kept alongside as a safety copy."
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Everywhere"
@@ -2109,6 +2277,10 @@ msgstr "Failed"
 msgid "Failed to add device"
 msgstr "Failed to add device"
 
+#: src/components/CoverPickerModal.tsx
+msgid "Failed to apply cover"
+msgstr "Failed to apply cover"
+
 #: src/pages/SettingsPage.tsx
 msgid "Failed to authorize"
 msgstr "Failed to authorize"
@@ -2133,6 +2305,10 @@ msgstr "Failed to create token"
 #: src/pages/HighlightsPage.tsx
 msgid "Failed to delete highlight"
 msgstr "Failed to delete highlight"
+
+#: src/components/CoverPickerModal.tsx
+msgid "Failed to fetch candidates"
+msgstr "Failed to fetch candidates"
 
 #: src/pages/LoginPage.tsx
 msgid "Failed to generate code. Try again."
@@ -2254,6 +2430,10 @@ msgstr "Failed to update reading status"
 msgid "Failed to update sharing"
 msgstr "Failed to update sharing"
 
+#: src/components/CoverPickerModal.tsx
+msgid "Failed to upload cover"
+msgstr "Failed to upload cover"
+
 #: src/pages/BinderyPage.tsx
 msgid "fantasy, action, romance"
 msgstr "fantasy, action, romance"
@@ -2316,6 +2496,10 @@ msgstr "Finished · 30d"
 #: src/pages/BookDetailPage.tsx
 msgid "First read"
 msgstr "First read"
+
+#: src/components/CoverAudit.tsx
+msgid "Fixed"
+msgstr "Fixed"
 
 #: src/pages/DashboardPage.tsx
 msgid "Focus"
@@ -2398,6 +2582,10 @@ msgstr "Full access"
 msgid "Full breakdown →"
 msgstr "Full breakdown →"
 
+#: src/components/ReadingImport.tsx
+msgid "fuzzy"
+msgstr "fuzzy"
+
 #: src/pages/SettingsPage.tsx
 msgid "Generate PIN"
 msgstr "Generate PIN"
@@ -2423,6 +2611,18 @@ msgstr "Go back"
 #: src/components/SendToDeviceModal.tsx
 msgid "Go to Settings"
 msgstr "Go to Settings"
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Goal"
+msgstr "Goal"
+
+#: src/lib/goals.ts
+msgid "Goal reached"
+msgstr "Goal reached"
+
+#: src/lib/goals.ts
+msgid "Goal reached today"
+msgstr "Goal reached today"
 
 #: src/components/WhatsNewPanel.tsx
 msgid "Got it"
@@ -2501,6 +2701,7 @@ msgstr "Highlight deleted"
 msgid "Highlighted {when}"
 msgstr "Highlighted {when}"
 
+#: src/components/CommandPalette.tsx
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/HighlightsPage.tsx
@@ -2523,6 +2724,7 @@ msgstr "Highlights you made on this day in past years"
 msgid "Hit Edit, then Add tile."
 msgstr "Hit Edit, then Add tile."
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Home"
@@ -2638,13 +2840,26 @@ msgstr "Include"
 msgid "Incoming"
 msgstr "Incoming"
 
+#: src/components/InstanceBackup.tsx
+msgid "Instance backup"
+msgstr "Instance backup"
+
 #: src/pages/AdminPage.tsx
 msgid "IP:"
 msgstr "IP:"
 
+#: src/components/ReadingImport.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "ISBN"
 msgstr "ISBN"
+
+#: src/components/InstanceBackup.tsx
+msgid "It applies at the next server restart."
+msgstr "It applies at the next server restart."
+
+#: src/components/CommandPalette.tsx
+msgid "Jump to a book, series, author, or page…"
+msgstr "Jump to a book, series, author, or page…"
 
 #: src/components/NotificationBell.tsx
 #: src/pages/AdminPage.tsx
@@ -2865,6 +3080,7 @@ msgstr "Loading..."
 #: src/components/ShareLinksOverview.tsx
 #: src/components/ShareShelfModal.tsx
 #: src/components/stats/BacklogEstimate.tsx
+#: src/components/stats/GoalWidget.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
 #: src/pages/StatsPage.tsx
@@ -2910,6 +3126,10 @@ msgstr "Longest volume"
 #: src/pages/StatsPage.tsx
 msgid "Longest: {d}d"
 msgstr "Longest: {d}d"
+
+#: src/components/CoverAudit.tsx
+msgid "Low resolution"
+msgstr "Low resolution"
 
 #: src/components/stats/widgets/taste.tsx
 msgid "Lowest"
@@ -3004,6 +3224,10 @@ msgstr "Metadata Suggestions"
 msgid "Metric"
 msgstr "Metric"
 
+#: src/lib/goals.ts
+msgid "min"
+msgstr "min"
+
 #: src/pages/SetupPage.tsx
 msgid "Minimum 8 characters"
 msgstr "Minimum 8 characters"
@@ -3011,6 +3235,14 @@ msgstr "Minimum 8 characters"
 #: src/pages/BookDetailPage.tsx
 msgid "Minutes"
 msgstr "Minutes"
+
+#: src/lib/goals.ts
+msgid "Minutes per day"
+msgstr "Minutes per day"
+
+#: src/lib/goals.ts
+msgid "Minutes per week"
+msgstr "Minutes per week"
 
 #: src/pages/StatsPage.tsx
 msgid "Minutes read per day"
@@ -3031,6 +3263,10 @@ msgstr "Mo"
 #: src/components/stats/HourDowHeatmap.tsx
 msgid "Mon"
 msgstr "Mon"
+
+#: src/lib/goals.ts
+msgid "Monthly goal"
+msgstr "Monthly goal"
 
 #: src/components/SendButton.tsx
 msgid "More send options"
@@ -3105,6 +3341,10 @@ msgstr "never used"
 #: src/pages/StatsPage.tsx
 msgid "New board"
 msgstr "New board"
+
+#: src/components/stats/GoalWidget.tsx
+msgid "New goal"
+msgstr "New goal"
 
 #: src/pages/SettingsPage.tsx
 msgid "New key"
@@ -3207,6 +3447,18 @@ msgstr "No comparison data."
 msgid "No completion data by type."
 msgstr "No completion data by type."
 
+#: src/components/CoverAudit.tsx
+msgid "No cover"
+msgstr "No cover"
+
+#: src/components/CoverPickerModal.tsx
+msgid "No cover candidates found."
+msgstr "No cover candidates found."
+
+#: src/components/CoverPickerModal.tsx
+msgid "No covers found — try a different search or use a custom URL below."
+msgstr "No covers found — try a different search or use a custom URL below."
+
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
 msgstr "No description"
@@ -3262,6 +3514,10 @@ msgstr "No library growth data."
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
 msgstr "No matches"
+
+#: src/components/CommandPalette.tsx
+msgid "No matches."
+msgstr "No matches."
 
 #: src/pages/AdminPage.tsx
 msgid "No matching volumes in the library yet."
@@ -3448,6 +3704,10 @@ msgstr "not estimated yet"
 msgid "Not found"
 msgstr "Not found"
 
+#: src/components/ReadingImport.tsx
+msgid "Not in your library ({n})"
+msgstr "Not in your library ({n})"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Not matched"
 msgstr "Not matched"
@@ -3535,6 +3795,10 @@ msgstr "on board"
 msgid "On board"
 msgstr "On board"
 
+#: src/lib/goals.ts
+msgid "on pace"
+msgstr "on pace"
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "On this day"
@@ -3575,6 +3839,10 @@ msgstr "Open"
 msgid "Open a book downloaded via OPDS"
 msgstr "Open a book downloaded via OPDS"
 
+#: src/components/CoverAudit.tsx
+msgid "Open book (pick a cover by eye)"
+msgstr "Open book (pick a cover by eye)"
+
 #: src/components/AppHeader.tsx
 msgid "Open navigation"
 msgstr "Open navigation"
@@ -3586,6 +3854,10 @@ msgstr "Open reader"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Open selected book"
 msgstr "Open selected book"
+
+#: src/components/CoverPickerModal.tsx
+msgid "or use a custom source"
+msgstr "or use a custom source"
 
 #: src/pages/SettingsPage.tsx
 msgid "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
@@ -3628,6 +3900,7 @@ msgid "Padding"
 msgstr "Padding"
 
 #: src/components/SeriesReadingStats.tsx
+#: src/lib/goals.ts
 #: src/pages/BookDetailPage.tsx
 msgid "pages"
 msgstr "pages"
@@ -3644,9 +3917,17 @@ msgstr "Pages / Day"
 msgid "Pages / Hour"
 msgstr "Pages / Hour"
 
+#: src/lib/goals.ts
+msgid "Pages per day"
+msgstr "Pages per day"
+
 #: src/pages/StatsPage.tsx
 msgid "Pages per minute over time"
 msgstr "Pages per minute over time"
+
+#: src/lib/goals.ts
+msgid "Pages per week"
+msgstr "Pages per week"
 
 #: src/pages/StatsPage.tsx
 msgid "Pages Turned"
@@ -3705,6 +3986,10 @@ msgstr "Personal Records"
 msgid "Pick"
 msgstr "Pick"
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Pick a rhythm — progress counts automatically."
+msgstr "Pick a rhythm — progress counts automatically."
+
 #: src/pages/StatsPage.tsx
 msgid "Pick a start & end"
 msgstr "Pick a start & end"
@@ -3745,6 +4030,7 @@ msgstr "Prefix"
 msgid "Preparing..."
 msgstr "Preparing..."
 
+#: src/components/InstanceBackup.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Preparing…"
 msgstr "Preparing…"
@@ -3780,6 +4066,10 @@ msgstr "Private — only assigned users can access"
 #: src/components/Sidebar.tsx
 msgid "Private library"
 msgstr "Private library"
+
+#: src/components/CoverAudit.tsx
+msgid "Problem"
+msgstr "Problem"
 
 #: src/pages/AdminPage.tsx
 msgid "Process files dropped into the <0>incoming/</0> directory and move them into the library."
@@ -4023,6 +4313,7 @@ msgstr "Reading Speed"
 msgid "Reading Speed Trend"
 msgstr "Reading Speed Trend"
 
+#: src/components/CommandPalette.tsx
 #: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/SetupPage.tsx
@@ -4067,6 +4358,10 @@ msgstr "Recently Finished"
 #: src/pages/BinderyPage.tsx
 msgid "Recently Imported"
 msgstr "Recently Imported"
+
+#: src/components/ReadingImport.tsx
+msgid "Recognized a <0>{dialect}</0> export: {matched} matched, {unmatched} not in your library, {skipped} to-read rows skipped."
+msgstr "Recognized a <0>{dialect}</0> export: {matched} matched, {unmatched} not in your library, {skipped} to-read rows skipped."
 
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -4145,6 +4440,10 @@ msgstr "Rename board"
 msgid "request failed"
 msgstr "request failed"
 
+#: src/components/CoverAudit.tsx
+msgid "Rescan"
+msgstr "Rescan"
+
 #: src/pages/BinderyPage.tsx
 msgid "Rescan the bindery folder"
 msgstr "Rescan the bindery folder"
@@ -4164,6 +4463,14 @@ msgstr "Restart KOReader"
 #: src/components/PositionHistoryModal.tsx
 msgid "Restore"
 msgstr "Restore"
+
+#: src/components/InstanceBackup.tsx
+msgid "Restore from backup…"
+msgstr "Restore from backup…"
+
+#: src/components/InstanceBackup.tsx
+msgid "Restore staged"
+msgstr "Restore staged"
 
 #: src/components/PositionHistoryModal.tsx
 msgid "Restoring sets the live position (and read status) back to that point; devices pick it up on their next sync. Restoring below 100% un-finishes a falsely completed book."
@@ -4235,6 +4542,7 @@ msgstr "Sat"
 
 #: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
+#: src/components/stats/GoalWidget.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Save"
@@ -4303,6 +4611,10 @@ msgstr "Scan Now"
 #: src/pages/AdminPage.tsx
 msgid "Scanner"
 msgstr "Scanner"
+
+#: src/components/CoverAudit.tsx
+msgid "Scanning covers…"
+msgstr "Scanning covers…"
 
 #: src/pages/AdminPage.tsx
 msgid "Scanning…"
@@ -4456,6 +4768,7 @@ msgstr "Sent \"{title}\" to device"
 msgid "Sent {sent}/{total}. {failedN} failed."
 msgstr "Sent {sent}/{total}. {failedN} failed."
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -4534,9 +4847,25 @@ msgstr "Sessions ({n})"
 msgid "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
 msgstr "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Set a goal"
+msgstr "Set a goal"
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Set a reading goal"
+msgstr "Set a reading goal"
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Set a target and watch the ring fill as you read."
+msgstr "Set a target and watch the ring fill as you read."
+
 #: src/components/UploadModal.tsx
 msgid "Set all to"
 msgstr "Set all to"
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Set goal"
+msgstr "Set goal"
 
 #: src/components/ForcePasswordChange.tsx
 msgid "Set password & continue"
@@ -4554,6 +4883,7 @@ msgstr "Set the following environment variables to enable Send to Device:"
 msgid "Set your password"
 msgstr "Set your password"
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Settings"
@@ -4685,6 +5015,7 @@ msgstr "Similar Title"
 msgid "Single Sign-On"
 msgstr "Single Sign-On"
 
+#: src/components/CoverAudit.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Size"
 msgstr "Size"
@@ -4700,6 +5031,10 @@ msgstr "Slowest"
 #: src/pages/AdminPage.tsx
 msgid "SMTP Status"
 msgstr "SMTP Status"
+
+#: src/components/CoverAudit.tsx
+msgid "Some books had no usable candidate or failed to apply — open them and use the cover picker."
+msgstr "Some books had no usable candidate or failed to apply — open them and use the cover picker."
 
 #: src/pages/AdminPage.tsx
 msgid "Sort Order"
@@ -4744,6 +5079,10 @@ msgstr "SSO sign-in failed. Please try again."
 #: src/pages/SettingsPage.tsx
 msgid "SSO sign-in linked to your account."
 msgstr "SSO sign-in linked to your account."
+
+#: src/components/InstanceBackup.tsx
+msgid "Stage restore"
+msgstr "Stage restore"
 
 #: src/pages/BookDetailPage.tsx
 msgid "start"
@@ -4854,6 +5193,10 @@ msgstr "Tag: {filterTag}"
 msgid "Tags (comma-separated)"
 msgstr "Tags (comma-separated)"
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Target"
+msgstr "Target"
+
 #: src/pages/StatsPage.tsx
 msgid "Taste"
 msgstr "Taste"
@@ -4881,6 +5224,10 @@ msgstr "Th"
 #: src/pages/StatsPage.tsx
 msgid "That file is not a Tome board export."
 msgstr "That file is not a Tome board export."
+
+#: src/components/InstanceBackup.tsx
+msgid "That file was rejected"
+msgstr "That file was rejected"
 
 #: src/pages/SettingsPage.tsx
 msgid "That SSO identity is already linked to another account."
@@ -4939,6 +5286,14 @@ msgstr "This period vs the last"
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
 msgstr "This permanently removes the selected books and their files from disk. This cannot be undone."
 
+#: src/components/InstanceBackup.tsx
+msgid "This replaces <0>the entire database</0> at the next restart. Type <1>RESTORE</1> to arm it."
+msgstr "This replaces <0>the entire database</0> at the next restart. Type <1>RESTORE</1> to arm it."
+
+#: src/lib/goals.ts
+msgid "this week"
+msgstr "this week"
+
 #: src/components/stats/HourDowHeatmap.tsx
 msgid "Thu"
 msgstr "Thu"
@@ -4986,6 +5341,10 @@ msgstr "Timeframe"
 #: src/pages/StatsPage.tsx
 msgid "Timeline"
 msgstr "Timeline"
+
+#: src/components/ReadingImport.tsx
+msgid "title"
+msgstr "title"
 
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -5137,6 +5496,10 @@ msgstr "unread"
 msgid "Unread"
 msgstr "Unread"
 
+#: src/components/CoverAudit.tsx
+msgid "Unreadable file"
+msgstr "Unreadable file"
+
 #: src/pages/DashboardPage.tsx
 msgid "Unserialized"
 msgstr "Unserialized"
@@ -5180,6 +5543,10 @@ msgstr "Upload Books"
 #: src/components/UploadModal.tsx
 msgid "Upload failed"
 msgstr "Upload failed"
+
+#: src/components/CoverPickerModal.tsx
+msgid "Upload from device"
+msgstr "Upload from device"
 
 #: src/pages/DashboardPage.tsx
 msgid "Upload or scan a folder to get started"
@@ -5338,6 +5705,14 @@ msgstr "Web reader"
 msgid "Wed"
 msgstr "Wed"
 
+#: src/lib/goals.ts
+msgid "Weekly minutes"
+msgstr "Weekly minutes"
+
+#: src/lib/goals.ts
+msgid "Weekly pages"
+msgstr "Weekly pages"
+
 #: src/pages/LoginPage.tsx
 msgid "Welcome back"
 msgstr "Welcome back"
@@ -5399,6 +5774,7 @@ msgstr "Wish added"
 msgid "Wish removed"
 msgstr "Wish removed"
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
@@ -5435,6 +5811,10 @@ msgstr "Words Read"
 msgid "Year"
 msgstr "Year"
 
+#: src/lib/goals.ts
+msgid "Year Challenge"
+msgstr "Year Challenge"
+
 #: src/pages/StatsPage.tsx
 msgid "Year in Review"
 msgstr "Year in Review"
@@ -5449,6 +5829,10 @@ msgstr "Yesterday"
 #: src/pages/AdminPage.tsx
 msgid "You"
 msgstr "You"
+
+#: src/components/stats/GoalWidget.tsx
+msgid "You already have this goal — edit it from its tile instead."
+msgstr "You already have this goal — edit it from its tile instead."
 
 #: src/pages/BookDetailPage.tsx
 msgid "You rated this {rating}/5"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -662,6 +662,10 @@ msgstr "{n} selected — Clear"
 msgid "{n} vols · "
 msgstr "{n} vols · "
 
+#: src/components/WishlistModal.tsx
+msgid "{n} volumes"
+msgstr "{n} volumes"
+
 #: src/pages/DashboardPage.tsx
 msgid "{name} · Vol. {start_index}–{end_index}"
 msgstr "{name} · Vol. {start_index}–{end_index}"
@@ -1009,6 +1013,10 @@ msgstr "Add a widget"
 msgid "Add a wish"
 msgstr "Add a wish"
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Add arc"
+msgstr "Add arc"
+
 #: src/pages/StatsPage.tsx
 msgid "Add board"
 msgstr "Add board"
@@ -1061,6 +1069,10 @@ msgstr "Add to library"
 #: src/pages/DashboardPage.tsx
 msgid "Add to Library"
 msgstr "Add to Library"
+
+#: src/components/WishlistModal.tsx
+msgid "Add to Wishlist"
+msgstr "Add to Wishlist"
 
 #: src/pages/AdminPage.tsx
 msgid "Add Type"
@@ -1243,6 +1255,14 @@ msgstr "Applying {done}/{total}…"
 msgid "Applying failed — nothing was changed."
 msgstr "Applying failed — nothing was changed."
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Arc name"
+msgstr "Arc name"
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Arcs"
+msgstr "Arcs"
+
 #: src/pages/StatsPage.tsx
 msgid "Are you getting faster?"
 msgstr "Are you getting faster?"
@@ -1268,6 +1288,7 @@ msgid "Auth"
 msgstr "Auth"
 
 #: src/components/stats/widgets/library.tsx
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -1278,6 +1299,7 @@ msgstr "Author"
 msgid "Author applied to {n} files"
 msgstr "Author applied to {n} files"
 
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Author name"
 msgstr "Author name"
@@ -1354,6 +1376,10 @@ msgstr "Avg Session"
 msgid "Back to list"
 msgstr "Back to list"
 
+#: src/components/WishlistModal.tsx
+msgid "Back to search"
+msgstr "Back to search"
+
 #: src/pages/StatsPage.tsx
 msgid "Backlog"
 msgstr "Backlog"
@@ -1415,6 +1441,7 @@ msgstr "book"
 #: src/components/CoverAudit.tsx
 #: src/components/SendToDeviceModal.tsx
 #: src/components/stats/widgets/overview.tsx
+#: src/components/WishlistModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Book"
 msgstr "Book"
@@ -1443,6 +1470,7 @@ msgstr "Book not found"
 msgid "Book rejected and removed"
 msgstr "Book rejected and removed"
 
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Book title"
 msgstr "Book title"
@@ -1520,13 +1548,19 @@ msgstr "Browse and download your library from KOReader or any OPDS client."
 msgid "Browse your library"
 msgstr "Browse your library"
 
+#: src/components/WishlistModal.tsx
+msgid "Can't find it? Add manually"
+msgstr "Can't find it? Add manually"
+
 #: src/components/EntityModal.tsx
 #: src/components/InstanceBackup.tsx
+#: src/components/ManageSeriesModal.tsx
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
 #: src/components/stats/widgets/overview.tsx
 #: src/components/UploadModal.tsx
+#: src/components/WishlistModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -1581,6 +1615,14 @@ msgstr "Chapters"
 #: src/pages/StatsPage.tsx
 msgid "Chart type"
 msgstr "Chart type"
+
+#: src/components/WishlistModal.tsx
+msgid "Choose a different book"
+msgstr "Choose a different book"
+
+#: src/components/WishlistModal.tsx
+msgid "Choose a different series"
+msgstr "Choose a different series"
 
 #: src/components/ReadingImport.tsx
 msgid "Choose CSV export"
@@ -1638,6 +1680,7 @@ msgstr "Click \"Download plugin ZIP\" above. An API key is automatically created
 msgid "Click for details"
 msgstr "Click for details"
 
+#: src/components/ManageSeriesModal.tsx
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareShelfModal.tsx
 #: src/components/stats/GoalWidget.tsx
@@ -1996,6 +2039,10 @@ msgstr "Delete {name}"
 msgid "Delete all {count} cached cover files ({mb} MB). Covers will be re-extracted on next access."
 msgstr "Delete all {count} cached cover files ({mb} MB). Covers will be re-extracted on next access."
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Delete arc"
+msgstr "Delete arc"
+
 #: src/pages/StatsPage.tsx
 msgid "Delete board"
 msgstr "Delete board"
@@ -2031,6 +2078,7 @@ msgstr "Deleting..."
 msgid "Deleting…"
 msgstr "Deleting…"
 
+#: src/components/ManageSeriesModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2278,6 +2326,10 @@ msgstr "Ember"
 msgid "Empty board"
 msgstr "Empty board"
 
+#: src/components/ManageSeriesModal.tsx
+msgid "End"
+msgstr "End"
+
 #: src/pages/StatsPage.tsx
 msgid "EPUB vs CBZ time split"
 msgstr "EPUB vs CBZ time split"
@@ -2405,6 +2457,10 @@ msgstr "Failed"
 #: src/pages/SettingsPage.tsx
 msgid "Failed to add device"
 msgstr "Failed to add device"
+
+#: src/components/WishlistModal.tsx
+msgid "Failed to add wish"
+msgstr "Failed to add wish"
 
 #: src/components/CoverPickerModal.tsx
 msgid "Failed to apply cover"
@@ -2612,6 +2668,7 @@ msgstr "Finish Rate per Book Category"
 msgid "finished"
 msgstr "finished"
 
+#: src/components/ManageSeriesModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Finished"
@@ -2658,6 +2715,10 @@ msgstr "Following \"{seriesName}\" — you'll hear when a new volume is out"
 #: src/pages/BinderyPage.tsx
 msgid "for {targetLabel} — click a file to switch"
 msgstr "for {targetLabel} — click a file to switch"
+
+#: src/components/WishlistModal.tsx
+msgid "For precise series tracking, use the <0>Series</0> tab instead."
+msgstr "For precise series tracking, use the <0>Series</0> tab instead."
 
 #: src/components/SendToDeviceModal.tsx
 #: src/pages/BinderyPage.tsx
@@ -2809,6 +2870,10 @@ msgstr "Hi <0>{username}</0> — your account was created by an admin. Please se
 #: src/pages/SharePage.tsx
 msgid "hiatus"
 msgstr "hiatus"
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Hiatus"
+msgstr "Hiatus"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Hide details"
@@ -3289,6 +3354,10 @@ msgstr "Manage"
 msgid "Manage series"
 msgstr "Manage series"
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Manage Series"
+msgstr "Manage Series"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Manual"
 msgstr "Manual"
@@ -3465,6 +3534,7 @@ msgstr "My Rating"
 msgid "My Theme"
 msgstr "My Theme"
 
+#: src/components/ManageSeriesModal.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Name"
 msgstr "Name"
@@ -3583,6 +3653,10 @@ msgstr "No API keys. Download the plugin to auto-create one."
 #: src/pages/SettingsPage.tsx
 msgid "No API tokens yet. Create one to use Scribe or scripts against Tome."
 msgstr "No API tokens yet. Create one to use Scribe or scripts against Tome."
+
+#: src/components/ManageSeriesModal.tsx
+msgid "No arcs defined yet. Click “Add arc” to create one."
+msgstr "No arcs defined yet. Click “Add arc” to create one."
 
 #: src/pages/AdminPage.tsx
 msgid "No audit entries yet."
@@ -3821,6 +3895,10 @@ msgstr "No results for \"{search}\""
 msgid "No results found"
 msgstr "No results found"
 
+#: src/components/WishlistModal.tsx
+msgid "No results found."
+msgstr "No results found."
+
 #: src/pages/DashboardPage.tsx
 msgid "No Series"
 msgstr "No Series"
@@ -3958,6 +4036,10 @@ msgstr "not syncing"
 msgid "Not used"
 msgstr "Not used"
 
+#: src/components/WishlistModal.tsx
+msgid "Note"
+msgstr "Note"
+
 #: src/pages/SettingsPage.tsx
 msgid "Note on KOSync coexistence"
 msgstr "Note on KOSync coexistence"
@@ -4043,6 +4125,10 @@ msgstr "One series front and center — you pick which"
 msgid "ongoing"
 msgstr "ongoing"
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Ongoing"
+msgstr "Ongoing"
+
 #: src/pages/DashboardPage.tsx
 msgid "Only filled fields will be updated. Leave blank to keep existing values."
 msgstr "Only filled fields will be updated. Leave blank to keep existing values."
@@ -4084,6 +4170,14 @@ msgstr "Open reader"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Open selected book"
 msgstr "Open selected book"
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Optional"
+msgstr "Optional"
+
+#: src/components/WishlistModal.tsx
+msgid "Optional note (e.g. 'the new one')"
+msgstr "Optional note (e.g. 'the new one')"
 
 #: src/components/CoverPickerModal.tsx
 msgid "or use a custom source"
@@ -4249,6 +4343,10 @@ msgstr "Pick your own metric — avg session, pages/day, best day…"
 msgid "PIN created — copy it now, it won't be shown again."
 msgstr "PIN created — copy it now, it won't be shown again."
 
+#: src/components/WishlistModal.tsx
+msgid "Please pick a result or use the manual form."
+msgstr "Please pick a result or use the manual form."
+
 #: src/pages/AdminPage.tsx
 msgid "Port"
 msgstr "Port"
@@ -4334,6 +4432,10 @@ msgstr "Progress Sync"
 #: src/components/Sidebar.tsx
 msgid "Public library"
 msgstr "Public library"
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Publication status"
+msgstr "Publication status"
 
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -4797,6 +4899,7 @@ msgid "Sat"
 msgstr "Sat"
 
 #: src/components/EntityModal.tsx
+#: src/components/ManageSeriesModal.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
 #: src/pages/AdminPage.tsx
@@ -4816,6 +4919,7 @@ msgstr "Save changes"
 msgid "Save Changes"
 msgstr "Save Changes"
 
+#: src/components/ManageSeriesModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Save failed"
@@ -4909,9 +5013,17 @@ msgstr "Search failed"
 msgid "Search for a book in the library…"
 msgstr "Search for a book in the library…"
 
+#: src/components/WishlistModal.tsx
+msgid "Search for a book…"
+msgstr "Search for a book…"
+
 #: src/pages/AdminPage.tsx
 msgid "Search for a different book…"
 msgstr "Search for a different book…"
+
+#: src/components/WishlistModal.tsx
+msgid "Search for a series…"
+msgstr "Search for a series…"
 
 #: src/pages/HardcoverPage.tsx
 msgid "Search Hardcover and pick the record yourself"
@@ -5029,7 +5141,9 @@ msgid "Sent {sent}/{total}. {failedN} failed."
 msgstr "Sent {sent}/{total}. {failedN} failed."
 
 #: src/components/CommandPalette.tsx
+#: src/components/ManageSeriesModal.tsx
 #: src/components/Sidebar.tsx
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/StatsPage.tsx
@@ -5052,11 +5166,20 @@ msgstr "Series Completion"
 msgid "Series index"
 msgstr "Series index"
 
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Series name"
 msgstr "Series name"
+
+#: src/components/WishlistModal.tsx
+msgid "Series name — fill this alone to wish for the whole series"
+msgstr "Series name — fill this alone to wish for the whole series"
+
+#: src/components/WishlistModal.tsx
+msgid "Series name is required."
+msgstr "Series name is required."
 
 #: src/pages/DashboardPage.tsx
 msgid "Series Progress"
@@ -5359,6 +5482,10 @@ msgstr "Stage restore"
 msgid "start"
 msgstr "start"
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Start"
+msgstr "Start"
+
 #: src/pages/DashboardPage.tsx
 msgid "Start {volLabel}"
 msgstr "Start {volLabel}"
@@ -5578,9 +5705,21 @@ msgstr "This permanently removes the selected books and their files from disk. T
 msgid "This replaces <0>the entire database</0> at the next restart. Type <1>RESTORE</1> to arm it."
 msgstr "This replaces <0>the entire database</0> at the next restart. Type <1>RESTORE</1> to arm it."
 
+#: src/components/ManageSeriesModal.tsx
+msgid "This series has no volumes with a numeric index yet. Add volumes before defining arcs."
+msgstr "This series has no volumes with a numeric index yet. Add volumes before defining arcs."
+
+#: src/components/WishlistModal.tsx
+msgid "This volume"
+msgstr "This volume"
+
 #: src/lib/goals.ts
 msgid "this week"
 msgstr "this week"
+
+#: src/components/WishlistModal.tsx
+msgid "This wish covers the whole series and stays open as new volumes arrive."
+msgstr "This wish covers the whole series and stays open as new volumes arrive."
 
 #: src/components/stats/HourDowHeatmap.tsx
 #: src/components/stats/widgets/habits.tsx
@@ -5647,9 +5786,17 @@ msgstr "Title"
 msgid "Title *"
 msgstr "Title *"
 
+#: src/components/WishlistModal.tsx
+msgid "Title <0>*</0>"
+msgstr "Title <0>*</0>"
+
 #: src/pages/BinderyPage.tsx
 msgid "Title is required"
 msgstr "Title is required"
+
+#: src/components/WishlistModal.tsx
+msgid "Title is required."
+msgstr "Title is required."
 
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -5793,6 +5940,10 @@ msgstr "Unfollow {name}"
 #: src/pages/BinderyPage.tsx
 msgid "Ungrouped files"
 msgstr "Ungrouped files"
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Unknown"
+msgstr "Unknown"
 
 #: src/pages/HardcoverPage.tsx
 msgid "unknown author"
@@ -6082,6 +6233,7 @@ msgstr "Where you read"
 msgid "Which weekday you read most"
 msgstr "Which weekday you read most"
 
+#: src/components/WishlistModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Whole series"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -13,18 +13,49 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/pages/BookDetailPage.tsx
+msgid " — click for sessions"
+msgstr " — click for sessions"
+
+#: src/pages/BookDetailPage.tsx
+msgid " · {prog}% in"
+msgstr " · {prog}% in"
+
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
 msgstr "— keep existing —"
+
+#: src/pages/BookDetailPage.tsx
+msgid ", {pages} pages"
+msgstr ", {pages} pages"
 
 #: src/pages/DashboardPage.tsx
 msgid "…and {more} more not shown"
 msgstr "…and {more} more not shown"
 
+#: src/pages/BookDetailPage.tsx
+msgid "· p. {page} of {totalPages}"
+msgstr "· p. {page} of {totalPages}"
+
 #. placeholder {0}: s.book_count
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
 msgstr "{0, plural, one {# book} other {# books}}"
+
+#. placeholder {0}: aggregate.distinct_readers
+#: src/pages/BookDetailPage.tsx
+msgid "{0, plural, one {# reader} other {# readers}}"
+msgstr "{0, plural, one {# reader} other {# readers}}"
+
+#. placeholder {0}: aggregate.total_sessions
+#: src/pages/BookDetailPage.tsx
+msgid "{0, plural, one {# reading day} other {# reading days}}"
+msgstr "{0, plural, one {# reading day} other {# reading days}}"
+
+#. placeholder {0}: data.reread_bins
+#: src/pages/BookDetailPage.tsx
+msgid "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
+msgstr "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
 
 #. placeholder {0}: selected.size
 #: src/pages/DashboardPage.tsx
@@ -51,6 +82,10 @@ msgstr "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Bo
 msgid "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
 msgstr "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
 
+#: src/pages/BookDetailPage.tsx
+msgid "{count} sittings · {from} – {to}"
+msgstr "{count} sittings · {from} – {to}"
+
 #: src/pages/DashboardPage.tsx
 msgid "{d}d ago"
 msgstr "{d}d ago"
@@ -59,9 +94,25 @@ msgstr "{d}d ago"
 msgid "{days}d ago"
 msgstr "{days}d ago"
 
+#: src/pages/BookDetailPage.tsx
+msgid "{dayStr}: {mins}m"
+msgstr "{dayStr}: {mins}m"
+
 #: src/pages/DashboardPage.tsx
 msgid "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
 msgstr "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
+
+#: src/pages/BookDetailPage.tsx
+msgid "{deltaStr}% vs last week"
+msgstr "{deltaStr}% vs last week"
+
+#: src/pages/BookDetailPage.tsx
+msgid "{dur} across {n} chapters"
+msgstr "{dur} across {n} chapters"
+
+#: src/pages/BookDetailPage.tsx
+msgid "{dur} on device"
+msgstr "{dur} on device"
 
 #: src/pages/DashboardPage.tsx
 msgid "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
@@ -100,9 +151,17 @@ msgstr "{n} selected"
 msgid "{name} · Vol. {start_index}–{end_index}"
 msgstr "{name} · Vol. {start_index}–{end_index}"
 
+#: src/pages/BookDetailPage.tsx
+msgid "{pacePerMin} pg/min"
+msgstr "{pacePerMin} pg/min"
+
 #: src/pages/DashboardPage.tsx
 msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
 msgstr "{readCount} read · {readingCount} reading · {unreadCount} unread"
+
+#: src/pages/BookDetailPage.tsx
+msgid "{recent} in the last 7 days vs {prior} the week before"
+msgstr "{recent} in the last 7 days vs {prior} the week before"
 
 #: src/pages/DashboardPage.tsx
 msgid "{seconds}s"
@@ -140,10 +199,43 @@ msgstr "{totalCount, plural, one {{shown} of # title} other {{shown} of # titles
 msgid "{totalCount, plural, one {# result for \"{search}\"} other {# results for \"{search}\"}}"
 msgstr "{totalCount, plural, one {# result for \"{search}\"} other {# results for \"{search}\"}}"
 
+#: src/pages/BookDetailPage.tsx
+msgid "{words} words"
+msgstr "{words} words"
+
+#: src/pages/BookDetailPage.tsx
+msgid "← Back to library"
+msgstr "← Back to library"
+
+#: src/pages/BookDetailPage.tsx
+msgid "~{at}% in · {dur}"
+msgstr "~{at}% in · {dur}"
+
+#: src/pages/BookDetailPage.tsx
+msgid "~{at}% in · not read"
+msgstr "~{at}% in · not read"
+
 #: src/pages/DashboardPage.tsx
 msgid "A while ago"
 msgstr "A while ago"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Activity"
+msgstr "Activity"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Add"
+msgstr "Add"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Add a note"
+msgstr "Add a note"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Add a review"
+msgstr "Add a review"
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Add tag…"
 msgstr "Add tag…"
@@ -152,9 +244,17 @@ msgstr "Add tag…"
 msgid "Add Tags"
 msgstr "Add Tags"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Add to library"
+msgstr "Add to library"
+
 #: src/pages/DashboardPage.tsx
 msgid "Add to Library"
 msgstr "Add to Library"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Added to Want to Read"
+msgstr "Added to Want to Read"
 
 #: src/components/Sidebar.tsx
 msgid "Admin"
@@ -176,6 +276,10 @@ msgstr "All →"
 msgid "All Books"
 msgstr "All Books"
 
+#: src/pages/BookDetailPage.tsx
+msgid "All readers: {dur} · {days} · {readers}"
+msgstr "All readers: {dur} · {days} · {readers}"
+
 #: src/pages/DashboardPage.tsx
 msgid "All users"
 msgstr "All users"
@@ -188,6 +292,11 @@ msgstr "Amber"
 msgid "Any"
 msgstr "Any"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Attach progress synced from a KOReader-compatible app to this book"
+msgstr "Attach progress synced from a KOReader-compatible app to this book"
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Author"
 msgstr "Author"
@@ -195,6 +304,10 @@ msgstr "Author"
 #: src/pages/DashboardPage.tsx
 msgid "Author: {filterAuthor}"
 msgstr "Author: {filterAuthor}"
+
+#: src/pages/BookDetailPage.tsx
+msgid "avg session"
+msgstr "avg session"
 
 #: src/components/Sidebar.tsx
 msgid "Bindery"
@@ -204,9 +317,17 @@ msgstr "Bindery"
 msgid "Black"
 msgstr "Black"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Book deleted"
+msgstr "Book deleted"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Book Detail"
 msgstr "Book Detail"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Book not found"
+msgstr "Book not found"
 
 #: src/pages/DashboardPage.tsx
 msgid "Books"
@@ -221,9 +342,22 @@ msgid "Browse your library"
 msgstr "Browse your library"
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Cancel"
 msgstr "Cancel"
+
+#: src/pages/BookDetailPage.tsx
+msgid "ch. {n}"
+msgstr "ch. {n}"
+
+#: src/pages/BookDetailPage.tsx
+msgid "ch. 1"
+msgstr "ch. 1"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Chapter"
+msgstr "Chapter"
 
 #: src/pages/DashboardPage.tsx
 msgid "Chapters"
@@ -233,6 +367,10 @@ msgstr "Chapters"
 msgid "Choose icon"
 msgstr "Choose icon"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Clear"
+msgstr "Clear"
+
 #: src/pages/DashboardPage.tsx
 msgid "Clear all"
 msgstr "Clear all"
@@ -240,6 +378,10 @@ msgstr "Clear all"
 #: src/pages/DashboardPage.tsx
 msgid "Clear all filters"
 msgstr "Clear all filters"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Clear imported history — remove this book's KOReader page data"
+msgstr "Clear imported history — remove this book's KOReader page data"
 
 #: src/components/AppHeader.tsx
 #: src/components/KeyboardShortcutsModal.tsx
@@ -250,6 +392,14 @@ msgstr "Clear search"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Clear selection / blur search"
 msgstr "Clear selection / blur search"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Clearing…"
+msgstr "Clearing…"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Close"
+msgstr "Close"
 
 #: src/components/Sidebar.tsx
 msgid "Close navigation"
@@ -266,6 +416,14 @@ msgstr "Collapse sidebar"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Command palette — jump to a book, series, author, or page"
 msgstr "Command palette — jump to a book, series, author, or page"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Confirm"
+msgstr "Confirm"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Content"
+msgstr "Content"
 
 #: src/pages/DashboardPage.tsx
 msgid "Continue Reading"
@@ -297,14 +455,29 @@ msgid "Day streak"
 msgstr "Day streak"
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete"
 msgstr "Delete"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Delete \"{title}\"?"
+msgstr "Delete \"{title}\"?"
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete failed"
 msgstr "Delete failed"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Delete this highlight"
+msgstr "Delete this highlight"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Deleting…"
+msgstr "Deleting…"
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Description"
 msgstr "Description"
@@ -312,6 +485,14 @@ msgstr "Description"
 #: src/pages/DashboardPage.tsx
 msgid "Deselect all"
 msgstr "Deselect all"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Details"
+msgstr "Details"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device."
+msgstr "Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device."
 
 #: src/pages/DashboardPage.tsx
 msgid "Dismiss"
@@ -325,6 +506,7 @@ msgstr "Docs"
 msgid "Done"
 msgstr "Done"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Download failed"
 msgstr "Download failed"
@@ -338,6 +520,7 @@ msgid "Download ZIP"
 msgstr "Download ZIP"
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Edit"
 msgstr "Edit"
 
@@ -349,6 +532,14 @@ msgstr "Edit Library"
 msgid "Edit Metadata"
 msgstr "Edit Metadata"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Edit note"
+msgstr "Edit note"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Edit review"
+msgstr "Edit review"
+
 #: src/components/Sidebar.tsx
 msgid "Edit Shelf"
 msgstr "Edit Shelf"
@@ -356,6 +547,10 @@ msgstr "Edit Shelf"
 #: src/components/Sidebar.tsx
 msgid "Ember"
 msgstr "Ember"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Est. remaining"
+msgstr "Est. remaining"
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Everywhere"
@@ -377,21 +572,65 @@ msgstr "Expand sidebar"
 msgid "Failed"
 msgstr "Failed"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to delete highlight"
+msgstr "Failed to delete highlight"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to link sync document"
+msgstr "Failed to link sync document"
+
 #: src/pages/DashboardPage.tsx
 msgid "Failed to load books"
 msgstr "Failed to load books"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to load facets"
+msgstr "Failed to load facets"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to load libraries"
+msgstr "Failed to load libraries"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to log session"
+msgstr "Failed to log session"
 
 #: src/components/Sidebar.tsx
 msgid "Failed to save"
 msgstr "Failed to save"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to save note"
+msgstr "Failed to save note"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to save rating"
+msgstr "Failed to save rating"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to save review"
+msgstr "Failed to save review"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to undo"
+msgstr "Failed to undo"
+
 #: src/pages/DashboardPage.tsx
 msgid "Failed to update metadata"
 msgstr "Failed to update metadata"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to update reading status"
+msgstr "Failed to update reading status"
+
 #: src/components/Sidebar.tsx
 msgid "Failed to update sharing"
 msgstr "Failed to update sharing"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Fetch Metadata"
+msgstr "Fetch Metadata"
 
 #: src/pages/DashboardPage.tsx
 msgid "Filters"
@@ -401,9 +640,17 @@ msgstr "Filters"
 msgid "finished"
 msgstr "finished"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Finished"
+msgstr "Finished"
+
 #: src/pages/DashboardPage.tsx
 msgid "Finished · 30d"
 msgstr "Finished · 30d"
+
+#: src/pages/BookDetailPage.tsx
+msgid "First read"
+msgstr "First read"
 
 #: src/pages/DashboardPage.tsx
 msgid "Focus"
@@ -413,6 +660,7 @@ msgstr "Focus"
 msgid "Focus search"
 msgstr "Focus search"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Format"
 msgstr "Format"
@@ -424,6 +672,10 @@ msgstr "Format: {filterFormatUpper}"
 #: src/pages/DashboardPage.tsx
 msgid "From your highlights"
 msgstr "From your highlights"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Genres"
+msgstr "Genres"
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Go back"
@@ -453,18 +705,39 @@ msgstr "Hardcover"
 msgid "hiatus"
 msgstr "hiatus"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Hide details"
+msgstr "Hide details"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Highlight deleted"
+msgstr "Highlight deleted"
+
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/components/Sidebar.tsx
 msgid "Highlights"
 msgstr "Highlights"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Highlights & Notes"
+msgstr "Highlights & Notes"
+
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Home"
 msgstr "Home"
+
+#: src/pages/BookDetailPage.tsx
+msgid "How far through the book you'd read by each date."
+msgstr "How far through the book you'd read by each date."
 
 #: src/components/Sidebar.tsx
 msgid "Icon"
 msgstr "Icon"
+
+#: src/pages/BookDetailPage.tsx
+msgid "ISBN"
+msgstr "ISBN"
 
 #: src/components/NotificationBell.tsx
 msgid "just now"
@@ -474,6 +747,11 @@ msgstr "just now"
 msgid "Keyboard Shortcuts"
 msgstr "Keyboard Shortcuts"
 
+#: src/pages/BookDetailPage.tsx
+msgid "KOReader sync linked"
+msgstr "KOReader sync linked"
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Language"
@@ -483,10 +761,16 @@ msgstr "Language"
 msgid "Language: {filterLanguageLabel}"
 msgstr "Language: {filterLanguageLabel}"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Last read"
+msgstr "Last read"
+
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Libraries"
 msgstr "Libraries"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Library"
 msgstr "Library"
@@ -499,6 +783,18 @@ msgstr "Library: {filterLibraryChipName}"
 msgid "Light"
 msgstr "Light"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Link"
+msgstr "Link"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Link KOReader sync…"
+msgstr "Link KOReader sync…"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Linking…"
+msgstr "Linking…"
+
 #: src/pages/DashboardPage.tsx
 msgid "List view"
 msgstr "List view"
@@ -506,6 +802,10 @@ msgstr "List view"
 #: src/components/Sidebar.tsx
 msgid "Log out"
 msgstr "Log out"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Log session"
+msgstr "Log session"
 
 #: src/pages/DashboardPage.tsx
 msgid "Manage"
@@ -515,10 +815,34 @@ msgstr "Manage"
 msgid "Manage series"
 msgstr "Manage series"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Manual"
+msgstr "Manual"
+
 #: src/components/NotificationBell.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Mark all read"
 msgstr "Mark all read"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Marked as read"
+msgstr "Marked as read"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Marked as reading"
+msgstr "Marked as reading"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Marked unread — reading progress cleared"
+msgstr "Marked unread — reading progress cleared"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Metadata saved"
+msgstr "Metadata saved"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Minutes"
+msgstr "Minutes"
 
 #: src/pages/DashboardPage.tsx
 msgid "Missing"
@@ -548,6 +872,10 @@ msgstr "New library"
 msgid "New Library"
 msgstr "New Library"
 
+#: src/pages/BookDetailPage.tsx
+msgid "new this week"
+msgstr "new this week"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next book"
 msgstr "Next book"
@@ -555,6 +883,10 @@ msgstr "Next book"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next page"
 msgstr "Next page"
+
+#: src/pages/BookDetailPage.tsx
+msgid "No description"
+msgstr "No description"
 
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
@@ -567,6 +899,10 @@ msgstr "No notifications yet"
 #: src/components/Sidebar.tsx
 msgid "No other users to share with."
 msgstr "No other users to share with."
+
+#: src/pages/BookDetailPage.tsx
+msgid "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
+msgstr "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
 
 #: src/pages/DashboardPage.tsx
 msgid "No results for \"{search}\""
@@ -584,9 +920,26 @@ msgstr "No Series"
 msgid "No series found — add series metadata to your books."
 msgstr "No series found — add series metadata to your books."
 
+#: src/pages/BookDetailPage.tsx
+msgid "No type"
+msgstr "No type"
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "None"
 msgstr "None"
+
+#: src/pages/BookDetailPage.tsx
+msgid "not read"
+msgstr "not read"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Note removed"
+msgstr "Note removed"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Note saved — syncs to your devices"
+msgstr "Note saved — syncs to your devices"
 
 #: src/pages/DashboardPage.tsx
 msgid "Nothing in progress"
@@ -599,6 +952,10 @@ msgstr "Nothing matched “{search}”"
 #: src/components/NotificationBell.tsx
 msgid "Notifications"
 msgstr "Notifications"
+
+#: src/pages/BookDetailPage.tsx
+msgid "of {totalPages} pages"
+msgstr "of {totalPages} pages"
 
 #: src/pages/DashboardPage.tsx
 msgid "On this day"
@@ -624,6 +981,14 @@ msgstr "Open reader"
 msgid "Open selected book"
 msgstr "Open selected book"
 
+#: src/pages/BookDetailPage.tsx
+msgid "pace"
+msgstr "pace"
+
+#: src/pages/BookDetailPage.tsx
+msgid "pages"
+msgstr "pages"
+
 #: src/pages/DashboardPage.tsx
 msgid "Pages · 30d"
 msgstr "Pages · 30d"
@@ -631,6 +996,10 @@ msgstr "Pages · 30d"
 #: src/pages/DashboardPage.tsx
 msgid "Pick up where you left off"
 msgstr "Pick up where you left off"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Position history — restore a bad sync"
+msgstr "Position history — restore a bad sync"
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Previous book"
@@ -648,9 +1017,25 @@ msgstr "Private — only assigned users can access"
 msgid "Private library"
 msgstr "Private library"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Progress"
+msgstr "Progress"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Progress % <0>(optional)</0>"
+msgstr "Progress % <0>(optional)</0>"
+
 #: src/components/Sidebar.tsx
 msgid "Public library"
 msgstr "Public library"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Publisher"
+msgstr "Publisher"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Rate this book"
+msgstr "Rate this book"
 
 #: src/pages/DashboardPage.tsx
 msgid "Rated"
@@ -672,7 +1057,12 @@ msgstr "Rated: 5 stars"
 msgid "Rating"
 msgstr "Rating"
 
+#: src/pages/BookDetailPage.tsx
+msgid "read"
+msgstr "read"
+
 #: src/components/BookCard.tsx
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Read"
 msgstr "Read"
@@ -680,6 +1070,22 @@ msgstr "Read"
 #: src/pages/DashboardPage.tsx
 msgid "Read · 30d"
 msgstr "Read · 30d"
+
+#: src/pages/BookDetailPage.tsx
+msgid "read {a}"
+msgstr "read {a}"
+
+#: src/pages/BookDetailPage.tsx
+msgid "read {a} – {b}"
+msgstr "read {a} – {b}"
+
+#: src/pages/BookDetailPage.tsx
+msgid "read {d}, {from} – {to}"
+msgstr "read {d}, {from} – {to}"
+
+#: src/pages/BookDetailPage.tsx
+msgid "read {span}"
+msgstr "read {span}"
 
 #: src/components/BookCard.tsx
 msgid "Read book"
@@ -689,13 +1095,29 @@ msgstr "Read book"
 msgid "Reader"
 msgstr "Reader"
 
+#: src/pages/BookDetailPage.tsx
+msgid "reading"
+msgstr "reading"
+
 #: src/pages/DashboardPage.tsx
 msgid "Reading"
 msgstr "Reading"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Reading days"
+msgstr "Reading days"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Reading intensity"
+msgstr "Reading intensity"
+
 #: src/pages/DashboardPage.tsx
 msgid "Reading Log"
 msgstr "Reading Log"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Reading Stats"
+msgstr "Reading Stats"
 
 #: src/pages/DashboardPage.tsx
 msgid "Recently Added"
@@ -705,11 +1127,20 @@ msgstr "Recently Added"
 msgid "Recently Finished"
 msgstr "Recently Finished"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
+msgstr "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
+
+#: src/pages/BookDetailPage.tsx
+msgid "Remove from library"
+msgstr "Remove from library"
+
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
 msgstr "Resume {volLabel}"
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Save"
 msgstr "Save"
 
@@ -717,9 +1148,21 @@ msgstr "Save"
 msgid "Save Changes"
 msgstr "Save Changes"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Save failed"
+msgstr "Save failed"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Save note"
+msgstr "Save note"
+
 #: src/components/Sidebar.tsx
 msgid "Save the library first, then reopen it to share with users."
 msgstr "Save the library first, then reopen it to share with users."
+
+#: src/pages/BookDetailPage.tsx
+msgid "Saving…"
+msgstr "Saving…"
 
 #: src/components/AppHeader.tsx
 msgid "Search books"
@@ -754,6 +1197,7 @@ msgstr "Select all"
 msgid "Series"
 msgstr "Series"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Series name"
 msgstr "Series name"
@@ -766,13 +1210,30 @@ msgstr "Series Progress"
 msgid "Series: {filterSeries}"
 msgstr "Series: {filterSeries}"
 
+#: src/pages/BookDetailPage.tsx
+msgid "sessions"
+msgstr "sessions"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Sessions · {d}"
+msgstr "Sessions · {d}"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Sessions ({n})"
+msgstr "Sessions ({n})"
+
 #: src/components/Sidebar.tsx
 msgid "Settings"
 msgstr "Settings"
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Share"
 msgstr "Share"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Share this book — a public metadata-only page"
+msgstr "Share this book — a public metadata-only page"
 
 #: src/pages/DashboardPage.tsx
 msgid "Share this series — a public metadata-only page"
@@ -786,9 +1247,18 @@ msgstr "Share with users"
 msgid "Shared Library"
 msgstr "Shared Library"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Shelved"
 msgstr "Shelved"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Shelved — kept your progress"
+msgstr "Shelved — kept your progress"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Shelved — set aside, keeps your progress"
+msgstr "Shelved — set aside, keeps your progress"
 
 #: src/components/Sidebar.tsx
 msgid "Shelves"
@@ -798,14 +1268,20 @@ msgstr "Shelves"
 msgid "Show another highlight"
 msgstr "Show another highlight"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Show details"
+msgstr "Show details"
+
 #: src/pages/DashboardPage.tsx
 msgid "Show individual volumes"
 msgstr "Show individual volumes"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Show less"
 msgstr "Show less"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Show more"
 msgstr "Show more"
@@ -813,6 +1289,10 @@ msgstr "Show more"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
 msgstr "Show this help"
+
+#: src/pages/BookDetailPage.tsx
+msgid "start"
+msgstr "start"
 
 #: src/pages/DashboardPage.tsx
 msgid "Start {volLabel}"
@@ -834,6 +1314,14 @@ msgstr "Status"
 msgid "Status: {filterStatusLabel}"
 msgstr "Status: {filterStatusLabel}"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Subtitle (optional)"
+msgstr "Subtitle (optional)"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Synced document"
+msgstr "Synced document"
+
 #: src/pages/DashboardPage.tsx
 msgid "Tag"
 msgstr "Tag"
@@ -850,6 +1338,15 @@ msgstr "Theme"
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
 msgstr "This permanently removes the selected books and their files from disk. This cannot be undone."
 
+#: src/pages/BookDetailPage.tsx
+msgid "Time per chapter"
+msgstr "Time per chapter"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Time per chapter, line view"
+msgstr "Time per chapter, line view"
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Title"
 msgstr "Title"
@@ -874,6 +1371,7 @@ msgstr "Translations are community-maintained. Anything not yet translated is sh
 msgid "Try adjusting your filters"
 msgstr "Try adjusting your filters"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Type"
 msgstr "Type"
@@ -881,6 +1379,18 @@ msgstr "Type"
 #: src/pages/DashboardPage.tsx
 msgid "Unassigned"
 msgstr "Unassigned"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Undo"
+msgstr "Undo"
+
+#: src/pages/BookDetailPage.tsx
+msgid "unknown device"
+msgstr "unknown device"
+
+#: src/pages/BookDetailPage.tsx
+msgid "unread"
+msgstr "unread"
 
 #: src/pages/DashboardPage.tsx
 msgid "Unread"
@@ -914,6 +1424,7 @@ msgstr "User menu"
 msgid "Viewing as <0>{impersonatedUsername}</0>"
 msgstr "Viewing as <0>{impersonatedUsername}</0>"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Vol. {idx}"
 msgstr "Vol. {idx}"
@@ -922,18 +1433,48 @@ msgstr "Vol. {idx}"
 msgid "Vol. {volIdx}"
 msgstr "Vol. {volIdx}"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Volume"
+msgstr "Volume"
+
 #: src/pages/DashboardPage.tsx
 msgid "Volumes"
 msgstr "Volumes"
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Want to Read"
 msgstr "Want to Read"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Want to Read — queue this book up next"
+msgstr "Want to Read — queue this book up next"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Web reader"
+msgstr "Web reader"
+
+#: src/pages/BookDetailPage.tsx
+msgid "What did you think? (optional, saved automatically)"
+msgstr "What did you think? (optional, saved automatically)"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Where in the book your time went — taller means more time spent on those pages."
+msgstr "Where in the book your time went — taller means more time spent on those pages."
+
+#: src/pages/BookDetailPage.tsx
+msgid "Where you read"
+msgstr "Where you read"
 
 #: src/components/Sidebar.tsx
 msgid "Wishlist"
 msgstr "Wishlist"
 
+#: src/pages/BookDetailPage.tsx
+msgid "Words"
+msgstr "Words"
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Year"
 msgstr "Year"
@@ -942,6 +1483,14 @@ msgstr "Year"
 msgid "Yesterday"
 msgstr "Yesterday"
 
+#: src/pages/BookDetailPage.tsx
+msgid "You rated this {rating}/5"
+msgstr "You rated this {rating}/5"
+
 #: src/pages/DashboardPage.tsx
 msgid "Your library is empty"
 msgstr "Your library is empty"
+
+#: src/pages/BookDetailPage.tsx
+msgid "Your note — syncs back to KOReader on the next sync"
+msgstr "Your note — syncs back to KOReader on the next sync"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1498,10 +1498,11 @@ msgid "Apply to all"
 msgstr "Apply to all"
 
 #: src/components/MetadataManager.tsx
-msgid "Applying {done}/{total}..."
-msgstr "Applying {done}/{total}..."
+#~ msgid "Applying {done}/{total}..."
+#~ msgstr "Applying {done}/{total}..."
 
 #: src/components/BulkMetadataReviewModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
 msgstr "Applying {done}/{total}…"
@@ -2463,9 +2464,10 @@ msgid "Deleted board “{name}”"
 msgstr "Deleted board “{name}”"
 
 #: src/pages/BinderyPage.tsx
-msgid "Deleting..."
-msgstr "Deleting..."
+#~ msgid "Deleting..."
+#~ msgstr "Deleting..."
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Deleting…"
 msgstr "Deleting…"
@@ -3511,10 +3513,11 @@ msgid "Imported board"
 msgstr "Imported board"
 
 #: src/pages/BinderyPage.tsx
-msgid "Importing..."
-msgstr "Importing..."
+#~ msgid "Importing..."
+#~ msgstr "Importing..."
 
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 msgid "Importing…"
 msgstr "Importing…"
 
@@ -3822,8 +3825,8 @@ msgstr "Loading your reading life…"
 
 #: src/pages/BinderyPage.tsx
 #: src/pages/SettingsPage.tsx
-msgid "Loading..."
-msgstr "Loading..."
+#~ msgid "Loading..."
+#~ msgstr "Loading..."
 
 #: src/components/HardcoverSync.tsx
 #: src/components/PositionHistoryModal.tsx
@@ -3831,7 +3834,9 @@ msgstr "Loading..."
 #: src/components/ShareShelfModal.tsx
 #: src/components/stats/BacklogEstimate.tsx
 #: src/components/stats/GoalWidget.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/HardcoverPage.tsx
+#: src/pages/SettingsPage.tsx
 #: src/pages/SharePage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Loading…"
@@ -5022,8 +5027,8 @@ msgid "Prefix"
 msgstr "Prefix"
 
 #: src/pages/SettingsPage.tsx
-msgid "Preparing..."
-msgstr "Preparing..."
+#~ msgid "Preparing..."
+#~ msgstr "Preparing..."
 
 #: src/components/InstanceBackup.tsx
 #: src/pages/SettingsPage.tsx
@@ -5707,12 +5712,13 @@ msgid "Saving"
 msgstr "Saving"
 
 #: src/pages/SettingsPage.tsx
-msgid "Saving..."
-msgstr "Saving..."
+#~ msgid "Saving..."
+#~ msgstr "Saving..."
 
 #: src/components/ForcePasswordChange.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Saving…"
 msgstr "Saving…"
 
@@ -5742,9 +5748,10 @@ msgid "Scanning covers…"
 msgstr "Scanning covers…"
 
 #: src/components/LibraryHealth.tsx
-msgid "Scanning..."
-msgstr "Scanning..."
+#~ msgid "Scanning..."
+#~ msgstr "Scanning..."
 
+#: src/components/LibraryHealth.tsx
 #: src/pages/AdminPage.tsx
 msgid "Scanning…"
 msgstr "Scanning…"
@@ -5922,8 +5929,13 @@ msgstr "Sending"
 
 #: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
-msgid "Sending..."
-msgstr "Sending..."
+#~ msgid "Sending..."
+#~ msgstr "Sending..."
+
+#: src/components/SendToDeviceModal.tsx
+#: src/pages/AdminPage.tsx
+msgid "Sending…"
+msgstr "Sending…"
 
 #: src/pages/AdminPage.tsx
 msgid "Sent"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -82,6 +82,14 @@ msgstr " · {n} volumes"
 msgid " · {n} want to read"
 msgstr " · {n} want to read"
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid " · {needsReview} needs review"
+msgstr " · {needsReview} needs review"
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid " · {noMatch} no match"
+msgstr " · {noMatch} no match"
+
 #: src/components/stats/widgets/overview.tsx
 msgid " · {pages} pages"
 msgstr " · {pages} pages"
@@ -136,9 +144,21 @@ msgstr " · to change expiry, revoke and re-create"
 msgid " · you have vol {v}"
 msgstr " · you have vol {v}"
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid " {n} had no confident match."
+msgstr " {n} had no confident match."
+
+#: src/components/LibraryHealth.tsx
+msgid " in {n} folders"
+msgstr " in {n} folders"
+
 #: src/components/stats/widgets/habits.tsx
 msgid " vs previous: <0>{prev}</0>"
 msgstr " vs previous: <0>{prev}</0>"
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "— {n} books"
+msgstr "— {n} books"
 
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
@@ -156,6 +176,10 @@ msgstr ", {errors} failed"
 msgid ", {failedN} failed"
 msgstr ", {failedN} failed"
 
+#: src/components/LibraryHealth.tsx
+msgid ", {n} errors"
+msgstr ", {n} errors"
+
 #: src/pages/AdminPage.tsx
 msgid ", {n} failed"
 msgstr ", {n} failed"
@@ -167,6 +191,10 @@ msgstr ", {pages} pages"
 #: src/components/UploadModal.tsx
 msgid ", {skipped} already in library"
 msgstr ", {skipped} already in library"
+
+#: src/components/LibraryHealth.tsx
+msgid ", removed {n} empty folders"
+msgstr ", removed {n} empty folders"
 
 #: src/pages/DashboardPage.tsx
 msgid "…and {more} more not shown"
@@ -245,6 +273,11 @@ msgstr "{0, plural, one {# active day in this window} other {# active days in th
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 msgstr "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 
+#. placeholder {0}: missingResult.removed_books.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# book entry removed} other {# book entries removed}}"
+msgstr "{0, plural, one {# book entry removed} other {# book entries removed}}"
+
 #. placeholder {0}: d.books_finished
 #: src/components/stats/widgets/habits.tsx
 msgid "{0, plural, one {# book finished} other {# books finished}}"
@@ -284,10 +317,30 @@ msgstr "{0, plural, one {# day} other {# days}}"
 msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
 msgstr "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
 
+#. placeholder {0}: healthData.missing_count
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# entry is missing from disk} other {# entries are missing from disk}}"
+msgstr "{0, plural, one {# entry is missing from disk} other {# entries are missing from disk}}"
+
+#. placeholder {0}: missingResult.removed_file_rows
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# file entry removed} other {# file entries removed}}"
+msgstr "{0, plural, one {# file entry removed} other {# file entries removed}}"
+
+#. placeholder {0}: healthData.missing.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# file in the database but missing from disk} other {# files in the database but missing from disk}}"
+msgstr "{0, plural, one {# file in the database but missing from disk} other {# files in the database but missing from disk}}"
+
 #. placeholder {0}: items.length
 #: src/components/UploadModal.tsx
 msgid "{0, plural, one {# file selected} other {# files selected}}"
 msgstr "{0, plural, one {# file selected} other {# files selected}}"
+
+#. placeholder {0}: group.issues.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# file} other {# files}}"
+msgstr "{0, plural, one {# file} other {# files}}"
 
 #. placeholder {0}: row.unestimated
 #: src/components/stats/BacklogEstimate.tsx
@@ -380,6 +433,11 @@ msgstr "{0, plural, one {Added # book to library} other {Added # books to librar
 msgid "{0, plural, one {Applied # group} other {Applied # groups}}"
 msgstr "{0, plural, one {Applied # group} other {Applied # groups}}"
 
+#. placeholder {0}: healthData.missing.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {Confirm — remove # entry} other {Confirm — remove # entries}}"
+msgstr "{0, plural, one {Confirm — remove # entry} other {Confirm — remove # entries}}"
+
 #. placeholder {0}: selectedIds.size
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Delete # book} other {Delete # books}}"
@@ -419,6 +477,11 @@ msgstr "{0, plural, one {Permanently delete # file from the bindery? This cannot
 #: src/pages/BinderyPage.tsx
 msgid "{0, plural, one {Rejected # file} other {Rejected # files}}"
 msgstr "{0, plural, one {Rejected # file} other {Rejected # files}}"
+
+#. placeholder {0}: purgeResult.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {Removed # empty folder.} other {Removed # empty folders.}}"
+msgstr "{0, plural, one {Removed # empty folder.} other {Removed # empty folders.}}"
 
 #. placeholder {0}: books.length
 #: src/components/SendToDeviceModal.tsx
@@ -643,6 +706,10 @@ msgstr "{m}m"
 msgid "{m}m {rem}s"
 msgstr "{m}m {rem}s"
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "{matched} matched"
+msgstr "{matched} matched"
+
 #: src/pages/AdminPage.tsx
 msgid "{mergeCount, plural, one {merge # group} other {merge # groups}}"
 msgstr "{mergeCount, plural, one {merge # group} other {merge # groups}}"
@@ -656,6 +723,10 @@ msgstr "{mins}m ago"
 #: src/pages/SettingsPage.tsx
 msgid "{minutes}m ago"
 msgstr "{minutes}m ago"
+
+#: src/components/LibraryHealth.tsx
+msgid "{misplaced} of {total} files need reorganization"
+msgstr "{misplaced} of {total} files need reorganization"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
@@ -691,6 +762,10 @@ msgstr "{n} selected"
 msgid "{n} selected — Clear"
 msgstr "{n} selected — Clear"
 
+#: src/components/LibraryHealth.tsx
+msgid "{n} skipped (file exists on disk)"
+msgstr "{n} skipped (file exists on disk)"
+
 #: src/components/HardcoverSync.tsx
 msgid "{n} synced"
 msgstr "{n} synced"
@@ -714,6 +789,10 @@ msgstr "{name} copy"
 #: src/components/ThemeToggle.tsx
 msgid "{name} theme"
 msgstr "{name} theme"
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "{ok} of {total} approved"
+msgstr "{ok} of {total} approved"
 
 #: src/components/UploadModal.tsx
 msgid "{ok} uploaded"
@@ -1180,6 +1259,10 @@ msgstr "All {loadedCount} books loaded"
 msgid "All {scanned} covers look healthy."
 msgstr "All {scanned} covers look healthy."
 
+#: src/components/LibraryHealth.tsx
+msgid "All {total} files are correctly placed."
+msgstr "All {total} files are correctly placed."
+
 #: src/pages/DashboardPage.tsx
 msgid "All →"
 msgstr "All →"
@@ -1205,6 +1288,10 @@ msgstr "All Books by Reading Time"
 #: src/pages/AdminPage.tsx
 msgid "All Devices"
 msgstr "All Devices"
+
+#: src/components/LibraryHealth.tsx
+msgid "All files are correctly placed."
+msgstr "All files are correctly placed."
 
 #: src/pages/BinderyPage.tsx
 msgid "All imported books accepted"
@@ -1276,6 +1363,10 @@ msgstr "Appearance"
 msgid "Application token (required)"
 msgstr "Application token (required)"
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Applied metadata to {n} books."
+msgstr "Applied metadata to {n} books."
+
 #: src/components/SeriesRating.tsx
 msgid "Applied to volumes you haven’t rated"
 msgstr "Applied to volumes you haven’t rated"
@@ -1289,6 +1380,10 @@ msgstr "Applied: {statuses} statuses, {ratings} ratings, {finishes} finish dates
 msgid "Apply"
 msgstr "Apply"
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Apply {n} Approved"
+msgstr "Apply {n} Approved"
+
 #: src/components/ReadingImport.tsx
 msgid "Apply {n} selected"
 msgstr "Apply {n} selected"
@@ -1296,6 +1391,10 @@ msgstr "Apply {n} selected"
 #: src/pages/AdminPage.tsx
 msgid "Apply All ({n})"
 msgstr "Apply All ({n})"
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Apply Approved"
+msgstr "Apply Approved"
 
 #: src/components/CoverAudit.tsx
 msgid "Apply the first cover-search candidate"
@@ -1305,6 +1404,7 @@ msgstr "Apply the first cover-search candidate"
 msgid "Apply to all"
 msgstr "Apply to all"
 
+#: src/components/BulkMetadataReviewModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
 msgstr "Applying {done}/{total}…"
@@ -1365,6 +1465,10 @@ msgstr "Author name"
 #: src/pages/DashboardPage.tsx
 msgid "Author: {filterAuthor}"
 msgstr "Author: {filterAuthor}"
+
+#: src/components/LibraryHealth.tsx
+msgid "Author: {name}"
+msgstr "Author: {name}"
 
 #: src/pages/SettingsPage.tsx
 msgid "Authorize"
@@ -1454,6 +1558,10 @@ msgstr "Backup"
 msgid "Backup failed"
 msgstr "Backup failed"
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Batch complete"
+msgstr "Batch complete"
+
 #: src/pages/StatsPage.tsx
 msgid "Best Day"
 msgstr "Best Day"
@@ -1515,6 +1623,10 @@ msgstr "Book deleted"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Book Detail"
 msgstr "Book Detail"
+
+#: src/components/LibraryHealth.tsx
+msgid "book entry will be removed"
+msgstr "book entry will be removed"
 
 #: src/pages/StatsPage.tsx
 msgid "Book Length"
@@ -1614,8 +1726,10 @@ msgstr "Browse your library"
 msgid "Can't find it? Add manually"
 msgstr "Can't find it? Add manually"
 
+#: src/components/BulkMetadataReviewModal.tsx
 #: src/components/EntityModal.tsx
 #: src/components/InstanceBackup.tsx
+#: src/components/LibraryHealth.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
@@ -1742,6 +1856,7 @@ msgstr "Click \"Download plugin ZIP\" above. An API key is automatically created
 msgid "Click for details"
 msgstr "Click for details"
 
+#: src/components/BulkMetadataReviewModal.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareShelfModal.tsx
@@ -1842,6 +1957,10 @@ msgstr "Configured"
 #: src/pages/BookDetailPage.tsx
 msgid "Confirm"
 msgstr "Confirm"
+
+#: src/components/LibraryHealth.tsx
+msgid "Confirm & Reorganize"
+msgstr "Confirm & Reorganize"
 
 #: src/components/ForcePasswordChange.tsx
 #: src/pages/SettingsPage.tsx
@@ -1964,6 +2083,10 @@ msgstr "Couldn't load the timeline."
 #: src/components/WordCount.tsx
 msgid "Counted"
 msgstr "Counted"
+
+#: src/components/WordCount.tsx
+msgid "Counting… {done} / {total}"
+msgstr "Counting… {done} / {total}"
 
 #: src/components/stats/GoalWidget.tsx
 msgid "Counts"
@@ -2113,6 +2236,10 @@ msgstr "Day streak"
 msgid "days at ~{mpd} min a day (last {win} days)"
 msgstr "days at ~{mpd} min a day (last {win} days)"
 
+#: src/components/LibraryHealth.tsx
+msgid "Dead entries removed"
+msgstr "Dead entries removed"
+
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -2215,6 +2342,7 @@ msgstr "Device reading time mapped into the book's chapters. Hover the line for 
 msgid "Directories"
 msgstr "Directories"
 
+#: src/components/LibraryHealth.tsx
 #: src/components/WhatsNewPanel.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -2306,6 +2434,14 @@ msgstr "Drop books here or <0>click to browse</0>"
 #: src/pages/BinderyPage.tsx
 msgid "Drop files in the incoming folder to get started"
 msgstr "Drop files in the incoming folder to get started"
+
+#: src/components/LibraryHealth.tsx
+msgid "Dry Run All"
+msgstr "Dry Run All"
+
+#: src/components/LibraryHealth.tsx
+msgid "Dry Run Preview — {n} files would be moved"
+msgstr "Dry Run Preview — {n} files would be moved"
 
 #: src/pages/StatsPage.tsx
 msgid "Duplicate “{name}”"
@@ -2744,6 +2880,11 @@ msgstr "fantasy, action, romance"
 msgid "Fastest"
 msgstr "Fastest"
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Fetch failed"
+msgstr "Fetch failed"
+
+#: src/components/BulkMetadataReviewModal.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
 msgstr "Fetch Metadata"
@@ -2752,6 +2893,14 @@ msgstr "Fetch Metadata"
 msgid "Fetching metadata..."
 msgstr "Fetching metadata..."
 
+#: src/components/LibraryHealth.tsx
+msgid "File {id}: {err}"
+msgstr "File {id}: {err}"
+
+#: src/components/LibraryHealth.tsx
+msgid "file entry only"
+msgstr "file entry only"
+
 #: src/pages/AdminPage.tsx
 msgid "File is missing from disk"
 msgstr "File is missing from disk"
@@ -2759,6 +2908,10 @@ msgstr "File is missing from disk"
 #: src/components/SendToDeviceModal.tsx
 msgid "File size: {size}"
 msgstr "File size: {size}"
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Fill missing fields only"
+msgstr "Fill missing fields only"
 
 #: src/pages/HardcoverPage.tsx
 msgid "Filter…"
@@ -3325,6 +3478,10 @@ msgstr "Library"
 msgid "Library Completion"
 msgstr "Library Completion"
 
+#: src/components/LibraryHealth.tsx
+msgid "Library Health"
+msgstr "Library Health"
+
 #: src/pages/StatsPage.tsx
 msgid "Library size over time"
 msgstr "Library size over time"
@@ -3654,6 +3811,10 @@ msgstr "Most-read authors"
 msgid "Most-read books by time"
 msgstr "Most-read books by time"
 
+#: src/components/LibraryHealth.tsx
+msgid "Moved {n} files"
+msgstr "Moved {n} files"
+
 #: src/pages/SettingsPage.tsx
 msgid "Must be exactly 10 comma-separated hex values (e.g. #1E1E2E)"
 msgstr "Must be exactly 10 comma-separated hex values (e.g. #1E1E2E)"
@@ -3886,6 +4047,10 @@ msgstr "No dismissed wishes."
 msgid "No duplicates found. Your library looks clean."
 msgstr "No duplicates found. Your library looks clean."
 
+#: src/components/LibraryHealth.tsx
+msgid "No empty folders found."
+msgstr "No empty folders found."
+
 #: src/pages/BinderyPage.tsx
 msgid "No files in the bindery"
 msgstr "No files in the bindery"
@@ -3918,6 +4083,10 @@ msgstr "No libraries"
 msgid "No library growth data."
 msgstr "No library growth data."
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "No match found"
+msgstr "No match found"
+
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
 msgstr "No matches"
@@ -3933,6 +4102,10 @@ msgstr "No matching volumes in the library yet."
 #: src/pages/BinderyPage.tsx
 msgid "No metadata found"
 msgstr "No metadata found"
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "no new fields"
+msgstr "no new fields"
 
 #: src/components/NotificationBell.tsx
 msgid "No notifications yet"
@@ -4235,6 +4408,10 @@ msgstr "Nothing matched “{search}”"
 msgid "Nothing shared yet. Use the share icon on a shelf, a series page, or a book page."
 msgstr "Nothing shared yet. Use the share icon on a shelf, a series page, or a book page."
 
+#: src/components/LibraryHealth.tsx
+msgid "Nothing to remove."
+msgstr "Nothing to remove."
+
 #: src/components/NotificationBell.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Notifications"
@@ -4339,6 +4516,14 @@ msgstr "or use a custom source"
 #: src/pages/SettingsPage.tsx
 msgid "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
 msgstr "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
+
+#: src/components/LibraryHealth.tsx
+msgid "Orphaned entries"
+msgstr "Orphaned entries"
+
+#: src/components/LibraryHealth.tsx
+msgid "Other"
+msgstr "Other"
 
 #: src/pages/BinderyPage.tsx
 msgid "Other files"
@@ -4603,6 +4788,18 @@ msgstr "Publication status"
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
 msgstr "Publisher"
+
+#: src/components/LibraryHealth.tsx
+msgid "Purge Empty Folders"
+msgstr "Purge Empty Folders"
+
+#: src/components/LibraryHealth.tsx
+msgid "Purge failed"
+msgstr "Purge failed"
+
+#: src/components/LibraryHealth.tsx
+msgid "Purging..."
+msgstr "Purging..."
 
 #: src/components/NotificationChannels.tsx
 msgid "Push Tome's notifications (wish fulfilled, new volume detected, reading goals) to ntfy, Gotify, or any webhook the moment they happen — the bell above only rings when you visit. Each channel can be tested, paused, or removed; tokens are stored server-side and never shown again."
@@ -4935,9 +5132,17 @@ msgstr "Remove all of this book's imported KOReader history? Web and manual sess
 msgid "Remove channel"
 msgstr "Remove channel"
 
+#: src/components/LibraryHealth.tsx
+msgid "Remove Dead Entries"
+msgstr "Remove Dead Entries"
+
 #: src/pages/SettingsPage.tsx
 msgid "Remove device"
 msgstr "Remove device"
+
+#: src/components/LibraryHealth.tsx
+msgid "Remove folders that contain only hidden files (.DS_Store, etc.)"
+msgstr "Remove folders that contain only hidden files (.DS_Store, etc.)"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Remove from library"
@@ -4959,6 +5164,18 @@ msgstr "Removed “{title}”"
 msgid "Removed a tile? Add it back — or add another copy."
 msgstr "Removed a tile? Add it back — or add another copy."
 
+#: src/components/LibraryHealth.tsx
+msgid "Removes the database entries only — no files are touched"
+msgstr "Removes the database entries only — no files are touched"
+
+#: src/components/LibraryHealth.tsx
+msgid "Removing dead entries failed"
+msgstr "Removing dead entries failed"
+
+#: src/components/LibraryHealth.tsx
+msgid "Removing..."
+msgstr "Removing..."
+
 #: src/pages/StatsPage.tsx
 msgid "Rename {name}"
 msgstr "Rename {name}"
@@ -4966,6 +5183,22 @@ msgstr "Rename {name}"
 #: src/pages/StatsPage.tsx
 msgid "Rename board"
 msgstr "Rename board"
+
+#: src/components/LibraryHealth.tsx
+msgid "Reorganization complete"
+msgstr "Reorganization complete"
+
+#: src/components/LibraryHealth.tsx
+msgid "Reorganize All"
+msgstr "Reorganize All"
+
+#: src/components/LibraryHealth.tsx
+msgid "Reorganize failed"
+msgstr "Reorganize failed"
+
+#: src/components/LibraryHealth.tsx
+msgid "Reorganize Selected ({n})"
+msgstr "Reorganize Selected ({n})"
 
 #: src/components/NotificationChannels.tsx
 msgid "request failed"
@@ -5026,6 +5259,10 @@ msgstr "Retry {n} failed"
 #: src/pages/BinderyPage.tsx
 msgid "Review"
 msgstr "Review"
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Review {n} Uncertain"
+msgstr "Review {n} Uncertain"
 
 #: src/pages/BinderyPage.tsx
 msgid "Review all failed"
@@ -5146,6 +5383,11 @@ msgstr "Saving…"
 msgid "Scan complete"
 msgstr "Scan complete"
 
+#: src/components/LibraryHealth.tsx
+msgid "Scan failed"
+msgstr "Scan failed"
+
+#: src/components/LibraryHealth.tsx
 #: src/pages/AdminPage.tsx
 msgid "Scan Library"
 msgstr "Scan Library"
@@ -5161,6 +5403,10 @@ msgstr "Scanner"
 #: src/components/CoverAudit.tsx
 msgid "Scanning covers…"
 msgstr "Scanning covers…"
+
+#: src/components/LibraryHealth.tsx
+msgid "Scanning..."
+msgstr "Scanning..."
 
 #: src/pages/AdminPage.tsx
 msgid "Scanning…"
@@ -5223,6 +5469,10 @@ msgstr "Search Hardcover…"
 msgid "Search icons…"
 msgstr "Search icons…"
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Search manually"
+msgstr "Search manually"
+
 #: src/pages/BinderyPage.tsx
 msgid "Search query..."
 msgstr "Search query..."
@@ -5238,6 +5488,10 @@ msgstr "Search widgets…"
 #: src/pages/HighlightsPage.tsx
 msgid "Search your highlights…"
 msgstr "Search your highlights…"
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Searching {n} books…"
+msgstr "Searching {n} books…"
 
 #: src/pages/HardcoverPage.tsx
 msgid "Searching…"
@@ -5386,6 +5640,10 @@ msgstr "Series Spotlight"
 #: src/pages/DashboardPage.tsx
 msgid "Series: {filterSeries}"
 msgstr "Series: {filterSeries}"
+
+#: src/components/LibraryHealth.tsx
+msgid "Series: {name}"
+msgstr "Series: {name}"
 
 #: src/pages/AdminPage.tsx
 msgid "Server"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -61,6 +61,10 @@ msgstr " · {n} read"
 msgid " · {n} volumes"
 msgstr " · {n} volumes"
 
+#: src/components/stats/widgets/overview.tsx
+msgid " · {pages} pages"
+msgstr " · {pages} pages"
+
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
 msgstr " · {prog}% in"
@@ -68,6 +72,10 @@ msgstr " · {prog}% in"
 #: src/components/ReadingImport.tsx
 msgid " · {r} stars"
 msgstr " · {r} stars"
+
+#: src/components/stats/widgets/overview.tsx
+msgid " · avg {avg}"
+msgstr " · avg {avg}"
 
 #: src/components/stats/BacklogEstimate.tsx
 msgid " · books without a word count use your average for that type"
@@ -106,6 +114,10 @@ msgstr " · to change expiry, revoke and re-create"
 #: src/pages/WishlistPage.tsx
 msgid " · you have vol {v}"
 msgstr " · you have vol {v}"
+
+#: src/components/stats/widgets/habits.tsx
+msgid " vs previous: <0>{prev}</0>"
+msgstr " vs previous: <0>{prev}</0>"
 
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
@@ -155,6 +167,10 @@ msgstr "· a shared shelf"
 msgid "· p. {page} of {totalPages}"
 msgstr "· p. {page} of {totalPages}"
 
+#: src/components/stats/widgets/habits.tsx
+msgid "({a} vs {b} pages/min)"
+msgstr "({a} vs {b} pages/min)"
+
 #: src/pages/SettingsPage.tsx
 msgid "(enables dark: variants)"
 msgstr "(enables dark: variants)"
@@ -170,6 +186,10 @@ msgstr "(last 100)"
 #: src/pages/AdminPage.tsx
 msgid "(leave blank to keep)"
 msgstr "(leave blank to keep)"
+
+#: src/components/stats/widgets/habits.tsx
+msgid "(low confidence)"
+msgstr "(low confidence)"
 
 #: src/pages/AdminPage.tsx
 msgid "(not set)"
@@ -190,10 +210,20 @@ msgstr "{0, plural, one {{dur} over # day} other {{dur} over # days}}"
 msgid "{0, plural, one {{fin} finished · # book read} other {{fin} finished · # books read}}"
 msgstr "{0, plural, one {{fin} finished · # book read} other {{fin} finished · # books read}}"
 
+#. placeholder {0}: dayEntries.length
+#: src/components/stats/widgets/habits.tsx
+msgid "{0, plural, one {# active day in this window} other {# active days in this window}}"
+msgstr "{0, plural, one {# active day in this window} other {# active days in this window}}"
+
 #. placeholder {0}: res.errors.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 msgstr "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+
+#. placeholder {0}: d.books_finished
+#: src/components/stats/widgets/habits.tsx
+msgid "{0, plural, one {# book finished} other {# books finished}}"
+msgstr "{0, plural, one {# book finished} other {# books finished}}"
 
 #. placeholder {0}: status.syncedDocuments
 #: src/components/SyncStatusBadge.tsx
@@ -273,7 +303,9 @@ msgid "{0, plural, one {# session · {pages} pages} other {# sessions · {pages}
 msgstr "{0, plural, one {# session · {pages} pages} other {# sessions · {pages} pages}}"
 
 #. placeholder {0}: aggregate.total_sessions
+#. placeholder {0}: d.sessions
 #: src/components/SeriesReadingStats.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "{0, plural, one {# session} other {# sessions}}"
 msgstr "{0, plural, one {# session} other {# sessions}}"
 
@@ -296,6 +328,11 @@ msgstr "{0, plural, one {# user} other {# users}}"
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# volume} other {# volumes}}"
 msgstr "{0, plural, one {# volume} other {# volumes}}"
+
+#. placeholder {0}: est.estimated_days
+#: src/components/stats/widgets/habits.tsx
+msgid "{0, plural, one {~# day remaining} other {~# days remaining}}"
+msgstr "{0, plural, one {~# day remaining} other {~# days remaining}}"
 
 #. placeholder {0}: group.files.length
 #: src/pages/BinderyPage.tsx
@@ -420,6 +457,10 @@ msgstr "{count} sittings · {from} – {to}"
 msgid "{d}d ago"
 msgstr "{d}d ago"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "{daily} finished · {count} total"
+msgstr "{daily} finished · {count} total"
+
 #: src/components/NotificationBell.tsx
 #: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
@@ -515,6 +556,10 @@ msgstr "{h}h {m}m"
 #: src/components/PositionHistoryModal.tsx
 msgid "{h}h ago"
 msgstr "{h}h ago"
+
+#: src/components/stats/widgets/habits.tsx
+msgid "{h}h reading"
+msgstr "{h}h reading"
 
 #: src/lib/goals.ts
 msgid "{hit}/7 days this week"
@@ -627,6 +672,22 @@ msgstr "{othersCount, plural, one {Delete # other} other {Delete # others}}"
 msgid "{pacePerMin} pg/min"
 msgstr "{pacePerMin} pg/min"
 
+#: src/components/stats/widgets/habits.tsx
+msgid "{pages} pages in {dur}"
+msgstr "{pages} pages in {dur}"
+
+#: src/components/stats/widgets/habits.tsx
+msgid "{pct}% less reading this period"
+msgstr "{pct}% less reading this period"
+
+#: src/components/stats/widgets/habits.tsx
+msgid "{pct}% more reading this period"
+msgstr "{pct}% more reading this period"
+
+#: src/components/stats/widgets/habits.tsx
+msgid "{ppm} pages/min"
+msgstr "{ppm} pages/min"
+
 #: src/pages/DashboardPage.tsx
 msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
 msgstr "{readCount} read · {readingCount} reading · {unreadCount} unread"
@@ -715,6 +776,18 @@ msgstr "← Back to library"
 #: src/pages/DashboardPage.tsx
 msgid "<0>{dur}</0> left in this series"
 msgstr "<0>{dur}</0> left in this series"
+
+#: src/components/stats/widgets/overview.tsx
+msgid "<0>Device name</0> (e.g. Kindle) — recorded live by the KOReader plugin. <1>web</1> / <2>manual</2> — the web reader, or logged by hand."
+msgstr "<0>Device name</0> (e.g. Kindle) — recorded live by the KOReader plugin. <1>web</1> / <2>manual</2> — the web reader, or logged by hand."
+
+#: src/components/stats/widgets/overview.tsx
+msgid "<0>imported</0> — from KOReader's synced reading history. Delete only: KOReader already caps idle time, so there is nothing to trim."
+msgstr "<0>imported</0> — from KOReader's synced reading history. Delete only: KOReader already caps idle time, so there is nothing to trim."
+
+#: src/components/stats/widgets/overview.tsx
+msgid "<0>not counted</0> — a live device session whose sitting is also described by imported history. Listed for completeness, excluded from the totals so nothing is counted twice."
+msgstr "<0>not counted</0> — a live device session whose sitting is also described by imported history. Listed for completeness, excluded from the totals so nothing is counted twice."
 
 #: src/pages/BookDetailPage.tsx
 msgid "~{at}% in · {dur}"
@@ -1218,6 +1291,10 @@ msgstr "average pace"
 msgid "Average rating per book type"
 msgstr "Average rating per book type"
 
+#: src/components/stats/widgets/habits.tsx
+msgid "avg {a} pages/min"
+msgstr "avg {a} pages/min"
+
 #: src/pages/StatsPage.tsx
 msgid "avg {avg}"
 msgstr "avg {avg}"
@@ -1302,6 +1379,7 @@ msgstr "book"
 
 #: src/components/CoverAudit.tsx
 #: src/components/SendToDeviceModal.tsx
+#: src/components/stats/widgets/overview.tsx
 #: src/pages/AdminPage.tsx
 msgid "Book"
 msgstr "Book"
@@ -1410,6 +1488,7 @@ msgstr "Browse your library"
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
+#: src/components/stats/widgets/overview.tsx
 #: src/components/UploadModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -1843,6 +1922,10 @@ msgstr "Data"
 msgid "Database"
 msgstr "Database"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Date"
+msgstr "Date"
+
 #: src/pages/DashboardPage.tsx
 msgid "Date Added"
 msgstr "Date Added"
@@ -1931,6 +2014,7 @@ msgid "Details:"
 msgstr "Details:"
 
 #: src/components/SendToDeviceModal.tsx
+#: src/components/stats/widgets/overview.tsx
 #: src/pages/AdminPage.tsx
 msgid "Device"
 msgstr "Device"
@@ -2062,6 +2146,10 @@ msgstr "Duplicate tile"
 msgid "Duplicates"
 msgstr "Duplicates"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Duration"
+msgstr "Duration"
+
 #: src/pages/SettingsPage.tsx
 msgid "E-Reader Devices"
 msgstr "E-Reader Devices"
@@ -2085,6 +2173,10 @@ msgstr "e.g. Novel"
 #: src/pages/SettingsPage.tsx
 msgid "e.g. scribe-laptop"
 msgstr "e.g. scribe-laptop"
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Each row is one reading session."
+msgstr "Each row is one reading session."
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
@@ -2546,6 +2638,7 @@ msgid "Fr"
 msgstr "Fr"
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Fri"
 msgstr "Fri"
 
@@ -2871,6 +2964,10 @@ msgstr "just now"
 msgid "Just now"
 msgstr "Just now"
 
+#: src/components/stats/widgets/habits.tsx
+msgid "Just started"
+msgstr "Just started"
+
 #: src/components/SyncStatusBadge.tsx
 msgid "Just synced"
 msgstr "Just synced"
@@ -2965,6 +3062,8 @@ msgstr "Latest: Vol {v} · {d}"
 msgid "Learn more"
 msgstr "Learn more"
 
+#: src/components/stats/widgets/habits.tsx
+#: src/components/stats/widgets/overview.tsx
 #: src/pages/SharePage.tsx
 msgid "Less"
 msgstr "Less"
@@ -3107,6 +3206,10 @@ msgstr "Login failed"
 msgid "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
 msgstr "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Longest first"
+msgstr "Longest first"
+
 #: src/pages/StatsPage.tsx
 msgid "Longest Session"
 msgstr "Longest Session"
@@ -3224,6 +3327,7 @@ msgstr "Metadata Suggestions"
 msgid "Metric"
 msgstr "Metric"
 
+#: src/components/stats/widgets/overview.tsx
 #: src/lib/goals.ts
 msgid "min"
 msgstr "min"
@@ -3261,12 +3365,18 @@ msgid "Mo"
 msgstr "Mo"
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Mon"
 msgstr "Mon"
 
 #: src/lib/goals.ts
 msgid "Monthly goal"
 msgstr "Monthly goal"
+
+#: src/components/stats/widgets/habits.tsx
+#: src/components/stats/widgets/overview.tsx
+msgid "More"
+msgstr "More"
 
 #: src/components/SendButton.tsx
 msgid "More send options"
@@ -3342,6 +3452,10 @@ msgstr "never used"
 msgid "New board"
 msgstr "New board"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "New duration"
+msgstr "New duration"
+
 #: src/components/stats/GoalWidget.tsx
 msgid "New goal"
 msgstr "New goal"
@@ -3382,6 +3496,10 @@ msgstr "New Type"
 #: src/pages/AdminPage.tsx
 msgid "New User"
 msgstr "New User"
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Newest first"
+msgstr "Newest first"
 
 #: src/pages/AdminPage.tsx
 msgid "Next"
@@ -3427,6 +3545,10 @@ msgstr "No author data."
 msgid "No book types yet."
 msgstr "No book types yet."
 
+#: src/components/stats/widgets/habits.tsx
+msgid "No books currently in progress."
+msgstr "No books currently in progress."
+
 #: src/pages/AdminPage.tsx
 msgid "No books found. Upload the book first, then fulfill."
 msgstr "No books found. Upload the book first, then fulfill."
@@ -3434,6 +3556,10 @@ msgstr "No books found. Upload the book first, then fulfill."
 #: src/pages/AdminPage.tsx
 msgid "No books have been sent yet."
 msgstr "No books have been sent yet."
+
+#: src/components/stats/widgets/overview.tsx
+msgid "No books in progress"
+msgstr "No books in progress"
 
 #: src/pages/HardcoverPage.tsx
 msgid "No books in this view."
@@ -3543,6 +3669,10 @@ msgstr "No other users to share with."
 msgid "No pace data by format."
 msgstr "No pace data by format."
 
+#: src/components/stats/widgets/habits.tsx
+msgid "No paced sessions."
+msgstr "No paced sessions."
+
 #: src/pages/SettingsPage.tsx
 msgid "No PINs yet. Generate one to use with OPDS clients."
 msgstr "No PINs yet. Generate one to use with OPDS clients."
@@ -3550,6 +3680,10 @@ msgstr "No PINs yet. Generate one to use with OPDS clients."
 #: src/components/PositionHistoryModal.tsx
 msgid "No position changes recorded yet — history starts with the next sync."
 msgstr "No position changes recorded yet — history starts with the next sync."
+
+#: src/components/stats/widgets/habits.tsx
+msgid "No previous data to compare"
+msgstr "No previous data to compare"
 
 #: src/components/stats/widgets/taste.tsx
 msgid "No rated books with reading time yet."
@@ -3579,6 +3713,10 @@ msgstr "no reading"
 msgid "No reading activity yet. Records appear when users start reading books."
 msgstr "No reading activity yet. Records appear when users start reading books."
 
+#: src/components/stats/widgets/habits.tsx
+msgid "No reading data"
+msgstr "No reading data"
+
 #: src/pages/StatsPage.tsx
 msgid "No reading data yet"
 msgstr "No reading data yet"
@@ -3594,6 +3732,10 @@ msgstr "No reading logged yet. Track time by hand — handy for a paper copy or 
 #: src/pages/StatsPage.tsx
 msgid "No reading sessions in this range — session-based tiles will be empty."
 msgstr "No reading sessions in this range — session-based tiles will be empty."
+
+#: src/components/stats/widgets/overview.tsx
+msgid "No reading sessions recorded."
+msgstr "No reading sessions recorded."
 
 #: src/pages/StatsPage.tsx
 msgid "no reading yet"
@@ -3633,8 +3775,13 @@ msgid "No series with reading progress yet."
 msgstr "No series with reading progress yet."
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "No session data."
 msgstr "No session data."
+
+#: src/components/stats/widgets/overview.tsx
+msgid "No sessions recorded."
+msgstr "No sessions recorded."
 
 #: src/pages/StatsPage.tsx
 msgid "no sessions yet"
@@ -3692,9 +3839,17 @@ msgstr "None"
 msgid "Not configured"
 msgstr "Not configured"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "not counted"
+msgstr "not counted"
+
 #: src/pages/StatsPage.tsx
 msgid "Not enough reading history yet."
 msgstr "Not enough reading history yet."
+
+#: src/components/stats/widgets/habits.tsx
+msgid "Not enough sessions yet."
+msgstr "Not enough sessions yet."
 
 #: src/components/stats/BacklogEstimate.tsx
 msgid "not estimated yet"
@@ -3749,6 +3904,10 @@ msgstr "Note saved — syncs to your devices"
 #: src/pages/HighlightsPage.tsx
 msgid "Note: {note}"
 msgstr "Note: {note}"
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Nothing finished in this range."
+msgstr "Nothing finished in this range."
 
 #: src/pages/SharePage.tsx
 msgid "Nothing here yet."
@@ -4309,9 +4468,21 @@ msgstr "Reading Pace"
 msgid "Reading Speed"
 msgstr "Reading Speed"
 
+#: src/components/stats/widgets/habits.tsx
+msgid "Reading speed down {down}%"
+msgstr "Reading speed down {down}%"
+
+#: src/components/stats/widgets/habits.tsx
+msgid "Reading speed steady"
+msgstr "Reading speed steady"
+
 #: src/pages/StatsPage.tsx
 msgid "Reading Speed Trend"
 msgstr "Reading Speed Trend"
+
+#: src/components/stats/widgets/habits.tsx
+msgid "Reading speed up {up}%"
+msgstr "Reading speed up {up}%"
 
 #: src/components/CommandPalette.tsx
 #: src/components/SeriesReadingStats.tsx
@@ -4528,6 +4699,10 @@ msgstr "Roles guide"
 msgid "Sa"
 msgstr "Sa"
 
+#: src/components/stats/widgets/habits.tsx
+msgid "Same as previous period"
+msgstr "Same as previous period"
+
 #: src/pages/AdminPage.tsx
 msgid "Same ISBN"
 msgstr "Same ISBN"
@@ -4537,6 +4712,7 @@ msgid "Same Series Volume"
 msgstr "Same Series Volume"
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Sat"
 msgstr "Sat"
 
@@ -4983,6 +5159,10 @@ msgstr "Show less"
 msgid "Show more"
 msgstr "Show more"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Show more ({left} remaining)"
+msgstr "Show more ({left} remaining)"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
 msgstr "Show this help"
@@ -5104,6 +5284,10 @@ msgstr "Start matching this book again"
 msgid "Start reading and your progress will show up here"
 msgstr "Start reading and your progress will show up here"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Start reading one and it'll show up here"
+msgstr "Start reading one and it'll show up here"
+
 #: src/pages/StatsPage.tsx
 msgid "Started vs finished ratio"
 msgstr "Started vs finished ratio"
@@ -5141,7 +5325,12 @@ msgstr "Su"
 msgid "Subtitle (optional)"
 msgstr "Subtitle (optional)"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Suggested: {dur}"
+msgstr "Suggested: {dur}"
+
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Sun"
 msgstr "Sun"
 
@@ -5241,6 +5430,10 @@ msgstr "The book type's own library is always added automatically."
 msgid "the sync password set above"
 msgstr "the sync password set above"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "The triangle marks an implausibly long session. Scissors shorten a session, the bin deletes it."
+msgstr "The triangle marks an implausibly long session. Scissors shorten a session, the bin deletes it."
+
 #: src/components/Sidebar.tsx
 #: src/components/ThemeToggle.tsx
 msgid "Theme"
@@ -5282,6 +5475,10 @@ msgstr "This page is yours — every tile can be moved, resized, swapped or remo
 msgid "This period vs the last"
 msgstr "This period vs the last"
 
+#: src/components/stats/widgets/habits.tsx
+msgid "This period: <0>{cur}</0>"
+msgstr "This period: <0>{cur}</0>"
+
 #: src/pages/DashboardPage.tsx
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
 msgstr "This permanently removes the selected books and their files from disk. This cannot be undone."
@@ -5295,6 +5492,7 @@ msgid "this week"
 msgstr "this week"
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Thu"
 msgstr "Thu"
 
@@ -5374,6 +5572,10 @@ msgstr "Toggle metadata edit"
 msgid "Toggle only-notes filter"
 msgstr "Toggle only-notes filter"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Toggle sort order"
+msgstr "Toggle sort order"
+
 #: src/components/ThemeToggle.tsx
 msgid "Toggle theme"
 msgstr "Toggle theme"
@@ -5419,6 +5621,14 @@ msgstr "Total: {total}"
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "Translations are community-maintained. Anything not yet translated is shown in English."
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Trim"
+msgstr "Trim"
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Trimming only shortens this session's length and end time — page turns, progress and every other session stay untouched, and the previous duration is kept in the audit log. The suggestion re-prices this session's page turns at your usual reading pace."
+msgstr "Trimming only shortens this session's length and end time — page turns, progress and every other session stay untouched, and the previous duration is kept in the audit log. The suggestion re-prices this session's page turns at your usual reading pace."
+
 #: src/pages/DashboardPage.tsx
 msgid "Try adjusting your filters"
 msgstr "Try adjusting your filters"
@@ -5436,6 +5646,7 @@ msgid "Tu"
 msgstr "Tu"
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Tue"
 msgstr "Tue"
 
@@ -5503,6 +5714,10 @@ msgstr "Unreadable file"
 #: src/pages/DashboardPage.tsx
 msgid "Unserialized"
 msgstr "Unserialized"
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Unusually long session"
+msgstr "Unusually long session"
 
 #: src/pages/SettingsPage.tsx
 msgid "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
@@ -5702,6 +5917,7 @@ msgid "Web reader"
 msgstr "Web reader"
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Wed"
 msgstr "Wed"
 
@@ -5878,6 +6094,10 @@ msgstr "Your library is empty"
 #: src/pages/HighlightsPage.tsx
 msgid "Your note — syncs back to KOReader on the next sync"
 msgstr "Your note — syncs back to KOReader on the next sync"
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Your page turns at your usual reading pace"
+msgstr "Your page turns at your usual reading pace"
 
 #: src/pages/StatsPage.tsx
 msgid "Your ratings over time"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -335,6 +335,10 @@ msgstr "{failed, plural, one {# book could not be deleted} other {# books could 
 msgid "{failedN} of {totalN} failed — {firstErr}"
 msgstr "{failedN} of {totalN} failed — {firstErr}"
 
+#: src/pages/StatsPage.tsx
+msgid "{fin} of {st} started"
+msgstr "{fin} of {st} started"
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h"
@@ -418,6 +422,10 @@ msgstr "{n} selected — Clear"
 msgid "{name} · Vol. {start_index}–{end_index}"
 msgstr "{name} · Vol. {start_index}–{end_index}"
 
+#: src/pages/StatsPage.tsx
+msgid "{name} copy"
+msgstr "{name} copy"
+
 #: src/pages/AdminPage.tsx
 msgid "{othersCount, plural, one {Delete # other} other {Delete # others}}"
 msgstr "{othersCount, plural, one {Delete # other} other {Delete # others}}"
@@ -495,6 +503,50 @@ msgstr "~{at}% in · {dur}"
 msgid "~{at}% in · not read"
 msgstr "~{at}% in · not read"
 
+#: src/pages/StatsPage.tsx
+msgid "12 mo"
+msgstr "12 mo"
+
+#: src/pages/StatsPage.tsx
+msgid "14d"
+msgstr "14d"
+
+#: src/pages/StatsPage.tsx
+msgid "1y"
+msgstr "1y"
+
+#: src/pages/StatsPage.tsx
+msgid "24 mo"
+msgstr "24 mo"
+
+#: src/pages/StatsPage.tsx
+msgid "30d"
+msgstr "30d"
+
+#: src/pages/StatsPage.tsx
+msgid "365 d"
+msgstr "365 d"
+
+#: src/pages/StatsPage.tsx
+msgid "7d"
+msgstr "7d"
+
+#: src/pages/StatsPage.tsx
+msgid "90d"
+msgstr "90d"
+
+#: src/pages/StatsPage.tsx
+msgid "A 24-hour radial of when you read"
+msgstr "A 24-hour radial of when you read"
+
+#: src/pages/StatsPage.tsx
+msgid "A bit"
+msgstr "A bit"
+
+#: src/pages/StatsPage.tsx
+msgid "A lot"
+msgstr "A lot"
+
 #: src/pages/SettingsPage.tsx
 msgid "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
 msgstr "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
@@ -506,6 +558,10 @@ msgstr "A sync is already running"
 #: src/pages/DashboardPage.tsx
 msgid "A while ago"
 msgstr "A while ago"
+
+#: src/pages/StatsPage.tsx
+msgid "A year of reading, heatmap"
+msgstr "A year of reading, heatmap"
 
 #: src/pages/SettingsPage.tsx
 msgid "About"
@@ -557,9 +613,17 @@ msgstr "Add a note"
 msgid "Add a review"
 msgstr "Add a review"
 
+#: src/pages/StatsPage.tsx
+msgid "Add a widget"
+msgstr "Add a widget"
+
 #: src/pages/WishlistPage.tsx
 msgid "Add a wish"
 msgstr "Add a wish"
+
+#: src/pages/StatsPage.tsx
+msgid "Add board"
+msgstr "Add board"
 
 #: src/pages/WishlistPage.tsx
 msgid "Add books you'd like to see in the library."
@@ -581,6 +645,10 @@ msgstr "Add Tags"
 #: src/pages/SettingsPage.tsx
 msgid "Add Theme"
 msgstr "Add Theme"
+
+#: src/pages/StatsPage.tsx
+msgid "Add tile"
+msgstr "Add tile"
 
 #: src/pages/BinderyPage.tsx
 msgid "Add to libraries…"
@@ -627,8 +695,13 @@ msgstr "Admin"
 msgid "Admin access required."
 msgstr "Admin access required."
 
+#: src/pages/StatsPage.tsx
+msgid "all"
+msgstr "all"
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/HardcoverPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "All"
 msgstr "All"
 
@@ -652,6 +725,10 @@ msgstr "All books"
 msgid "All Books"
 msgstr "All Books"
 
+#: src/pages/StatsPage.tsx
+msgid "All Books by Reading Time"
+msgstr "All Books by Reading Time"
+
 #: src/pages/AdminPage.tsx
 msgid "All Devices"
 msgstr "All Devices"
@@ -672,6 +749,14 @@ msgstr "All readers: {dur} · {days} · {readers}"
 #: src/pages/SettingsPage.tsx
 msgid "All users"
 msgstr "All users"
+
+#: src/pages/StatsPage.tsx
+msgid "All your reading goals — rings fill as you read, managed in place"
+msgstr "All your reading goals — rings fill as you read, managed in place"
+
+#: src/pages/StatsPage.tsx
+msgid "All-time hours, pages, books, streak"
+msgstr "All-time hours, pages, books, streak"
 
 #: src/components/Sidebar.tsx
 msgid "Amber"
@@ -697,6 +782,10 @@ msgstr "App-specific PINs"
 msgid "Appearance"
 msgstr "Appearance"
 
+#: src/pages/StatsPage.tsx
+msgid "Apply"
+msgstr "Apply"
+
 #: src/pages/AdminPage.tsx
 msgid "Apply All ({n})"
 msgstr "Apply All ({n})"
@@ -708,6 +797,10 @@ msgstr "Apply to all"
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
 msgstr "Applying {done}/{total}…"
+
+#: src/pages/StatsPage.tsx
+msgid "Are you getting faster?"
+msgstr "Are you getting faster?"
 
 #: src/pages/SettingsPage.tsx
 msgid "Ask your server admin if you don't manage the Tome installation yourself."
@@ -759,9 +852,33 @@ msgstr "Authorize this code from another device"
 msgid "Authorizing..."
 msgstr "Authorizing..."
 
+#: src/pages/StatsPage.tsx
+msgid "Auto"
+msgstr "Auto"
+
+#: src/pages/StatsPage.tsx
+msgid "Auto-fit height"
+msgstr "Auto-fit height"
+
+#: src/pages/StatsPage.tsx
+msgid "average pace"
+msgstr "average pace"
+
+#: src/pages/StatsPage.tsx
+msgid "Average rating per book type"
+msgstr "Average rating per book type"
+
+#: src/pages/StatsPage.tsx
+msgid "avg {avg}"
+msgstr "avg {avg}"
+
 #: src/pages/BookDetailPage.tsx
 msgid "avg session"
 msgstr "avg session"
+
+#: src/pages/StatsPage.tsx
+msgid "Avg Session"
+msgstr "Avg Session"
 
 #: src/pages/BinderyPage.tsx
 msgid "Back to list"
@@ -771,6 +888,10 @@ msgstr "Back to list"
 msgid "Backup"
 msgstr "Backup"
 
+#: src/pages/StatsPage.tsx
+msgid "Best Day"
+msgstr "Best Day"
+
 #: src/pages/BinderyPage.tsx
 msgid "Best match applied to {matched} of {totalN} files — no match for the rest"
 msgstr "Best match applied to {matched} of {totalN} files — no match for the rest"
@@ -778,6 +899,10 @@ msgstr "Best match applied to {matched} of {totalN} files — no match for the r
 #: src/pages/BinderyPage.tsx
 msgid "Best match applied to all {matched} files"
 msgstr "Best match applied to all {matched} files"
+
+#: src/pages/StatsPage.tsx
+msgid "Best-Rated Series"
+msgstr "Best-Rated Series"
 
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
@@ -812,6 +937,10 @@ msgstr "Book deleted"
 msgid "Book Detail"
 msgstr "Book Detail"
 
+#: src/pages/StatsPage.tsx
+msgid "Book Length"
+msgstr "Book Length"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Book not found"
 msgstr "Book not found"
@@ -841,9 +970,29 @@ msgstr "Book Types"
 msgid "Books"
 msgstr "Books"
 
+#: src/pages/StatsPage.tsx
+msgid "Books completed"
+msgstr "Books completed"
+
 #: src/pages/SettingsPage.tsx
 msgid "Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately."
 msgstr "Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately."
+
+#: src/pages/StatsPage.tsx
+msgid "Books Finished"
+msgstr "Books Finished"
+
+#: src/pages/StatsPage.tsx
+msgid "Books in progress, with covers"
+msgstr "Books in progress, with covers"
+
+#: src/pages/StatsPage.tsx
+msgid "Books Started"
+msgstr "Books Started"
+
+#: src/pages/StatsPage.tsx
+msgid "Books whose pages you revisit"
+msgstr "Books whose pages you revisit"
 
 #: src/pages/DashboardPage.tsx
 msgid "Books without a series"
@@ -867,6 +1016,14 @@ msgstr "Browse your library"
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
 msgstr "Cancel"
+
+#: src/pages/StatsPage.tsx
+msgid "Category Breakdown"
+msgstr "Category Breakdown"
+
+#: src/pages/StatsPage.tsx
+msgid "Category mix over the year"
+msgstr "Category mix over the year"
 
 #: src/pages/BookDetailPage.tsx
 msgid "ch. {n}"
@@ -893,12 +1050,17 @@ msgstr "Chapter"
 msgid "Chapters"
 msgstr "Chapters"
 
+#: src/pages/StatsPage.tsx
+msgid "Chart type"
+msgstr "Chart type"
+
 #: src/components/Sidebar.tsx
 msgid "Choose icon"
 msgstr "Choose icon"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Clear"
 msgstr "Clear"
 
@@ -942,6 +1104,7 @@ msgstr "Click for details"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Close"
 msgstr "Close"
 
@@ -1008,6 +1171,18 @@ msgstr "Complete"
 #: src/pages/AdminPage.tsx
 msgid "Complete series: {title}"
 msgstr "Complete series: {title}"
+
+#: src/pages/StatsPage.tsx
+msgid "Completion"
+msgstr "Completion"
+
+#: src/pages/StatsPage.tsx
+msgid "Completion Estimates"
+msgstr "Completion Estimates"
+
+#: src/pages/StatsPage.tsx
+msgid "Configure"
+msgstr "Configure"
 
 #: src/pages/AdminPage.tsx
 msgid "Configured"
@@ -1083,6 +1258,10 @@ msgstr "Could not start SSO linking."
 msgid "Could not start sync"
 msgstr "Could not start sync"
 
+#: src/pages/StatsPage.tsx
+msgid "Couldn’t load stats."
+msgstr "Couldn’t load stats."
+
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr "Cover"
@@ -1124,9 +1303,41 @@ msgstr "Created"
 msgid "Creating..."
 msgstr "Creating..."
 
+#: src/pages/StatsPage.tsx
+msgid "Cumulative Books Added — Last 24 Months"
+msgstr "Cumulative Books Added — Last 24 Months"
+
+#: src/pages/StatsPage.tsx
+msgid "Cumulative finishes over time"
+msgstr "Cumulative finishes over time"
+
+#: src/pages/StatsPage.tsx
+msgid "current"
+msgstr "current"
+
+#: src/pages/StatsPage.tsx
+msgid "Current & longest daily streak"
+msgstr "Current & longest daily streak"
+
 #: src/pages/SettingsPage.tsx
 msgid "Current password"
 msgstr "Current password"
+
+#: src/pages/StatsPage.tsx
+msgid "Currently Reading"
+msgstr "Currently Reading"
+
+#: src/pages/StatsPage.tsx
+msgid "Custom"
+msgstr "Custom"
+
+#: src/pages/StatsPage.tsx
+msgid "Custom Stat"
+msgstr "Custom Stat"
+
+#: src/pages/StatsPage.tsx
+msgid "Daily sessions on a 24h track"
+msgstr "Daily sessions on a 24h track"
 
 #: src/pages/AdminPage.tsx
 msgid "Danger Zone"
@@ -1174,9 +1385,17 @@ msgstr "Delete"
 msgid "Delete \"{title}\"?"
 msgstr "Delete \"{title}\"?"
 
+#: src/pages/StatsPage.tsx
+msgid "Delete {name}"
+msgstr "Delete {name}"
+
 #: src/pages/AdminPage.tsx
 msgid "Delete all {count} cached cover files ({mb} MB). Covers will be re-extracted on next access."
 msgstr "Delete all {count} cached cover files ({mb} MB). Covers will be re-extracted on next access."
+
+#: src/pages/StatsPage.tsx
+msgid "Delete board"
+msgstr "Delete board"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -1196,6 +1415,10 @@ msgstr "Delete this book from the library? The file will be removed and this can
 #: src/pages/HighlightsPage.tsx
 msgid "Delete this highlight"
 msgstr "Delete this highlight"
+
+#: src/pages/StatsPage.tsx
+msgid "Deleted board “{name}”"
+msgstr "Deleted board “{name}”"
 
 #: src/pages/BinderyPage.tsx
 msgid "Deleting..."
@@ -1247,6 +1470,7 @@ msgstr "Directories"
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Dismiss"
 msgstr "Dismiss"
 
@@ -1262,12 +1486,17 @@ msgstr "Dismiss wish"
 msgid "Dismissed"
 msgstr "Dismissed"
 
+#: src/pages/StatsPage.tsx
+msgid "Do you rate books you spend longer on higher?"
+msgstr "Do you rate books you spend longer on higher?"
+
 #: src/components/Sidebar.tsx
 msgid "Docs"
 msgstr "Docs"
 
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Done"
 msgstr "Done"
 
@@ -1300,6 +1529,10 @@ msgstr "Download plugin ZIP"
 msgid "Download the plugin"
 msgstr "Download the plugin"
 
+#: src/pages/StatsPage.tsx
+msgid "Download the plugin from Settings"
+msgstr "Download the plugin from Settings"
+
 #: src/pages/SettingsPage.tsx
 msgid "Download your entire library catalog — all titles, authors, series, tags and formats."
 msgstr "Download your entire library catalog — all titles, authors, series, tags and formats."
@@ -1316,9 +1549,21 @@ msgstr "Downloaded {n} highlights"
 msgid "Drop files in the incoming folder to get started"
 msgstr "Drop files in the incoming folder to get started"
 
+#: src/pages/StatsPage.tsx
+msgid "Duplicate “{name}”"
+msgstr "Duplicate “{name}”"
+
+#: src/pages/StatsPage.tsx
+msgid "Duplicate {title}"
+msgstr "Duplicate {title}"
+
 #: src/pages/AdminPage.tsx
 msgid "Duplicate Detection"
 msgstr "Duplicate Detection"
+
+#: src/pages/StatsPage.tsx
+msgid "Duplicate tile"
+msgstr "Duplicate tile"
 
 #: src/pages/AdminPage.tsx
 msgid "Duplicates"
@@ -1351,6 +1596,7 @@ msgstr "e.g. scribe-laptop"
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Edit"
 msgstr "Edit"
 
@@ -1397,6 +1643,14 @@ msgstr "Email delivery is not set up yet."
 msgid "Ember"
 msgstr "Ember"
 
+#: src/pages/StatsPage.tsx
+msgid "Empty board"
+msgstr "Empty board"
+
+#: src/pages/StatsPage.tsx
+msgid "EPUB vs CBZ time split"
+msgstr "EPUB vs CBZ time split"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Error"
 msgstr "Error"
@@ -1408,6 +1662,14 @@ msgstr "Errors"
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
 msgstr "Est. remaining"
+
+#: src/pages/StatsPage.tsx
+msgid "Every session — paginated, deletable"
+msgstr "Every session — paginated, deletable"
+
+#: src/pages/StatsPage.tsx
+msgid "Every widget is already on this board."
+msgstr "Every widget is already on this board."
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Everywhere"
@@ -1455,6 +1717,7 @@ msgstr "Expires in {timeLeft}"
 
 #: src/pages/HighlightsPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Export"
 msgstr "Export"
 
@@ -1465,6 +1728,10 @@ msgstr "Export {label}"
 #: src/pages/HighlightsPage.tsx
 msgid "Export failed"
 msgstr "Export failed"
+
+#: src/pages/StatsPage.tsx
+msgid "Export this board as a JSON file (share or back up)"
+msgstr "Export this board as a JSON file (share or back up)"
 
 #: src/pages/SettingsPage.tsx
 msgid "Exporting..."
@@ -1632,12 +1899,21 @@ msgstr "Filter…"
 msgid "Filters"
 msgstr "Filters"
 
+#: src/pages/StatsPage.tsx
+msgid "Finish rate by book type"
+msgstr "Finish rate by book type"
+
+#: src/pages/StatsPage.tsx
+msgid "Finish Rate per Book Category"
+msgstr "Finish Rate per Book Category"
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "finished"
 msgstr "finished"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Finished"
 msgstr "Finished"
 
@@ -1678,6 +1954,10 @@ msgstr "Format"
 #: src/pages/DashboardPage.tsx
 msgid "Format: {filterFormatUpper}"
 msgstr "Format: {filterFormatUpper}"
+
+#: src/pages/StatsPage.tsx
+msgid "Fr"
+msgstr "Fr"
 
 #: src/pages/AdminPage.tsx
 msgid "From"
@@ -1748,6 +2028,10 @@ msgstr "Group volumes by series"
 msgid "Guest"
 msgstr "Guest"
 
+#: src/pages/StatsPage.tsx
+msgid "Habits"
+msgstr "Habits"
+
 #: src/components/Sidebar.tsx
 msgid "Hardcover"
 msgstr "Hardcover"
@@ -1755,6 +2039,10 @@ msgstr "Hardcover"
 #: src/pages/HardcoverPage.tsx
 msgid "Hardcover sync is disabled on this server."
 msgstr "Hardcover sync is disabled on this server."
+
+#: src/pages/StatsPage.tsx
+msgid "Height auto-fits the content — only width is resizable"
+msgstr "Height auto-fits the content — only width is resizable"
 
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
@@ -1764,6 +2052,10 @@ msgstr "hiatus"
 #: src/pages/BookDetailPage.tsx
 msgid "Hide details"
 msgstr "Hide details"
+
+#: src/pages/StatsPage.tsx
+msgid "Highest & Lowest Rated"
+msgstr "Highest & Lowest Rated"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
@@ -1792,6 +2084,10 @@ msgstr "Highlights and notes you make in KOReader sync here automatically. Highl
 msgid "Highlights you made on this day in past years"
 msgstr "Highlights you made on this day in past years"
 
+#: src/pages/StatsPage.tsx
+msgid "Hit Edit, then Add tile."
+msgstr "Hit Edit, then Add tile."
+
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Home"
@@ -1801,9 +2097,25 @@ msgstr "Home"
 msgid "Host"
 msgstr "Host"
 
+#: src/pages/StatsPage.tsx
+msgid "Hours & finishes, last 12 months"
+msgstr "Hours & finishes, last 12 months"
+
+#: src/pages/StatsPage.tsx
+msgid "How far through each series"
+msgstr "How far through each series"
+
 #: src/pages/BookDetailPage.tsx
 msgid "How far through the book you'd read by each date."
 msgstr "How far through the book you'd read by each date."
+
+#: src/pages/StatsPage.tsx
+msgid "How long the books you finish are"
+msgstr "How long the books you finish are"
+
+#: src/pages/StatsPage.tsx
+msgid "How much of what you own you’ve read"
+msgstr "How much of what you own you’ve read"
 
 #: src/pages/LoginPage.tsx
 msgid "How to authorize"
@@ -1813,6 +2125,10 @@ msgstr "How to authorize"
 msgid "How to set it up"
 msgstr "How to set it up"
 
+#: src/pages/StatsPage.tsx
+msgid "How you spread your 1–5 stars"
+msgstr "How you spread your 1–5 stars"
+
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 msgid "Icon"
@@ -1821,6 +2137,10 @@ msgstr "Icon"
 #: src/pages/AdminPage.tsx
 msgid "Impersonation failed"
 msgstr "Impersonation failed"
+
+#: src/pages/StatsPage.tsx
+msgid "Import board…"
+msgstr "Import board…"
 
 #: src/pages/AdminPage.tsx
 msgid "Import complete"
@@ -1837,6 +2157,10 @@ msgstr "Import Now"
 #: src/pages/SettingsPage.tsx
 msgid "Import reading history"
 msgstr "Import reading history"
+
+#: src/pages/StatsPage.tsx
+msgid "Imported board"
+msgstr "Imported board"
 
 #: src/pages/BinderyPage.tsx
 msgid "Importing..."
@@ -1955,6 +2279,10 @@ msgstr "Last Synced"
 msgid "Last used"
 msgstr "Last used"
 
+#: src/pages/StatsPage.tsx
+msgid "Latest finishes, newest first"
+msgstr "Latest finishes, newest first"
+
 #: src/pages/WishlistPage.tsx
 msgid "Latest: vol {v}"
 msgstr "Latest: vol {v}"
@@ -1988,12 +2316,33 @@ msgstr "Libraries applied to {n} files"
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Library"
 msgstr "Library"
+
+#: src/pages/StatsPage.tsx
+msgid "Library Completion"
+msgstr "Library Completion"
+
+#: src/pages/StatsPage.tsx
+msgid "Library size over time"
+msgstr "Library size over time"
 
 #: src/pages/DashboardPage.tsx
 msgid "Library: {filterLibraryChipName}"
 msgstr "Library: {filterLibraryChipName}"
+
+#: src/pages/StatsPage.tsx
+msgid "lifetime"
+msgstr "lifetime"
+
+#: src/pages/StatsPage.tsx
+msgid "Lifetime Totals"
+msgstr "Lifetime Totals"
+
+#: src/pages/StatsPage.tsx
+msgid "Lifetime words read, by year"
+msgstr "Lifetime words read, by year"
 
 #: src/components/Sidebar.tsx
 msgid "Light"
@@ -2072,6 +2421,22 @@ msgstr "Login failed"
 #: src/pages/SettingsPage.tsx
 msgid "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
 msgstr "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
+
+#: src/pages/StatsPage.tsx
+msgid "Longest Session"
+msgstr "Longest Session"
+
+#: src/pages/StatsPage.tsx
+msgid "Longest session, biggest day, most pages"
+msgstr "Longest session, biggest day, most pages"
+
+#: src/pages/StatsPage.tsx
+msgid "Longest Streak"
+msgstr "Longest Streak"
+
+#: src/pages/StatsPage.tsx
+msgid "Longest: {d}d"
+msgstr "Longest: {d}d"
 
 #: src/pages/DashboardPage.tsx
 msgid "Manage"
@@ -2158,6 +2523,10 @@ msgstr "Metadata saved"
 msgid "Metadata Suggestions"
 msgstr "Metadata Suggestions"
 
+#: src/pages/StatsPage.tsx
+msgid "Metric"
+msgstr "Metric"
+
 #: src/pages/SetupPage.tsx
 msgid "Minimum 8 characters"
 msgstr "Minimum 8 characters"
@@ -2166,6 +2535,10 @@ msgstr "Minimum 8 characters"
 msgid "Minutes"
 msgstr "Minutes"
 
+#: src/pages/StatsPage.tsx
+msgid "Minutes read per day"
+msgstr "Minutes read per day"
+
 #: src/pages/DashboardPage.tsx
 msgid "Missing"
 msgstr "Missing"
@@ -2173,6 +2546,22 @@ msgstr "Missing"
 #: src/pages/DashboardPage.tsx
 msgid "Missing: {filterMissingLabel}"
 msgstr "Missing: {filterMissingLabel}"
+
+#: src/pages/StatsPage.tsx
+msgid "Mo"
+msgstr "Mo"
+
+#: src/pages/StatsPage.tsx
+msgid "Morning vs evening reader?"
+msgstr "Morning vs evening reader?"
+
+#: src/pages/StatsPage.tsx
+msgid "Most-read authors"
+msgstr "Most-read authors"
+
+#: src/pages/StatsPage.tsx
+msgid "Most-read books by time"
+msgstr "Most-read books by time"
 
 #: src/pages/SettingsPage.tsx
 msgid "Must be exactly 10 comma-separated hex values (e.g. #1E1E2E)"
@@ -2218,6 +2607,10 @@ msgstr "Never sync this book"
 msgid "never used"
 msgstr "never used"
 
+#: src/pages/StatsPage.tsx
+msgid "New board"
+msgstr "New board"
+
 #: src/pages/SettingsPage.tsx
 msgid "New key"
 msgstr "New key"
@@ -2262,6 +2655,10 @@ msgstr "Next"
 msgid "Next book"
 msgstr "Next book"
 
+#: src/pages/StatsPage.tsx
+msgid "Next month"
+msgstr "Next month"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next page"
 msgstr "Next page"
@@ -2293,6 +2690,10 @@ msgstr "No books have been sent yet."
 #: src/pages/HardcoverPage.tsx
 msgid "No books in this view."
 msgstr "No books in this view."
+
+#: src/pages/StatsPage.tsx
+msgid "No comparison data."
+msgstr "No comparison data."
 
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
@@ -2370,9 +2771,21 @@ msgstr "No PINs yet. Generate one to use with OPDS clients."
 msgid "No reading activity yet. Records appear when users start reading books."
 msgstr "No reading activity yet. Records appear when users start reading books."
 
+#: src/pages/StatsPage.tsx
+msgid "No reading data yet"
+msgstr "No reading data yet"
+
 #: src/pages/BookDetailPage.tsx
 msgid "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
 msgstr "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
+
+#: src/pages/StatsPage.tsx
+msgid "No reading sessions in this range — session-based tiles will be empty."
+msgstr "No reading sessions in this range — session-based tiles will be empty."
+
+#: src/pages/StatsPage.tsx
+msgid "no reading yet"
+msgstr "no reading yet"
 
 #: src/pages/HardcoverPage.tsx
 msgid "No results — try a different query."
@@ -2393,6 +2806,14 @@ msgstr "No Series"
 #: src/pages/DashboardPage.tsx
 msgid "No series found — add series metadata to your books."
 msgstr "No series found — add series metadata to your books."
+
+#: src/pages/StatsPage.tsx
+msgid "No series with reading progress yet."
+msgstr "No series with reading progress yet."
+
+#: src/pages/StatsPage.tsx
+msgid "no sessions yet"
+msgstr "no sessions yet"
 
 #: src/pages/AdminPage.tsx
 msgid "No suggested match yet — search for the book to link, or upload it first."
@@ -2415,14 +2836,27 @@ msgstr "No type (staging / admin only)"
 msgid "No users have added devices yet."
 msgstr "No users have added devices yet."
 
+#: src/pages/StatsPage.tsx
+msgid "No widgets match “{q}”."
+msgstr "No widgets match “{q}”."
+
+#: src/pages/StatsPage.tsx
+msgid "No widgets on this board yet."
+msgstr "No widgets on this board yet."
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "None"
 msgstr "None"
 
 #: src/pages/AdminPage.tsx
 msgid "Not configured"
 msgstr "Not configured"
+
+#: src/pages/StatsPage.tsx
+msgid "Not enough reading history yet."
+msgstr "Not enough reading history yet."
 
 #: src/pages/SharePage.tsx
 msgid "Not found"
@@ -2431,6 +2865,10 @@ msgstr "Not found"
 #: src/pages/HardcoverPage.tsx
 msgid "Not matched"
 msgstr "Not matched"
+
+#: src/pages/StatsPage.tsx
+msgid "Not on board"
+msgstr "Not on board"
 
 #: src/pages/BookDetailPage.tsx
 msgid "not read"
@@ -2483,6 +2921,10 @@ msgstr "Nothing matched “{search}”"
 msgid "Notifications"
 msgstr "Notifications"
 
+#: src/pages/StatsPage.tsx
+msgid "Number of reading sessions"
+msgstr "Number of reading sessions"
+
 #: src/pages/BookDetailPage.tsx
 msgid "of {totalPages} pages"
 msgstr "of {totalPages} pages"
@@ -2491,10 +2933,22 @@ msgstr "of {totalPages} pages"
 msgid "On a device where you're already signed in, go to <0>Settings → Security → Quick Connect</0> and enter this code."
 msgstr "On a device where you're already signed in, go to <0>Settings → Security → Quick Connect</0> and enter this code."
 
+#: src/pages/StatsPage.tsx
+msgid "on board"
+msgstr "on board"
+
+#: src/pages/StatsPage.tsx
+msgid "On board"
+msgstr "On board"
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "On this day"
 msgstr "On this day"
+
+#: src/pages/StatsPage.tsx
+msgid "One series front and center — you pick which"
+msgstr "One series front and center — you pick which"
 
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
@@ -2554,6 +3008,14 @@ msgstr "Other providers"
 msgid "Other volumes"
 msgstr "Other volumes"
 
+#: src/pages/StatsPage.tsx
+msgid "over {days} days"
+msgstr "over {days} days"
+
+#: src/pages/StatsPage.tsx
+msgid "Overview"
+msgstr "Overview"
+
 #: src/pages/SettingsPage.tsx
 msgid "Owner"
 msgstr "Owner"
@@ -2562,6 +3024,14 @@ msgstr "Owner"
 msgid "pace"
 msgstr "pace"
 
+#: src/pages/StatsPage.tsx
+msgid "Pace by Format"
+msgstr "Pace by Format"
+
+#: src/pages/StatsPage.tsx
+msgid "Padding"
+msgstr "Padding"
+
 #: src/pages/BookDetailPage.tsx
 msgid "pages"
 msgstr "pages"
@@ -2569,6 +3039,22 @@ msgstr "pages"
 #: src/pages/DashboardPage.tsx
 msgid "Pages · 30d"
 msgstr "Pages · 30d"
+
+#: src/pages/StatsPage.tsx
+msgid "Pages / Day"
+msgstr "Pages / Day"
+
+#: src/pages/StatsPage.tsx
+msgid "Pages / Hour"
+msgstr "Pages / Hour"
+
+#: src/pages/StatsPage.tsx
+msgid "Pages per minute over time"
+msgstr "Pages per minute over time"
+
+#: src/pages/StatsPage.tsx
+msgid "Pages Turned"
+msgstr "Pages Turned"
 
 #: src/pages/AdminPage.tsx
 msgid "password"
@@ -2599,9 +3085,21 @@ msgstr "Passwords do not match"
 msgid "Per-file details"
 msgstr "Per-file details"
 
+#: src/pages/StatsPage.tsx
+msgid "Period Comparison"
+msgstr "Period Comparison"
+
+#: src/pages/StatsPage.tsx
+msgid "Personal Records"
+msgstr "Personal Records"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Pick"
 msgstr "Pick"
+
+#: src/pages/StatsPage.tsx
+msgid "Pick a start & end"
+msgstr "Pick a start & end"
 
 #: src/pages/DashboardPage.tsx
 msgid "Pick up where you left off"
@@ -2610,6 +3108,10 @@ msgstr "Pick up where you left off"
 #: src/pages/AdminPage.tsx
 msgid "Pick which book to keep and an action per group — Merge, Delete Others, or Dismiss — then apply everything at once."
 msgstr "Pick which book to keep and an action per group — Merge, Delete Others, or Dismiss — then apply everything at once."
+
+#: src/pages/StatsPage.tsx
+msgid "Pick your own metric — avg session, pages/day, best day…"
+msgstr "Pick your own metric — avg session, pages/day, best day…"
 
 #: src/pages/SettingsPage.tsx
 msgid "PIN created — copy it now, it won't be shown again."
@@ -2650,6 +3152,10 @@ msgstr "Previous"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Previous book"
 msgstr "Previous book"
+
+#: src/pages/StatsPage.tsx
+msgid "Previous month"
+msgstr "Previous month"
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Previous page"
@@ -2718,6 +3224,14 @@ msgstr "Quick Accept: {done}/{total} done"
 msgid "Quick Connect"
 msgstr "Quick Connect"
 
+#: src/pages/StatsPage.tsx
+msgid "Range"
+msgstr "Range"
+
+#: src/pages/StatsPage.tsx
+msgid "Range follows the page's range picker; days show the newest slice of it."
+msgstr "Range follows the page's range picker; days show the newest slice of it."
+
 #: src/pages/BookDetailPage.tsx
 msgid "Rate this book"
 msgstr "Rate this book"
@@ -2742,9 +3256,25 @@ msgstr "Rated: 5 stars"
 msgid "Rating"
 msgstr "Rating"
 
+#: src/pages/StatsPage.tsx
+msgid "Rating Distribution"
+msgstr "Rating Distribution"
+
+#: src/pages/StatsPage.tsx
+msgid "Rating Trend"
+msgstr "Rating Trend"
+
+#: src/pages/StatsPage.tsx
+msgid "Rating vs Time Spent"
+msgstr "Rating vs Time Spent"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Re-match"
 msgstr "Re-match"
+
+#: src/pages/StatsPage.tsx
+msgid "Re-reads"
+msgstr "Re-reads"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -2800,28 +3330,102 @@ msgstr "reading"
 msgid "Reading"
 msgstr "Reading"
 
+#: src/pages/StatsPage.tsx
+msgid "Reading Activity — Last 365 Days"
+msgstr "Reading Activity — Last 365 Days"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading by Category — Last 12 Months"
+msgstr "Reading by Category — Last 12 Months"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading by Language"
+msgstr "Reading by Language"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading by Weekday"
+msgstr "Reading by Weekday"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Clock"
+msgstr "Reading Clock"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Reading days"
 msgstr "Reading days"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading DNA"
+msgstr "Reading DNA"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Goals"
+msgstr "Reading Goals"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Hours & Books Finished — Last 12 Months"
+msgstr "Reading Hours & Books Finished — Last 12 Months"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Reading intensity"
 msgstr "Reading intensity"
 
+#: src/pages/StatsPage.tsx
+msgid "Reading Intensity by Hour and Day"
+msgstr "Reading Intensity by Hour and Day"
+
 #: src/pages/DashboardPage.tsx
 msgid "Reading Log"
 msgstr "Reading Log"
 
+#: src/pages/StatsPage.tsx
+msgid "Reading Pace"
+msgstr "Reading Pace"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Speed"
+msgstr "Reading Speed"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Speed Trend"
+msgstr "Reading Speed Trend"
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/SetupPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Reading Stats"
 msgstr "Reading Stats"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading stats appear once sessions arrive — synced from the TomeSync KOReader plugin, logged by hand on a book page, or imported from a KOReader statistics file."
+msgstr "Reading stats appear once sessions arrive — synced from the TomeSync KOReader plugin, logged by hand on a book page, or imported from a KOReader statistics file."
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Time"
+msgstr "Reading Time"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Time per Day"
+msgstr "Reading Time per Day"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading time split by language"
+msgstr "Reading time split by language"
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Timeline"
+msgstr "Reading Timeline"
+
+#: src/pages/StatsPage.tsx
+msgid "Recent Sessions"
+msgstr "Recent Sessions"
 
 #: src/pages/DashboardPage.tsx
 msgid "Recently Added"
 msgstr "Recently Added"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Recently Finished"
 msgstr "Recently Finished"
 
@@ -2858,6 +3462,10 @@ msgstr "Reject files"
 msgid "Reject imported book"
 msgstr "Reject imported book"
 
+#: src/pages/StatsPage.tsx
+msgid "Remove {title}"
+msgstr "Remove {title}"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
 msgstr "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
@@ -2878,9 +3486,29 @@ msgstr "Remove our entry from Hardcover and re-match automatically"
 msgid "Remove wish"
 msgstr "Remove wish"
 
+#: src/pages/StatsPage.tsx
+msgid "Removed “{title}”"
+msgstr "Removed “{title}”"
+
+#: src/pages/StatsPage.tsx
+msgid "Removed a tile? Add it back — or add another copy."
+msgstr "Removed a tile? Add it back — or add another copy."
+
+#: src/pages/StatsPage.tsx
+msgid "Rename {name}"
+msgstr "Rename {name}"
+
+#: src/pages/StatsPage.tsx
+msgid "Rename board"
+msgstr "Rename board"
+
 #: src/pages/BinderyPage.tsx
 msgid "Rescan the bindery folder"
 msgstr "Rescan the bindery folder"
+
+#: src/pages/StatsPage.tsx
+msgid "Reset"
+msgstr "Reset"
 
 #: src/pages/AdminPage.tsx
 msgid "Resource:"
@@ -2930,6 +3558,10 @@ msgstr "Role"
 msgid "Roles guide"
 msgstr "Roles guide"
 
+#: src/pages/StatsPage.tsx
+msgid "Sa"
+msgstr "Sa"
+
 #: src/pages/AdminPage.tsx
 msgid "Same ISBN"
 msgstr "Same ISBN"
@@ -2944,6 +3576,10 @@ msgstr "Same Series Volume"
 msgid "Save"
 msgstr "Save"
 
+#: src/pages/StatsPage.tsx
+msgid "Save board as image"
+msgstr "Save board as image"
+
 #: src/pages/SettingsPage.tsx
 msgid "Save changes"
 msgstr "Save changes"
@@ -2953,6 +3589,7 @@ msgid "Save Changes"
 msgstr "Save Changes"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Save failed"
 msgstr "Save failed"
 
@@ -2964,6 +3601,18 @@ msgstr "Save note"
 #: src/components/Sidebar.tsx
 msgid "Save the library first, then reopen it to share with users."
 msgstr "Save the library first, then reopen it to share with users."
+
+#: src/pages/StatsPage.tsx
+msgid "Save this board as an image"
+msgstr "Save this board as an image"
+
+#: src/pages/StatsPage.tsx
+msgid "Saved"
+msgstr "Saved"
+
+#: src/pages/StatsPage.tsx
+msgid "Saving"
+msgstr "Saving"
 
 #: src/pages/SettingsPage.tsx
 msgid "Saving..."
@@ -3042,6 +3691,10 @@ msgstr "Search query..."
 msgid "Search to find more icons"
 msgstr "Search to find more icons"
 
+#: src/pages/StatsPage.tsx
+msgid "Search widgets…"
+msgstr "Search widgets…"
+
 #: src/pages/HighlightsPage.tsx
 msgid "Search your highlights…"
 msgstr "Search your highlights…"
@@ -3097,6 +3750,7 @@ msgstr "Sent"
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Series"
 msgstr "Series"
 
@@ -3107,6 +3761,10 @@ msgstr "Series #"
 #: src/pages/BinderyPage.tsx
 msgid "Series applied to {n} files"
 msgstr "Series applied to {n} files"
+
+#: src/pages/StatsPage.tsx
+msgid "Series Completion"
+msgstr "Series Completion"
 
 #: src/pages/BinderyPage.tsx
 msgid "Series index"
@@ -3122,9 +3780,17 @@ msgstr "Series name"
 msgid "Series Progress"
 msgstr "Series Progress"
 
+#: src/pages/StatsPage.tsx
+msgid "Series ranked by your rating"
+msgstr "Series ranked by your rating"
+
 #: src/pages/BinderyPage.tsx
 msgid "Series review"
 msgstr "Series review"
+
+#: src/pages/StatsPage.tsx
+msgid "Series Spotlight"
+msgstr "Series Spotlight"
 
 #: src/pages/DashboardPage.tsx
 msgid "Series: {filterSeries}"
@@ -3134,9 +3800,17 @@ msgstr "Series: {filterSeries}"
 msgid "Server"
 msgstr "Server"
 
+#: src/pages/StatsPage.tsx
+msgid "Session Timeline"
+msgstr "Session Timeline"
+
 #: src/pages/BookDetailPage.tsx
 msgid "sessions"
 msgstr "sessions"
+
+#: src/pages/StatsPage.tsx
+msgid "Sessions"
+msgstr "Sessions"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Sessions · {d}"
@@ -3256,6 +3930,10 @@ msgstr "Show more"
 msgid "Show this help"
 msgstr "Show this help"
 
+#: src/pages/StatsPage.tsx
+msgid "Shrink/grow this tile to fit its content. Off: set the height yourself (content scrolls)."
+msgstr "Shrink/grow this tile to fit its content. Off: set the height yourself (content scrolls)."
+
 #: src/pages/LoginPage.tsx
 msgid "Sign in"
 msgstr "Sign in"
@@ -3296,9 +3974,17 @@ msgstr "SMTP Status"
 msgid "Sort Order"
 msgstr "Sort Order"
 
+#: src/pages/StatsPage.tsx
+msgid "Sortable table of every book"
+msgstr "Sortable table of every book"
+
 #: src/pages/AdminPage.tsx
 msgid "Source"
 msgstr "Source"
+
+#: src/pages/StatsPage.tsx
+msgid "Speed by book format"
+msgstr "Speed by book format"
 
 #: src/pages/LoginPage.tsx
 msgid "SSO is misconfigured on the server (redirect URL). Contact your admin."
@@ -3336,6 +4022,10 @@ msgstr "start"
 msgid "Start {volLabel}"
 msgstr "Start {volLabel}"
 
+#: src/pages/StatsPage.tsx
+msgid "Start from default"
+msgstr "Start from default"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Start matching this book again"
 msgstr "Start matching this book again"
@@ -3343,6 +4033,10 @@ msgstr "Start matching this book again"
 #: src/pages/DashboardPage.tsx
 msgid "Start reading and your progress will show up here"
 msgstr "Start reading and your progress will show up here"
+
+#: src/pages/StatsPage.tsx
+msgid "Started vs finished ratio"
+msgstr "Started vs finished ratio"
 
 #: src/components/Sidebar.tsx
 msgid "Stats"
@@ -3357,9 +4051,17 @@ msgstr "Status"
 msgid "Status: {filterStatusLabel}"
 msgstr "Status: {filterStatusLabel}"
 
+#: src/pages/StatsPage.tsx
+msgid "Streak"
+msgstr "Streak"
+
 #: src/pages/SetupPage.tsx
 msgid "Strong enough"
 msgstr "Strong enough"
+
+#: src/pages/StatsPage.tsx
+msgid "Su"
+msgstr "Su"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Subtitle (optional)"
@@ -3413,6 +4115,14 @@ msgstr "Tag: {filterTag}"
 msgid "Tags (comma-separated)"
 msgstr "Tags (comma-separated)"
 
+#: src/pages/StatsPage.tsx
+msgid "Taste"
+msgstr "Taste"
+
+#: src/pages/StatsPage.tsx
+msgid "Taste by Genre"
+msgstr "Taste by Genre"
+
 #: src/pages/AdminPage.tsx
 msgid "Test"
 msgstr "Test"
@@ -3420,6 +4130,14 @@ msgstr "Test"
 #: src/pages/AdminPage.tsx
 msgid "Test email sent successfully."
 msgstr "Test email sent successfully."
+
+#: src/pages/StatsPage.tsx
+msgid "Th"
+msgstr "Th"
+
+#: src/pages/StatsPage.tsx
+msgid "That file is not a Tome board export."
+msgstr "That file is not a Tome board export."
 
 #: src/pages/SettingsPage.tsx
 msgid "That SSO identity is already linked to another account."
@@ -3445,6 +4163,10 @@ msgstr "Theme name"
 msgid "Theme name is required"
 msgstr "Theme name is required"
 
+#: src/pages/StatsPage.tsx
+msgid "This board is empty."
+msgstr "This board is empty."
+
 #: src/pages/AdminPage.tsx
 msgid "This is a whole-series wish — it stays open as volumes arrive."
 msgstr "This is a whole-series wish — it stays open as volumes arrive."
@@ -3452,6 +4174,22 @@ msgstr "This is a whole-series wish — it stays open as volumes arrive."
 #: src/pages/SettingsPage.tsx
 msgid "This is the only time you will see this token. Store it somewhere safe — it cannot be recovered."
 msgstr "This is the only time you will see this token. Store it somewhere safe — it cannot be recovered."
+
+#: src/pages/StatsPage.tsx
+msgid "This Month"
+msgstr "This Month"
+
+#: src/pages/StatsPage.tsx
+msgid "This month, read days filled"
+msgstr "This month, read days filled"
+
+#: src/pages/StatsPage.tsx
+msgid "This page is yours — every tile can be moved, resized, swapped or removed, per board. Hit <0>Edit</0> to start. Reset always brings the defaults back."
+msgstr "This page is yours — every tile can be moved, resized, swapped or removed, per board. Hit <0>Edit</0> to start. Reset always brings the defaults back."
+
+#: src/pages/StatsPage.tsx
+msgid "This period vs the last"
+msgstr "This period vs the last"
 
 #: src/pages/DashboardPage.tsx
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
@@ -3461,6 +4199,22 @@ msgstr "This permanently removes the selected books and their files from disk. T
 msgid "Time"
 msgstr "Time"
 
+#: src/pages/StatsPage.tsx
+msgid "Time / Day"
+msgstr "Time / Day"
+
+#: src/pages/StatsPage.tsx
+msgid "Time by Format"
+msgstr "Time by Format"
+
+#: src/pages/StatsPage.tsx
+msgid "Time left on books in progress"
+msgstr "Time left on books in progress"
+
+#: src/pages/StatsPage.tsx
+msgid "Time of Day Split"
+msgstr "Time of Day Split"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Time per chapter"
 msgstr "Time per chapter"
@@ -3468,6 +4222,18 @@ msgstr "Time per chapter"
 #: src/pages/BookDetailPage.tsx
 msgid "Time per chapter, line view"
 msgstr "Time per chapter, line view"
+
+#: src/pages/StatsPage.tsx
+msgid "Time split across categories"
+msgstr "Time split across categories"
+
+#: src/pages/StatsPage.tsx
+msgid "Timeframe"
+msgstr "Timeframe"
+
+#: src/pages/StatsPage.tsx
+msgid "Timeline"
+msgstr "Timeline"
 
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -3514,6 +4280,22 @@ msgstr "TomeSync and KOSync can both be active. TomeSync tracks full reading ses
 msgid "TomeSync Plugin"
 msgstr "TomeSync Plugin"
 
+#: src/pages/StatsPage.tsx
+msgid "Top Authors by Reading Time"
+msgstr "Top Authors by Reading Time"
+
+#: src/pages/StatsPage.tsx
+msgid "Top Books by Reading Time"
+msgstr "Top Books by Reading Time"
+
+#: src/pages/StatsPage.tsx
+msgid "Total pages turned"
+msgstr "Total pages turned"
+
+#: src/pages/StatsPage.tsx
+msgid "Total time read + avg session"
+msgstr "Total time read + avg session"
+
 #: src/pages/SettingsPage.tsx
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "Translations are community-maintained. Anything not yet translated is shown in English."
@@ -3530,6 +4312,10 @@ msgstr "Try again"
 msgid "Try editing the title or series fields"
 msgstr "Try editing the title or series fields"
 
+#: src/pages/StatsPage.tsx
+msgid "Tu"
+msgstr "Tu"
+
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -3545,6 +4331,7 @@ msgid "Unassigned"
 msgstr "Unassigned"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Undo"
 msgstr "Undo"
 
@@ -3624,6 +4411,10 @@ msgstr "Uploader: {filterUploaderName}"
 #: src/pages/SettingsPage.tsx
 msgid "URL"
 msgstr "URL"
+
+#: src/pages/StatsPage.tsx
+msgid "Use “Add tile” to build your {name} board."
+msgstr "Use “Add tile” to build your {name} board."
 
 #: src/pages/SettingsPage.tsx
 msgid "Use a <0>Google App Password</0>, not your regular password."
@@ -3727,6 +4518,10 @@ msgstr "Want to Read — queue this book up next"
 msgid "Warm"
 msgstr "Warm"
 
+#: src/pages/StatsPage.tsx
+msgid "We"
+msgstr "We"
+
 #: src/pages/AdminPage.tsx
 msgid "Web"
 msgstr "Web"
@@ -3747,9 +4542,17 @@ msgstr "Welcome to Tome"
 msgid "What did you think? (optional, saved automatically)"
 msgstr "What did you think? (optional, saved automatically)"
 
+#: src/pages/StatsPage.tsx
+msgid "What do these mean? — read the stats docs"
+msgstr "What do these mean? — read the stats docs"
+
 #: src/pages/HardcoverPage.tsx
 msgid "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
 msgstr "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
+
+#: src/pages/StatsPage.tsx
+msgid "When you read — hour × weekday"
+msgstr "When you read — hour × weekday"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Where in the book your time went — taller means more time spent on those pages."
@@ -3758,6 +4561,10 @@ msgstr "Where in the book your time went — taller means more time spent on tho
 #: src/pages/BookDetailPage.tsx
 msgid "Where you read"
 msgstr "Where you read"
+
+#: src/pages/StatsPage.tsx
+msgid "Which weekday you read most"
+msgstr "Which weekday you read most"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
@@ -3794,11 +4601,19 @@ msgstr "Word Counts"
 msgid "Words"
 msgstr "Words"
 
+#: src/pages/StatsPage.tsx
+msgid "Words Read"
+msgstr "Words Read"
+
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Year"
 msgstr "Year"
+
+#: src/pages/StatsPage.tsx
+msgid "Year in Review"
+msgstr "Year in Review"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -3826,6 +4641,10 @@ msgstr "Your account is linked to SSO — you can sign in with your identity pro
 msgid "Your account is not permitted to sign in to Tome."
 msgstr "Your account is not permitted to sign in to Tome."
 
+#: src/pages/StatsPage.tsx
+msgid "Your highest & lowest rated books"
+msgstr "Your highest & lowest rated books"
+
 #: src/pages/SetupPage.tsx
 msgid "Your library"
 msgstr "Your library"
@@ -3843,6 +4662,18 @@ msgstr "Your library is empty"
 msgid "Your note — syncs back to KOReader on the next sync"
 msgstr "Your note — syncs back to KOReader on the next sync"
 
+#: src/pages/StatsPage.tsx
+msgid "Your ratings over time"
+msgstr "Your ratings over time"
+
+#: src/pages/StatsPage.tsx
+msgid "Your reading life — every book a bar in time"
+msgstr "Your reading life — every book a bar in time"
+
+#: src/pages/StatsPage.tsx
+msgid "Your real reading speed — words ÷ time"
+msgstr "Your real reading speed — words ÷ time"
+
 #: src/pages/SettingsPage.tsx
 msgid "Your server admin needs to set SMTP environment variables:"
 msgstr "Your server admin needs to set SMTP environment variables:"
@@ -3858,3 +4689,7 @@ msgstr "your Tome password"
 #: src/pages/WishlistPage.tsx
 msgid "Your wishlist is empty"
 msgstr "Your wishlist is empty"
+
+#: src/pages/StatsPage.tsx
+msgid "Your year, at a glance (1y/All)"
+msgstr "Your year, at a glance (1y/All)"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -65,6 +65,7 @@ msgstr " · {prog}% in"
 msgid " · books without a word count use your average for that type"
 msgstr " · books without a word count use your average for that type"
 
+#: src/components/stats/TimelineRibbon.tsx
 #: src/pages/SharePage.tsx
 msgid " · finished {d}"
 msgstr " · finished {d}"
@@ -72,6 +73,10 @@ msgstr " · finished {d}"
 #: src/pages/HardcoverPage.tsx
 msgid " · last synced {when}"
 msgstr " · last synced {when}"
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid " · longest <0>{title}</0> ({words})"
+msgstr " · longest <0>{title}</0> ({words})"
 
 #: src/pages/BinderyPage.tsx
 msgid " · reviewed"
@@ -175,6 +180,11 @@ msgstr "{0, plural, one {# book, none estimated yet.} other {# books, none estim
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
 msgstr "{0, plural, one {# book} other {# books}}"
+
+#. placeholder {0}: hover.b.days.length
+#: src/components/stats/TimelineRibbon.tsx
+msgid "{0, plural, one {# day} other {# days}}"
+msgstr "{0, plural, one {# day} other {# days}}"
 
 #. placeholder {0}: groups.length
 #: src/pages/AdminPage.tsx
@@ -314,6 +324,16 @@ msgstr "{0, plural, one {Suggested match:} other {Suggested matches:}}"
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
 msgstr "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
+
+#. placeholder {0}: data.books_counted
+#: src/components/stats/widgets/wordstats.tsx
+msgid "{0, plural, one {words read · # book} other {words read · # books}}"
+msgstr "{0, plural, one {words read · # book} other {words read · # books}}"
+
+#. placeholder {0}: data.books_counted
+#: src/components/stats/widgets/wordstats.tsx
+msgid "{0, plural, one {words/min · across # book} other {words/min · across # books}}"
+msgstr "{0, plural, one {words/min · across # book} other {words/min · across # books}}"
 
 #: src/pages/AdminPage.tsx
 msgid "{added} added · {skipped} skipped"
@@ -502,6 +522,10 @@ msgstr "{n} selected"
 msgid "{n} selected — Clear"
 msgstr "{n} selected — Clear"
 
+#: src/components/stats/TimelineRibbon.tsx
+msgid "{n} vols · "
+msgstr "{n} vols · "
+
 #: src/pages/DashboardPage.tsx
 msgid "{name} · Vol. {start_index}–{end_index}"
 msgstr "{name} · Vol. {start_index}–{end_index}"
@@ -553,6 +577,10 @@ msgstr "{shown, plural, one {# title} other {# titles}}"
 #: src/components/Sidebar.tsx
 msgid "{themeName} theme"
 msgstr "{themeName} theme"
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "{title} — {dur} between {from} and {to}"
+msgstr "{title} — {dur} between {from} and {to}"
 
 #: src/pages/DashboardPage.tsx
 msgid "{total, plural, one {# volume} other {# volumes}}"
@@ -703,6 +731,10 @@ msgstr "Accept failed"
 msgid "Accepted: {title}"
 msgstr "Accepted: {title}"
 
+#: src/components/NotificationChannels.tsx
+msgid "Access token (only for protected topics)"
+msgstr "Access token (only for protected topics)"
+
 #: src/pages/SettingsPage.tsx
 msgid "Account & Security"
 msgstr "Account & Security"
@@ -748,6 +780,10 @@ msgstr "Add board"
 #: src/pages/WishlistPage.tsx
 msgid "Add books you'd like to see in the library."
 msgstr "Add books you'd like to see in the library."
+
+#: src/components/NotificationChannels.tsx
+msgid "Add channel"
+msgstr "Add channel"
 
 #: src/pages/SettingsPage.tsx
 msgid "Add custom theme"
@@ -919,6 +955,10 @@ msgstr "App-specific PINs"
 msgid "Appearance"
 msgstr "Appearance"
 
+#: src/components/NotificationChannels.tsx
+msgid "Application token (required)"
+msgstr "Application token (required)"
+
 #: src/components/SeriesRating.tsx
 msgid "Applied to volumes you haven’t rated"
 msgstr "Applied to volumes you haven’t rated"
@@ -1016,6 +1056,14 @@ msgstr "avg {avg}"
 #: src/components/SeriesReadingStats.tsx
 msgid "avg / volume"
 msgstr "avg / volume"
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid "avg <0>{avg}</0> · median {median}"
+msgstr "avg <0>{avg}</0> · median {median}"
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid "avg <0>{avg}</0> words per book"
+msgstr "avg <0>{avg}</0> words per book"
 
 #: src/pages/BookDetailPage.tsx
 msgid "avg session"
@@ -1435,6 +1483,10 @@ msgstr "Could not start sync"
 msgid "Couldn’t load stats."
 msgstr "Couldn’t load stats."
 
+#: src/components/stats/TimelineRibbon.tsx
+msgid "Couldn't load the timeline."
+msgstr "Couldn't load the timeline."
+
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr "Cover"
@@ -1646,6 +1698,7 @@ msgstr "Device reading time mapped into the book's chapters. Hover the line for 
 msgid "Directories"
 msgstr "Directories"
 
+#: src/components/WhatsNewPanel.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -1933,6 +1986,10 @@ msgstr "Export this board as a JSON file (share or back up)"
 msgid "Exporting..."
 msgstr "Exporting..."
 
+#: src/components/NotificationChannels.tsx
+msgid "failed"
+msgstr "failed"
+
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2088,6 +2145,10 @@ msgstr "Failed to update sharing"
 msgid "fantasy, action, romance"
 msgstr "fantasy, action, romance"
 
+#: src/components/stats/widgets/wordstats.tsx
+msgid "Fastest"
+msgstr "Fastest"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
 msgstr "Fetch Metadata"
@@ -2240,6 +2301,10 @@ msgstr "Get notified when a new volume of a followed series is released."
 #: src/pages/WishlistPage.tsx
 msgid "Go back"
 msgstr "Go back"
+
+#: src/components/WhatsNewPanel.tsx
+msgid "Got it"
+msgstr "Got it"
 
 #: src/pages/DashboardPage.tsx
 msgid "Grid view"
@@ -2473,6 +2538,10 @@ msgstr "Just now"
 msgid "Just synced"
 msgstr "Just synced"
 
+#: src/components/WhatsNewPanel.tsx
+msgid "Just updated"
+msgstr "Just updated"
+
 #: src/pages/AdminPage.tsx
 msgid "Keep this one"
 msgstr "Keep this one"
@@ -2599,6 +2668,7 @@ msgstr "Library size over time"
 msgid "Library: {filterLibraryChipName}"
 msgstr "Library: {filterLibraryChipName}"
 
+#: src/components/stats/TimelineRibbon.tsx
 #: src/pages/StatsPage.tsx
 msgid "lifetime"
 msgstr "lifetime"
@@ -2659,6 +2729,10 @@ msgstr "Load more ({left} left)"
 #: src/pages/HardcoverPage.tsx
 msgid "Loading books…"
 msgstr "Loading books…"
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "Loading your reading life…"
+msgstr "Loading your reading life…"
 
 #: src/pages/BinderyPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -3106,6 +3180,14 @@ msgstr "No rated series yet."
 msgid "No ratings yet."
 msgstr "No ratings yet."
 
+#: src/components/stats/widgets/wordstats.tsx
+msgid "No re-reads yet — pages you revisit on a later day show up here."
+msgstr "No re-reads yet — pages you revisit on a later day show up here."
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "no reading"
+msgstr "no reading"
+
 #: src/pages/AdminPage.tsx
 msgid "No reading activity yet. Records appear when users start reading books."
 msgstr "No reading activity yet. Records appear when users start reading books."
@@ -3113,6 +3195,10 @@ msgstr "No reading activity yet. Records appear when users start reading books."
 #: src/pages/StatsPage.tsx
 msgid "No reading data yet"
 msgstr "No reading data yet"
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "No reading history yet — sessions and imported KOReader history land here."
+msgstr "No reading history yet — sessions and imported KOReader history land here."
 
 #: src/pages/BookDetailPage.tsx
 msgid "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
@@ -3171,6 +3257,10 @@ msgstr "no sessions yet"
 msgid "No suggested match yet — search for the book to link, or upload it first."
 msgstr "No suggested match yet — search for the book to link, or upload it first."
 
+#: src/components/stats/widgets/wordstats.tsx
+msgid "No timed reading with word counts yet."
+msgstr "No timed reading with word counts yet."
+
 #: src/pages/LoginPage.tsx
 msgid "No Tome account is linked to this identity, and self-signup is disabled."
 msgstr "No Tome account is linked to this identity, and self-signup is disabled."
@@ -3199,6 +3289,10 @@ msgstr "No widgets match “{q}”."
 #: src/pages/StatsPage.tsx
 msgid "No widgets on this board yet."
 msgstr "No widgets on this board yet."
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid "No word counts yet."
+msgstr "No word counts yet."
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -3241,6 +3335,10 @@ msgstr "Not synced yet"
 #: src/pages/HardcoverPage.tsx
 msgid "not syncing"
 msgstr "not syncing"
+
+#: src/components/NotificationChannels.tsx
+msgid "Not used"
+msgstr "Not used"
 
 #: src/pages/SettingsPage.tsx
 msgid "Note on KOSync coexistence"
@@ -3455,6 +3553,10 @@ msgstr "Passwords do not match"
 msgid "Passwords do not match."
 msgstr "Passwords do not match."
 
+#: src/components/NotificationChannels.tsx
+msgid "Pause"
+msgstr "Pause"
+
 #: src/pages/BinderyPage.tsx
 msgid "Per-file details"
 msgstr "Per-file details"
@@ -3576,6 +3678,10 @@ msgstr "Public library"
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
 msgstr "Publisher"
+
+#: src/components/NotificationChannels.tsx
+msgid "Push Tome's notifications (wish fulfilled, new volume detected, reading goals) to ntfy, Gotify, or any webhook the moment they happen — the bell above only rings when you visit. Each channel can be tested, paused, or removed; tokens are stored server-side and never shown again."
+msgstr "Push Tome's notifications (wish fulfilled, new volume detected, reading goals) to ntfy, Gotify, or any webhook the moment they happen — the bell above only rings when you visit. Each channel can be tested, paused, or removed; tokens are stored server-side and never shown again."
 
 #: src/pages/AdminPage.tsx
 msgid "Queue: fold the other copies into the kept book"
@@ -3808,6 +3914,7 @@ msgstr "Reading Time per Day"
 msgid "Reading time split by language"
 msgstr "Reading time split by language"
 
+#: src/components/stats/TimelineRibbon.tsx
 #: src/pages/StatsPage.tsx
 msgid "Reading Timeline"
 msgstr "Reading Timeline"
@@ -3866,6 +3973,10 @@ msgstr "Remove {title}"
 msgid "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
 msgstr "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
 
+#: src/components/NotificationChannels.tsx
+msgid "Remove channel"
+msgstr "Remove channel"
+
 #: src/pages/SettingsPage.tsx
 msgid "Remove device"
 msgstr "Remove device"
@@ -3898,6 +4009,10 @@ msgstr "Rename {name}"
 msgid "Rename board"
 msgstr "Rename board"
 
+#: src/components/NotificationChannels.tsx
+msgid "request failed"
+msgstr "request failed"
+
 #: src/pages/BinderyPage.tsx
 msgid "Rescan the bindery folder"
 msgstr "Rescan the bindery folder"
@@ -3921,6 +4036,10 @@ msgstr "Restore"
 #: src/components/PositionHistoryModal.tsx
 msgid "Restoring sets the live position (and read status) back to that point; devices pick it up on their next sync. Restoring below 100% un-finishes a falsely completed book."
 msgstr "Restoring sets the live position (and read status) back to that point; devices pick it up on their next sync. Restoring below 100% un-finishes a falsely completed book."
+
+#: src/components/NotificationChannels.tsx
+msgid "Resume"
+msgstr "Resume"
 
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
@@ -4141,6 +4260,10 @@ msgstr "Select all"
 #: src/pages/BinderyPage.tsx
 msgid "Select All"
 msgstr "Select All"
+
+#: src/components/NotificationChannels.tsx
+msgid "Send a test notification"
+msgstr "Send a test notification"
 
 #: src/pages/AdminPage.tsx
 msgid "Send failed"
@@ -4403,6 +4526,10 @@ msgstr "Size"
 #: src/pages/BinderyPage.tsx
 msgid "Skip"
 msgstr "Skip"
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid "Slowest"
+msgstr "Slowest"
 
 #: src/pages/AdminPage.tsx
 msgid "SMTP Status"
@@ -5056,6 +5183,10 @@ msgstr "What is this?"
 msgid "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
 msgstr "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
 
+#: src/components/WhatsNewPanel.tsx
+msgid "What's new in Tome {version}"
+msgstr "What's new in Tome {version}"
+
 #: src/pages/StatsPage.tsx
 msgid "When you read — hour × weekday"
 msgstr "When you read — hour × weekday"
@@ -5220,3 +5351,11 @@ msgstr "Your wishlist is empty"
 #: src/pages/StatsPage.tsx
 msgid "Your year, at a glance (1y/All)"
 msgstr "Your year, at a glance (1y/All)"
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "Zoom in"
+msgstr "Zoom in"
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "Zoom out"
+msgstr "Zoom out"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1011,6 +1011,10 @@ msgstr "~{h} h"
 msgid "~{m} min"
 msgstr "~{m} min"
 
+#: src/pages/ReaderPage.tsx
+msgid "~{m} min left"
+msgstr "~{m} min left"
+
 #: src/lib/backlog.ts
 msgid "~{mo} months"
 msgstr "~{mo} months"
@@ -1178,6 +1182,10 @@ msgstr "Add a device in Settings to start sending books."
 msgid "Add a note"
 msgstr "Add a note"
 
+#: src/pages/ReaderPage.tsx
+msgid "Add a note…"
+msgstr "Add a note…"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Add a review"
 msgstr "Add a review"
@@ -1209,6 +1217,10 @@ msgstr "Add channel"
 #: src/pages/SettingsPage.tsx
 msgid "Add custom theme"
 msgstr "Add custom theme"
+
+#: src/pages/ReaderPage.tsx
+msgid "Add note"
+msgstr "Add note"
 
 #: src/components/SaveFilterButton.tsx
 msgid "Add shelf"
@@ -1657,6 +1669,14 @@ msgstr "Backup"
 msgid "Backup failed"
 msgstr "Backup failed"
 
+#: src/pages/ReaderPage.tsx
+msgid "Based on a default pace (no reading history yet)"
+msgstr "Based on a default pace (no reading history yet)"
+
+#: src/pages/ReaderPage.tsx
+msgid "Based on your measured reading pace"
+msgstr "Based on your measured reading pace"
+
 #: src/components/BulkMetadataReviewModal.tsx
 msgid "Batch complete"
 msgstr "Batch complete"
@@ -1750,6 +1770,10 @@ msgstr "Book Length"
 #: src/pages/BookDetailPage.tsx
 msgid "Book not found"
 msgstr "Book not found"
+
+#: src/pages/ReaderPage.tsx
+msgid "Book not found."
+msgstr "Book not found."
 
 #: src/pages/BinderyPage.tsx
 msgid "Book rejected and removed"
@@ -1861,6 +1885,7 @@ msgstr "Can't find it? Add manually"
 #: src/pages/DashboardPage.tsx
 #: src/pages/HighlightsPage.tsx
 #: src/pages/LoginPage.tsx
+#: src/pages/ReaderPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
 msgstr "Cancel"
@@ -1991,6 +2016,7 @@ msgstr "Click for details"
 #: src/components/UploadModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
+#: src/pages/ReaderPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Close"
 msgstr "Close"
@@ -2105,6 +2131,10 @@ msgstr "Content"
 #: src/pages/BinderyPage.tsx
 msgid "Content Type"
 msgstr "Content Type"
+
+#: src/pages/ReaderPage.tsx
+msgid "Contents"
+msgstr "Contents"
 
 #: src/components/home/FocusMode.tsx
 msgid "Continue reading"
@@ -2334,6 +2364,7 @@ msgstr "Danger Zone"
 
 #: src/components/Sidebar.tsx
 #: src/components/ThemeToggle.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Dark"
 msgstr "Dark"
 
@@ -2374,12 +2405,17 @@ msgstr "days at ~{mpd} min a day (last {win} days)"
 msgid "Dead entries removed"
 msgstr "Dead entries removed"
 
+#: src/pages/ReaderPage.tsx
+msgid "Default"
+msgstr "Default"
+
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/HighlightsPage.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Delete"
 msgstr "Delete"
 
@@ -2656,6 +2692,7 @@ msgstr "Edit Metadata"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Edit note"
 msgstr "Edit note"
 
@@ -2705,6 +2742,10 @@ msgstr "Empty board"
 #: src/components/ManageSeriesModal.tsx
 msgid "End"
 msgstr "End"
+
+#: src/pages/ReaderPage.tsx
+msgid "EPUB failed to open: {msg2}"
+msgstr "EPUB failed to open: {msg2}"
 
 #: src/pages/StatsPage.tsx
 msgid "EPUB vs CBZ time split"
@@ -2908,9 +2949,17 @@ msgstr "Failed to load bindery"
 msgid "Failed to load books"
 msgstr "Failed to load books"
 
+#: src/pages/ReaderPage.tsx
+msgid "Failed to load comic pages: {msg2}"
+msgstr "Failed to load comic pages: {msg2}"
+
 #: src/pages/AdminPage.tsx
 msgid "Failed to load duplicates"
 msgstr "Failed to load duplicates"
+
+#: src/pages/ReaderPage.tsx
+msgid "Failed to load EPUB: {msg2}"
+msgstr "Failed to load EPUB: {msg2}"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to load facets"
@@ -2927,6 +2976,10 @@ msgstr "Failed to load metadata audit data."
 #: src/pages/HighlightsPage.tsx
 msgid "Failed to load more"
 msgstr "Failed to load more"
+
+#: src/pages/ReaderPage.tsx
+msgid "Failed to load PDF: {msg2}"
+msgstr "Failed to load PDF: {msg2}"
 
 #: src/pages/AdminPage.tsx
 msgid "Failed to load server stats"
@@ -3148,6 +3201,10 @@ msgstr "Following"
 msgid "Following \"{seriesName}\" — you'll hear when a new volume is out"
 msgstr "Following \"{seriesName}\" — you'll hear when a new volume is out"
 
+#: src/pages/ReaderPage.tsx
+msgid "FONT SIZE"
+msgstr "FONT SIZE"
+
 #: src/pages/BinderyPage.tsx
 msgid "for {targetLabel} — click a file to switch"
 msgstr "for {targetLabel} — click a file to switch"
@@ -3235,6 +3292,7 @@ msgstr "Get token"
 
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/ReaderPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Go back"
 msgstr "Go back"
@@ -3332,10 +3390,18 @@ msgstr "Highest"
 msgid "Highest & Lowest Rated"
 msgstr "Highest & Lowest Rated"
 
+#: src/pages/ReaderPage.tsx
+msgid "Highlight"
+msgstr "Highlight"
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "Highlight deleted"
 msgstr "Highlight deleted"
+
+#: src/pages/ReaderPage.tsx
+msgid "Highlight in {c}"
+msgstr "Highlight in {c}"
 
 #: src/pages/HighlightsPage.tsx
 msgid "Highlighted {when}"
@@ -3690,6 +3756,7 @@ msgstr "Lifetime words read, by year"
 
 #: src/components/Sidebar.tsx
 #: src/components/ThemeToggle.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Light"
 msgstr "Light"
 
@@ -3827,6 +3894,10 @@ msgstr "Low resolution"
 #: src/components/stats/widgets/taste.tsx
 msgid "Lowest"
 msgstr "Lowest"
+
+#: src/pages/ReaderPage.tsx
+msgid "Made on the web — syncs to KOReader"
+msgstr "Made on the web — syncs to KOReader"
 
 #: src/pages/DashboardPage.tsx
 msgid "Manage"
@@ -4367,6 +4438,10 @@ msgstr "No ratings yet."
 msgid "No re-reads yet — pages you revisit on a later day show up here."
 msgstr "No re-reads yet — pages you revisit on a later day show up here."
 
+#: src/pages/ReaderPage.tsx
+msgid "No readable file found for this book."
+msgstr "No readable file found for this book."
+
 #: src/components/stats/TimelineRibbon.tsx
 msgid "no reading"
 msgstr "no reading"
@@ -4476,6 +4551,10 @@ msgstr "no sessions yet"
 #: src/pages/AdminPage.tsx
 msgid "No suggested match yet — search for the book to link, or upload it first."
 msgstr "No suggested match yet — search for the book to link, or upload it first."
+
+#: src/pages/ReaderPage.tsx
+msgid "No table of contents available."
+msgstr "No table of contents available."
 
 #: src/components/stats/widgets/wordstats.tsx
 msgid "No timed reading with word counts yet."
@@ -4789,6 +4868,10 @@ msgstr "Pace by Format"
 #: src/pages/StatsPage.tsx
 msgid "Padding"
 msgstr "Padding"
+
+#: src/pages/ReaderPage.tsx
+msgid "Page {n}"
+msgstr "Page {n}"
 
 #: src/components/SeriesReadingStats.tsx
 #: src/lib/goals.ts
@@ -5565,6 +5648,10 @@ msgstr "Same ISBN"
 msgid "Same Series Volume"
 msgstr "Same Series Volume"
 
+#: src/pages/ReaderPage.tsx
+msgid "Sans"
+msgstr "Sans"
+
 #: src/components/stats/HourDowHeatmap.tsx
 #: src/components/stats/widgets/habits.tsx
 msgid "Sat"
@@ -5576,6 +5663,7 @@ msgstr "Sat"
 #: src/components/stats/GoalWidget.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Save"
 msgstr "Save"
 
@@ -5849,6 +5937,10 @@ msgstr "Sent \"{title}\" to device"
 msgid "Sent {sent}/{total}. {failedN} failed."
 msgstr "Sent {sent}/{total}. {failedN} failed."
 
+#: src/pages/ReaderPage.tsx
+msgid "Sepia"
+msgstr "Sepia"
+
 #: src/components/CommandPalette.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/MetadataFetchModal.tsx
@@ -5917,6 +6009,10 @@ msgstr "Series: {filterSeries}"
 #: src/components/LibraryHealth.tsx
 msgid "Series: {name}"
 msgstr "Series: {name}"
+
+#: src/pages/ReaderPage.tsx
+msgid "Serif"
+msgstr "Serif"
 
 #: src/pages/AdminPage.tsx
 msgid "Server"
@@ -5987,6 +6083,7 @@ msgstr "Set your password"
 
 #: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
+#: src/pages/ReaderPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Settings"
 msgstr "Settings"
@@ -6349,6 +6446,7 @@ msgid "Synced from Kobo"
 msgstr "Synced from Kobo"
 
 #: src/components/home/FocusMode.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Synced from KOReader"
 msgstr "Synced from KOReader"
 

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/MetadataManager.tsx
+msgid " — {detected} chapter numbers detected"
+msgstr " — {detected} chapter numbers detected"
+
 #: src/components/InstanceBackup.tsx
 msgid " — backup from {when} (v{v}, {users} users, {books} books)."
 msgstr " — backup from {when} (v{v}, {users} users, {books} books)."
@@ -301,6 +305,11 @@ msgstr "{0, plural, one {# book, none estimated yet.} other {# books, none estim
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
 msgstr "{0, plural, one {# book} other {# books}}"
+
+#. placeholder {0}: candidates.length
+#: src/components/MetadataManager.tsx
+msgid "{0, plural, one {# candidate — click to select} other {# candidates — click to select}}"
+msgstr "{0, plural, one {# candidate — click to select} other {# candidates — click to select}}"
 
 #. placeholder {0}: candidates.length
 #: src/components/CoverPickerModal.tsx
@@ -755,10 +764,20 @@ msgid "{n, plural, one {Confirm — apply # decision} other {Confirm — apply #
 msgstr "{n, plural, one {Confirm — apply # decision} other {Confirm — apply # decisions}}"
 
 #: src/components/AppShell.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 msgid "{n, plural, one {This upload satisfies # wish — review in Admin > Wishlist} other {This upload satisfies # wishes — review in Admin > Wishlist}}"
 msgstr "{n, plural, one {This upload satisfies # wish — review in Admin > Wishlist} other {This upload satisfies # wishes — review in Admin > Wishlist}}"
 
+#: src/components/MetadataManager.tsx
+msgid "{n} chapters uploaded"
+msgstr "{n} chapters uploaded"
+
+#: src/components/MetadataManager.tsx
+msgid "{n} of {total} books would change"
+msgstr "{n} of {total} books would change"
+
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 msgid "{n} selected"
 msgstr "{n} selected"
@@ -870,6 +889,10 @@ msgstr "{s}s"
 #: src/pages/DashboardPage.tsx
 msgid "{seconds}s"
 msgstr "{seconds}s"
+
+#: src/components/MetadataManager.tsx
+msgid "{seriesName} Chapter {num}"
+msgstr "{seriesName} Chapter {num}"
 
 #: src/pages/DashboardPage.tsx
 msgid "{sessions} sessions · {time}"
@@ -1266,6 +1289,7 @@ msgstr "Admin access required."
 msgid "all"
 msgstr "all"
 
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/StatsPage.tsx
@@ -1322,6 +1346,10 @@ msgstr "All imported books accepted"
 msgid "All items must have a title"
 msgstr "All items must have a title"
 
+#: src/components/MetadataManager.tsx
+msgid "All libraries"
+msgstr "All libraries"
+
 #: src/pages/BookDetailPage.tsx
 msgid "All readers: {dur} · {days} · {readers}"
 msgstr "All readers: {dur} · {days} · {readers}"
@@ -1329,6 +1357,14 @@ msgstr "All readers: {dur} · {days} · {readers}"
 #: src/components/SeriesReadingStats.tsx
 msgid "All readers: {dur} · {sess} · {readers}"
 msgstr "All readers: {dur} · {sess} · {readers}"
+
+#: src/components/MetadataManager.tsx
+msgid "All series"
+msgstr "All series"
+
+#: src/components/MetadataManager.tsx
+msgid "All types"
+msgstr "All types"
 
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -1405,9 +1441,17 @@ msgstr "Apply"
 msgid "Apply {n} Approved"
 msgstr "Apply {n} Approved"
 
+#: src/components/MetadataManager.tsx
+msgid "Apply {n} Changes"
+msgstr "Apply {n} Changes"
+
 #: src/components/ReadingImport.tsx
 msgid "Apply {n} selected"
 msgstr "Apply {n} selected"
+
+#: src/components/MetadataManager.tsx
+msgid "Apply & Next"
+msgstr "Apply & Next"
 
 #: src/pages/AdminPage.tsx
 msgid "Apply All ({n})"
@@ -1416,6 +1460,10 @@ msgstr "Apply All ({n})"
 #: src/components/BulkMetadataReviewModal.tsx
 msgid "Apply Approved"
 msgstr "Apply Approved"
+
+#: src/components/MetadataManager.tsx
+msgid "Apply Changes"
+msgstr "Apply Changes"
 
 #: src/components/MetadataFetchModal.tsx
 msgid "Apply failed"
@@ -1429,9 +1477,17 @@ msgstr "Apply Selected"
 msgid "Apply the first cover-search candidate"
 msgstr "Apply the first cover-search candidate"
 
+#: src/components/MetadataManager.tsx
+msgid "Apply to {n} Chapters"
+msgstr "Apply to {n} Chapters"
+
 #: src/pages/BinderyPage.tsx
 msgid "Apply to all"
 msgstr "Apply to all"
+
+#: src/components/MetadataManager.tsx
+msgid "Applying {done}/{total}..."
+msgstr "Applying {done}/{total}..."
 
 #: src/components/BulkMetadataReviewModal.tsx
 #: src/pages/AdminPage.tsx
@@ -1458,6 +1514,10 @@ msgstr "Are you getting faster?"
 msgid "Ask your server admin if you don't manage the Tome installation yourself."
 msgstr "Ask your server admin if you don't manage the Tome installation yourself."
 
+#: src/components/MetadataManager.tsx
+msgid "Assign Chapter Metadata"
+msgstr "Assign Chapter Metadata"
+
 #: src/pages/AdminPage.tsx
 msgid "Assign type to new books"
 msgstr "Assign type to new books"
@@ -1475,6 +1535,7 @@ msgid "Auth"
 msgstr "Auth"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/stats/widgets/library.tsx
 #: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
@@ -1519,6 +1580,10 @@ msgstr "Authors"
 #: src/pages/StatsPage.tsx
 msgid "Auto"
 msgstr "Auto"
+
+#: src/components/MetadataManager.tsx
+msgid "Auto-filled from series"
+msgstr "Auto-filled from series"
 
 #: src/pages/StatsPage.tsx
 msgid "Auto-fit height"
@@ -1572,6 +1637,10 @@ msgstr "Back to list"
 msgid "Back to search"
 msgstr "Back to search"
 
+#: src/components/MetadataManager.tsx
+msgid "Back to Table"
+msgstr "Back to Table"
+
 #: src/pages/StatsPage.tsx
 msgid "Backlog"
 msgstr "Backlog"
@@ -1592,9 +1661,21 @@ msgstr "Backup failed"
 msgid "Batch complete"
 msgstr "Batch complete"
 
+#: src/components/MetadataManager.tsx
+msgid "Batch Fetch"
+msgstr "Batch Fetch"
+
+#: src/components/MetadataManager.tsx
+msgid "Batch Fetch ({n})"
+msgstr "Batch Fetch ({n})"
+
 #: src/pages/StatsPage.tsx
 msgid "Best Day"
 msgstr "Best Day"
+
+#: src/components/MetadataFetchModal.tsx
+msgid "Best match"
+msgstr "Best match"
 
 #: src/pages/BinderyPage.tsx
 msgid "Best match applied to {matched} of {totalN} files — no match for the rest"
@@ -1642,6 +1723,10 @@ msgstr "book"
 msgid "Book"
 msgstr "Book"
 
+#: src/components/MetadataManager.tsx
+msgid "Book {at} of {total}"
+msgstr "Book {at} of {total}"
+
 #: src/pages/BinderyPage.tsx
 msgid "Book accepted"
 msgstr "Book accepted"
@@ -1675,6 +1760,7 @@ msgstr "Book rejected and removed"
 msgid "Book title"
 msgstr "Book title"
 
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Book Type"
 msgstr "Book Type"
@@ -1762,6 +1848,7 @@ msgstr "Can't find it? Add manually"
 #: src/components/LibraryHealth.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
@@ -1793,6 +1880,10 @@ msgstr "Category mix over the year"
 #: src/pages/BookDetailPage.tsx
 msgid "ch. {n}"
 msgstr "ch. {n}"
+
+#: src/components/MetadataManager.tsx
+msgid "Ch. {num}"
+msgstr "Ch. {num}"
 
 #: src/pages/BookDetailPage.tsx
 msgid "ch. 1"
@@ -1843,6 +1934,7 @@ msgstr "Choose file…"
 msgid "Choose icon"
 msgstr "Choose icon"
 
+#: src/components/MetadataManager.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/StatsPage.tsx
@@ -1874,6 +1966,10 @@ msgstr "Clear search"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Clear selection / blur search"
 msgstr "Clear selection / blur search"
+
+#: src/components/MetadataManager.tsx
+msgid "cleared"
+msgstr "cleared"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Clearing…"
@@ -2124,6 +2220,7 @@ msgid "Counts"
 msgstr "Counts"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr "Cover"
@@ -2183,6 +2280,7 @@ msgid "current"
 msgstr "current"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "Current"
 msgstr "Current"
 
@@ -2336,8 +2434,13 @@ msgstr "Deleting..."
 msgid "Deleting…"
 msgstr "Deleting…"
 
+#: src/components/MetadataManager.tsx
+msgid "Desc"
+msgstr "Desc"
+
 #: src/components/ManageSeriesModal.tsx
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2748,6 +2851,10 @@ msgstr "Failed to add wish"
 msgid "Failed to apply cover"
 msgstr "Failed to apply cover"
 
+#: src/components/MetadataManager.tsx
+msgid "Failed to apply metadata."
+msgstr "Failed to apply metadata."
+
 #: src/pages/SettingsPage.tsx
 msgid "Failed to authorize"
 msgstr "Failed to authorize"
@@ -2776,6 +2883,10 @@ msgstr "Failed to delete highlight"
 #: src/components/CoverPickerModal.tsx
 msgid "Failed to fetch candidates"
 msgstr "Failed to fetch candidates"
+
+#: src/components/MetadataManager.tsx
+msgid "Failed to fetch candidates."
+msgstr "Failed to fetch candidates."
 
 #: src/pages/LoginPage.tsx
 msgid "Failed to generate code. Try again."
@@ -2808,6 +2919,10 @@ msgstr "Failed to load facets"
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to load libraries"
 msgstr "Failed to load libraries"
+
+#: src/components/MetadataManager.tsx
+msgid "Failed to load metadata audit data."
+msgstr "Failed to load metadata audit data."
 
 #: src/pages/HighlightsPage.tsx
 msgid "Failed to load more"
@@ -2917,6 +3032,10 @@ msgstr "fantasy, action, romance"
 msgid "Fastest"
 msgstr "Fastest"
 
+#: src/components/MetadataManager.tsx
+msgid "Fetch"
+msgstr "Fetch"
+
 #: src/components/BulkMetadataReviewModal.tsx
 msgid "Fetch failed"
 msgstr "Fetch failed"
@@ -2932,8 +3051,13 @@ msgid "Fetching metadata..."
 msgstr "Fetching metadata..."
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "Field"
 msgstr "Field"
+
+#: src/components/MetadataManager.tsx
+msgid "Field diff"
+msgstr "Field diff"
 
 #: src/components/LibraryHealth.tsx
 msgid "File {id}: {err}"
@@ -3170,6 +3294,7 @@ msgid "Hardcover sync is disabled on this server."
 msgstr "Hardcover sync is disabled on this server."
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "Has cover"
 msgstr "Has cover"
 
@@ -3352,9 +3477,14 @@ msgid "Include"
 msgstr "Include"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/AdminPage.tsx
 msgid "Incoming"
 msgstr "Incoming"
+
+#: src/components/MetadataManager.tsx
+msgid "Index"
+msgstr "Index"
 
 #: src/components/InstanceBackup.tsx
 msgid "Instance backup"
@@ -3365,6 +3495,7 @@ msgid "IP:"
 msgstr "IP:"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/ReadingImport.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "ISBN"
@@ -3442,7 +3573,12 @@ msgstr "Label"
 msgid "Label (e.g. KOReader)"
 msgstr "Label (e.g. KOReader)"
 
+#: src/components/MetadataManager.tsx
+msgid "Lang"
+msgstr "Lang"
+
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -3810,6 +3946,7 @@ msgstr "Minutes per week"
 msgid "Minutes read per day"
 msgstr "Minutes read per day"
 
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Missing"
 msgstr "Missing"
@@ -4020,6 +4157,10 @@ msgstr "No arcs defined yet. Click “Add arc” to create one."
 msgid "No audit entries yet."
 msgstr "No audit entries yet."
 
+#: src/components/MetadataManager.tsx
+msgid "No author"
+msgstr "No author"
+
 #: src/components/stats/AuthorAffinity.tsx
 msgid "No author data."
 msgstr "No author data."
@@ -4048,6 +4189,14 @@ msgstr "No books in progress"
 msgid "No books in this view."
 msgstr "No books in this view."
 
+#: src/components/MetadataManager.tsx
+msgid "No books match the current filters."
+msgstr "No books match the current filters."
+
+#: src/components/MetadataManager.tsx
+msgid "No candidates found."
+msgstr "No candidates found."
+
 #: src/components/stats/widgets/library.tsx
 msgid "No category data."
 msgstr "No category data."
@@ -4062,6 +4211,7 @@ msgstr "No completion data by type."
 
 #: src/components/CoverAudit.tsx
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "No cover"
 msgstr "No cover"
 
@@ -4331,6 +4481,10 @@ msgstr "No suggested match yet — search for the book to link, or upload it fir
 msgid "No timed reading with word counts yet."
 msgstr "No timed reading with word counts yet."
 
+#: src/components/MetadataManager.tsx
+msgid "No titles need standardizing."
+msgstr "No titles need standardizing."
+
 #: src/pages/LoginPage.tsx
 msgid "No Tome account is linked to this identity, and self-signup is disabled."
 msgstr "No Tome account is linked to this identity, and self-signup is disabled."
@@ -4365,6 +4519,7 @@ msgstr "No widgets on this board yet."
 msgid "No word counts yet."
 msgstr "No word counts yet."
 
+#: src/components/MetadataManager.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/StatsPage.tsx
@@ -4611,6 +4766,10 @@ msgstr "over {days} days"
 msgid "Override search query (optional)…"
 msgstr "Override search query (optional)…"
 
+#: src/components/MetadataManager.tsx
+msgid "Override search query…"
+msgstr "Override search query…"
+
 #: src/pages/StatsPage.tsx
 msgid "Overview"
 msgstr "Overview"
@@ -4797,6 +4956,7 @@ msgstr "Preview"
 msgid "Preview:"
 msgstr "Preview:"
 
+#: src/components/MetadataManager.tsx
 #: src/pages/AdminPage.tsx
 msgid "Previous"
 msgstr "Previous"
@@ -4856,6 +5016,7 @@ msgid "Publication status"
 msgstr "Publication status"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
@@ -5340,6 +5501,22 @@ msgstr "Review {n} Uncertain"
 msgid "Review all failed"
 msgstr "Review all failed"
 
+#: src/components/MetadataManager.tsx
+msgid "Review All Filtered ({n})"
+msgstr "Review All Filtered ({n})"
+
+#: src/components/MetadataManager.tsx
+msgid "Review complete"
+msgstr "Review complete"
+
+#: src/components/MetadataManager.tsx
+msgid "Review Selected"
+msgstr "Review Selected"
+
+#: src/components/MetadataManager.tsx
+msgid "Reviewed {total} books — applied changes to {applied}, skipped {skipped}."
+msgstr "Reviewed {total} books — applied changes to {applied}, skipped {skipped}."
+
 #: src/pages/BinderyPage.tsx
 msgid "Reviewing {n} files"
 msgstr "Reviewing {n} files"
@@ -5489,6 +5666,10 @@ msgstr "Scanning…"
 msgid "Scope"
 msgstr "Scope"
 
+#: src/components/MetadataManager.tsx
+msgid "Score"
+msgstr "Score"
+
 #: src/components/HScrollRow.tsx
 msgid "Scroll left"
 msgstr "Scroll left"
@@ -5551,6 +5732,10 @@ msgstr "Search manually"
 msgid "Search query..."
 msgstr "Search query..."
 
+#: src/components/MetadataManager.tsx
+msgid "Search title, author…"
+msgstr "Search title, author…"
+
 #: src/components/Sidebar.tsx
 msgid "Search to find more icons"
 msgstr "Search to find more icons"
@@ -5604,6 +5789,10 @@ msgstr "Select all"
 #: src/pages/BinderyPage.tsx
 msgid "Select All"
 msgstr "Select All"
+
+#: src/components/MetadataManager.tsx
+msgid "Select all ({n})"
+msgstr "Select all ({n})"
 
 #: src/components/SendToDeviceModal.tsx
 msgid "Send"
@@ -5663,6 +5852,7 @@ msgstr "Sent {sent}/{total}. {failedN} failed."
 #: src/components/CommandPalette.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/Sidebar.tsx
 #: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
@@ -5672,6 +5862,7 @@ msgid "Series"
 msgstr "Series"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Series #"
 msgstr "Series #"
@@ -5940,6 +6131,7 @@ msgstr "Single Sign-On"
 msgid "Size"
 msgstr "Size"
 
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Skip"
 msgstr "Skip"
@@ -5955,6 +6147,10 @@ msgstr "SMTP Status"
 #: src/components/CoverAudit.tsx
 msgid "Some books had no usable candidate or failed to apply — open them and use the cover picker."
 msgstr "Some books had no usable candidate or failed to apply — open them and use the cover picker."
+
+#: src/components/MetadataManager.tsx
+msgid "Some changes failed to apply."
+msgstr "Some changes failed to apply."
 
 #: src/pages/AdminPage.tsx
 msgid "Sort Order"
@@ -6004,6 +6200,14 @@ msgstr "SSO sign-in linked to your account."
 msgid "Stage restore"
 msgstr "Stage restore"
 
+#: src/components/MetadataManager.tsx
+msgid "Standardize"
+msgstr "Standardize"
+
+#: src/components/MetadataManager.tsx
+msgid "Standardize Titles"
+msgstr "Standardize Titles"
+
 #: src/pages/BookDetailPage.tsx
 msgid "start"
 msgstr "start"
@@ -6039,6 +6243,10 @@ msgstr "Start reading and your progress will show up here"
 #: src/components/stats/widgets/overview.tsx
 msgid "Start reading one and it'll show up here"
 msgstr "Start reading one and it'll show up here"
+
+#: src/components/MetadataManager.tsx
+msgid "Start typing to search..."
+msgstr "Start typing to search..."
 
 #: src/pages/StatsPage.tsx
 msgid "Started vs finished ratio"
@@ -6076,6 +6284,10 @@ msgstr "Strong enough"
 #: src/pages/StatsPage.tsx
 msgid "Su"
 msgstr "Su"
+
+#: src/components/MetadataManager.tsx
+msgid "Subtitle"
+msgstr "Subtitle"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Subtitle (optional)"
@@ -6162,6 +6374,7 @@ msgid "Tag: {filterTag}"
 msgstr "Tag: {filterTag}"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "Tags"
 msgstr "Tags"
 
@@ -6345,6 +6558,7 @@ msgid "title"
 msgstr "title"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/stats/widgets/library.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -6590,6 +6804,7 @@ msgid "Update to v{v}"
 msgstr "Update to v{v}"
 
 #: src/components/AppHeader.tsx
+#: src/components/MetadataManager.tsx
 msgid "Upload"
 msgstr "Upload"
 
@@ -6600,6 +6815,10 @@ msgstr "Upload All"
 #: src/components/UploadModal.tsx
 msgid "Upload Books"
 msgstr "Upload Books"
+
+#: src/components/MetadataManager.tsx
+msgid "Upload Chapters"
+msgstr "Upload Chapters"
 
 #: src/components/UploadModal.tsx
 msgid "Upload failed"
@@ -6893,6 +7112,7 @@ msgid "Words Read"
 msgstr "Words Read"
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -25,13 +25,25 @@ msgstr " — MISSING"
 msgid " · {dups} duplicates"
 msgstr " · {dups} duplicates"
 
+#: src/pages/SharePage.tsx
+msgid " · {dur} read time"
+msgstr " · {dur} read time"
+
 #: src/pages/AdminPage.tsx
 msgid " · {errs} error(s)"
 msgstr " · {errs} error(s)"
 
+#: src/pages/SharePage.tsx
+msgid " · {n} read"
+msgstr " · {n} read"
+
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
 msgstr " · {prog}% in"
+
+#: src/pages/SharePage.tsx
+msgid " · finished {d}"
+msgstr " · finished {d}"
 
 #: src/pages/BinderyPage.tsx
 msgid " · reviewed"
@@ -61,6 +73,18 @@ msgstr "…and {more} more not shown"
 msgid "· {n} docs"
 msgstr "· {n} docs"
 
+#: src/pages/SharePage.tsx
+msgid "· a shared book"
+msgstr "· a shared book"
+
+#: src/pages/SharePage.tsx
+msgid "· a shared series"
+msgstr "· a shared series"
+
+#: src/pages/SharePage.tsx
+msgid "· a shared shelf"
+msgstr "· a shared shelf"
+
 #: src/pages/BookDetailPage.tsx
 msgid "· p. {page} of {totalPages}"
 msgstr "· p. {page} of {totalPages}"
@@ -81,13 +105,20 @@ msgstr "(leave blank to keep)"
 msgid "(not set)"
 msgstr "(not set)"
 
+#. placeholder {0}: b.stats.reading_days
+#: src/pages/SharePage.tsx
+msgid "{0, plural, one {{dur} over # day} other {{dur} over # days}}"
+msgstr "{0, plural, one {{dur} over # day} other {{dur} over # days}}"
+
 #. placeholder {0}: res.errors.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 msgstr "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 
+#. placeholder {0}: data.totals.books
 #. placeholder {0}: s.book_count
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
 msgstr "{0, plural, one {# book} other {# books}}"
 
@@ -131,6 +162,11 @@ msgstr "{0, plural, one {# suggested match} other {# suggested matches}}"
 msgid "{0, plural, one {# user} other {# users}}"
 msgstr "{0, plural, one {# user} other {# users}}"
 
+#. placeholder {0}: data.totals.books
+#: src/pages/SharePage.tsx
+msgid "{0, plural, one {# volume} other {# volumes}}"
+msgstr "{0, plural, one {# volume} other {# volumes}}"
+
 #. placeholder {0}: group.files.length
 #: src/pages/BinderyPage.tsx
 msgid "{0, plural, one {Accept # volume} other {Accept # volumes}}"
@@ -161,6 +197,11 @@ msgstr "{0, plural, one {Delete # book} other {Delete # books}}"
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Deleting # book...} other {Deleting # books...}}"
 msgstr "{0, plural, one {Deleting # book...} other {Deleting # books...}}"
+
+#. placeholder {0}: b.highlights.length
+#: src/pages/SharePage.tsx
+msgid "{0, plural, one {Description & # highlight} other {Description & # highlights}}"
+msgstr "{0, plural, one {Description & # highlight} other {Description & # highlights}}"
 
 #. placeholder {0}: selected.size
 #: src/pages/DashboardPage.tsx
@@ -263,10 +304,12 @@ msgid "{failedN} of {totalN} failed — {firstErr}"
 msgstr "{failedN} of {totalN} failed — {firstErr}"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "{h}h"
 msgstr "{h}h"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
 msgstr "{h}h {m}m"
 
@@ -288,6 +331,7 @@ msgid "{inc, plural, one {# file waiting for review} other {# files waiting for 
 msgstr "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "{m}m"
 msgstr "{m}m"
 
@@ -352,6 +396,10 @@ msgstr "{pacePerMin} pg/min"
 #: src/pages/DashboardPage.tsx
 msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
 msgstr "{readCount} read · {readingCount} reading · {unreadCount} unread"
+
+#: src/pages/SharePage.tsx
+msgid "{readN} read · {unreadN} unread"
+msgstr "{readN} read · {unreadN} unread"
 
 #: src/pages/BookDetailPage.tsx
 msgid "{recent} in the last 7 days vs {prior} the week before"
@@ -647,6 +695,10 @@ msgstr "Author: {filterAuthor}"
 msgid "Authorize"
 msgstr "Authorize"
 
+#: src/pages/LoginPage.tsx
+msgid "Authorize this code from another device"
+msgstr "Authorize this code from another device"
+
 #: src/pages/SettingsPage.tsx
 msgid "Authorizing..."
 msgstr "Authorizing..."
@@ -754,6 +806,7 @@ msgstr "Browse your library"
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
 msgstr "Cancel"
@@ -838,6 +891,10 @@ msgstr "Close"
 msgid "Close navigation"
 msgstr "Close navigation"
 
+#: src/pages/LoginPage.tsx
+msgid "Code expired. Try again."
+msgstr "Code expired. Try again."
+
 #: src/pages/SettingsPage.tsx
 msgid "Code from new device"
 msgstr "Code from new device"
@@ -900,6 +957,10 @@ msgstr "Confirm"
 msgid "Confirm new password"
 msgstr "Confirm new password"
 
+#: src/pages/SetupPage.tsx
+msgid "Confirm password"
+msgstr "Confirm password"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Content"
 msgstr "Content"
@@ -956,6 +1017,14 @@ msgstr "Covers"
 #: src/pages/SettingsPage.tsx
 msgid "Create"
 msgstr "Create"
+
+#: src/pages/SetupPage.tsx
+msgid "Create admin account"
+msgstr "Create admin account"
+
+#: src/pages/SetupPage.tsx
+msgid "Create your admin account to get started"
+msgstr "Create your admin account to get started"
 
 #: src/pages/SettingsPage.tsx
 msgid "Created"
@@ -1047,6 +1116,7 @@ msgstr "Deleting…"
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "Description"
 msgstr "Description"
 
@@ -1210,6 +1280,7 @@ msgstr "Edit User"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Email"
 msgstr "Email"
 
@@ -1248,6 +1319,10 @@ msgstr "Exit selection mode"
 #: src/components/Sidebar.tsx
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
+
+#: src/pages/LoginPage.tsx
+msgid "Expires in {timeLeft}"
+msgstr "Expires in {timeLeft}"
 
 #: src/pages/SettingsPage.tsx
 msgid "Export"
@@ -1294,6 +1369,10 @@ msgstr "Failed to create token"
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to delete highlight"
 msgstr "Failed to delete highlight"
+
+#: src/pages/LoginPage.tsx
+msgid "Failed to generate code. Try again."
+msgstr "Failed to generate code. Try again."
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to link sync document"
@@ -1402,6 +1481,7 @@ msgid "Filters"
 msgstr "Filters"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "finished"
 msgstr "finished"
 
@@ -1505,6 +1585,7 @@ msgid "Hardcover"
 msgstr "Hardcover"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "hiatus"
 msgstr "hiatus"
 
@@ -1537,6 +1618,10 @@ msgstr "Host"
 #: src/pages/BookDetailPage.tsx
 msgid "How far through the book you'd read by each date."
 msgstr "How far through the book you'd read by each date."
+
+#: src/pages/LoginPage.tsx
+msgid "How to authorize"
+msgstr "How to authorize"
 
 #: src/pages/SettingsPage.tsx
 msgid "How to set it up"
@@ -1633,6 +1718,10 @@ msgstr "Keyboard Shortcuts"
 msgid "Kindle users"
 msgstr "Kindle users"
 
+#: src/pages/SetupPage.tsx
+msgid "KOReader Sync"
+msgstr "KOReader Sync"
+
 #: src/pages/BookDetailPage.tsx
 msgid "KOReader sync linked"
 msgstr "KOReader sync linked"
@@ -1680,6 +1769,14 @@ msgstr "Last used"
 #: src/pages/SettingsPage.tsx
 msgid "Learn more"
 msgstr "Learn more"
+
+#: src/pages/SharePage.tsx
+msgid "Less"
+msgstr "Less"
+
+#: src/pages/SetupPage.tsx
+msgid "librarian"
+msgstr "librarian"
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
@@ -1744,6 +1841,10 @@ msgstr "List view"
 msgid "Loading..."
 msgstr "Loading..."
 
+#: src/pages/SharePage.tsx
+msgid "Loading…"
+msgstr "Loading…"
+
 #: src/pages/AdminPage.tsx
 msgid "Log in as this user"
 msgstr "Log in as this user"
@@ -1755,6 +1856,10 @@ msgstr "Log out"
 #: src/pages/BookDetailPage.tsx
 msgid "Log session"
 msgstr "Log session"
+
+#: src/pages/LoginPage.tsx
+msgid "Login failed"
+msgstr "Login failed"
 
 #: src/pages/SettingsPage.tsx
 msgid "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
@@ -1828,6 +1933,10 @@ msgstr "Metadata saved"
 #: src/pages/BinderyPage.tsx
 msgid "Metadata Suggestions"
 msgstr "Metadata Suggestions"
+
+#: src/pages/SetupPage.tsx
+msgid "Minimum 8 characters"
+msgstr "Minimum 8 characters"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Minutes"
@@ -2037,6 +2146,10 @@ msgstr "No series found — add series metadata to your books."
 msgid "No suggested match yet — search for the book to link, or upload it first."
 msgstr "No suggested match yet — search for the book to link, or upload it first."
 
+#: src/pages/LoginPage.tsx
+msgid "No Tome account is linked to this identity, and self-signup is disabled."
+msgstr "No Tome account is linked to this identity, and self-signup is disabled."
+
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "No type"
@@ -2059,6 +2172,10 @@ msgstr "None"
 msgid "Not configured"
 msgstr "Not configured"
 
+#: src/pages/SharePage.tsx
+msgid "Not found"
+msgstr "Not found"
+
 #: src/pages/BookDetailPage.tsx
 msgid "not read"
 msgstr "not read"
@@ -2074,6 +2191,10 @@ msgstr "Note removed"
 #: src/pages/BookDetailPage.tsx
 msgid "Note saved — syncs to your devices"
 msgstr "Note saved — syncs to your devices"
+
+#: src/pages/SharePage.tsx
+msgid "Nothing here yet."
+msgstr "Nothing here yet."
 
 #: src/pages/DashboardPage.tsx
 msgid "Nothing in progress"
@@ -2092,11 +2213,16 @@ msgstr "Notifications"
 msgid "of {totalPages} pages"
 msgstr "of {totalPages} pages"
 
+#: src/pages/LoginPage.tsx
+msgid "On a device where you're already signed in, go to <0>Settings → Security → Quick Connect</0> and enter this code."
+msgstr "On a device where you're already signed in, go to <0>Settings → Security → Quick Connect</0> and enter this code."
+
 #: src/pages/DashboardPage.tsx
 msgid "On this day"
 msgstr "On this day"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "ongoing"
 msgstr "ongoing"
 
@@ -2140,6 +2266,10 @@ msgstr "Other files"
 msgid "Other providers"
 msgstr "Other providers"
 
+#: src/pages/SharePage.tsx
+msgid "Other volumes"
+msgstr "Other volumes"
+
 #: src/pages/SettingsPage.tsx
 msgid "Owner"
 msgstr "Owner"
@@ -2161,11 +2291,14 @@ msgid "password"
 msgstr "password"
 
 #: src/pages/AdminPage.tsx
+#: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Password"
 msgstr "Password"
 
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Password must be at least 8 characters"
 msgstr "Password must be at least 8 characters"
 
@@ -2174,6 +2307,7 @@ msgid "Password updated successfully"
 msgstr "Password updated successfully"
 
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Passwords do not match"
 msgstr "Passwords do not match"
 
@@ -2291,6 +2425,7 @@ msgstr "Quick Accept Progress"
 msgid "Quick Accept: {done}/{total} done"
 msgstr "Quick Accept: {done}/{total} done"
 
+#: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Quick Connect"
 msgstr "Quick Connect"
@@ -2327,6 +2462,7 @@ msgstr "read"
 #: src/components/BookCard.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "Read"
 msgstr "Read"
 
@@ -2368,6 +2504,7 @@ msgid "reading"
 msgstr "reading"
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "Reading"
 msgstr "Reading"
 
@@ -2384,6 +2521,7 @@ msgid "Reading Log"
 msgstr "Reading Log"
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Reading Stats"
 msgstr "Reading Stats"
 
@@ -2699,6 +2837,10 @@ msgstr "Set the following environment variables to enable Send to Device:"
 msgid "Settings"
 msgstr "Settings"
 
+#: src/pages/SetupPage.tsx
+msgid "Setup failed"
+msgstr "Setup failed"
+
 #: src/pages/SettingsPage.tsx
 msgid "Setup instructions"
 msgstr "Setup instructions"
@@ -2727,6 +2869,10 @@ msgstr "Share with users"
 #: src/pages/BinderyPage.tsx
 msgid "Shared fields — applies to all {n} items"
 msgstr "Shared fields — applies to all {n} items"
+
+#: src/pages/SharePage.tsx
+msgid "Shared from a self-hosted Tome library"
+msgstr "Shared from a self-hosted Tome library"
 
 #: src/pages/DashboardPage.tsx
 msgid "Shared Library"
@@ -2783,9 +2929,21 @@ msgstr "Show more"
 msgid "Show this help"
 msgstr "Show this help"
 
+#: src/pages/LoginPage.tsx
+msgid "Sign in"
+msgstr "Sign in"
+
 #: src/pages/SettingsPage.tsx
 msgid "Sign in on a new device without entering your password. On the new device, tap \"Quick Connect\" on the login screen to get a 6-character code, then enter it here."
 msgstr "Sign in on a new device without entering your password. On the new device, tap \"Quick Connect\" on the login screen to get a 6-character code, then enter it here."
+
+#: src/pages/LoginPage.tsx
+msgid "Sign in to your library"
+msgstr "Sign in to your library"
+
+#: src/pages/OidcCallbackPage.tsx
+msgid "Signing you in…"
+msgstr "Signing you in…"
 
 #: src/pages/AdminPage.tsx
 msgid "Similar Title"
@@ -2815,6 +2973,30 @@ msgstr "Sort Order"
 msgid "Source"
 msgstr "Source"
 
+#: src/pages/LoginPage.tsx
+msgid "SSO is misconfigured on the server (redirect URL). Contact your admin."
+msgstr "SSO is misconfigured on the server (redirect URL). Contact your admin."
+
+#: src/pages/LoginPage.tsx
+msgid "SSO is not enabled."
+msgstr "SSO is not enabled."
+
+#: src/pages/LoginPage.tsx
+msgid "SSO sign-in could not be completed. Please try again."
+msgstr "SSO sign-in could not be completed. Please try again."
+
+#: src/pages/LoginPage.tsx
+msgid "SSO sign-in did not complete. Please try again."
+msgstr "SSO sign-in did not complete. Please try again."
+
+#: src/pages/LoginPage.tsx
+msgid "SSO sign-in failed: no identity information was returned."
+msgstr "SSO sign-in failed: no identity information was returned."
+
+#: src/pages/LoginPage.tsx
+msgid "SSO sign-in failed. Please try again."
+msgstr "SSO sign-in failed. Please try again."
+
 #: src/pages/SettingsPage.tsx
 msgid "SSO sign-in linked to your account."
 msgstr "SSO sign-in linked to your account."
@@ -2843,6 +3025,10 @@ msgstr "Status"
 #: src/pages/DashboardPage.tsx
 msgid "Status: {filterStatusLabel}"
 msgstr "Status: {filterStatusLabel}"
+
+#: src/pages/SetupPage.tsx
+msgid "Strong enough"
+msgstr "Strong enough"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Subtitle (optional)"
@@ -2963,6 +3149,11 @@ msgstr "Toggle only-notes filter"
 msgid "Token name"
 msgstr "Token name"
 
+#: src/pages/LoginPage.tsx
+#: src/pages/SetupPage.tsx
+msgid "Tome · Your personal library"
+msgstr "Tome · Your personal library"
+
 #: src/pages/SettingsPage.tsx
 msgid "TomeSync and KOSync can both be active. TomeSync tracks full reading sessions; KOSync only stores your last position."
 msgstr "TomeSync and KOSync can both be active. TomeSync tracks full reading sessions; KOSync only stores your last position."
@@ -2978,6 +3169,10 @@ msgstr "Translations are community-maintained. Anything not yet translated is sh
 #: src/pages/DashboardPage.tsx
 msgid "Try adjusting your filters"
 msgstr "Try adjusting your filters"
+
+#: src/pages/LoginPage.tsx
+msgid "Try again"
+msgstr "Try again"
 
 #: src/pages/BinderyPage.tsx
 msgid "Try editing the title or series fields"
@@ -3084,8 +3279,13 @@ msgstr "User menu"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Username"
 msgstr "Username"
+
+#: src/pages/LoginPage.tsx
+msgid "Username or email"
+msgstr "Username or email"
 
 #: src/pages/AdminPage.tsx
 msgid "Users"
@@ -3106,6 +3306,10 @@ msgstr "Viewing as <0>{impersonatedUsername}</0>"
 #: src/pages/BinderyPage.tsx
 msgid "Vol {idx}"
 msgstr "Vol {idx}"
+
+#: src/pages/SharePage.tsx
+msgid "Vol. {a}–{b}"
+msgstr "Vol. {a}–{b}"
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -3128,6 +3332,10 @@ msgstr "Volume"
 #: src/pages/DashboardPage.tsx
 msgid "Volumes"
 msgstr "Volumes"
+
+#: src/pages/LoginPage.tsx
+msgid "Waiting for authorization…"
+msgstr "Waiting for authorization…"
 
 #: src/pages/AdminPage.tsx
 msgid "Walk the library directory and add any new book files found."
@@ -3157,6 +3365,14 @@ msgstr "Web"
 #: src/pages/BookDetailPage.tsx
 msgid "Web reader"
 msgstr "Web reader"
+
+#: src/pages/LoginPage.tsx
+msgid "Welcome back"
+msgstr "Welcome back"
+
+#: src/pages/SetupPage.tsx
+msgid "Welcome to Tome"
+msgstr "Welcome to Tome"
 
 #: src/pages/BookDetailPage.tsx
 msgid "What did you think? (optional, saved automatically)"
@@ -3218,6 +3434,18 @@ msgstr "You're signed in via SSO. Manage your credentials at your identity provi
 msgid "Your account is linked to SSO — you can sign in with your identity provider."
 msgstr "Your account is linked to SSO — you can sign in with your identity provider."
 
+#: src/pages/LoginPage.tsx
+msgid "Your account is not permitted to sign in to Tome."
+msgstr "Your account is not permitted to sign in to Tome."
+
+#: src/pages/SetupPage.tsx
+msgid "Your library"
+msgstr "Your library"
+
+#: src/pages/SetupPage.tsx
+msgid "Your Library"
+msgstr "Your Library"
+
 #: src/pages/DashboardPage.tsx
 msgid "Your library is empty"
 msgstr "Your library is empty"
@@ -3229,6 +3457,10 @@ msgstr "Your note — syncs back to KOReader on the next sync"
 #: src/pages/SettingsPage.tsx
 msgid "Your server admin needs to set SMTP environment variables:"
 msgstr "Your server admin needs to set SMTP environment variables:"
+
+#: src/pages/LoginPage.tsx
+msgid "Your Tome account is disabled."
+msgstr "Your Tome account is disabled."
 
 #: src/pages/SettingsPage.tsx
 msgid "your Tome password"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -13,37 +13,188 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/pages/DashboardPage.tsx
+msgid "— keep existing —"
+msgstr "— keep existing —"
+
+#: src/pages/DashboardPage.tsx
+msgid "…and {more} more not shown"
+msgstr "…and {more} more not shown"
+
+#. placeholder {0}: s.book_count
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {# book} other {# books}}"
+msgstr "{0, plural, one {# book} other {# books}}"
+
+#. placeholder {0}: selected.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Added # book to library} other {Added # books to library}}"
+msgstr "{0, plural, one {Added # book to library} other {Added # books to library}}"
+
+#. placeholder {0}: selectedIds.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Delete # book} other {Delete # books}}"
+msgstr "{0, plural, one {Delete # book} other {Delete # books}}"
+
+#. placeholder {0}: selectedIds.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Deleting # book...} other {Deleting # books...}}"
+msgstr "{0, plural, one {Deleting # book...} other {Deleting # books...}}"
+
+#. placeholder {0}: selected.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Books}}"
+msgstr "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Books}}"
+
+#. placeholder {0}: selected.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
+msgstr "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{d}d ago"
+msgstr "{d}d ago"
+
 #: src/components/NotificationBell.tsx
 msgid "{days}d ago"
 msgstr "{days}d ago"
 
+#: src/pages/DashboardPage.tsx
+msgid "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
+msgstr "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+msgstr "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{h}h"
+msgstr "{h}h"
+
+#: src/pages/DashboardPage.tsx
+msgid "{h}h {m}m"
+msgstr "{h}h {m}m"
+
 #: src/components/NotificationBell.tsx
 msgid "{hrs}h ago"
 msgstr "{hrs}h ago"
+
+#: src/pages/DashboardPage.tsx
+msgid "{m}m"
+msgstr "{m}m"
 
 #: src/components/NotificationBell.tsx
 msgid "{mins}m ago"
 msgstr "{mins}m ago"
 
 #: src/components/AppShell.tsx
+#: src/pages/DashboardPage.tsx
 msgid "{n, plural, one {This upload satisfies # wish — review in Admin > Wishlist} other {This upload satisfies # wishes — review in Admin > Wishlist}}"
 msgstr "{n, plural, one {This upload satisfies # wish — review in Admin > Wishlist} other {This upload satisfies # wishes — review in Admin > Wishlist}}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{n} selected"
+msgstr "{n} selected"
+
+#: src/pages/DashboardPage.tsx
+msgid "{name} · Vol. {start_index}–{end_index}"
+msgstr "{name} · Vol. {start_index}–{end_index}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
+msgstr "{readCount} read · {readingCount} reading · {unreadCount} unread"
+
+#: src/pages/DashboardPage.tsx
+msgid "{seconds}s"
+msgstr "{seconds}s"
+
+#: src/pages/DashboardPage.tsx
+msgid "{sessions} sessions · {time}"
+msgstr "{sessions} sessions · {time}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{shown, plural, one {# book} other {# books}}"
+msgstr "{shown, plural, one {# book} other {# books}}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{shown, plural, one {# title} other {# titles}}"
+msgstr "{shown, plural, one {# title} other {# titles}}"
 
 #: src/components/Sidebar.tsx
 msgid "{themeName} theme"
 msgstr "{themeName} theme"
 
+#: src/pages/DashboardPage.tsx
+msgid "{total, plural, one {# volume} other {# volumes}}"
+msgstr "{total, plural, one {# volume} other {# volumes}}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{totalCount, plural, one {{shown} of # book} other {{shown} of # books}}"
+msgstr "{totalCount, plural, one {{shown} of # book} other {{shown} of # books}}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{totalCount, plural, one {{shown} of # title} other {{shown} of # titles}}"
+msgstr "{totalCount, plural, one {{shown} of # title} other {{shown} of # titles}}"
+
+#: src/pages/DashboardPage.tsx
+msgid "{totalCount, plural, one {# result for \"{search}\"} other {# results for \"{search}\"}}"
+msgstr "{totalCount, plural, one {# result for \"{search}\"} other {# results for \"{search}\"}}"
+
+#: src/pages/DashboardPage.tsx
+msgid "A while ago"
+msgstr "A while ago"
+
+#: src/pages/DashboardPage.tsx
+msgid "Add tag…"
+msgstr "Add tag…"
+
+#: src/pages/DashboardPage.tsx
+msgid "Add Tags"
+msgstr "Add Tags"
+
+#: src/pages/DashboardPage.tsx
+msgid "Add to Library"
+msgstr "Add to Library"
+
 #: src/components/Sidebar.tsx
 msgid "Admin"
 msgstr "Admin"
+
+#: src/pages/DashboardPage.tsx
+msgid "All"
+msgstr "All"
+
+#: src/pages/DashboardPage.tsx
+msgid "All {loadedCount} books loaded"
+msgstr "All {loadedCount} books loaded"
+
+#: src/pages/DashboardPage.tsx
+msgid "All →"
+msgstr "All →"
 
 #: src/components/Sidebar.tsx
 msgid "All Books"
 msgstr "All Books"
 
+#: src/pages/DashboardPage.tsx
+msgid "All users"
+msgstr "All users"
+
 #: src/components/Sidebar.tsx
 msgid "Amber"
 msgstr "Amber"
+
+#: src/pages/DashboardPage.tsx
+msgid "Any"
+msgstr "Any"
+
+#: src/pages/DashboardPage.tsx
+msgid "Author"
+msgstr "Author"
+
+#: src/pages/DashboardPage.tsx
+msgid "Author: {filterAuthor}"
+msgstr "Author: {filterAuthor}"
 
 #: src/components/Sidebar.tsx
 msgid "Bindery"
@@ -57,16 +208,42 @@ msgstr "Black"
 msgid "Book Detail"
 msgstr "Book Detail"
 
+#: src/pages/DashboardPage.tsx
+msgid "Books"
+msgstr "Books"
+
+#: src/pages/DashboardPage.tsx
+msgid "Books without a series"
+msgstr "Books without a series"
+
+#: src/pages/DashboardPage.tsx
+msgid "Browse your library"
+msgstr "Browse your library"
+
 #: src/components/Sidebar.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Cancel"
 msgstr "Cancel"
+
+#: src/pages/DashboardPage.tsx
+msgid "Chapters"
+msgstr "Chapters"
 
 #: src/components/Sidebar.tsx
 msgid "Choose icon"
 msgstr "Choose icon"
 
+#: src/pages/DashboardPage.tsx
+msgid "Clear all"
+msgstr "Clear all"
+
+#: src/pages/DashboardPage.tsx
+msgid "Clear all filters"
+msgstr "Clear all filters"
+
 #: src/components/AppHeader.tsx
 #: src/components/KeyboardShortcutsModal.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Clear search"
 msgstr "Clear search"
 
@@ -90,25 +267,75 @@ msgstr "Collapse sidebar"
 msgid "Command palette — jump to a book, series, author, or page"
 msgstr "Command palette — jump to a book, series, author, or page"
 
+#: src/pages/DashboardPage.tsx
+msgid "Continue Reading"
+msgstr "Continue Reading"
+
+#: src/pages/DashboardPage.tsx
+msgid "Cover"
+msgstr "Cover"
+
+#: src/pages/DashboardPage.tsx
+msgid "Cover size"
+msgstr "Cover size"
+
 #: src/components/Sidebar.tsx
 msgid "Dark"
 msgstr "Dark"
 
 #: src/components/KeyboardShortcutsModal.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Dashboard"
 msgstr "Dashboard"
 
+#: src/pages/DashboardPage.tsx
+msgid "Date Added"
+msgstr "Date Added"
+
+#: src/pages/DashboardPage.tsx
+msgid "Day streak"
+msgstr "Day streak"
+
 #: src/components/Sidebar.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Delete"
 msgstr "Delete"
+
+#: src/pages/DashboardPage.tsx
+msgid "Delete failed"
+msgstr "Delete failed"
+
+#: src/pages/DashboardPage.tsx
+msgid "Description"
+msgstr "Description"
+
+#: src/pages/DashboardPage.tsx
+msgid "Deselect all"
+msgstr "Deselect all"
+
+#: src/pages/DashboardPage.tsx
+msgid "Dismiss"
+msgstr "Dismiss"
 
 #: src/components/Sidebar.tsx
 msgid "Docs"
 msgstr "Docs"
 
+#: src/pages/DashboardPage.tsx
+msgid "Done"
+msgstr "Done"
+
+#: src/pages/DashboardPage.tsx
+msgid "Download failed"
+msgstr "Download failed"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Download Markdown export"
 msgstr "Download Markdown export"
+
+#: src/pages/DashboardPage.tsx
+msgid "Download ZIP"
+msgstr "Download ZIP"
 
 #: src/components/Sidebar.tsx
 msgid "Edit"
@@ -117,6 +344,10 @@ msgstr "Edit"
 #: src/components/Sidebar.tsx
 msgid "Edit Library"
 msgstr "Edit Library"
+
+#: src/pages/DashboardPage.tsx
+msgid "Edit Metadata"
+msgstr "Edit Metadata"
 
 #: src/components/Sidebar.tsx
 msgid "Edit Shelf"
@@ -134,29 +365,93 @@ msgstr "Everywhere"
 msgid "Exit impersonation"
 msgstr "Exit impersonation"
 
+#: src/pages/DashboardPage.tsx
+msgid "Exit selection mode"
+msgstr "Exit selection mode"
+
 #: src/components/Sidebar.tsx
 msgid "Expand sidebar"
 msgstr "Expand sidebar"
+
+#: src/pages/DashboardPage.tsx
+msgid "Failed"
+msgstr "Failed"
+
+#: src/pages/DashboardPage.tsx
+msgid "Failed to load books"
+msgstr "Failed to load books"
 
 #: src/components/Sidebar.tsx
 msgid "Failed to save"
 msgstr "Failed to save"
 
+#: src/pages/DashboardPage.tsx
+msgid "Failed to update metadata"
+msgstr "Failed to update metadata"
+
 #: src/components/Sidebar.tsx
 msgid "Failed to update sharing"
 msgstr "Failed to update sharing"
+
+#: src/pages/DashboardPage.tsx
+msgid "Filters"
+msgstr "Filters"
+
+#: src/pages/DashboardPage.tsx
+msgid "finished"
+msgstr "finished"
+
+#: src/pages/DashboardPage.tsx
+msgid "Finished · 30d"
+msgstr "Finished · 30d"
+
+#: src/pages/DashboardPage.tsx
+msgid "Focus"
+msgstr "Focus"
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Focus search"
 msgstr "Focus search"
 
+#: src/pages/DashboardPage.tsx
+msgid "Format"
+msgstr "Format"
+
+#: src/pages/DashboardPage.tsx
+msgid "Format: {filterFormatUpper}"
+msgstr "Format: {filterFormatUpper}"
+
+#: src/pages/DashboardPage.tsx
+msgid "From your highlights"
+msgstr "From your highlights"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Go back"
 msgstr "Go back"
 
+#: src/pages/DashboardPage.tsx
+msgid "Grid view"
+msgstr "Grid view"
+
+#: src/pages/DashboardPage.tsx
+msgid "Group by series"
+msgstr "Group by series"
+
+#: src/pages/DashboardPage.tsx
+msgid "Group series"
+msgstr "Group series"
+
+#: src/pages/DashboardPage.tsx
+msgid "Group volumes by series"
+msgstr "Group volumes by series"
+
 #: src/components/Sidebar.tsx
 msgid "Hardcover"
 msgstr "Hardcover"
+
+#: src/pages/DashboardPage.tsx
+msgid "hiatus"
+msgstr "hiatus"
 
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/components/Sidebar.tsx
@@ -179,25 +474,67 @@ msgstr "just now"
 msgid "Keyboard Shortcuts"
 msgstr "Keyboard Shortcuts"
 
+#: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Language"
 msgstr "Language"
+
+#: src/pages/DashboardPage.tsx
+msgid "Language: {filterLanguageLabel}"
+msgstr "Language: {filterLanguageLabel}"
 
 #: src/components/Sidebar.tsx
 msgid "Libraries"
 msgstr "Libraries"
 
+#: src/pages/DashboardPage.tsx
+msgid "Library"
+msgstr "Library"
+
+#: src/pages/DashboardPage.tsx
+msgid "Library: {filterLibraryChipName}"
+msgstr "Library: {filterLibraryChipName}"
+
 #: src/components/Sidebar.tsx
 msgid "Light"
 msgstr "Light"
+
+#: src/pages/DashboardPage.tsx
+msgid "List view"
+msgstr "List view"
 
 #: src/components/Sidebar.tsx
 msgid "Log out"
 msgstr "Log out"
 
+#: src/pages/DashboardPage.tsx
+msgid "Manage"
+msgstr "Manage"
+
+#: src/pages/DashboardPage.tsx
+msgid "Manage series"
+msgstr "Manage series"
+
 #: src/components/NotificationBell.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Mark all read"
 msgstr "Mark all read"
+
+#: src/pages/DashboardPage.tsx
+msgid "Missing"
+msgstr "Missing"
+
+#: src/pages/DashboardPage.tsx
+msgid "Missing: {filterMissingLabel}"
+msgstr "Missing: {filterMissingLabel}"
+
+#: src/pages/DashboardPage.tsx
+msgid "My Books"
+msgstr "My Books"
+
+#: src/pages/DashboardPage.tsx
+msgid "My Rating"
+msgstr "My Rating"
 
 #: src/components/Sidebar.tsx
 msgid "Name…"
@@ -219,6 +556,10 @@ msgstr "Next book"
 msgid "Next page"
 msgstr "Next page"
 
+#: src/pages/DashboardPage.tsx
+msgid "No matches"
+msgstr "No matches"
+
 #: src/components/NotificationBell.tsx
 msgid "No notifications yet"
 msgstr "No notifications yet"
@@ -227,9 +568,49 @@ msgstr "No notifications yet"
 msgid "No other users to share with."
 msgstr "No other users to share with."
 
+#: src/pages/DashboardPage.tsx
+msgid "No results for \"{search}\""
+msgstr "No results for \"{search}\""
+
+#: src/pages/DashboardPage.tsx
+msgid "No results found"
+msgstr "No results found"
+
+#: src/pages/DashboardPage.tsx
+msgid "No Series"
+msgstr "No Series"
+
+#: src/pages/DashboardPage.tsx
+msgid "No series found — add series metadata to your books."
+msgstr "No series found — add series metadata to your books."
+
+#: src/pages/DashboardPage.tsx
+msgid "None"
+msgstr "None"
+
+#: src/pages/DashboardPage.tsx
+msgid "Nothing in progress"
+msgstr "Nothing in progress"
+
+#: src/pages/DashboardPage.tsx
+msgid "Nothing matched “{search}”"
+msgstr "Nothing matched “{search}”"
+
 #: src/components/NotificationBell.tsx
 msgid "Notifications"
 msgstr "Notifications"
+
+#: src/pages/DashboardPage.tsx
+msgid "On this day"
+msgstr "On this day"
+
+#: src/pages/DashboardPage.tsx
+msgid "ongoing"
+msgstr "ongoing"
+
+#: src/pages/DashboardPage.tsx
+msgid "Only filled fields will be updated. Leave blank to keep existing values."
+msgstr "Only filled fields will be updated. Leave blank to keep existing values."
 
 #: src/components/AppHeader.tsx
 msgid "Open navigation"
@@ -242,6 +623,14 @@ msgstr "Open reader"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Open selected book"
 msgstr "Open selected book"
+
+#: src/pages/DashboardPage.tsx
+msgid "Pages · 30d"
+msgstr "Pages · 30d"
+
+#: src/pages/DashboardPage.tsx
+msgid "Pick up where you left off"
+msgstr "Pick up where you left off"
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Previous book"
@@ -263,13 +652,70 @@ msgstr "Private library"
 msgid "Public library"
 msgstr "Public library"
 
+#: src/pages/DashboardPage.tsx
+msgid "Rated"
+msgstr "Rated"
+
+#: src/components/BookCard.tsx
+msgid "Rated {rating} of 5"
+msgstr "Rated {rating} of 5"
+
+#: src/pages/DashboardPage.tsx
+msgid "Rated: {filterMinRating}+ stars"
+msgstr "Rated: {filterMinRating}+ stars"
+
+#: src/pages/DashboardPage.tsx
+msgid "Rated: 5 stars"
+msgstr "Rated: 5 stars"
+
+#: src/pages/DashboardPage.tsx
+msgid "Rating"
+msgstr "Rating"
+
+#: src/components/BookCard.tsx
+#: src/pages/DashboardPage.tsx
+msgid "Read"
+msgstr "Read"
+
+#: src/pages/DashboardPage.tsx
+msgid "Read · 30d"
+msgstr "Read · 30d"
+
+#: src/components/BookCard.tsx
+msgid "Read book"
+msgstr "Read book"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Reader"
 msgstr "Reader"
 
+#: src/pages/DashboardPage.tsx
+msgid "Reading"
+msgstr "Reading"
+
+#: src/pages/DashboardPage.tsx
+msgid "Reading Log"
+msgstr "Reading Log"
+
+#: src/pages/DashboardPage.tsx
+msgid "Recently Added"
+msgstr "Recently Added"
+
+#: src/pages/DashboardPage.tsx
+msgid "Recently Finished"
+msgstr "Recently Finished"
+
+#: src/pages/DashboardPage.tsx
+msgid "Resume {volLabel}"
+msgstr "Resume {volLabel}"
+
 #: src/components/Sidebar.tsx
 msgid "Save"
 msgstr "Save"
+
+#: src/pages/DashboardPage.tsx
+msgid "Save Changes"
+msgstr "Save Changes"
 
 #: src/components/Sidebar.tsx
 msgid "Save the library first, then reopen it to share with users."
@@ -295,9 +741,30 @@ msgstr "Search to find more icons"
 msgid "See all results for \"{searchQuery}\""
 msgstr "See all results for \"{searchQuery}\""
 
+#: src/pages/DashboardPage.tsx
+msgid "Select"
+msgstr "Select"
+
+#: src/pages/DashboardPage.tsx
+msgid "Select all"
+msgstr "Select all"
+
 #: src/components/Sidebar.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Series"
 msgstr "Series"
+
+#: src/pages/DashboardPage.tsx
+msgid "Series name"
+msgstr "Series name"
+
+#: src/pages/DashboardPage.tsx
+msgid "Series Progress"
+msgstr "Series Progress"
+
+#: src/pages/DashboardPage.tsx
+msgid "Series: {filterSeries}"
+msgstr "Series: {filterSeries}"
 
 #: src/components/Sidebar.tsx
 msgid "Settings"
@@ -307,25 +774,89 @@ msgstr "Settings"
 msgid "Share"
 msgstr "Share"
 
+#: src/pages/DashboardPage.tsx
+msgid "Share this series — a public metadata-only page"
+msgstr "Share this series — a public metadata-only page"
+
 #: src/components/Sidebar.tsx
 msgid "Share with users"
 msgstr "Share with users"
+
+#: src/pages/DashboardPage.tsx
+msgid "Shared Library"
+msgstr "Shared Library"
+
+#: src/pages/DashboardPage.tsx
+msgid "Shelved"
+msgstr "Shelved"
 
 #: src/components/Sidebar.tsx
 msgid "Shelves"
 msgstr "Shelves"
 
+#: src/pages/DashboardPage.tsx
+msgid "Show another highlight"
+msgstr "Show another highlight"
+
+#: src/pages/DashboardPage.tsx
+msgid "Show individual volumes"
+msgstr "Show individual volumes"
+
+#: src/pages/DashboardPage.tsx
+msgid "Show less"
+msgstr "Show less"
+
+#: src/pages/DashboardPage.tsx
+msgid "Show more"
+msgstr "Show more"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
 msgstr "Show this help"
+
+#: src/pages/DashboardPage.tsx
+msgid "Start {volLabel}"
+msgstr "Start {volLabel}"
+
+#: src/pages/DashboardPage.tsx
+msgid "Start reading and your progress will show up here"
+msgstr "Start reading and your progress will show up here"
 
 #: src/components/Sidebar.tsx
 msgid "Stats"
 msgstr "Stats"
 
+#: src/pages/DashboardPage.tsx
+msgid "Status"
+msgstr "Status"
+
+#: src/pages/DashboardPage.tsx
+msgid "Status: {filterStatusLabel}"
+msgstr "Status: {filterStatusLabel}"
+
+#: src/pages/DashboardPage.tsx
+msgid "Tag"
+msgstr "Tag"
+
+#: src/pages/DashboardPage.tsx
+msgid "Tag: {filterTag}"
+msgstr "Tag: {filterTag}"
+
 #: src/components/Sidebar.tsx
 msgid "Theme"
 msgstr "Theme"
+
+#: src/pages/DashboardPage.tsx
+msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
+msgstr "This permanently removes the selected books and their files from disk. This cannot be undone."
+
+#: src/pages/DashboardPage.tsx
+msgid "Title"
+msgstr "Title"
+
+#: src/pages/DashboardPage.tsx
+msgid "Today"
+msgstr "Today"
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Toggle metadata edit"
@@ -339,9 +870,41 @@ msgstr "Toggle only-notes filter"
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "Translations are community-maintained. Anything not yet translated is shown in English."
 
+#: src/pages/DashboardPage.tsx
+msgid "Try adjusting your filters"
+msgstr "Try adjusting your filters"
+
+#: src/pages/DashboardPage.tsx
+msgid "Type"
+msgstr "Type"
+
+#: src/pages/DashboardPage.tsx
+msgid "Unassigned"
+msgstr "Unassigned"
+
+#: src/pages/DashboardPage.tsx
+msgid "Unread"
+msgstr "Unread"
+
+#: src/pages/DashboardPage.tsx
+msgid "Unserialized"
+msgstr "Unserialized"
+
 #: src/components/AppHeader.tsx
 msgid "Upload"
 msgstr "Upload"
+
+#: src/pages/DashboardPage.tsx
+msgid "Upload or scan a folder to get started"
+msgstr "Upload or scan a folder to get started"
+
+#: src/pages/DashboardPage.tsx
+msgid "Uploader"
+msgstr "Uploader"
+
+#: src/pages/DashboardPage.tsx
+msgid "Uploader: {filterUploaderName}"
+msgstr "Uploader: {filterUploaderName}"
 
 #: src/components/Sidebar.tsx
 msgid "User menu"
@@ -351,6 +914,34 @@ msgstr "User menu"
 msgid "Viewing as <0>{impersonatedUsername}</0>"
 msgstr "Viewing as <0>{impersonatedUsername}</0>"
 
+#: src/pages/DashboardPage.tsx
+msgid "Vol. {idx}"
+msgstr "Vol. {idx}"
+
+#: src/pages/DashboardPage.tsx
+msgid "Vol. {volIdx}"
+msgstr "Vol. {volIdx}"
+
+#: src/pages/DashboardPage.tsx
+msgid "Volumes"
+msgstr "Volumes"
+
+#: src/pages/DashboardPage.tsx
+msgid "Want to Read"
+msgstr "Want to Read"
+
 #: src/components/Sidebar.tsx
 msgid "Wishlist"
 msgstr "Wishlist"
+
+#: src/pages/DashboardPage.tsx
+msgid "Year"
+msgstr "Year"
+
+#: src/pages/DashboardPage.tsx
+msgid "Yesterday"
+msgstr "Yesterday"
+
+#: src/pages/DashboardPage.tsx
+msgid "Your library is empty"
+msgstr "Your library is empty"

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -136,6 +136,11 @@ msgstr "{0, plural, one {{fin} finished · # book read} other {{fin} finished ·
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 msgstr "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 
+#. placeholder {0}: status.syncedDocuments
+#: src/components/SyncStatusBadge.tsx
+msgid "{0, plural, one {# book tracked} other {# books tracked}}"
+msgstr "{0, plural, one {# book tracked} other {# books tracked}}"
+
 #. placeholder {0}: data.totals.books
 #. placeholder {0}: s.book_count
 #: src/pages/DashboardPage.tsx
@@ -246,6 +251,11 @@ msgstr "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Bo
 msgid "{0, plural, one {In library · # vol} other {In library · # vols}}"
 msgstr "{0, plural, one {In library · # vol} other {In library · # vols}}"
 
+#. placeholder {0}: status.syncedDocuments
+#: src/components/SyncStatusBadge.tsx
+msgid "{0, plural, one {Last sync from {lastDevice} · # book tracked} other {Last sync from {lastDevice} · # books tracked}}"
+msgstr "{0, plural, one {Last sync from {lastDevice} · # book tracked} other {Last sync from {lastDevice} · # books tracked}}"
+
 #. placeholder {0}: confirmReject?.length ?? 0
 #: src/pages/BinderyPage.tsx
 msgid "{0, plural, one {Permanently delete # file from the bindery? This cannot be undone.} other {Permanently delete # files from the bindery? This cannot be undone.}}"
@@ -295,6 +305,7 @@ msgid "{d}d ago"
 msgstr "{d}d ago"
 
 #: src/components/NotificationBell.tsx
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 #: src/pages/WishlistPage.tsx
@@ -372,11 +383,16 @@ msgstr "{h}h"
 msgid "{h}h {m}m"
 msgstr "{h}h {m}m"
 
+#: src/components/PositionHistoryModal.tsx
+msgid "{h}h ago"
+msgstr "{h}h ago"
+
 #: src/pages/SettingsPage.tsx
 msgid "{hours}h ago"
 msgstr "{hours}h ago"
 
 #: src/components/NotificationBell.tsx
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
 msgid "{hrs}h ago"
 msgstr "{hrs}h ago"
@@ -389,6 +405,10 @@ msgstr "{imp} imported + {inc} incoming"
 msgid "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
 msgstr "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
 
+#: src/components/PositionHistoryModal.tsx
+msgid "{m} min ago"
+msgstr "{m} min ago"
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{m}m"
@@ -399,6 +419,7 @@ msgid "{mergeCount, plural, one {merge # group} other {merge # groups}}"
 msgstr "{mergeCount, plural, one {merge # group} other {merge # groups}}"
 
 #: src/components/NotificationBell.tsx
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
 msgid "{mins}m ago"
 msgstr "{mins}m ago"
@@ -448,6 +469,10 @@ msgstr "{name} · Vol. {start_index}–{end_index}"
 #: src/pages/StatsPage.tsx
 msgid "{name} copy"
 msgstr "{name} copy"
+
+#: src/components/ThemeToggle.tsx
+msgid "{name} theme"
+msgstr "{name} theme"
 
 #: src/pages/AdminPage.tsx
 msgid "{othersCount, plural, one {Delete # other} other {Delete # others}}"
@@ -789,7 +814,12 @@ msgstr "All your reading goals — rings fill as you read, managed in place"
 msgid "All-time hours, pages, books, streak"
 msgstr "All-time hours, pages, books, streak"
 
+#: src/components/SendButton.tsx
+msgid "Already in your KOReader inbox"
+msgstr "Already in your KOReader inbox"
+
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Amber"
 msgstr "Amber"
 
@@ -939,6 +969,10 @@ msgstr "Best match applied to all {matched} files"
 msgid "Best-Rated Series"
 msgstr "Best-Rated Series"
 
+#: src/components/SendButton.tsx
+msgid "Beta"
+msgstr "Beta"
+
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Bindery"
@@ -949,6 +983,7 @@ msgid "Bindery flow explained — open docs"
 msgstr "Bindery flow explained — open docs"
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Black"
 msgstr "Black"
 
@@ -1138,6 +1173,7 @@ msgstr "Click \"Download plugin ZIP\" above. An API key is automatically created
 msgid "Click for details"
 msgstr "Click for details"
 
+#: src/components/PositionHistoryModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/StatsPage.tsx
@@ -1286,6 +1322,10 @@ msgstr "Core"
 msgid "Could not link SSO. Please try again."
 msgstr "Could not link SSO. Please try again."
 
+#: src/components/SeriesFollowButton.tsx
+msgid "Could not resolve this series on Hardcover"
+msgstr "Could not resolve this series on Hardcover"
+
 #: src/pages/HardcoverPage.tsx
 msgid "Could not set match"
 msgstr "Could not set match"
@@ -1351,6 +1391,7 @@ msgstr "Cumulative Books Added — Last 24 Months"
 msgid "Cumulative finishes over time"
 msgstr "Cumulative finishes over time"
 
+#: src/components/PositionHistoryModal.tsx
 #: src/pages/StatsPage.tsx
 msgid "current"
 msgstr "current"
@@ -1384,6 +1425,7 @@ msgid "Danger Zone"
 msgstr "Danger Zone"
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Dark"
 msgstr "Dark"
 
@@ -1680,6 +1722,7 @@ msgid "Email delivery is not set up yet."
 msgstr "Email delivery is not set up yet."
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Ember"
 msgstr "Ember"
 
@@ -1881,6 +1924,10 @@ msgstr "Failed to load wishlist"
 msgid "Failed to log session"
 msgstr "Failed to log session"
 
+#: src/components/SendButton.tsx
+msgid "Failed to queue for KOReader"
+msgstr "Failed to queue for KOReader"
+
 #: src/pages/SettingsPage.tsx
 msgid "Failed to register"
 msgstr "Failed to register"
@@ -1990,13 +2037,22 @@ msgstr "Focus"
 msgid "Focus search"
 msgstr "Focus search"
 
+#: src/components/SeriesFollowButton.tsx
+msgid "Follow"
+msgstr "Follow"
+
 #: src/pages/WishlistPage.tsx
 msgid "Follow a series — search Hardcover…"
 msgstr "Follow a series — search Hardcover…"
 
+#: src/components/SeriesFollowButton.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Following"
 msgstr "Following"
+
+#: src/components/SeriesFollowButton.tsx
+msgid "Following \"{seriesName}\" — you'll hear when a new volume is out"
+msgstr "Following \"{seriesName}\" — you'll hear when a new volume is out"
 
 #: src/pages/BinderyPage.tsx
 msgid "for {targetLabel} — click a file to switch"
@@ -2057,6 +2113,10 @@ msgstr "Generate PIN"
 msgid "Genres"
 msgstr "Genres"
 
+#: src/components/SeriesFollowButton.tsx
+msgid "Get notified when a new volume is released"
+msgstr "Get notified when a new volume is released"
+
 #: src/pages/WishlistPage.tsx
 msgid "Get notified when a new volume of a followed series is released."
 msgstr "Get notified when a new volume of a followed series is released."
@@ -2113,6 +2173,10 @@ msgstr "hiatus"
 #: src/pages/BookDetailPage.tsx
 msgid "Hide details"
 msgstr "Hide details"
+
+#: src/components/stats/widgets/taste.tsx
+msgid "Highest"
+msgstr "Highest"
 
 #: src/pages/StatsPage.tsx
 msgid "Highest & Lowest Rated"
@@ -2278,6 +2342,10 @@ msgstr "just now"
 msgid "Just now"
 msgstr "Just now"
 
+#: src/components/SyncStatusBadge.tsx
+msgid "Just synced"
+msgstr "Just synced"
+
 #: src/pages/AdminPage.tsx
 msgid "Keep this one"
 msgstr "Keep this one"
@@ -2301,6 +2369,10 @@ msgstr "KOReader Sync"
 #: src/pages/BookDetailPage.tsx
 msgid "KOReader sync linked"
 msgstr "KOReader sync linked"
+
+#: src/components/SyncStatusBadge.tsx
+msgid "KOReader sync: {label}. {tooltip}"
+msgstr "KOReader sync: {label}. {tooltip}"
 
 #: src/pages/SettingsPage.tsx
 msgid "KOSync registered successfully"
@@ -2348,6 +2420,10 @@ msgstr "Latest finishes, newest first"
 #: src/pages/WishlistPage.tsx
 msgid "Latest: vol {v}"
 msgstr "Latest: vol {v}"
+
+#: src/components/SeriesFollowButton.tsx
+msgid "Latest: Vol {v} · {d}"
+msgstr "Latest: Vol {v} · {d}"
 
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -2407,6 +2483,7 @@ msgid "Lifetime words read, by year"
 msgstr "Lifetime words read, by year"
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Light"
 msgstr "Light"
 
@@ -2459,6 +2536,7 @@ msgstr "Loading books…"
 msgid "Loading..."
 msgstr "Loading..."
 
+#: src/components/PositionHistoryModal.tsx
 #: src/components/ShareLinksOverview.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
@@ -2500,6 +2578,10 @@ msgstr "Longest Streak"
 #: src/pages/StatsPage.tsx
 msgid "Longest: {d}d"
 msgstr "Longest: {d}d"
+
+#: src/components/stats/widgets/taste.tsx
+msgid "Lowest"
+msgstr "Lowest"
 
 #: src/pages/DashboardPage.tsx
 msgid "Manage"
@@ -2614,6 +2696,10 @@ msgstr "Missing: {filterMissingLabel}"
 msgid "Mo"
 msgstr "Mo"
 
+#: src/components/SendButton.tsx
+msgid "More send options"
+msgstr "More send options"
+
 #: src/pages/StatsPage.tsx
 msgid "Morning vs evening reader?"
 msgstr "Morning vs evening reader?"
@@ -2659,6 +2745,7 @@ msgstr "Name…"
 msgid "Native KOReader plugin — tracks reading sessions and syncs by book ID. More reliable than KOSync."
 msgstr "Native KOReader plugin — tracks reading sessions and syncs by book ID. More reliable than KOSync."
 
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Never"
 msgstr "Never"
@@ -2730,6 +2817,10 @@ msgstr "Next month"
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next page"
 msgstr "Next page"
+
+#: src/components/SeriesFollowButton.tsx
+msgid "Next: Vol {v} · {d}"
+msgstr "Next: Vol {v} · {d}"
 
 #: src/pages/SettingsPage.tsx
 msgid "No API keys. Download the plugin to auto-create one."
@@ -2850,6 +2941,26 @@ msgstr "No pace data by format."
 #: src/pages/SettingsPage.tsx
 msgid "No PINs yet. Generate one to use with OPDS clients."
 msgstr "No PINs yet. Generate one to use with OPDS clients."
+
+#: src/components/PositionHistoryModal.tsx
+msgid "No position changes recorded yet — history starts with the next sync."
+msgstr "No position changes recorded yet — history starts with the next sync."
+
+#: src/components/stats/widgets/taste.tsx
+msgid "No rated books with reading time yet."
+msgstr "No rated books with reading time yet."
+
+#: src/components/stats/widgets/taste.tsx
+msgid "No rated books yet."
+msgstr "No rated books yet."
+
+#: src/components/stats/widgets/taste.tsx
+msgid "No rated series yet."
+msgstr "No rated series yet."
+
+#: src/components/stats/widgets/taste.tsx
+msgid "No ratings yet."
+msgstr "No ratings yet."
 
 #: src/pages/AdminPage.tsx
 msgid "No reading activity yet. Records appear when users start reading books."
@@ -3214,6 +3325,10 @@ msgstr "PIN created — copy it now, it won't be shown again."
 msgid "Port"
 msgstr "Port"
 
+#: src/components/PositionHistoryModal.tsx
+msgid "Position history"
+msgstr "Position history"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Position history — restore a bad sync"
 msgstr "Position history — restore a bad sync"
@@ -3300,6 +3415,10 @@ msgstr "Queue: fold the other copies into the kept book"
 msgid "Queue: not a duplicate — never show this group again"
 msgstr "Queue: not a duplicate — never show this group again"
 
+#: src/components/SendButton.tsx
+msgid "Queued {n} to KOReader — arrives next time KOReader syncs"
+msgstr "Queued {n} to KOReader — arrives next time KOReader syncs"
+
 #: src/pages/BinderyPage.tsx
 msgid "Quick Accept"
 msgstr "Quick Accept"
@@ -3324,6 +3443,10 @@ msgstr "Range"
 #: src/pages/StatsPage.tsx
 msgid "Range follows the page's range picker; days show the newest slice of it."
 msgstr "Range follows the page's range picker; days show the newest slice of it."
+
+#: src/components/stats/widgets/taste.tsx
+msgid "Rate a few books to see a trend."
+msgstr "Rate a few books to see a trend."
 
 #: src/components/SeriesRating.tsx
 msgid "Rate the whole series"
@@ -3620,6 +3743,14 @@ msgstr "Resource:"
 msgid "Restart KOReader"
 msgstr "Restart KOReader"
 
+#: src/components/PositionHistoryModal.tsx
+msgid "Restore"
+msgstr "Restore"
+
+#: src/components/PositionHistoryModal.tsx
+msgid "Restoring sets the live position (and read status) back to that point; devices pick it up on their next sync. Restoring below 100% un-finishes a falsely completed book."
+msgstr "Restoring sets the live position (and read status) back to that point; devices pick it up on their next sync. Restoring below 100% un-finishes a falsely completed book."
+
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
 msgstr "Resume {volLabel}"
@@ -3846,9 +3977,18 @@ msgstr "Send History"
 msgid "Send test email"
 msgstr "Send test email"
 
+#: src/components/SendButton.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Send to Device"
 msgstr "Send to Device"
+
+#: src/components/SendButton.tsx
+msgid "Send to KOReader"
+msgstr "Send to KOReader"
+
+#: src/components/SendButton.tsx
+msgid "Send via email…"
+msgstr "Send via email…"
 
 #: src/pages/AdminPage.tsx
 msgid "Sending..."
@@ -4162,6 +4302,10 @@ msgstr "Status"
 msgid "Status: {filterStatusLabel}"
 msgstr "Status: {filterStatusLabel}"
 
+#: src/components/SeriesFollowButton.tsx
+msgid "Stop following this series"
+msgstr "Stop following this series"
+
 #: src/pages/StatsPage.tsx
 msgid "Streak"
 msgstr "Streak"
@@ -4263,6 +4407,7 @@ msgid "the sync password set above"
 msgstr "the sync password set above"
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Theme"
 msgstr "Theme"
 
@@ -4374,6 +4519,10 @@ msgstr "Toggle metadata edit"
 msgid "Toggle only-notes filter"
 msgstr "Toggle only-notes filter"
 
+#: src/components/ThemeToggle.tsx
+msgid "Toggle theme"
+msgstr "Toggle theme"
+
 #: src/pages/SettingsPage.tsx
 msgid "Token name"
 msgstr "Token name"
@@ -4470,6 +4619,7 @@ msgstr "unknown author"
 msgid "Unknown author"
 msgstr "Unknown author"
 
+#: src/components/PositionHistoryModal.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "unknown device"
 msgstr "unknown device"
@@ -4742,6 +4892,7 @@ msgstr "Year"
 msgid "Year in Review"
 msgstr "Year in Review"
 
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/WishlistPage.tsx

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -13,10 +13,344 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/NotificationBell.tsx
+msgid "{days}d ago"
+msgstr "{days}d ago"
+
+#: src/components/NotificationBell.tsx
+msgid "{hrs}h ago"
+msgstr "{hrs}h ago"
+
+#: src/components/NotificationBell.tsx
+msgid "{mins}m ago"
+msgstr "{mins}m ago"
+
+#: src/components/AppShell.tsx
+msgid "{n, plural, one {This upload satisfies # wish — review in Admin > Wishlist} other {This upload satisfies # wishes — review in Admin > Wishlist}}"
+msgstr "{n, plural, one {This upload satisfies # wish — review in Admin > Wishlist} other {This upload satisfies # wishes — review in Admin > Wishlist}}"
+
+#: src/components/Sidebar.tsx
+msgid "{themeName} theme"
+msgstr "{themeName} theme"
+
+#: src/components/Sidebar.tsx
+msgid "Admin"
+msgstr "Admin"
+
+#: src/components/Sidebar.tsx
+msgid "All Books"
+msgstr "All Books"
+
+#: src/components/Sidebar.tsx
+msgid "Amber"
+msgstr "Amber"
+
+#: src/components/Sidebar.tsx
+msgid "Bindery"
+msgstr "Bindery"
+
+#: src/components/Sidebar.tsx
+msgid "Black"
+msgstr "Black"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Book Detail"
+msgstr "Book Detail"
+
+#: src/components/Sidebar.tsx
+msgid "Cancel"
+msgstr "Cancel"
+
+#: src/components/Sidebar.tsx
+msgid "Choose icon"
+msgstr "Choose icon"
+
+#: src/components/AppHeader.tsx
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Clear search"
+msgstr "Clear search"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Clear selection / blur search"
+msgstr "Clear selection / blur search"
+
+#: src/components/Sidebar.tsx
+msgid "Close navigation"
+msgstr "Close navigation"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Collapse / expand all books"
+msgstr "Collapse / expand all books"
+
+#: src/components/Sidebar.tsx
+msgid "Collapse sidebar"
+msgstr "Collapse sidebar"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Command palette — jump to a book, series, author, or page"
+msgstr "Command palette — jump to a book, series, author, or page"
+
+#: src/components/Sidebar.tsx
+msgid "Dark"
+msgstr "Dark"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Dashboard"
+msgstr "Dashboard"
+
+#: src/components/Sidebar.tsx
+msgid "Delete"
+msgstr "Delete"
+
+#: src/components/Sidebar.tsx
+msgid "Docs"
+msgstr "Docs"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Download Markdown export"
+msgstr "Download Markdown export"
+
+#: src/components/Sidebar.tsx
+msgid "Edit"
+msgstr "Edit"
+
+#: src/components/Sidebar.tsx
+msgid "Edit Library"
+msgstr "Edit Library"
+
+#: src/components/Sidebar.tsx
+msgid "Edit Shelf"
+msgstr "Edit Shelf"
+
+#: src/components/Sidebar.tsx
+msgid "Ember"
+msgstr "Ember"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Everywhere"
+msgstr "Everywhere"
+
+#: src/components/ImpersonationBanner.tsx
+msgid "Exit impersonation"
+msgstr "Exit impersonation"
+
+#: src/components/Sidebar.tsx
+msgid "Expand sidebar"
+msgstr "Expand sidebar"
+
+#: src/components/Sidebar.tsx
+msgid "Failed to save"
+msgstr "Failed to save"
+
+#: src/components/Sidebar.tsx
+msgid "Failed to update sharing"
+msgstr "Failed to update sharing"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Focus search"
+msgstr "Focus search"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Go back"
+msgstr "Go back"
+
+#: src/components/Sidebar.tsx
+msgid "Hardcover"
+msgstr "Hardcover"
+
+#: src/components/KeyboardShortcutsModal.tsx
+#: src/components/Sidebar.tsx
+msgid "Highlights"
+msgstr "Highlights"
+
+#: src/components/Sidebar.tsx
+msgid "Home"
+msgstr "Home"
+
+#: src/components/Sidebar.tsx
+msgid "Icon"
+msgstr "Icon"
+
+#: src/components/NotificationBell.tsx
+msgid "just now"
+msgstr "just now"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Keyboard Shortcuts"
+msgstr "Keyboard Shortcuts"
+
 #: src/pages/SettingsPage.tsx
 msgid "Language"
 msgstr "Language"
 
+#: src/components/Sidebar.tsx
+msgid "Libraries"
+msgstr "Libraries"
+
+#: src/components/Sidebar.tsx
+msgid "Light"
+msgstr "Light"
+
+#: src/components/Sidebar.tsx
+msgid "Log out"
+msgstr "Log out"
+
+#: src/components/NotificationBell.tsx
+msgid "Mark all read"
+msgstr "Mark all read"
+
+#: src/components/Sidebar.tsx
+msgid "Name…"
+msgstr "Name…"
+
+#: src/components/Sidebar.tsx
+msgid "New library"
+msgstr "New library"
+
+#: src/components/Sidebar.tsx
+msgid "New Library"
+msgstr "New Library"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Next book"
+msgstr "Next book"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Next page"
+msgstr "Next page"
+
+#: src/components/NotificationBell.tsx
+msgid "No notifications yet"
+msgstr "No notifications yet"
+
+#: src/components/Sidebar.tsx
+msgid "No other users to share with."
+msgstr "No other users to share with."
+
+#: src/components/NotificationBell.tsx
+msgid "Notifications"
+msgstr "Notifications"
+
+#: src/components/AppHeader.tsx
+msgid "Open navigation"
+msgstr "Open navigation"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Open reader"
+msgstr "Open reader"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Open selected book"
+msgstr "Open selected book"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Previous book"
+msgstr "Previous book"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Previous page"
+msgstr "Previous page"
+
+#: src/components/Sidebar.tsx
+msgid "Private — only assigned users can access"
+msgstr "Private — only assigned users can access"
+
+#: src/components/Sidebar.tsx
+msgid "Private library"
+msgstr "Private library"
+
+#: src/components/Sidebar.tsx
+msgid "Public library"
+msgstr "Public library"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Reader"
+msgstr "Reader"
+
+#: src/components/Sidebar.tsx
+msgid "Save"
+msgstr "Save"
+
+#: src/components/Sidebar.tsx
+msgid "Save the library first, then reopen it to share with users."
+msgstr "Save the library first, then reopen it to share with users."
+
+#: src/components/AppHeader.tsx
+msgid "Search books"
+msgstr "Search books"
+
+#: src/components/AppHeader.tsx
+msgid "Search books… (/)"
+msgstr "Search books… (/)"
+
+#: src/components/Sidebar.tsx
+msgid "Search icons…"
+msgstr "Search icons…"
+
+#: src/components/Sidebar.tsx
+msgid "Search to find more icons"
+msgstr "Search to find more icons"
+
+#: src/components/AppShell.tsx
+msgid "See all results for \"{searchQuery}\""
+msgstr "See all results for \"{searchQuery}\""
+
+#: src/components/Sidebar.tsx
+msgid "Series"
+msgstr "Series"
+
+#: src/components/Sidebar.tsx
+msgid "Settings"
+msgstr "Settings"
+
+#: src/components/Sidebar.tsx
+msgid "Share"
+msgstr "Share"
+
+#: src/components/Sidebar.tsx
+msgid "Share with users"
+msgstr "Share with users"
+
+#: src/components/Sidebar.tsx
+msgid "Shelves"
+msgstr "Shelves"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Show this help"
+msgstr "Show this help"
+
+#: src/components/Sidebar.tsx
+msgid "Stats"
+msgstr "Stats"
+
+#: src/components/Sidebar.tsx
+msgid "Theme"
+msgstr "Theme"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Toggle metadata edit"
+msgstr "Toggle metadata edit"
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Toggle only-notes filter"
+msgstr "Toggle only-notes filter"
+
 #: src/pages/SettingsPage.tsx
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "Translations are community-maintained. Anything not yet translated is shown in English."
+
+#: src/components/AppHeader.tsx
+msgid "Upload"
+msgstr "Upload"
+
+#: src/components/Sidebar.tsx
+msgid "User menu"
+msgstr "User menu"
+
+#: src/components/ImpersonationBanner.tsx
+msgid "Viewing as <0>{impersonatedUsername}</0>"
+msgstr "Viewing as <0>{impersonatedUsername}</0>"
+
+#: src/components/Sidebar.tsx
+msgid "Wishlist"
+msgstr "Wishlist"

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -1011,6 +1011,10 @@ msgstr ""
 msgid "~{m} min"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "~{m} min left"
+msgstr ""
+
 #: src/lib/backlog.ts
 msgid "~{mo} months"
 msgstr ""
@@ -1178,6 +1182,10 @@ msgstr ""
 msgid "Add a note"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Add a note…"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Add a review"
 msgstr ""
@@ -1208,6 +1216,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Add custom theme"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Add note"
 msgstr ""
 
 #: src/components/SaveFilterButton.tsx
@@ -1657,6 +1669,14 @@ msgstr ""
 msgid "Backup failed"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Based on a default pace (no reading history yet)"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Based on your measured reading pace"
+msgstr ""
+
 #: src/components/BulkMetadataReviewModal.tsx
 msgid "Batch complete"
 msgstr ""
@@ -1749,6 +1769,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Book not found"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Book not found."
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -1861,6 +1885,7 @@ msgstr ""
 #: src/pages/DashboardPage.tsx
 #: src/pages/HighlightsPage.tsx
 #: src/pages/LoginPage.tsx
+#: src/pages/ReaderPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
 msgstr ""
@@ -1991,6 +2016,7 @@ msgstr ""
 #: src/components/UploadModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
+#: src/pages/ReaderPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Close"
 msgstr ""
@@ -2104,6 +2130,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Content Type"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Contents"
 msgstr ""
 
 #: src/components/home/FocusMode.tsx
@@ -2334,6 +2364,7 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 #: src/components/ThemeToggle.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Dark"
 msgstr ""
 
@@ -2374,12 +2405,17 @@ msgstr ""
 msgid "Dead entries removed"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Default"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/HighlightsPage.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Delete"
 msgstr ""
 
@@ -2656,6 +2692,7 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Edit note"
 msgstr ""
 
@@ -2704,6 +2741,10 @@ msgstr ""
 
 #: src/components/ManageSeriesModal.tsx
 msgid "End"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "EPUB failed to open: {msg2}"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -2908,8 +2949,16 @@ msgstr ""
 msgid "Failed to load books"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Failed to load comic pages: {msg2}"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Failed to load duplicates"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Failed to load EPUB: {msg2}"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2926,6 +2975,10 @@ msgstr ""
 
 #: src/pages/HighlightsPage.tsx
 msgid "Failed to load more"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Failed to load PDF: {msg2}"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3148,6 +3201,10 @@ msgstr ""
 msgid "Following \"{seriesName}\" — you'll hear when a new volume is out"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "FONT SIZE"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "for {targetLabel} — click a file to switch"
 msgstr ""
@@ -3235,6 +3292,7 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/ReaderPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Go back"
 msgstr ""
@@ -3332,9 +3390,17 @@ msgstr ""
 msgid "Highest & Lowest Rated"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Highlight"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "Highlight deleted"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Highlight in {c}"
 msgstr ""
 
 #: src/pages/HighlightsPage.tsx
@@ -3690,6 +3756,7 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 #: src/components/ThemeToggle.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Light"
 msgstr ""
 
@@ -3826,6 +3893,10 @@ msgstr ""
 
 #: src/components/stats/widgets/taste.tsx
 msgid "Lowest"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Made on the web — syncs to KOReader"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -4367,6 +4438,10 @@ msgstr ""
 msgid "No re-reads yet — pages you revisit on a later day show up here."
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "No readable file found for this book."
+msgstr ""
+
 #: src/components/stats/TimelineRibbon.tsx
 msgid "no reading"
 msgstr ""
@@ -4475,6 +4550,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "No suggested match yet — search for the book to link, or upload it first."
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "No table of contents available."
 msgstr ""
 
 #: src/components/stats/widgets/wordstats.tsx
@@ -4788,6 +4867,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Padding"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Page {n}"
 msgstr ""
 
 #: src/components/SeriesReadingStats.tsx
@@ -5565,6 +5648,10 @@ msgstr ""
 msgid "Same Series Volume"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Sans"
+msgstr ""
+
 #: src/components/stats/HourDowHeatmap.tsx
 #: src/components/stats/widgets/habits.tsx
 msgid "Sat"
@@ -5576,6 +5663,7 @@ msgstr ""
 #: src/components/stats/GoalWidget.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Save"
 msgstr ""
 
@@ -5849,6 +5937,10 @@ msgstr ""
 msgid "Sent {sent}/{total}. {failedN} failed."
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Sepia"
+msgstr ""
+
 #: src/components/CommandPalette.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/MetadataFetchModal.tsx
@@ -5916,6 +6008,10 @@ msgstr ""
 
 #: src/components/LibraryHealth.tsx
 msgid "Series: {name}"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Serif"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -5987,6 +6083,7 @@ msgstr ""
 
 #: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
+#: src/pages/ReaderPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Settings"
 msgstr ""
@@ -6349,6 +6446,7 @@ msgid "Synced from Kobo"
 msgstr ""
 
 #: src/components/home/FocusMode.tsx
+#: src/pages/ReaderPage.tsx
 msgid "Synced from KOReader"
 msgstr ""
 

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -82,6 +82,10 @@ msgstr ""
 msgid " · reviewed"
 msgstr ""
 
+#: src/components/ShareShelfModal.tsx
+msgid " · to change expiry, revoke and re-create"
+msgstr ""
+
 #: src/pages/WishlistPage.tsx
 msgid " · you have vol {v}"
 msgstr ""
@@ -94,12 +98,20 @@ msgstr ""
 msgid ", {errors} failed"
 msgstr ""
 
+#: src/components/UploadModal.tsx
+msgid ", {failedN} failed"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid ", {n} failed"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid ", {pages} pages"
+msgstr ""
+
+#: src/components/UploadModal.tsx
+msgid ", {skipped} already in library"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -128,6 +140,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "(enables dark: variants)"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+msgid "(exceeds 25 MB email limit)"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -189,6 +205,11 @@ msgstr ""
 #. placeholder {0}: groups.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
+msgstr ""
+
+#. placeholder {0}: items.length
+#: src/components/UploadModal.tsx
+msgid "{0, plural, one {# file selected} other {# files selected}}"
 msgstr ""
 
 #. placeholder {0}: row.unestimated
@@ -315,6 +336,16 @@ msgstr ""
 msgid "{0, plural, one {Rejected # file} other {Rejected # files}}"
 msgstr ""
 
+#. placeholder {0}: books.length
+#: src/components/SendToDeviceModal.tsx
+msgid "{0, plural, one {Send # book} other {Send # books}}"
+msgstr ""
+
+#. placeholder {0}: res.sent
+#: src/components/SendToDeviceModal.tsx
+msgid "{0, plural, one {Sent # book to device} other {Sent # books to device}}"
+msgstr ""
+
 #. placeholder {0}: suggestedBooks.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {Suggested match:} other {Suggested matches:}}"
@@ -413,6 +444,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+msgstr ""
+
+#: src/components/UploadModal.tsx
+msgid "{failed, plural, one {Upload failed for # file} other {Upload failed for # files}}"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -538,6 +573,10 @@ msgstr ""
 msgid "{name} theme"
 msgstr ""
 
+#: src/components/UploadModal.tsx
+msgid "{ok} uploaded"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "{othersCount, plural, one {Delete # other} other {Delete # others}}"
 msgstr ""
@@ -572,6 +611,18 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "{shown, plural, one {# title} other {# titles}}"
+msgstr ""
+
+#: src/components/UploadModal.tsx
+msgid "{skipped, plural, one {Nothing to upload — # file is already in your library} other {Nothing to upload — # files are already in your library}}"
+msgstr ""
+
+#: src/components/UploadModal.tsx
+msgid "{success, plural, one {# book uploaded} other {# books uploaded}}"
+msgstr ""
+
+#: src/components/UploadModal.tsx
+msgid "{success} uploaded, {failed} failed"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -647,6 +698,10 @@ msgstr ""
 msgid "~1 day"
 msgstr ""
 
+#: src/components/ShareShelfModal.tsx
+msgid "1 day"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "12 mo"
 msgstr ""
@@ -663,12 +718,20 @@ msgstr ""
 msgid "24 mo"
 msgstr ""
 
+#: src/components/ShareShelfModal.tsx
+msgid "30 days"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "30d"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "365 d"
+msgstr ""
+
+#: src/components/ShareShelfModal.tsx
+msgid "7 days"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -693,6 +756,18 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
+msgstr ""
+
+#: src/components/ShareShelfModal.tsx
+msgid "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for the books in this series. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
+msgstr ""
+
+#: src/components/ShareShelfModal.tsx
+msgid "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for the books on this shelf. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
+msgstr ""
+
+#: src/components/ShareShelfModal.tsx
+msgid "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for this book. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -754,6 +829,10 @@ msgstr ""
 #: src/pages/BookDetailPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Add"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Add a device in Settings to start sending books."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -928,6 +1007,10 @@ msgstr ""
 
 #: src/components/SendButton.tsx
 msgid "Already in your KOReader inbox"
+msgstr ""
+
+#: src/components/UploadModal.tsx
+msgid "Already in your library — will be skipped."
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1127,6 +1210,7 @@ msgstr ""
 msgid "book"
 msgstr ""
 
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Book"
 msgstr ""
@@ -1171,6 +1255,7 @@ msgstr ""
 msgid "Book Types"
 msgstr ""
 
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Books"
@@ -1214,6 +1299,7 @@ msgstr ""
 
 #: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
+#: src/components/UploadModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -1310,6 +1396,8 @@ msgid "Click for details"
 msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
+#: src/components/ShareShelfModal.tsx
+#: src/components/UploadModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/StatsPage.tsx
@@ -1443,6 +1531,10 @@ msgstr ""
 msgid "Copy all as Markdown"
 msgstr ""
 
+#: src/components/ShareShelfModal.tsx
+msgid "Copy link"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Copy to KOReader"
 msgstr ""
@@ -1514,6 +1606,10 @@ msgstr ""
 
 #: src/pages/SetupPage.tsx
 msgid "Create admin account"
+msgstr ""
+
+#: src/components/ShareShelfModal.tsx
+msgid "Create share link"
 msgstr ""
 
 #: src/pages/SetupPage.tsx
@@ -1678,6 +1774,7 @@ msgstr ""
 msgid "Details:"
 msgstr ""
 
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Device"
 msgstr ""
@@ -1777,6 +1874,10 @@ msgstr ""
 msgid "Downloaded {n} highlights"
 msgstr ""
 
+#: src/components/UploadModal.tsx
+msgid "Drop books here or <0>click to browse</0>"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Drop files in the incoming folder to get started"
 msgstr ""
@@ -1865,6 +1966,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Email address"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Email delivery is not set up yet"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1958,6 +2063,10 @@ msgstr ""
 
 #: src/components/ShareLinksOverview.tsx
 msgid "expires {d}"
+msgstr ""
+
+#: src/components/ShareShelfModal.tsx
+msgid "Expires {d}"
 msgstr ""
 
 #: src/pages/LoginPage.tsx
@@ -2121,6 +2230,10 @@ msgstr ""
 msgid "Failed to save series rating"
 msgstr ""
 
+#: src/components/SendToDeviceModal.tsx
+msgid "Failed to send"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to undo"
 msgstr ""
@@ -2159,6 +2272,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "File is missing from disk"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+msgid "File size: {size}"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -2229,6 +2346,7 @@ msgstr ""
 msgid "for {targetLabel} — click a file to switch"
 msgstr ""
 
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2300,6 +2418,10 @@ msgstr ""
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Go back"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Go to Settings"
 msgstr ""
 
 #: src/components/WhatsNewPanel.tsx
@@ -2741,6 +2863,7 @@ msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareLinksOverview.tsx
+#: src/components/ShareShelfModal.tsx
 #: src/components/stats/BacklogEstimate.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
@@ -2967,6 +3090,10 @@ msgstr ""
 msgid "never expires"
 msgstr ""
 
+#: src/components/ShareShelfModal.tsx
+msgid "Never expires"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Never sync this book"
 msgstr ""
@@ -3082,6 +3209,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+msgid "No devices configured"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -3265,6 +3396,7 @@ msgstr ""
 msgid "No Tome account is linked to this identity, and self-signup is disabled."
 msgstr ""
 
+#: src/components/UploadModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "No type"
@@ -4061,6 +4193,10 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
+#: src/components/ShareShelfModal.tsx
+msgid "Revoke link"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Revoke this token? Any scripts or tools using it will stop working immediately."
 msgstr ""
@@ -4245,6 +4381,10 @@ msgstr ""
 msgid "See all results for \"{searchQuery}\""
 msgstr ""
 
+#: src/components/SendToDeviceModal.tsx
+msgid "See Settings for setup instructions."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Select"
 msgstr ""
@@ -4259,6 +4399,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Select All"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Send"
 msgstr ""
 
 #: src/components/NotificationChannels.tsx
@@ -4278,6 +4422,7 @@ msgid "Send test email"
 msgstr ""
 
 #: src/components/SendButton.tsx
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Send to Device"
 msgstr ""
@@ -4290,12 +4435,25 @@ msgstr ""
 msgid "Send via email…"
 msgstr ""
 
+#: src/components/SendToDeviceModal.tsx
+msgid "Sending"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Sending..."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Sent"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Sent \"{title}\" to device"
+msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+msgid "Sent {sent}/{total}. {failedN} failed."
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -4376,6 +4534,10 @@ msgstr ""
 msgid "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
 msgstr ""
 
+#: src/components/UploadModal.tsx
+msgid "Set all to"
+msgstr ""
+
 #: src/components/ForcePasswordChange.tsx
 msgid "Set password & continue"
 msgstr ""
@@ -4408,6 +4570,10 @@ msgstr ""
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Share"
+msgstr ""
+
+#: src/components/ShareShelfModal.tsx
+msgid "Share \"{title}\""
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -5003,6 +5169,18 @@ msgstr ""
 msgid "Upload"
 msgstr ""
 
+#: src/components/UploadModal.tsx
+msgid "Upload All"
+msgstr ""
+
+#: src/components/UploadModal.tsx
+msgid "Upload Books"
+msgstr ""
+
+#: src/components/UploadModal.tsx
+msgid "Upload failed"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Upload or scan a folder to get started"
 msgstr ""
@@ -5061,6 +5239,7 @@ msgstr ""
 msgid "Verify it's working"
 msgstr ""
 
+#: src/components/UploadModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "View book"

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -21,6 +21,10 @@ msgstr ""
 msgid " — MISSING"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid " · {d} at your pace"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid " · {dups} duplicates"
 msgstr ""
@@ -37,6 +41,14 @@ msgstr ""
 msgid " · {n} in progress"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid " · {n} not estimated"
+msgstr ""
+
+#: src/components/stats/BacklogEstimate.tsx
+msgid " · {n} not estimated yet"
+msgstr ""
+
 #: src/pages/SharePage.tsx
 msgid " · {n} read"
 msgstr ""
@@ -47,6 +59,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
+msgstr ""
+
+#: src/components/stats/BacklogEstimate.tsx
+msgid " · books without a word count use your average for that type"
 msgstr ""
 
 #: src/pages/SharePage.tsx
@@ -146,8 +162,15 @@ msgstr ""
 msgid "{0, plural, one {# book tracked} other {# books tracked}}"
 msgstr ""
 
+#. placeholder {0}: data.books
+#: src/components/stats/BacklogEstimate.tsx
+msgid "{0, plural, one {# book, none estimated yet.} other {# books, none estimated yet.}}"
+msgstr ""
+
+#. placeholder {0}: data.books
 #. placeholder {0}: data.totals.books
-#. placeholder {0}: s.book_count
+#. placeholder {0}: row.books
+#: src/components/stats/BacklogEstimate.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
@@ -156,6 +179,11 @@ msgstr ""
 #. placeholder {0}: groups.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
+msgstr ""
+
+#. placeholder {0}: row.unestimated
+#: src/components/stats/BacklogEstimate.tsx
+msgid "{0, plural, one {# not estimated} other {# not estimated}}"
 msgstr ""
 
 #. placeholder {0}: aggregate.distinct_readers
@@ -555,12 +583,40 @@ msgstr ""
 msgid "← Back to library"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "<0>{dur}</0> left in this series"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "~{at}% in · {dur}"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "~{at}% in · not read"
+msgstr ""
+
+#: src/lib/backlog.ts
+msgid "~{d} days"
+msgstr ""
+
+#: src/lib/backlog.ts
+msgid "~{h} h"
+msgstr ""
+
+#: src/lib/backlog.ts
+msgid "~{m} min"
+msgstr ""
+
+#: src/lib/backlog.ts
+msgid "~{mo} months"
+msgstr ""
+
+#: src/lib/backlog.ts
+msgid "~{w} weeks"
+msgstr ""
+
+#: src/lib/backlog.ts
+msgid "~1 day"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -625,6 +681,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "About"
+msgstr ""
+
+#: src/components/stats/BacklogEstimate.tsx
+msgid "about <0>{d}</0> at your pace"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -967,6 +1027,14 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Back to list"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Backlog"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Backlog · {scope}"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1343,6 +1411,10 @@ msgstr ""
 msgid "Could not link SSO. Please try again."
 msgstr ""
 
+#: src/components/stats/BacklogEstimate.tsx
+msgid "Could not load this scope."
+msgstr ""
+
 #: src/components/SeriesFollowButton.tsx
 msgid "Could not resolve this series on Hardcover"
 msgstr ""
@@ -1473,6 +1545,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Day streak"
+msgstr ""
+
+#: src/lib/backlog.ts
+msgid "days at ~{mpd} min a day (last {win} days)"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1763,7 +1839,10 @@ msgstr ""
 msgid "Errors"
 msgstr ""
 
-#: src/components/SeriesReadingStats.tsx
+#: src/pages/BookDetailPage.tsx
+msgid "Est. read time"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
 msgstr ""
@@ -2029,6 +2108,10 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
+#: src/components/stats/BacklogEstimate.tsx
+msgid "Finish a couple of books of each type so Tome can measure your pace."
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Finish rate by book type"
 msgstr ""
@@ -2279,6 +2362,10 @@ msgid "How long the books you finish are"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
+msgid "How long your unread pile would take"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
 msgid "How much of what you own you’ve read"
 msgstr ""
 
@@ -2484,6 +2571,7 @@ msgstr ""
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Libraries"
 msgstr ""
 
@@ -2579,8 +2667,10 @@ msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareLinksOverview.tsx
+#: src/components/stats/BacklogEstimate.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Loading…"
 msgstr ""
 
@@ -3036,6 +3126,11 @@ msgstr ""
 msgid "no reading yet"
 msgstr ""
 
+#: src/components/stats/BacklogEstimate.tsx
+#: src/lib/backlog.ts
+msgid "no recent reading, so no day estimate"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "No results — try a different query."
 msgstr ""
@@ -3089,6 +3184,10 @@ msgstr ""
 msgid "No type (staging / admin only)"
 msgstr ""
 
+#: src/components/stats/BacklogEstimate.tsx
+msgid "No unstarted books in this scope."
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "No users have added devices yet."
 msgstr ""
@@ -3113,6 +3212,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Not enough reading history yet."
+msgstr ""
+
+#: src/components/stats/BacklogEstimate.tsx
+msgid "not estimated yet"
 msgstr ""
 
 #: src/pages/SharePage.tsx
@@ -3951,6 +4054,7 @@ msgid "Scanning…"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Scope"
 msgstr ""
 
@@ -4229,6 +4333,7 @@ msgid "Shelved — set aside, keeps your progress"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/StatsPage.tsx
 msgid "Shelves"
 msgstr ""
 
@@ -4696,6 +4801,10 @@ msgstr ""
 msgid "Unassigned"
 msgstr ""
 
+#: src/lib/backlog.ts
+msgid "under a day"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Undo"
@@ -4895,6 +5004,7 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Want to Read"
 msgstr ""
 
@@ -4989,6 +5099,14 @@ msgstr ""
 msgid "Without a type, new books are only visible to admins until assigned."
 msgstr ""
 
+#: src/lib/backlog.ts
+msgid "Word count at a default {wpm} wpm (no finished books to measure your pace yet)"
+msgstr ""
+
+#: src/lib/backlog.ts
+msgid "Word count at your measured {wpm} wpm"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Word Counts"
 msgstr ""
@@ -5026,6 +5144,10 @@ msgstr ""
 msgid "You rated this {rating}/5"
 msgstr ""
 
+#: src/components/stats/BacklogEstimate.tsx
+msgid "you read ~{mpd} min a day (last {win} days)"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "You're signed in via SSO. Manage your credentials at your identity provider — there's no Tome password to change."
 msgstr ""
@@ -5036,6 +5158,10 @@ msgstr ""
 
 #: src/pages/LoginPage.tsx
 msgid "Your account is not permitted to sign in to Tome."
+msgstr ""
+
+#: src/lib/backlog.ts
+msgid "Your average time per finished book of this type (no word count)"
 msgstr ""
 
 #: src/pages/StatsPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -13,12 +13,74 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/pages/DashboardPage.tsx
+msgid "— keep existing —"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "…and {more} more not shown"
+msgstr ""
+
+#. placeholder {0}: s.book_count
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {# book} other {# books}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Added # book to library} other {Added # books to library}}"
+msgstr ""
+
+#. placeholder {0}: selectedIds.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Delete # book} other {Delete # books}}"
+msgstr ""
+
+#. placeholder {0}: selectedIds.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Deleting # book...} other {Deleting # books...}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Books}}"
+msgstr ""
+
+#. placeholder {0}: selected.size
+#: src/pages/DashboardPage.tsx
+msgid "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{d}d ago"
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 msgid "{days}d ago"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{h}h"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{h}h {m}m"
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 msgid "{hrs}h ago"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{m}m"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
@@ -26,23 +88,112 @@ msgid "{mins}m ago"
 msgstr ""
 
 #: src/components/AppShell.tsx
+#: src/pages/DashboardPage.tsx
 msgid "{n, plural, one {This upload satisfies # wish — review in Admin > Wishlist} other {This upload satisfies # wishes — review in Admin > Wishlist}}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{n} selected"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{name} · Vol. {start_index}–{end_index}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{seconds}s"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{sessions} sessions · {time}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{shown, plural, one {# book} other {# books}}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{shown, plural, one {# title} other {# titles}}"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "{themeName} theme"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "{total, plural, one {# volume} other {# volumes}}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{totalCount, plural, one {{shown} of # book} other {{shown} of # books}}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{totalCount, plural, one {{shown} of # title} other {{shown} of # titles}}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "{totalCount, plural, one {# result for \"{search}\"} other {# results for \"{search}\"}}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "A while ago"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Add tag…"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Add Tags"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Add to Library"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Admin"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "All"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "All {loadedCount} books loaded"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "All →"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "All Books"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "All users"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Amber"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Any"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Author"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Author: {filterAuthor}"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -57,16 +208,42 @@ msgstr ""
 msgid "Book Detail"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Books"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Books without a series"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Browse your library"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Cancel"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Chapters"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Choose icon"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Clear all"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Clear all filters"
+msgstr ""
+
 #: src/components/AppHeader.tsx
 #: src/components/KeyboardShortcutsModal.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Clear search"
 msgstr ""
 
@@ -90,24 +267,74 @@ msgstr ""
 msgid "Command palette — jump to a book, series, author, or page"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Continue Reading"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Cover"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Cover size"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Dark"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Dashboard"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Date Added"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Day streak"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Delete"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Delete failed"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Description"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Deselect all"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Dismiss"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Docs"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Done"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Download failed"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Download Markdown export"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Download ZIP"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -116,6 +343,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Edit Library"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Edit Metadata"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -134,28 +365,92 @@ msgstr ""
 msgid "Exit impersonation"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Exit selection mode"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Expand sidebar"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Failed"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Failed to load books"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Failed to save"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Failed to update metadata"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Failed to update sharing"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Filters"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "finished"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Finished · 30d"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Focus"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Focus search"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Format"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Format: {filterFormatUpper}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "From your highlights"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Go back"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Grid view"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Group by series"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Group series"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Group volumes by series"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Hardcover"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "hiatus"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -179,24 +474,66 @@ msgstr ""
 msgid "Keyboard Shortcuts"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Language"
 msgstr "语言"
 
+#: src/pages/DashboardPage.tsx
+msgid "Language: {filterLanguageLabel}"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Libraries"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Library"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Library: {filterLibraryChipName}"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Light"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "List view"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Log out"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Manage"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Manage series"
+msgstr ""
+
 #: src/components/NotificationBell.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Mark all read"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Missing"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Missing: {filterMissingLabel}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "My Books"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "My Rating"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -219,6 +556,10 @@ msgstr ""
 msgid "Next page"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "No matches"
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 msgid "No notifications yet"
 msgstr ""
@@ -227,8 +568,48 @@ msgstr ""
 msgid "No other users to share with."
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "No results for \"{search}\""
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "No results found"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "No Series"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "No series found — add series metadata to your books."
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "None"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Nothing in progress"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Nothing matched “{search}”"
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 msgid "Notifications"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "On this day"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "ongoing"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Only filled fields will be updated. Leave blank to keep existing values."
 msgstr ""
 
 #: src/components/AppHeader.tsx
@@ -241,6 +622,14 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Open selected book"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Pages · 30d"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Pick up where you left off"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -263,12 +652,69 @@ msgstr ""
 msgid "Public library"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Rated"
+msgstr ""
+
+#: src/components/BookCard.tsx
+msgid "Rated {rating} of 5"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Rated: {filterMinRating}+ stars"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Rated: 5 stars"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Rating"
+msgstr ""
+
+#: src/components/BookCard.tsx
+#: src/pages/DashboardPage.tsx
+msgid "Read"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Read · 30d"
+msgstr ""
+
+#: src/components/BookCard.tsx
+msgid "Read book"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Reader"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Reading"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Reading Log"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Recently Added"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Recently Finished"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Resume {volLabel}"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Save"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Save Changes"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -295,8 +741,29 @@ msgstr ""
 msgid "See all results for \"{searchQuery}\""
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Select"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Select all"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/DashboardPage.tsx
 msgid "Series"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Series name"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Series Progress"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Series: {filterSeries}"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -307,24 +774,88 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Share this series — a public metadata-only page"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Share with users"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Shared Library"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Shelved"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Shelves"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Show another highlight"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Show individual volumes"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Show less"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Show more"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Start {volLabel}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Start reading and your progress will show up here"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Stats"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Status"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Status: {filterStatusLabel}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Tag"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Tag: {filterTag}"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Theme"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Title"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Today"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -339,8 +870,40 @@ msgstr ""
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "翻译由社区维护。尚未翻译的内容将以英文显示。"
 
+#: src/pages/DashboardPage.tsx
+msgid "Try adjusting your filters"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Type"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Unassigned"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Unread"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Unserialized"
+msgstr ""
+
 #: src/components/AppHeader.tsx
 msgid "Upload"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Upload or scan a folder to get started"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Uploader"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Uploader: {filterUploaderName}"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -351,6 +914,34 @@ msgstr ""
 msgid "Viewing as <0>{impersonatedUsername}</0>"
 msgstr ""
 
+#: src/pages/DashboardPage.tsx
+msgid "Vol. {idx}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Vol. {volIdx}"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Volumes"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Want to Read"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Wishlist"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Year"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Yesterday"
+msgstr ""
+
+#: src/pages/DashboardPage.tsx
+msgid "Your library is empty"
 msgstr ""

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -33,6 +33,10 @@ msgstr ""
 msgid " · {errs} error(s)"
 msgstr ""
 
+#: src/components/stats/SeriesCompletionGrid.tsx
+msgid " · {n} in progress"
+msgstr ""
+
 #: src/pages/SharePage.tsx
 msgid " · {n} read"
 msgstr ""
@@ -122,6 +126,11 @@ msgstr ""
 msgid "{0, plural, one {{dur} over # day} other {{dur} over # days}}"
 msgstr ""
 
+#. placeholder {0}: a.book_count
+#: src/components/stats/AuthorAffinity.tsx
+msgid "{0, plural, one {{fin} finished · # book read} other {{fin} finished · # books read}}"
+msgstr ""
+
 #. placeholder {0}: res.errors.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
@@ -164,6 +173,11 @@ msgstr ""
 #. placeholder {0}: follows.length
 #: src/pages/WishlistPage.tsx
 msgid "{0, plural, one {# series} other {# series}}"
+msgstr ""
+
+#. placeholder {0}: f.sessions
+#: src/components/stats/PaceByFormat.tsx
+msgid "{0, plural, one {# session · {pages} pages} other {# sessions · {pages} pages}}"
 msgstr ""
 
 #. placeholder {0}: data.reread_bins
@@ -335,8 +349,16 @@ msgstr ""
 msgid "{failedN} of {totalN} failed — {firstErr}"
 msgstr ""
 
+#: src/components/stats/CompletionByType.tsx
+msgid "{fin} of {st} finished"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "{fin} of {st} started"
+msgstr ""
+
+#: src/components/stats/CompletionRateCard.tsx
+msgid "{fin} of {st} started · all time"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -344,6 +366,7 @@ msgstr ""
 msgid "{h}h"
 msgstr ""
 
+#: src/components/stats/AuthorAffinity.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
@@ -633,6 +656,14 @@ msgstr ""
 msgid "Add custom theme"
 msgstr ""
 
+#: src/components/SaveFilterButton.tsx
+msgid "Add shelf"
+msgstr ""
+
+#: src/components/SaveFilterButton.tsx
+msgid "Add Shelf"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Add tag…"
@@ -780,6 +811,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Appearance"
+msgstr ""
+
+#: src/components/SeriesRating.tsx
+msgid "Applied to volumes you haven’t rated"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -1006,6 +1041,7 @@ msgstr ""
 msgid "Browse your library"
 msgstr ""
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -1178,6 +1214,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Completion Estimates"
+msgstr ""
+
+#: src/components/stats/CompletionRateCard.tsx
+msgid "Completion Rate"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -1663,6 +1703,10 @@ msgstr ""
 msgid "Est. remaining"
 msgstr ""
 
+#: src/components/ShareLinksOverview.tsx
+msgid "Every public link you've shared — shelves, series, and books. Links show metadata, your ratings, highlights, and reading stats; never files. Revoking kills a link instantly."
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Every session — paginated, deletable"
 msgstr ""
@@ -1709,6 +1753,14 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Expand sidebar"
+msgstr ""
+
+#: src/components/ShareLinksOverview.tsx
+msgid "expired"
+msgstr ""
+
+#: src/components/ShareLinksOverview.tsx
+msgid "expires {d}"
 msgstr ""
 
 #: src/pages/LoginPage.tsx
@@ -1837,6 +1889,7 @@ msgstr ""
 msgid "Failed to remove wish"
 msgstr ""
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -1857,6 +1910,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Failed to save role"
+msgstr ""
+
+#: src/components/SeriesRating.tsx
+msgid "Failed to save series rating"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1986,6 +2043,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Full access"
+msgstr ""
+
+#: src/components/stats/ReadingDNACard.tsx
+msgid "Full breakdown →"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2129,6 +2190,7 @@ msgstr ""
 msgid "How you spread your 1–5 stars"
 msgstr ""
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 msgid "Icon"
@@ -2397,6 +2459,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
+#: src/components/ShareLinksOverview.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
 msgid "Loading…"
@@ -2587,6 +2650,7 @@ msgstr ""
 msgid "Name"
 msgstr ""
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 msgid "Name…"
 msgstr ""
@@ -2597,6 +2661,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Never"
+msgstr ""
+
+#: src/components/ShareLinksOverview.tsx
+msgid "never expires"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -2675,6 +2743,10 @@ msgstr ""
 msgid "No audit entries yet."
 msgstr ""
 
+#: src/components/stats/AuthorAffinity.tsx
+msgid "No author data."
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "No book types yet."
 msgstr ""
@@ -2693,6 +2765,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "No comparison data."
+msgstr ""
+
+#: src/components/stats/CompletionByType.tsx
+msgid "No completion data by type."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2739,6 +2815,10 @@ msgstr ""
 msgid "No libraries"
 msgstr ""
 
+#: src/components/stats/LibraryGrowthChart.tsx
+msgid "No library growth data."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
 msgstr ""
@@ -2761,6 +2841,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "No other users to share with."
+msgstr ""
+
+#: src/components/stats/PaceByFormat.tsx
+msgid "No pace data by format."
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2805,6 +2889,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "No series found — add series metadata to your books."
+msgstr ""
+
+#: src/components/stats/SeriesCompletionGrid.tsx
+msgid "No series with reading history yet."
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -2916,6 +3004,10 @@ msgstr ""
 msgid "Nothing matched “{search}”"
 msgstr ""
 
+#: src/components/ShareLinksOverview.tsx
+msgid "Nothing shared yet. Use the share icon on a shelf, a series page, or a book page."
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Notifications"
@@ -2971,6 +3063,7 @@ msgstr ""
 msgid "OPDS Catalog"
 msgstr ""
 
+#: src/components/ShareLinksOverview.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Open"
@@ -3232,6 +3325,10 @@ msgstr ""
 msgid "Range follows the page's range picker; days show the newest slice of it."
 msgstr ""
 
+#: src/components/SeriesRating.tsx
+msgid "Rate the whole series"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Rate this book"
 msgstr ""
@@ -3242,6 +3339,10 @@ msgstr ""
 
 #: src/components/BookCard.tsx
 msgid "Rated {rating} of 5"
+msgstr ""
+
+#: src/components/StarRating.tsx
+msgid "Rated {value} of 5"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -3354,6 +3455,7 @@ msgstr ""
 msgid "Reading days"
 msgstr ""
 
+#: src/components/stats/ReadingDNACard.tsx
 #: src/pages/StatsPage.tsx
 msgid "Reading DNA"
 msgstr ""
@@ -3570,6 +3672,7 @@ msgstr ""
 msgid "Same Series Volume"
 msgstr ""
 
+#: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -3645,6 +3748,14 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Scope"
+msgstr ""
+
+#: src/components/HScrollRow.tsx
+msgid "Scroll left"
+msgstr ""
+
+#: src/components/HScrollRow.tsx
+msgid "Scroll right"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -4296,6 +4407,10 @@ msgstr ""
 msgid "Total time read + avg session"
 msgstr ""
 
+#: src/components/stats/LibraryGrowthChart.tsx
+msgid "Total: {total}"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "翻译由社区维护。尚未翻译的内容将以英文显示。"
@@ -4374,6 +4489,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
+msgstr ""
+
+#: src/components/UpcomingReleases.tsx
+msgid "Upcoming releases"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -4467,6 +4586,10 @@ msgstr ""
 msgid "Vol {idx}"
 msgstr ""
 
+#: src/components/UpcomingReleases.tsx
+msgid "Vol {v} · "
+msgstr ""
+
 #: src/pages/SharePage.tsx
 msgid "Vol. {a}–{b}"
 msgstr ""
@@ -4544,6 +4667,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "What do these mean? — read the stats docs"
+msgstr ""
+
+#: src/components/InfoHint.tsx
+msgid "What is this?"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -4684,6 +4811,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "your Tome password"
+msgstr ""
+
+#: src/components/SeriesRating.tsx
+msgid "Your volumes average {avg} ({rated} rated)"
 msgstr ""
 
 #: src/pages/WishlistPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -49,6 +49,10 @@ msgstr ""
 msgid " · finished {d}"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid " · last synced {when}"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid " · reviewed"
 msgstr ""
@@ -136,7 +140,9 @@ msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups foun
 msgstr ""
 
 #. placeholder {0}: aggregate.distinct_readers
+#. placeholder {0}: c.users_count
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "{0, plural, one {# reader} other {# readers}}"
 msgstr ""
 
@@ -248,6 +254,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "{added} added · {skipped} skipped"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "{base} · Vol. {idx}"
 msgstr ""
 
 #: src/pages/HighlightsPage.tsx
@@ -489,6 +499,10 @@ msgstr ""
 msgid "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "A sync is already running"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "A while ago"
 msgstr ""
@@ -515,6 +529,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Account & Security"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Action failed"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -610,6 +628,7 @@ msgid "Admin access required."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "All"
 msgstr ""
 
@@ -623,6 +642,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "All actions"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "All books"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -918,6 +941,7 @@ msgid "Click for details"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "Close"
 msgstr ""
 
@@ -1047,8 +1071,16 @@ msgstr ""
 msgid "Could not link SSO. Please try again."
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Could not set match"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Could not start SSO linking."
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Could not start sync"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1365,6 +1397,14 @@ msgstr ""
 msgid "Ember"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Error"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Errors"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
 msgstr ""
@@ -1375,6 +1415,18 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Exact Match"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Exclude"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Excluded"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Excluded from Hardcover sync"
 msgstr ""
 
 #: src/components/ImpersonationBanner.tsx
@@ -1572,6 +1624,10 @@ msgstr ""
 msgid "File is missing from disk"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Filter…"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Filters"
 msgstr ""
@@ -1679,10 +1735,12 @@ msgid "Group by series"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "Group series"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "Group volumes by series"
 msgstr ""
 
@@ -1692,6 +1750,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Hardcover"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Hardcover sync is disabled on this server."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1802,6 +1864,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Inactive"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Include"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1953,6 +2019,10 @@ msgstr ""
 msgid "Link your identity provider to this account so you can sign in with SSO. Your existing login keeps working."
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Link your personal API token in <0>Settings → Hardcover</0> — syncing starts right after."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Linked"
 msgstr ""
@@ -1969,11 +2039,16 @@ msgstr ""
 msgid "Load more ({left} left)"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Loading books…"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Loading..."
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
 msgid "Loading…"
 msgstr ""
@@ -2035,8 +2110,20 @@ msgstr ""
 msgid "Marked unread — reading progress cleared"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Match “{title}” to…"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Match all"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Match cleared — re-matching on the next sync"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Matched to “{title}”"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -2123,6 +2210,10 @@ msgstr ""
 msgid "Never"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Never sync this book"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "never used"
 msgstr ""
@@ -2199,6 +2290,10 @@ msgstr ""
 msgid "No books have been sent yet."
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "No books in this view."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
 msgstr ""
@@ -2223,12 +2318,20 @@ msgstr ""
 msgid "No fulfilled wishes."
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "No Hardcover account linked yet."
+msgstr ""
+
 #: src/pages/HighlightsPage.tsx
 msgid "No highlights match your search."
 msgstr ""
 
 #: src/pages/HighlightsPage.tsx
 msgid "No highlights yet"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "no ISBN"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -2269,6 +2372,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "No results — try a different query."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2321,8 +2428,20 @@ msgstr ""
 msgid "Not found"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Not matched"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "not read"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Not synced yet"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "not syncing"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2480,6 +2599,10 @@ msgstr ""
 msgid "Per-file details"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Pick"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Pick up where you left off"
 msgstr ""
@@ -2619,6 +2742,10 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Re-match"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "read"
@@ -2741,6 +2868,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Remove from library"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Remove our entry from Hardcover and re-match automatically"
 msgstr ""
 
 #: src/pages/WishlistPage.tsx
@@ -2867,6 +2998,10 @@ msgstr ""
 msgid "Scope"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Search"
+msgstr ""
+
 #: src/components/AppHeader.tsx
 msgid "Search books"
 msgstr ""
@@ -2875,12 +3010,24 @@ msgstr ""
 msgid "Search books… (/)"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Search failed"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Search for a book in the library…"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Search for a different book…"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Search Hardcover and pick the record yourself"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Search Hardcover…"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -2897,6 +3044,10 @@ msgstr ""
 
 #: src/pages/HighlightsPage.tsx
 msgid "Search your highlights…"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Searching…"
 msgstr ""
 
 #: src/components/AppShell.tsx
@@ -3087,6 +3238,7 @@ msgid "Show details"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HardcoverPage.tsx
 msgid "Show individual volumes"
 msgstr ""
 
@@ -3184,6 +3336,10 @@ msgstr ""
 msgid "Start {volLabel}"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Start matching this book again"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Start reading and your progress will show up here"
 msgstr ""
@@ -3209,12 +3365,24 @@ msgstr ""
 msgid "Subtitle (optional)"
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Sync now"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Sync reading position between KOReader and Tome."
 msgstr ""
 
+#: src/pages/HardcoverPage.tsx
+msgid "Sync started"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Sync Status"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Synced"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3223,6 +3391,10 @@ msgstr ""
 
 #: src/pages/HighlightsPage.tsx
 msgid "Synced to Tome {when}"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "Syncing…"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -3386,6 +3558,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Ungrouped files"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "unknown author"
 msgstr ""
 
 #: src/pages/WishlistPage.tsx
@@ -3569,6 +3745,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "What did you think? (optional, saved automatically)"
+msgstr ""
+
+#: src/pages/HardcoverPage.tsx
+msgid "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -61,12 +61,20 @@ msgstr ""
 msgid " · {n} volumes"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid " · {pages} pages"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
 msgstr ""
 
 #: src/components/ReadingImport.tsx
 msgid " · {r} stars"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid " · avg {avg}"
 msgstr ""
 
 #: src/components/stats/BacklogEstimate.tsx
@@ -105,6 +113,10 @@ msgstr ""
 
 #: src/pages/WishlistPage.tsx
 msgid " · you have vol {v}"
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid " vs previous: <0>{prev}</0>"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -155,6 +167,10 @@ msgstr ""
 msgid "· p. {page} of {totalPages}"
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "({a} vs {b} pages/min)"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "(enables dark: variants)"
 msgstr ""
@@ -169,6 +185,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "(leave blank to keep)"
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid "(low confidence)"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -190,9 +210,19 @@ msgstr ""
 msgid "{0, plural, one {{fin} finished · # book read} other {{fin} finished · # books read}}"
 msgstr ""
 
+#. placeholder {0}: dayEntries.length
+#: src/components/stats/widgets/habits.tsx
+msgid "{0, plural, one {# active day in this window} other {# active days in this window}}"
+msgstr ""
+
 #. placeholder {0}: res.errors.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+msgstr ""
+
+#. placeholder {0}: d.books_finished
+#: src/components/stats/widgets/habits.tsx
+msgid "{0, plural, one {# book finished} other {# books finished}}"
 msgstr ""
 
 #. placeholder {0}: status.syncedDocuments
@@ -273,7 +303,9 @@ msgid "{0, plural, one {# session · {pages} pages} other {# sessions · {pages}
 msgstr ""
 
 #. placeholder {0}: aggregate.total_sessions
+#. placeholder {0}: d.sessions
 #: src/components/SeriesReadingStats.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "{0, plural, one {# session} other {# sessions}}"
 msgstr ""
 
@@ -295,6 +327,11 @@ msgstr ""
 #. placeholder {0}: data.totals.books
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# volume} other {# volumes}}"
+msgstr ""
+
+#. placeholder {0}: est.estimated_days
+#: src/components/stats/widgets/habits.tsx
+msgid "{0, plural, one {~# day remaining} other {~# days remaining}}"
 msgstr ""
 
 #. placeholder {0}: group.files.length
@@ -420,6 +457,10 @@ msgstr ""
 msgid "{d}d ago"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "{daily} finished · {count} total"
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 #: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
@@ -514,6 +555,10 @@ msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
 msgid "{h}h ago"
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid "{h}h reading"
 msgstr ""
 
 #: src/lib/goals.ts
@@ -627,6 +672,22 @@ msgstr ""
 msgid "{pacePerMin} pg/min"
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "{pages} pages in {dur}"
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid "{pct}% less reading this period"
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid "{pct}% more reading this period"
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid "{ppm} pages/min"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
 msgstr ""
@@ -714,6 +775,18 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "<0>{dur}</0> left in this series"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "<0>Device name</0> (e.g. Kindle) — recorded live by the KOReader plugin. <1>web</1> / <2>manual</2> — the web reader, or logged by hand."
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "<0>imported</0> — from KOReader's synced reading history. Delete only: KOReader already caps idle time, so there is nothing to trim."
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "<0>not counted</0> — a live device session whose sitting is also described by imported history. Listed for completeness, excluded from the totals so nothing is counted twice."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1218,6 +1291,10 @@ msgstr ""
 msgid "Average rating per book type"
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "avg {a} pages/min"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "avg {avg}"
 msgstr ""
@@ -1302,6 +1379,7 @@ msgstr ""
 
 #: src/components/CoverAudit.tsx
 #: src/components/SendToDeviceModal.tsx
+#: src/components/stats/widgets/overview.tsx
 #: src/pages/AdminPage.tsx
 msgid "Book"
 msgstr ""
@@ -1410,6 +1488,7 @@ msgstr ""
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
+#: src/components/stats/widgets/overview.tsx
 #: src/components/UploadModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -1843,6 +1922,10 @@ msgstr ""
 msgid "Database"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Date"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Date Added"
 msgstr ""
@@ -1931,6 +2014,7 @@ msgid "Details:"
 msgstr ""
 
 #: src/components/SendToDeviceModal.tsx
+#: src/components/stats/widgets/overview.tsx
 #: src/pages/AdminPage.tsx
 msgid "Device"
 msgstr ""
@@ -2062,6 +2146,10 @@ msgstr ""
 msgid "Duplicates"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Duration"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "E-Reader Devices"
 msgstr ""
@@ -2084,6 +2172,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "e.g. scribe-laptop"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Each row is one reading session."
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -2546,6 +2638,7 @@ msgid "Fr"
 msgstr ""
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Fri"
 msgstr ""
 
@@ -2871,6 +2964,10 @@ msgstr ""
 msgid "Just now"
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "Just started"
+msgstr ""
+
 #: src/components/SyncStatusBadge.tsx
 msgid "Just synced"
 msgstr ""
@@ -2965,6 +3062,8 @@ msgstr ""
 msgid "Learn more"
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+#: src/components/stats/widgets/overview.tsx
 #: src/pages/SharePage.tsx
 msgid "Less"
 msgstr ""
@@ -3107,6 +3206,10 @@ msgstr ""
 msgid "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Longest first"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Longest Session"
 msgstr ""
@@ -3224,6 +3327,7 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
 #: src/lib/goals.ts
 msgid "min"
 msgstr ""
@@ -3261,11 +3365,17 @@ msgid "Mo"
 msgstr ""
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Mon"
 msgstr ""
 
 #: src/lib/goals.ts
 msgid "Monthly goal"
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+#: src/components/stats/widgets/overview.tsx
+msgid "More"
 msgstr ""
 
 #: src/components/SendButton.tsx
@@ -3342,6 +3452,10 @@ msgstr ""
 msgid "New board"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "New duration"
+msgstr ""
+
 #: src/components/stats/GoalWidget.tsx
 msgid "New goal"
 msgstr ""
@@ -3381,6 +3495,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "New User"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Newest first"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3427,12 +3545,20 @@ msgstr ""
 msgid "No book types yet."
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "No books currently in progress."
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "No books found. Upload the book first, then fulfill."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "No books have been sent yet."
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "No books in progress"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -3543,12 +3669,20 @@ msgstr ""
 msgid "No pace data by format."
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "No paced sessions."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "No PINs yet. Generate one to use with OPDS clients."
 msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
 msgid "No position changes recorded yet — history starts with the next sync."
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid "No previous data to compare"
 msgstr ""
 
 #: src/components/stats/widgets/taste.tsx
@@ -3579,6 +3713,10 @@ msgstr ""
 msgid "No reading activity yet. Records appear when users start reading books."
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "No reading data"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "No reading data yet"
 msgstr ""
@@ -3593,6 +3731,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "No reading sessions in this range — session-based tiles will be empty."
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "No reading sessions recorded."
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -3633,7 +3775,12 @@ msgid "No series with reading progress yet."
 msgstr ""
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "No session data."
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "No sessions recorded."
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -3692,8 +3839,16 @@ msgstr ""
 msgid "Not configured"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "not counted"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Not enough reading history yet."
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid "Not enough sessions yet."
 msgstr ""
 
 #: src/components/stats/BacklogEstimate.tsx
@@ -3748,6 +3903,10 @@ msgstr ""
 
 #: src/pages/HighlightsPage.tsx
 msgid "Note: {note}"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Nothing finished in this range."
 msgstr ""
 
 #: src/pages/SharePage.tsx
@@ -4309,8 +4468,20 @@ msgstr ""
 msgid "Reading Speed"
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "Reading speed down {down}%"
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid "Reading speed steady"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Reading Speed Trend"
+msgstr ""
+
+#: src/components/stats/widgets/habits.tsx
+msgid "Reading speed up {up}%"
 msgstr ""
 
 #: src/components/CommandPalette.tsx
@@ -4528,6 +4699,10 @@ msgstr ""
 msgid "Sa"
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "Same as previous period"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Same ISBN"
 msgstr ""
@@ -4537,6 +4712,7 @@ msgid "Same Series Volume"
 msgstr ""
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Sat"
 msgstr ""
 
@@ -4983,6 +5159,10 @@ msgstr ""
 msgid "Show more"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Show more ({left} remaining)"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
 msgstr ""
@@ -5104,6 +5284,10 @@ msgstr ""
 msgid "Start reading and your progress will show up here"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Start reading one and it'll show up here"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Started vs finished ratio"
 msgstr ""
@@ -5141,7 +5325,12 @@ msgstr ""
 msgid "Subtitle (optional)"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Suggested: {dur}"
+msgstr ""
+
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Sun"
 msgstr ""
 
@@ -5241,6 +5430,10 @@ msgstr ""
 msgid "the sync password set above"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "The triangle marks an implausibly long session. Scissors shorten a session, the bin deletes it."
+msgstr ""
+
 #: src/components/Sidebar.tsx
 #: src/components/ThemeToggle.tsx
 msgid "Theme"
@@ -5282,6 +5475,10 @@ msgstr ""
 msgid "This period vs the last"
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "This period: <0>{cur}</0>"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
 msgstr ""
@@ -5295,6 +5492,7 @@ msgid "this week"
 msgstr ""
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Thu"
 msgstr ""
 
@@ -5374,6 +5572,10 @@ msgstr ""
 msgid "Toggle only-notes filter"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Toggle sort order"
+msgstr ""
+
 #: src/components/ThemeToggle.tsx
 msgid "Toggle theme"
 msgstr ""
@@ -5419,6 +5621,14 @@ msgstr ""
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "翻译由社区维护。尚未翻译的内容将以英文显示。"
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Trim"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Trimming only shortens this session's length and end time — page turns, progress and every other session stay untouched, and the previous duration is kept in the audit log. The suggestion re-prices this session's page turns at your usual reading pace."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Try adjusting your filters"
 msgstr ""
@@ -5436,6 +5646,7 @@ msgid "Tu"
 msgstr ""
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Tue"
 msgstr ""
 
@@ -5502,6 +5713,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Unserialized"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Unusually long session"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -5702,6 +5917,7 @@ msgid "Web reader"
 msgstr ""
 
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/habits.tsx
 msgid "Wed"
 msgstr ""
 
@@ -5877,6 +6093,10 @@ msgstr ""
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "Your note — syncs back to KOReader on the next sync"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Your page turns at your usual reading pace"
 msgstr ""
 
 #: src/pages/StatsPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -65,12 +65,17 @@ msgstr ""
 msgid " · books without a word count use your average for that type"
 msgstr ""
 
+#: src/components/stats/TimelineRibbon.tsx
 #: src/pages/SharePage.tsx
 msgid " · finished {d}"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
 msgid " · last synced {when}"
+msgstr ""
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid " · longest <0>{title}</0> ({words})"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -174,6 +179,11 @@ msgstr ""
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
+msgstr ""
+
+#. placeholder {0}: hover.b.days.length
+#: src/components/stats/TimelineRibbon.tsx
+msgid "{0, plural, one {# day} other {# days}}"
 msgstr ""
 
 #. placeholder {0}: groups.length
@@ -313,6 +323,16 @@ msgstr ""
 #. placeholder {0}: selected.size
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
+msgstr ""
+
+#. placeholder {0}: data.books_counted
+#: src/components/stats/widgets/wordstats.tsx
+msgid "{0, plural, one {words read · # book} other {words read · # books}}"
+msgstr ""
+
+#. placeholder {0}: data.books_counted
+#: src/components/stats/widgets/wordstats.tsx
+msgid "{0, plural, one {words/min · across # book} other {words/min · across # books}}"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -502,6 +522,10 @@ msgstr ""
 msgid "{n} selected — Clear"
 msgstr ""
 
+#: src/components/stats/TimelineRibbon.tsx
+msgid "{n} vols · "
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{name} · Vol. {start_index}–{end_index}"
 msgstr ""
@@ -552,6 +576,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "{themeName} theme"
+msgstr ""
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "{title} — {dur} between {from} and {to}"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -703,6 +731,10 @@ msgstr ""
 msgid "Accepted: {title}"
 msgstr ""
 
+#: src/components/NotificationChannels.tsx
+msgid "Access token (only for protected topics)"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Account & Security"
 msgstr ""
@@ -747,6 +779,10 @@ msgstr ""
 
 #: src/pages/WishlistPage.tsx
 msgid "Add books you'd like to see in the library."
+msgstr ""
+
+#: src/components/NotificationChannels.tsx
+msgid "Add channel"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -919,6 +955,10 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
+#: src/components/NotificationChannels.tsx
+msgid "Application token (required)"
+msgstr ""
+
 #: src/components/SeriesRating.tsx
 msgid "Applied to volumes you haven’t rated"
 msgstr ""
@@ -1015,6 +1055,14 @@ msgstr ""
 
 #: src/components/SeriesReadingStats.tsx
 msgid "avg / volume"
+msgstr ""
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid "avg <0>{avg}</0> · median {median}"
+msgstr ""
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid "avg <0>{avg}</0> words per book"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1435,6 +1483,10 @@ msgstr ""
 msgid "Couldn’t load stats."
 msgstr ""
 
+#: src/components/stats/TimelineRibbon.tsx
+msgid "Couldn't load the timeline."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr ""
@@ -1646,6 +1698,7 @@ msgstr ""
 msgid "Directories"
 msgstr ""
 
+#: src/components/WhatsNewPanel.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -1933,6 +1986,10 @@ msgstr ""
 msgid "Exporting..."
 msgstr ""
 
+#: src/components/NotificationChannels.tsx
+msgid "failed"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2088,6 +2145,10 @@ msgstr ""
 msgid "fantasy, action, romance"
 msgstr ""
 
+#: src/components/stats/widgets/wordstats.tsx
+msgid "Fastest"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
 msgstr ""
@@ -2239,6 +2300,10 @@ msgstr ""
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Go back"
+msgstr ""
+
+#: src/components/WhatsNewPanel.tsx
+msgid "Got it"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2473,6 +2538,10 @@ msgstr ""
 msgid "Just synced"
 msgstr ""
 
+#: src/components/WhatsNewPanel.tsx
+msgid "Just updated"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Keep this one"
 msgstr ""
@@ -2599,6 +2668,7 @@ msgstr ""
 msgid "Library: {filterLibraryChipName}"
 msgstr ""
 
+#: src/components/stats/TimelineRibbon.tsx
 #: src/pages/StatsPage.tsx
 msgid "lifetime"
 msgstr ""
@@ -2658,6 +2728,10 @@ msgstr ""
 
 #: src/pages/HardcoverPage.tsx
 msgid "Loading books…"
+msgstr ""
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "Loading your reading life…"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -3106,12 +3180,24 @@ msgstr ""
 msgid "No ratings yet."
 msgstr ""
 
+#: src/components/stats/widgets/wordstats.tsx
+msgid "No re-reads yet — pages you revisit on a later day show up here."
+msgstr ""
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "no reading"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "No reading activity yet. Records appear when users start reading books."
 msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "No reading data yet"
+msgstr ""
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "No reading history yet — sessions and imported KOReader history land here."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3171,6 +3257,10 @@ msgstr ""
 msgid "No suggested match yet — search for the book to link, or upload it first."
 msgstr ""
 
+#: src/components/stats/widgets/wordstats.tsx
+msgid "No timed reading with word counts yet."
+msgstr ""
+
 #: src/pages/LoginPage.tsx
 msgid "No Tome account is linked to this identity, and self-signup is disabled."
 msgstr ""
@@ -3198,6 +3288,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "No widgets on this board yet."
+msgstr ""
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid "No word counts yet."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3240,6 +3334,10 @@ msgstr ""
 
 #: src/pages/HardcoverPage.tsx
 msgid "not syncing"
+msgstr ""
+
+#: src/components/NotificationChannels.tsx
+msgid "Not used"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -3455,6 +3553,10 @@ msgstr ""
 msgid "Passwords do not match."
 msgstr ""
 
+#: src/components/NotificationChannels.tsx
+msgid "Pause"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Per-file details"
 msgstr ""
@@ -3575,6 +3677,10 @@ msgstr ""
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
+msgstr ""
+
+#: src/components/NotificationChannels.tsx
+msgid "Push Tome's notifications (wish fulfilled, new volume detected, reading goals) to ntfy, Gotify, or any webhook the moment they happen — the bell above only rings when you visit. Each channel can be tested, paused, or removed; tokens are stored server-side and never shown again."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3808,6 +3914,7 @@ msgstr ""
 msgid "Reading time split by language"
 msgstr ""
 
+#: src/components/stats/TimelineRibbon.tsx
 #: src/pages/StatsPage.tsx
 msgid "Reading Timeline"
 msgstr ""
@@ -3866,6 +3973,10 @@ msgstr ""
 msgid "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
 msgstr ""
 
+#: src/components/NotificationChannels.tsx
+msgid "Remove channel"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Remove device"
 msgstr ""
@@ -3898,6 +4009,10 @@ msgstr ""
 msgid "Rename board"
 msgstr ""
 
+#: src/components/NotificationChannels.tsx
+msgid "request failed"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Rescan the bindery folder"
 msgstr ""
@@ -3920,6 +4035,10 @@ msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
 msgid "Restoring sets the live position (and read status) back to that point; devices pick it up on their next sync. Restoring below 100% un-finishes a falsely completed book."
+msgstr ""
+
+#: src/components/NotificationChannels.tsx
+msgid "Resume"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -4140,6 +4259,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Select All"
+msgstr ""
+
+#: src/components/NotificationChannels.tsx
+msgid "Send a test notification"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -4402,6 +4525,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Skip"
+msgstr ""
+
+#: src/components/stats/widgets/wordstats.tsx
+msgid "Slowest"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -5056,6 +5183,10 @@ msgstr ""
 msgid "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
 msgstr ""
 
+#: src/components/WhatsNewPanel.tsx
+msgid "What's new in Tome {version}"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "When you read — hour × weekday"
 msgstr ""
@@ -5219,4 +5350,12 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Your year, at a glance (1y/All)"
+msgstr ""
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "Zoom in"
+msgstr ""
+
+#: src/components/stats/TimelineRibbon.tsx
+msgid "Zoom out"
 msgstr ""

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -1,0 +1,22 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-08-19 19:42+0200\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: zh-CN\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/pages/SettingsPage.tsx
+msgid "Language"
+msgstr "语言"
+
+#: src/pages/SettingsPage.tsx
+msgid "Translations are community-maintained. Anything not yet translated is shown in English."
+msgstr "翻译由社区维护。尚未翻译的内容将以英文显示。"

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -121,6 +121,11 @@ msgstr ""
 msgid "(not set)"
 msgstr ""
 
+#. placeholder {0}: tooltip.sessions
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "{0, plural, one {{dur} · # session} other {{dur} · # sessions}}"
+msgstr ""
+
 #. placeholder {0}: b.stats.reading_days
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {{dur} over # day} other {{dur} over # days}}"
@@ -155,6 +160,7 @@ msgstr ""
 
 #. placeholder {0}: aggregate.distinct_readers
 #. placeholder {0}: c.users_count
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "{0, plural, one {# reader} other {# readers}}"
@@ -183,6 +189,11 @@ msgstr ""
 #. placeholder {0}: f.sessions
 #: src/components/stats/PaceByFormat.tsx
 msgid "{0, plural, one {# session · {pages} pages} other {# sessions · {pages} pages}}"
+msgstr ""
+
+#. placeholder {0}: aggregate.total_sessions
+#: src/components/SeriesReadingStats.tsx
+msgid "{0, plural, one {# session} other {# sessions}}"
 msgstr ""
 
 #. placeholder {0}: data.reread_bins
@@ -378,6 +389,7 @@ msgid "{h}h"
 msgstr ""
 
 #: src/components/stats/AuthorAffinity.tsx
+#: src/components/stats/HourDowHeatmap.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
@@ -801,6 +813,10 @@ msgstr ""
 msgid "All readers: {dur} · {days} · {readers}"
 msgstr ""
 
+#: src/components/SeriesReadingStats.tsx
+msgid "All readers: {dur} · {sess} · {readers}"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "All users"
@@ -935,6 +951,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "avg {avg}"
+msgstr ""
+
+#: src/components/SeriesReadingStats.tsx
+msgid "avg / volume"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1270,6 +1290,7 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
+#: src/components/ForcePasswordChange.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Confirm new password"
 msgstr ""
@@ -1742,6 +1763,7 @@ msgstr ""
 msgid "Errors"
 msgstr ""
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
 msgstr ""
@@ -1971,6 +1993,10 @@ msgstr ""
 msgid "Failed to update metadata"
 msgstr ""
 
+#: src/components/ForcePasswordChange.tsx
+msgid "Failed to update password."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to update reading status"
 msgstr ""
@@ -2025,6 +2051,7 @@ msgstr ""
 msgid "Finished · 30d"
 msgstr ""
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "First read"
 msgstr ""
@@ -2070,6 +2097,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Fr"
+msgstr ""
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Fri"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2163,6 +2194,15 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Height auto-fits the content — only width is resizable"
+msgstr ""
+
+#. placeholder {0}: user?.username
+#: src/components/ForcePasswordChange.tsx
+#~ msgid "Hi <0>{0}</0> — your account was created by an admin. Please set a personal password before continuing."
+#~ msgstr ""
+
+#: src/components/ForcePasswordChange.tsx
+msgid "Hi <0>{username}</0> — your account was created by an admin. Please set a personal password before continuing."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2397,6 +2437,7 @@ msgstr "语言"
 msgid "Language: {filterLanguageLabel}"
 msgstr ""
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Last read"
 msgstr ""
@@ -2575,6 +2616,10 @@ msgstr ""
 msgid "Longest Streak"
 msgstr ""
 
+#: src/components/SeriesReadingStats.tsx
+msgid "Longest volume"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Longest: {d}d"
 msgstr ""
@@ -2696,6 +2741,10 @@ msgstr ""
 msgid "Mo"
 msgstr ""
 
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Mon"
+msgstr ""
+
 #: src/components/SendButton.tsx
 msgid "More send options"
 msgstr ""
@@ -2778,6 +2827,7 @@ msgstr ""
 msgid "New Library"
 msgstr ""
 
+#: src/components/ForcePasswordChange.tsx
 #: src/pages/SettingsPage.tsx
 msgid "New password"
 msgstr ""
@@ -2820,6 +2870,10 @@ msgstr ""
 
 #: src/components/SeriesFollowButton.tsx
 msgid "Next: Vol {v} · {d}"
+msgstr ""
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "No activity"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -3008,6 +3062,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "No series with reading progress yet."
+msgstr ""
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "No session data."
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -3236,6 +3294,7 @@ msgstr ""
 msgid "Padding"
 msgstr ""
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "pages"
 msgstr ""
@@ -3276,6 +3335,10 @@ msgstr ""
 msgid "Password must be at least 8 characters"
 msgstr ""
 
+#: src/components/ForcePasswordChange.tsx
+msgid "Password must be at least 8 characters."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Password updated successfully"
 msgstr ""
@@ -3283,6 +3346,10 @@ msgstr ""
 #: src/pages/SettingsPage.tsx
 #: src/pages/SetupPage.tsx
 msgid "Passwords do not match"
+msgstr ""
+
+#: src/components/ForcePasswordChange.tsx
+msgid "Passwords do not match."
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -3615,6 +3682,7 @@ msgstr ""
 msgid "Reading Speed Trend"
 msgstr ""
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/SetupPage.tsx
 #: src/pages/StatsPage.tsx
@@ -3803,6 +3871,10 @@ msgstr ""
 msgid "Same Series Volume"
 msgstr ""
 
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Sat"
+msgstr ""
+
 #: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
@@ -3852,6 +3924,7 @@ msgstr ""
 msgid "Saving..."
 msgstr ""
 
+#: src/components/ForcePasswordChange.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "Saving…"
@@ -4055,6 +4128,7 @@ msgstr ""
 msgid "Session Timeline"
 msgstr ""
 
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "sessions"
 msgstr ""
@@ -4075,12 +4149,20 @@ msgstr ""
 msgid "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
 msgstr ""
 
+#: src/components/ForcePasswordChange.tsx
+msgid "Set password & continue"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Set sync password"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Set the following environment variables to enable Send to Device:"
+msgstr ""
+
+#: src/components/ForcePasswordChange.tsx
+msgid "Set your password"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -4322,6 +4404,10 @@ msgstr ""
 msgid "Subtitle (optional)"
 msgstr ""
 
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Sun"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Sync now"
 msgstr ""
@@ -4376,6 +4462,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Taste by Genre"
+msgstr ""
+
+#: src/components/ForcePasswordChange.tsx
+msgid "Temporary password"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -4451,6 +4541,10 @@ msgstr ""
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
 msgstr ""
 
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Thu"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Time"
 msgstr ""
@@ -4477,6 +4571,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Time per chapter, line view"
+msgstr ""
+
+#: src/components/SeriesReadingStats.tsx
+msgid "Time per volume"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -4578,6 +4676,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Tu"
+msgstr ""
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Tue"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -4732,8 +4834,21 @@ msgstr ""
 msgid "Viewing as <0>{impersonatedUsername}</0>"
 msgstr ""
 
+#: src/components/SeriesReadingStats.tsx
+msgid "Vol {firstIdx}"
+msgstr ""
+
+#: src/components/SeriesReadingStats.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Vol {idx}"
+msgstr ""
+
+#: src/components/SeriesReadingStats.tsx
+msgid "Vol {idx} · {dur}"
+msgstr ""
+
+#: src/components/SeriesReadingStats.tsx
+msgid "Vol {lastIdx}"
 msgstr ""
 
 #: src/components/UpcomingReleases.tsx
@@ -4801,6 +4916,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Web reader"
+msgstr ""
+
+#: src/components/stats/HourDowHeatmap.tsx
+msgid "Wed"
 msgstr ""
 
 #: src/pages/LoginPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -57,8 +57,17 @@ msgstr ""
 msgid " · {n} read"
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
+msgid " · {n} reading"
+msgstr ""
+
 #: src/pages/WishlistPage.tsx
 msgid " · {n} volumes"
+msgstr ""
+
+#: src/components/stats/widgets/insights.tsx
+msgid " · {n} want to read"
 msgstr ""
 
 #: src/components/stats/widgets/overview.tsx
@@ -505,6 +514,10 @@ msgstr ""
 msgid "{dismissCount, plural, one {dismiss # group} other {dismiss # groups}}"
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+msgid "{dur} · {books} books — your only language"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "{dur} across {n} chapters"
 msgstr ""
@@ -548,6 +561,7 @@ msgstr ""
 
 #: src/components/stats/AuthorAffinity.tsx
 #: src/components/stats/HourDowHeatmap.tsx
+#: src/components/stats/widgets/library.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
@@ -688,6 +702,14 @@ msgstr ""
 msgid "{ppm} pages/min"
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+msgid "{read} of {owned} owned read"
+msgstr ""
+
+#: src/components/stats/widgets/library.tsx
+msgid "{read} of {total} read"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
 msgstr ""
@@ -754,6 +776,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "{totalCount, plural, one {# result for \"{search}\"} other {# results for \"{search}\"}}"
+msgstr ""
+
+#: src/components/stats/widgets/library.tsx
+msgid "{v}m"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -947,6 +973,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Active"
+msgstr ""
+
+#: src/components/stats/widgets/insights.tsx
+msgid "Active Days"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1237,6 +1267,7 @@ msgstr ""
 msgid "Auth"
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -1359,6 +1390,10 @@ msgstr ""
 msgid "Beta"
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+msgid "Biggest reading day"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Bindery"
@@ -1443,6 +1478,8 @@ msgstr ""
 msgid "Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately."
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
 #: src/pages/StatsPage.tsx
 msgid "Books Finished"
 msgstr ""
@@ -3210,6 +3247,10 @@ msgstr ""
 msgid "Longest first"
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+msgid "Longest session"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Longest Session"
 msgstr ""
@@ -3218,6 +3259,8 @@ msgstr ""
 msgid "Longest session, biggest day, most pages"
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
 #: src/pages/StatsPage.tsx
 msgid "Longest Streak"
 msgstr ""
@@ -3384,6 +3427,14 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Morning vs evening reader?"
+msgstr ""
+
+#: src/components/stats/widgets/library.tsx
+msgid "Most Active Month"
+msgstr ""
+
+#: src/components/stats/widgets/insights.tsx
+msgid "Most pages in a day"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -3565,6 +3616,10 @@ msgstr ""
 msgid "No books in this view."
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
+msgid "No category data."
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "No comparison data."
 msgstr ""
@@ -3583,6 +3638,10 @@ msgstr ""
 
 #: src/components/CoverPickerModal.tsx
 msgid "No covers found — try a different search or use a custom URL below."
+msgstr ""
+
+#: src/components/stats/widgets/insights.tsx
+msgid "No data yet."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3741,6 +3800,10 @@ msgstr ""
 msgid "no reading yet"
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+msgid "No reading-time data yet."
+msgstr ""
+
 #: src/components/stats/BacklogEstimate.tsx
 #: src/lib/backlog.ts
 msgid "no recent reading, so no day estimate"
@@ -3766,6 +3829,10 @@ msgstr ""
 msgid "No series found — add series metadata to your books."
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
+msgid "No series read yet."
+msgstr ""
+
 #: src/components/stats/SeriesCompletionGrid.tsx
 msgid "No series with reading history yet."
 msgstr ""
@@ -3777,6 +3844,10 @@ msgstr ""
 #: src/components/stats/HourDowHeatmap.tsx
 #: src/components/stats/widgets/habits.tsx
 msgid "No session data."
+msgstr ""
+
+#: src/components/stats/widgets/insights.tsx
+msgid "No session-time data yet."
 msgstr ""
 
 #: src/components/stats/widgets/overview.tsx
@@ -4064,6 +4135,11 @@ msgstr ""
 msgid "pages"
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
+msgid "Pages"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Pages · 30d"
 msgstr ""
@@ -4127,6 +4203,10 @@ msgstr ""
 
 #: src/components/NotificationChannels.tsx
 msgid "Pause"
+msgstr ""
+
+#: src/components/stats/widgets/insights.tsx
+msgid "Peak hour: <0>{peak}:00–{peakEnd}:00</0> · {dur} total"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -4877,6 +4957,10 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
+msgid "Select <0>1y</0> or <1>All</1> to see your year in review."
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Select a book first."
 msgstr ""
@@ -5007,6 +5091,8 @@ msgstr ""
 msgid "sessions"
 msgstr ""
 
+#: src/components/stats/widgets/insights.tsx
+#: src/components/stats/widgets/library.tsx
 #: src/pages/StatsPage.tsx
 msgid "Sessions"
 msgstr ""
@@ -5136,6 +5222,10 @@ msgstr ""
 msgid "Short app-specific passwords for OPDS — easier to type on an e-reader than your full password."
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
+msgid "Show all ({n} books)"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Show another highlight"
 msgstr ""
@@ -5149,6 +5239,7 @@ msgstr ""
 msgid "Show individual volumes"
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Show less"
@@ -5496,6 +5587,7 @@ msgstr ""
 msgid "Thu"
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
 #: src/pages/AdminPage.tsx
 msgid "Time"
 msgstr ""
@@ -5544,6 +5636,7 @@ msgstr ""
 msgid "title"
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -5605,8 +5698,24 @@ msgstr ""
 msgid "Top Books by Reading Time"
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
+msgid "Top Genre"
+msgstr ""
+
+#: src/components/stats/widgets/library.tsx
+msgid "Total Hours"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Total pages turned"
+msgstr ""
+
+#: src/components/stats/widgets/library.tsx
+msgid "Total Sessions"
+msgstr ""
+
+#: src/components/stats/widgets/insights.tsx
+msgid "Total Time"
 msgstr ""
 
 #: src/pages/StatsPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -13,17 +13,48 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/pages/BookDetailPage.tsx
+msgid " — click for sessions"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid " · {prog}% in"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid ", {pages} pages"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "…and {more} more not shown"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "· p. {page} of {totalPages}"
+msgstr ""
+
 #. placeholder {0}: s.book_count
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
+msgstr ""
+
+#. placeholder {0}: aggregate.distinct_readers
+#: src/pages/BookDetailPage.tsx
+msgid "{0, plural, one {# reader} other {# readers}}"
+msgstr ""
+
+#. placeholder {0}: aggregate.total_sessions
+#: src/pages/BookDetailPage.tsx
+msgid "{0, plural, one {# reading day} other {# reading days}}"
+msgstr ""
+
+#. placeholder {0}: data.reread_bins
+#: src/pages/BookDetailPage.tsx
+msgid "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
 msgstr ""
 
 #. placeholder {0}: selected.size
@@ -51,6 +82,10 @@ msgstr ""
 msgid "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "{count} sittings · {from} – {to}"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{d}d ago"
 msgstr ""
@@ -59,8 +94,24 @@ msgstr ""
 msgid "{days}d ago"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "{dayStr}: {mins}m"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "{deltaStr}% vs last week"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "{dur} across {n} chapters"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "{dur} on device"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -100,8 +151,16 @@ msgstr ""
 msgid "{name} · Vol. {start_index}–{end_index}"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "{pacePerMin} pg/min"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "{recent} in the last 7 days vs {prior} the week before"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -140,10 +199,43 @@ msgstr ""
 msgid "{totalCount, plural, one {# result for \"{search}\"} other {# results for \"{search}\"}}"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "{words} words"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "← Back to library"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "~{at}% in · {dur}"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "~{at}% in · not read"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "A while ago"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Activity"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Add"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Add a note"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Add a review"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Add tag…"
 msgstr ""
@@ -152,8 +244,16 @@ msgstr ""
 msgid "Add Tags"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Add to library"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Add to Library"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Added to Want to Read"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -176,6 +276,10 @@ msgstr ""
 msgid "All Books"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "All readers: {dur} · {days} · {readers}"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "All users"
 msgstr ""
@@ -188,12 +292,21 @@ msgstr ""
 msgid "Any"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Attach progress synced from a KOReader-compatible app to this book"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Author"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Author: {filterAuthor}"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "avg session"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -204,8 +317,16 @@ msgstr ""
 msgid "Black"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Book deleted"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Book Detail"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Book not found"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -221,8 +342,21 @@ msgid "Browse your library"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Cancel"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "ch. {n}"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "ch. 1"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Chapter"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -233,12 +367,20 @@ msgstr ""
 msgid "Choose icon"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Clear"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Clear all"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Clear all filters"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Clear imported history — remove this book's KOReader page data"
 msgstr ""
 
 #: src/components/AppHeader.tsx
@@ -249,6 +391,14 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Clear selection / blur search"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Clearing…"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Close"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -265,6 +415,14 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Command palette — jump to a book, series, author, or page"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Confirm"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Content"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -297,20 +455,43 @@ msgid "Day streak"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Delete \"{title}\"?"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete failed"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Delete this highlight"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Deleting…"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Description"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Deselect all"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Details"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -325,6 +506,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Download failed"
 msgstr ""
@@ -338,6 +520,7 @@ msgid "Download ZIP"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Edit"
 msgstr ""
 
@@ -349,12 +532,24 @@ msgstr ""
 msgid "Edit Metadata"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Edit note"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Edit review"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Edit Shelf"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Ember"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Est. remaining"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -377,20 +572,64 @@ msgstr ""
 msgid "Failed"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to delete highlight"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to link sync document"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Failed to load books"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to load facets"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to load libraries"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to log session"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Failed to save"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to save note"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to save rating"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to save review"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to undo"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Failed to update metadata"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Failed to update reading status"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Failed to update sharing"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Fetch Metadata"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -401,8 +640,16 @@ msgstr ""
 msgid "finished"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Finished"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Finished · 30d"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "First read"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -413,6 +660,7 @@ msgstr ""
 msgid "Focus search"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Format"
 msgstr ""
@@ -423,6 +671,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "From your highlights"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Genres"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -453,17 +705,38 @@ msgstr ""
 msgid "hiatus"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Hide details"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Highlight deleted"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/components/Sidebar.tsx
 msgid "Highlights"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Highlights & Notes"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Home"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "How far through the book you'd read by each date."
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Icon"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "ISBN"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
@@ -474,6 +747,11 @@ msgstr ""
 msgid "Keyboard Shortcuts"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "KOReader sync linked"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Language"
@@ -483,10 +761,16 @@ msgstr "语言"
 msgid "Language: {filterLanguageLabel}"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Last read"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Libraries"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Library"
 msgstr ""
@@ -499,12 +783,28 @@ msgstr ""
 msgid "Light"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Link"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Link KOReader sync…"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Linking…"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "List view"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Log out"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Log session"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -515,9 +815,33 @@ msgstr ""
 msgid "Manage series"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Manual"
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Mark all read"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Marked as read"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Marked as reading"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Marked unread — reading progress cleared"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Metadata saved"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Minutes"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -548,12 +872,20 @@ msgstr ""
 msgid "New Library"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "new this week"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next book"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next page"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "No description"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -566,6 +898,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "No other users to share with."
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -584,8 +920,25 @@ msgstr ""
 msgid "No series found — add series metadata to your books."
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "No type"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "None"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "not read"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Note removed"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Note saved — syncs to your devices"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -598,6 +951,10 @@ msgstr ""
 
 #: src/components/NotificationBell.tsx
 msgid "Notifications"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "of {totalPages} pages"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -624,12 +981,24 @@ msgstr ""
 msgid "Open selected book"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "pace"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "pages"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Pages · 30d"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Pick up where you left off"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Position history — restore a bad sync"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -648,8 +1017,24 @@ msgstr ""
 msgid "Private library"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Progress"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Progress % <0>(optional)</0>"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Public library"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Publisher"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Rate this book"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -672,13 +1057,34 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "read"
+msgstr ""
+
 #: src/components/BookCard.tsx
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Read"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Read · 30d"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "read {a}"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "read {a} – {b}"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "read {d}, {from} – {to}"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "read {span}"
 msgstr ""
 
 #: src/components/BookCard.tsx
@@ -689,12 +1095,28 @@ msgstr ""
 msgid "Reader"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "reading"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Reading"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Reading days"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Reading intensity"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Reading Log"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Reading Stats"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -705,11 +1127,20 @@ msgstr ""
 msgid "Recently Finished"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Remove from library"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Save"
 msgstr ""
 
@@ -717,8 +1148,20 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Save failed"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Save note"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Save the library first, then reopen it to share with users."
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Saving…"
 msgstr ""
 
 #: src/components/AppHeader.tsx
@@ -754,6 +1197,7 @@ msgstr ""
 msgid "Series"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Series name"
 msgstr ""
@@ -766,12 +1210,29 @@ msgstr ""
 msgid "Series: {filterSeries}"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "sessions"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Sessions · {d}"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Sessions ({n})"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Settings"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/BookDetailPage.tsx
 msgid "Share"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Share this book — a public metadata-only page"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -786,8 +1247,17 @@ msgstr ""
 msgid "Shared Library"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Shelved"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Shelved — kept your progress"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Shelved — set aside, keeps your progress"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -798,20 +1268,30 @@ msgstr ""
 msgid "Show another highlight"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Show details"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Show individual volumes"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Show less"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Show more"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "start"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -834,6 +1314,14 @@ msgstr ""
 msgid "Status: {filterStatusLabel}"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Subtitle (optional)"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Synced document"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Tag"
 msgstr ""
@@ -850,6 +1338,15 @@ msgstr ""
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Time per chapter"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Time per chapter, line view"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Title"
 msgstr ""
@@ -874,12 +1371,25 @@ msgstr "翻译由社区维护。尚未翻译的内容将以英文显示。"
 msgid "Try adjusting your filters"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Type"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Unassigned"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Undo"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "unknown device"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "unread"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -914,6 +1424,7 @@ msgstr ""
 msgid "Viewing as <0>{impersonatedUsername}</0>"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Vol. {idx}"
 msgstr ""
@@ -922,18 +1433,48 @@ msgstr ""
 msgid "Vol. {volIdx}"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Volume"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Volumes"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Want to Read"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Want to Read — queue this book up next"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Web reader"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "What did you think? (optional, saved automatically)"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Where in the book your time went — taller means more time spent on those pages."
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Where you read"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Wishlist"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "Words"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Year"
 msgstr ""
@@ -942,6 +1483,14 @@ msgstr ""
 msgid "Yesterday"
 msgstr ""
 
+#: src/pages/BookDetailPage.tsx
+msgid "You rated this {rating}/5"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Your library is empty"
+msgstr ""
+
+#: src/pages/BookDetailPage.tsx
+msgid "Your note — syncs back to KOReader on the next sync"
 msgstr ""

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -13,10 +13,344 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/NotificationBell.tsx
+msgid "{days}d ago"
+msgstr ""
+
+#: src/components/NotificationBell.tsx
+msgid "{hrs}h ago"
+msgstr ""
+
+#: src/components/NotificationBell.tsx
+msgid "{mins}m ago"
+msgstr ""
+
+#: src/components/AppShell.tsx
+msgid "{n, plural, one {This upload satisfies # wish — review in Admin > Wishlist} other {This upload satisfies # wishes — review in Admin > Wishlist}}"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "{themeName} theme"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Admin"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "All Books"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Amber"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Bindery"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Black"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Book Detail"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Cancel"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Choose icon"
+msgstr ""
+
+#: src/components/AppHeader.tsx
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Clear search"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Clear selection / blur search"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Close navigation"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Collapse / expand all books"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Collapse sidebar"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Command palette — jump to a book, series, author, or page"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Dark"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Dashboard"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Delete"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Docs"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Download Markdown export"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Edit"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Edit Library"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Edit Shelf"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Ember"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Everywhere"
+msgstr ""
+
+#: src/components/ImpersonationBanner.tsx
+msgid "Exit impersonation"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Expand sidebar"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Failed to save"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Failed to update sharing"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Focus search"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Go back"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Hardcover"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+#: src/components/Sidebar.tsx
+msgid "Highlights"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Home"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Icon"
+msgstr ""
+
+#: src/components/NotificationBell.tsx
+msgid "just now"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Keyboard Shortcuts"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Language"
 msgstr "语言"
 
+#: src/components/Sidebar.tsx
+msgid "Libraries"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Light"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Log out"
+msgstr ""
+
+#: src/components/NotificationBell.tsx
+msgid "Mark all read"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Name…"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "New library"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "New Library"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Next book"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Next page"
+msgstr ""
+
+#: src/components/NotificationBell.tsx
+msgid "No notifications yet"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "No other users to share with."
+msgstr ""
+
+#: src/components/NotificationBell.tsx
+msgid "Notifications"
+msgstr ""
+
+#: src/components/AppHeader.tsx
+msgid "Open navigation"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Open reader"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Open selected book"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Previous book"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Previous page"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Private — only assigned users can access"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Private library"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Public library"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Reader"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Save"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Save the library first, then reopen it to share with users."
+msgstr ""
+
+#: src/components/AppHeader.tsx
+msgid "Search books"
+msgstr ""
+
+#: src/components/AppHeader.tsx
+msgid "Search books… (/)"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Search icons…"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Search to find more icons"
+msgstr ""
+
+#: src/components/AppShell.tsx
+msgid "See all results for \"{searchQuery}\""
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Series"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Settings"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Share"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Share with users"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Shelves"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Show this help"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Stats"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Theme"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Toggle metadata edit"
+msgstr ""
+
+#: src/components/KeyboardShortcutsModal.tsx
+msgid "Toggle only-notes filter"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "翻译由社区维护。尚未翻译的内容将以英文显示。"
+
+#: src/components/AppHeader.tsx
+msgid "Upload"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "User menu"
+msgstr ""
+
+#: src/components/ImpersonationBanner.tsx
+msgid "Viewing as <0>{impersonatedUsername}</0>"
+msgstr ""
+
+#: src/components/Sidebar.tsx
+msgid "Wishlist"
+msgstr ""

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/MetadataManager.tsx
+msgid " — {detected} chapter numbers detected"
+msgstr ""
+
 #: src/components/InstanceBackup.tsx
 msgid " — backup from {when} (v{v}, {users} users, {books} books)."
 msgstr ""
@@ -300,6 +304,11 @@ msgstr ""
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
+msgstr ""
+
+#. placeholder {0}: candidates.length
+#: src/components/MetadataManager.tsx
+msgid "{0, plural, one {# candidate — click to select} other {# candidates — click to select}}"
 msgstr ""
 
 #. placeholder {0}: candidates.length
@@ -755,10 +764,20 @@ msgid "{n, plural, one {Confirm — apply # decision} other {Confirm — apply #
 msgstr ""
 
 #: src/components/AppShell.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 msgid "{n, plural, one {This upload satisfies # wish — review in Admin > Wishlist} other {This upload satisfies # wishes — review in Admin > Wishlist}}"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "{n} chapters uploaded"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "{n} of {total} books would change"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 msgid "{n} selected"
 msgstr ""
@@ -869,6 +888,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "{seconds}s"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "{seriesName} Chapter {num}"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1266,6 +1289,7 @@ msgstr ""
 msgid "all"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/StatsPage.tsx
@@ -1322,12 +1346,24 @@ msgstr ""
 msgid "All items must have a title"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "All libraries"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "All readers: {dur} · {days} · {readers}"
 msgstr ""
 
 #: src/components/SeriesReadingStats.tsx
 msgid "All readers: {dur} · {sess} · {readers}"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "All series"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "All types"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1405,8 +1441,16 @@ msgstr ""
 msgid "Apply {n} Approved"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Apply {n} Changes"
+msgstr ""
+
 #: src/components/ReadingImport.tsx
 msgid "Apply {n} selected"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Apply & Next"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1415,6 +1459,10 @@ msgstr ""
 
 #: src/components/BulkMetadataReviewModal.tsx
 msgid "Apply Approved"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Apply Changes"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
@@ -1429,8 +1477,16 @@ msgstr ""
 msgid "Apply the first cover-search candidate"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Apply to {n} Chapters"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Apply to all"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Applying {done}/{total}..."
 msgstr ""
 
 #: src/components/BulkMetadataReviewModal.tsx
@@ -1458,6 +1514,10 @@ msgstr ""
 msgid "Ask your server admin if you don't manage the Tome installation yourself."
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Assign Chapter Metadata"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Assign type to new books"
 msgstr ""
@@ -1475,6 +1535,7 @@ msgid "Auth"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/stats/widgets/library.tsx
 #: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
@@ -1518,6 +1579,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Auto"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Auto-filled from series"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -1572,6 +1637,10 @@ msgstr ""
 msgid "Back to search"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Back to Table"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Backlog"
 msgstr ""
@@ -1592,8 +1661,20 @@ msgstr ""
 msgid "Batch complete"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Batch Fetch"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Batch Fetch ({n})"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Best Day"
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
+msgid "Best match"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -1642,6 +1723,10 @@ msgstr ""
 msgid "Book"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Book {at} of {total}"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Book accepted"
 msgstr ""
@@ -1675,6 +1760,7 @@ msgstr ""
 msgid "Book title"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Book Type"
 msgstr ""
@@ -1762,6 +1848,7 @@ msgstr ""
 #: src/components/LibraryHealth.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
@@ -1792,6 +1879,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "ch. {n}"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Ch. {num}"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1843,6 +1934,7 @@ msgstr ""
 msgid "Choose icon"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/StatsPage.tsx
@@ -1873,6 +1965,10 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Clear selection / blur search"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "cleared"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2124,6 +2220,7 @@ msgid "Counts"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr ""
@@ -2183,6 +2280,7 @@ msgid "current"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "Current"
 msgstr ""
 
@@ -2336,8 +2434,13 @@ msgstr ""
 msgid "Deleting…"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Desc"
+msgstr ""
+
 #: src/components/ManageSeriesModal.tsx
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2748,6 +2851,10 @@ msgstr ""
 msgid "Failed to apply cover"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Failed to apply metadata."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Failed to authorize"
 msgstr ""
@@ -2775,6 +2882,10 @@ msgstr ""
 
 #: src/components/CoverPickerModal.tsx
 msgid "Failed to fetch candidates"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Failed to fetch candidates."
 msgstr ""
 
 #: src/pages/LoginPage.tsx
@@ -2807,6 +2918,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to load libraries"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Failed to load metadata audit data."
 msgstr ""
 
 #: src/pages/HighlightsPage.tsx
@@ -2917,6 +3032,10 @@ msgstr ""
 msgid "Fastest"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Fetch"
+msgstr ""
+
 #: src/components/BulkMetadataReviewModal.tsx
 msgid "Fetch failed"
 msgstr ""
@@ -2932,7 +3051,12 @@ msgid "Fetching metadata..."
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "Field"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Field diff"
 msgstr ""
 
 #: src/components/LibraryHealth.tsx
@@ -3170,6 +3294,7 @@ msgid "Hardcover sync is disabled on this server."
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "Has cover"
 msgstr ""
 
@@ -3352,8 +3477,13 @@ msgid "Include"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/AdminPage.tsx
 msgid "Incoming"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Index"
 msgstr ""
 
 #: src/components/InstanceBackup.tsx
@@ -3365,6 +3495,7 @@ msgid "IP:"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/ReadingImport.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "ISBN"
@@ -3442,7 +3573,12 @@ msgstr ""
 msgid "Label (e.g. KOReader)"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Lang"
+msgstr ""
+
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -3810,6 +3946,7 @@ msgstr ""
 msgid "Minutes read per day"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Missing"
 msgstr ""
@@ -4020,6 +4157,10 @@ msgstr ""
 msgid "No audit entries yet."
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "No author"
+msgstr ""
+
 #: src/components/stats/AuthorAffinity.tsx
 msgid "No author data."
 msgstr ""
@@ -4048,6 +4189,14 @@ msgstr ""
 msgid "No books in this view."
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "No books match the current filters."
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "No candidates found."
+msgstr ""
+
 #: src/components/stats/widgets/library.tsx
 msgid "No category data."
 msgstr ""
@@ -4062,6 +4211,7 @@ msgstr ""
 
 #: src/components/CoverAudit.tsx
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "No cover"
 msgstr ""
 
@@ -4331,6 +4481,10 @@ msgstr ""
 msgid "No timed reading with word counts yet."
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "No titles need standardizing."
+msgstr ""
+
 #: src/pages/LoginPage.tsx
 msgid "No Tome account is linked to this identity, and self-signup is disabled."
 msgstr ""
@@ -4365,6 +4519,7 @@ msgstr ""
 msgid "No word counts yet."
 msgstr ""
 
+#: src/components/MetadataManager.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/StatsPage.tsx
@@ -4611,6 +4766,10 @@ msgstr ""
 msgid "Override search query (optional)…"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Override search query…"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Overview"
 msgstr ""
@@ -4797,6 +4956,7 @@ msgstr ""
 msgid "Preview:"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
 #: src/pages/AdminPage.tsx
 msgid "Previous"
 msgstr ""
@@ -4856,6 +5016,7 @@ msgid "Publication status"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
@@ -5340,6 +5501,22 @@ msgstr ""
 msgid "Review all failed"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Review All Filtered ({n})"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Review complete"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Review Selected"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Reviewed {total} books — applied changes to {applied}, skipped {skipped}."
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Reviewing {n} files"
 msgstr ""
@@ -5489,6 +5666,10 @@ msgstr ""
 msgid "Scope"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Score"
+msgstr ""
+
 #: src/components/HScrollRow.tsx
 msgid "Scroll left"
 msgstr ""
@@ -5551,6 +5732,10 @@ msgstr ""
 msgid "Search query..."
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Search title, author…"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Search to find more icons"
 msgstr ""
@@ -5603,6 +5788,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Select All"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Select all ({n})"
 msgstr ""
 
 #: src/components/SendToDeviceModal.tsx
@@ -5663,6 +5852,7 @@ msgstr ""
 #: src/components/CommandPalette.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/Sidebar.tsx
 #: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
@@ -5672,6 +5862,7 @@ msgid "Series"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Series #"
 msgstr ""
@@ -5940,6 +6131,7 @@ msgstr ""
 msgid "Size"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Skip"
 msgstr ""
@@ -5954,6 +6146,10 @@ msgstr ""
 
 #: src/components/CoverAudit.tsx
 msgid "Some books had no usable candidate or failed to apply — open them and use the cover picker."
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Some changes failed to apply."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -6004,6 +6200,14 @@ msgstr ""
 msgid "Stage restore"
 msgstr ""
 
+#: src/components/MetadataManager.tsx
+msgid "Standardize"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Standardize Titles"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "start"
 msgstr ""
@@ -6038,6 +6242,10 @@ msgstr ""
 
 #: src/components/stats/widgets/overview.tsx
 msgid "Start reading one and it'll show up here"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Start typing to search..."
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -6075,6 +6283,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Su"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Subtitle"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -6162,6 +6374,7 @@ msgid "Tag: {filterTag}"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 msgid "Tags"
 msgstr ""
 
@@ -6345,6 +6558,7 @@ msgid "title"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/components/stats/widgets/library.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -6590,6 +6804,7 @@ msgid "Update to v{v}"
 msgstr ""
 
 #: src/components/AppHeader.tsx
+#: src/components/MetadataManager.tsx
 msgid "Upload"
 msgstr ""
 
@@ -6599,6 +6814,10 @@ msgstr ""
 
 #: src/components/UploadModal.tsx
 msgid "Upload Books"
+msgstr ""
+
+#: src/components/MetadataManager.tsx
+msgid "Upload Chapters"
 msgstr ""
 
 #: src/components/UploadModal.tsx
@@ -6893,6 +7112,7 @@ msgid "Words Read"
 msgstr ""
 
 #: src/components/MetadataFetchModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -662,6 +662,10 @@ msgstr ""
 msgid "{n} vols · "
 msgstr ""
 
+#: src/components/WishlistModal.tsx
+msgid "{n} volumes"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{name} · Vol. {start_index}–{end_index}"
 msgstr ""
@@ -1009,6 +1013,10 @@ msgstr ""
 msgid "Add a wish"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Add arc"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Add board"
 msgstr ""
@@ -1060,6 +1068,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Add to Library"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "Add to Wishlist"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1243,6 +1255,14 @@ msgstr ""
 msgid "Applying failed — nothing was changed."
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Arc name"
+msgstr ""
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Arcs"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Are you getting faster?"
 msgstr ""
@@ -1268,6 +1288,7 @@ msgid "Auth"
 msgstr ""
 
 #: src/components/stats/widgets/library.tsx
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -1278,6 +1299,7 @@ msgstr ""
 msgid "Author applied to {n} files"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Author name"
 msgstr ""
@@ -1354,6 +1376,10 @@ msgstr ""
 msgid "Back to list"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
+msgid "Back to search"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Backlog"
 msgstr ""
@@ -1415,6 +1441,7 @@ msgstr ""
 #: src/components/CoverAudit.tsx
 #: src/components/SendToDeviceModal.tsx
 #: src/components/stats/widgets/overview.tsx
+#: src/components/WishlistModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Book"
 msgstr ""
@@ -1443,6 +1470,7 @@ msgstr ""
 msgid "Book rejected and removed"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Book title"
 msgstr ""
@@ -1520,13 +1548,19 @@ msgstr ""
 msgid "Browse your library"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
+msgid "Can't find it? Add manually"
+msgstr ""
+
 #: src/components/EntityModal.tsx
 #: src/components/InstanceBackup.tsx
+#: src/components/ManageSeriesModal.tsx
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
 #: src/components/stats/widgets/overview.tsx
 #: src/components/UploadModal.tsx
+#: src/components/WishlistModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -1580,6 +1614,14 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Chart type"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "Choose a different book"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "Choose a different series"
 msgstr ""
 
 #: src/components/ReadingImport.tsx
@@ -1638,6 +1680,7 @@ msgstr ""
 msgid "Click for details"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareShelfModal.tsx
 #: src/components/stats/GoalWidget.tsx
@@ -1996,6 +2039,10 @@ msgstr ""
 msgid "Delete all {count} cached cover files ({mb} MB). Covers will be re-extracted on next access."
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Delete arc"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Delete board"
 msgstr ""
@@ -2031,6 +2078,7 @@ msgstr ""
 msgid "Deleting…"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2278,6 +2326,10 @@ msgstr ""
 msgid "Empty board"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
+msgid "End"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "EPUB vs CBZ time split"
 msgstr ""
@@ -2404,6 +2456,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Failed to add device"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "Failed to add wish"
 msgstr ""
 
 #: src/components/CoverPickerModal.tsx
@@ -2612,6 +2668,7 @@ msgstr ""
 msgid "finished"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Finished"
@@ -2657,6 +2714,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "for {targetLabel} — click a file to switch"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "For precise series tracking, use the <0>Series</0> tab instead."
 msgstr ""
 
 #: src/components/SendToDeviceModal.tsx
@@ -2808,6 +2869,10 @@ msgstr ""
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "hiatus"
+msgstr ""
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Hiatus"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3289,6 +3354,10 @@ msgstr ""
 msgid "Manage series"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Manage Series"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Manual"
 msgstr ""
@@ -3465,6 +3534,7 @@ msgstr ""
 msgid "My Theme"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Name"
 msgstr ""
@@ -3582,6 +3652,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "No API tokens yet. Create one to use Scribe or scripts against Tome."
+msgstr ""
+
+#: src/components/ManageSeriesModal.tsx
+msgid "No arcs defined yet. Click “Add arc” to create one."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3821,6 +3895,10 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
+msgid "No results found."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "No Series"
 msgstr ""
@@ -3958,6 +4036,10 @@ msgstr ""
 msgid "Not used"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
+msgid "Note"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Note on KOSync coexistence"
 msgstr ""
@@ -4043,6 +4125,10 @@ msgstr ""
 msgid "ongoing"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Ongoing"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Only filled fields will be updated. Leave blank to keep existing values."
 msgstr ""
@@ -4083,6 +4169,14 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Open selected book"
+msgstr ""
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Optional"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "Optional note (e.g. 'the new one')"
 msgstr ""
 
 #: src/components/CoverPickerModal.tsx
@@ -4249,6 +4343,10 @@ msgstr ""
 msgid "PIN created — copy it now, it won't be shown again."
 msgstr ""
 
+#: src/components/WishlistModal.tsx
+msgid "Please pick a result or use the manual form."
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Port"
 msgstr ""
@@ -4333,6 +4431,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Public library"
+msgstr ""
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Publication status"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -4797,6 +4899,7 @@ msgid "Sat"
 msgstr ""
 
 #: src/components/EntityModal.tsx
+#: src/components/ManageSeriesModal.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
 #: src/pages/AdminPage.tsx
@@ -4816,6 +4919,7 @@ msgstr ""
 msgid "Save Changes"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Save failed"
@@ -4909,8 +5013,16 @@ msgstr ""
 msgid "Search for a book in the library…"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
+msgid "Search for a book…"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Search for a different book…"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "Search for a series…"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -5029,7 +5141,9 @@ msgid "Sent {sent}/{total}. {failedN} failed."
 msgstr ""
 
 #: src/components/CommandPalette.tsx
+#: src/components/ManageSeriesModal.tsx
 #: src/components/Sidebar.tsx
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/StatsPage.tsx
@@ -5052,10 +5166,19 @@ msgstr ""
 msgid "Series index"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Series name"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "Series name — fill this alone to wish for the whole series"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "Series name is required."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -5359,6 +5482,10 @@ msgstr ""
 msgid "start"
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
+msgid "Start"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Start {volLabel}"
 msgstr ""
@@ -5578,8 +5705,20 @@ msgstr ""
 msgid "This replaces <0>the entire database</0> at the next restart. Type <1>RESTORE</1> to arm it."
 msgstr ""
 
+#: src/components/ManageSeriesModal.tsx
+msgid "This series has no volumes with a numeric index yet. Add volumes before defining arcs."
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "This volume"
+msgstr ""
+
 #: src/lib/goals.ts
 msgid "this week"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "This wish covers the whole series and stays open as new volumes arrive."
 msgstr ""
 
 #: src/components/stats/HourDowHeatmap.tsx
@@ -5647,8 +5786,16 @@ msgstr ""
 msgid "Title *"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
+msgid "Title <0>*</0>"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Title is required"
+msgstr ""
+
+#: src/components/WishlistModal.tsx
+msgid "Title is required."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -5792,6 +5939,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Ungrouped files"
+msgstr ""
+
+#: src/components/ManageSeriesModal.tsx
+msgid "Unknown"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -6082,6 +6233,7 @@ msgstr ""
 msgid "Which weekday you read most"
 msgstr ""
 
+#: src/components/WishlistModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Whole series"

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -33,8 +33,16 @@ msgstr ""
 msgid " · {prog}% in"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid " · reviewed"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid ", {errors} failed"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -103,6 +111,11 @@ msgstr ""
 msgid "{0, plural, one {# record} other {# records}}"
 msgstr ""
 
+#. placeholder {0}: candidates.length
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {# result — click to fill form} other {# results — click to fill form}}"
+msgstr ""
+
 #. placeholder {0}: data.reread_bins
 #: src/pages/BookDetailPage.tsx
 msgid "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
@@ -116,6 +129,17 @@ msgstr ""
 #. placeholder {0}: users.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# user} other {# users}}"
+msgstr ""
+
+#. placeholder {0}: group.files.length
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {Accept # volume} other {Accept # volumes}}"
+msgstr ""
+
+#. placeholder {0}: acceptedPaths.length
+#. placeholder {0}: result.accepted.length
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {Accepted # book} other {Accepted # books}}"
 msgstr ""
 
 #. placeholder {0}: selected.size
@@ -141,6 +165,21 @@ msgstr ""
 #. placeholder {0}: selected.size
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Books}}"
+msgstr ""
+
+#. placeholder {0}: group.library_match.volume_count
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {In library · # vol} other {In library · # vols}}"
+msgstr ""
+
+#. placeholder {0}: confirmReject?.length ?? 0
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {Permanently delete # file from the bindery? This cannot be undone.} other {Permanently delete # files from the bindery? This cannot be undone.}}"
+msgstr ""
+
+#. placeholder {0}: result.rejected
+#: src/pages/BinderyPage.tsx
+msgid "{0, plural, one {Rejected # file} other {Rejected # files}}"
 msgstr ""
 
 #. placeholder {0}: suggestedBooks.length
@@ -191,6 +230,18 @@ msgstr ""
 msgid "{deltaStr}% vs last week"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "{diffDays}d ago"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "{diffHrs}h ago"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "{diffMins}m ago"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "{dismissCount, plural, one {dismiss # group} other {dismiss # groups}}"
 msgstr ""
@@ -205,6 +256,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "{failed, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "{failedN} of {totalN} failed — {firstErr}"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -222,6 +277,14 @@ msgstr ""
 #: src/components/NotificationBell.tsx
 #: src/pages/AdminPage.tsx
 msgid "{hrs}h ago"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "{imp} imported + {inc} incoming"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -249,6 +312,14 @@ msgstr ""
 msgid "{n, plural, one {# matching volume currently in the library.} other {# matching volumes currently in the library.}}"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "{n, plural, one {Accepted # volume of {seriesName}} other {Accepted # volumes of {seriesName}}}"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "{n, plural, one {Accepted # volume} other {Accepted # volumes}}"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "{n, plural, one {Confirm — apply # decision} other {Confirm — apply # decisions}}"
 msgstr ""
@@ -260,6 +331,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "{n} selected"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "{n} selected — Clear"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -350,6 +425,22 @@ msgstr ""
 msgid "About"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Accept"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Accept All"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Accept failed"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Accepted: {title}"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Account & Security"
 msgstr ""
@@ -392,6 +483,10 @@ msgstr ""
 msgid "Add Theme"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Add to libraries…"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Add to library"
 msgstr ""
@@ -414,6 +509,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Added"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Added {timeAgo}"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -453,6 +552,14 @@ msgstr ""
 msgid "All Devices"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "All imported books accepted"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "All items must have a title"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "All readers: {dur} · {days} · {readers}"
 msgstr ""
@@ -490,6 +597,10 @@ msgstr ""
 msgid "Apply All ({n})"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Apply to all"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
 msgstr ""
@@ -514,9 +625,18 @@ msgstr ""
 msgid "Auth"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Author"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Author applied to {n} files"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Author name"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -535,20 +655,45 @@ msgstr ""
 msgid "avg session"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Back to list"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Backup"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Best match applied to {matched} of {totalN} files — no match for the rest"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Best match applied to all {matched} files"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/BinderyPage.tsx
 msgid "Bindery"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Bindery flow explained — open docs"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Black"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "book"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Book"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Book accepted"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -561,6 +706,22 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Book not found"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Book rejected and removed"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Book title"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Book Type"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Book type applied to {n} files"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -590,6 +751,7 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -608,6 +770,11 @@ msgstr ""
 msgid "Change Password"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "chapter"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Chapter"
 msgstr ""
@@ -657,6 +824,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Click \"Download plugin ZIP\" above. An API key is automatically created and baked into the plugin — no manual configuration needed."
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Click for details"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -720,6 +891,7 @@ msgid "Configured"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Confirm"
 msgstr ""
@@ -730,6 +902,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Content"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Content Type"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -760,8 +936,16 @@ msgstr ""
 msgid "Cover"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Cover preview"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Cover size"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Cover URL"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -820,6 +1004,7 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete"
@@ -843,14 +1028,23 @@ msgstr ""
 msgid "Delete Others"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Delete this book from the library? The file will be removed and this cannot be undone."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Delete this highlight"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Deleting..."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Deleting…"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Description"
@@ -889,6 +1083,7 @@ msgid "Directories"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Dismiss"
 msgstr ""
@@ -947,6 +1142,10 @@ msgstr ""
 msgid "Download ZIP"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Drop files in the incoming folder to get started"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Duplicate Detection"
 msgstr ""
@@ -957,6 +1156,18 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "E-Reader Devices"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "e.g. 1"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "e.g. 2023"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "e.g. en"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1051,6 +1262,7 @@ msgid "Exporting..."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Failed"
 msgstr ""
@@ -1085,6 +1297,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to link sync document"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Failed to load bindery"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1165,8 +1381,16 @@ msgstr ""
 msgid "Failed to update sharing"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "fantasy, action, romance"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Fetching metadata..."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1201,6 +1425,11 @@ msgstr ""
 msgid "Focus search"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "for {targetLabel} — click a file to switch"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Format"
@@ -1338,6 +1567,10 @@ msgstr ""
 msgid "Import reading history"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Importing..."
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Importing…"
 msgstr ""
@@ -1376,6 +1609,7 @@ msgstr ""
 
 #: src/components/NotificationBell.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 msgid "just now"
 msgstr ""
 
@@ -1415,6 +1649,7 @@ msgstr ""
 msgid "Label (e.g. KOReader)"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -1448,8 +1683,13 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Libraries"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Libraries applied to {n} files"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1499,6 +1739,7 @@ msgstr ""
 msgid "List view"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Loading..."
 msgstr ""
@@ -1556,6 +1797,18 @@ msgstr ""
 msgid "Marked unread — reading progress cleared"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Match all"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Matches \"{name}\" already in your library — name, author, type and libraries adopted from it"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Matching {matchingAll}/{total}…"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Member"
 msgstr ""
@@ -1570,6 +1823,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Metadata saved"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Metadata Suggestions"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1640,6 +1897,10 @@ msgstr ""
 msgid "New password"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "New series"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "new this week"
 msgstr ""
@@ -1708,8 +1969,16 @@ msgstr ""
 msgid "No duplicates found. Your library looks clean."
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "No files in the bindery"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "No fulfilled wishes."
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "No libraries"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1718,6 +1987,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "No matching volumes in the library yet."
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "No metadata found"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
@@ -1764,6 +2037,7 @@ msgstr ""
 msgid "No suggested match yet — search for the book to link, or upload it first."
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "No type"
 msgstr ""
@@ -1858,6 +2132,10 @@ msgstr ""
 msgid "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Other files"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Other providers"
 msgstr ""
@@ -1897,6 +2175,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Passwords do not match"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Per-file details"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1984,6 +2266,7 @@ msgstr ""
 msgid "Public library"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
 msgstr ""
@@ -1994,6 +2277,18 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Queue: not a duplicate — never show this group again"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Quick Accept"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Quick Accept Progress"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Quick Accept: {done}/{total} done"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2100,12 +2395,37 @@ msgstr ""
 msgid "Recently Finished"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Recently Imported"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 msgid "Refresh"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Register"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject All"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject failed"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject files"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Reject imported book"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2120,6 +2440,10 @@ msgstr ""
 msgid "Remove from library"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Rescan the bindery folder"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Resource:"
 msgstr ""
@@ -2130,6 +2454,18 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Review"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Review all failed"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Reviewing {n} files"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2242,6 +2578,10 @@ msgstr ""
 msgid "Search icons…"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Search query..."
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Search to find more icons"
 msgstr ""
@@ -2260,6 +2600,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Select all"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Select All"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2287,10 +2631,24 @@ msgid "Sent"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Series"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Series #"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Series applied to {n} files"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Series index"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Series name"
@@ -2298,6 +2656,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Series Progress"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Series review"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2360,6 +2722,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Share with users"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Shared fields — applies to all {n} items"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2429,6 +2795,14 @@ msgstr ""
 msgid "Single Sign-On"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Size"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Skip"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "SMTP Status"
 msgstr ""
@@ -2486,12 +2860,20 @@ msgstr ""
 msgid "Synced document"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Synopsis or description"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Tag"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Tag: {filterTag}"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Tags (comma-separated)"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2504,6 +2886,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "That SSO identity is already linked to another account."
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "The book type's own library is always added automatically."
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2546,9 +2932,18 @@ msgstr ""
 msgid "Time per chapter, line view"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Title"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Title *"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Title is required"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2584,6 +2979,11 @@ msgstr "翻译由社区维护。尚未翻译的内容将以英文显示。"
 msgid "Try adjusting your filters"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Try editing the title or series fields"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Type"
@@ -2599,6 +2999,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Undo"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
+msgid "Ungrouped files"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2699,6 +3103,10 @@ msgstr ""
 msgid "Viewing as <0>{impersonatedUsername}</0>"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "Vol {idx}"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Vol. {idx}"
@@ -2708,6 +3116,11 @@ msgstr ""
 msgid "Vol. {volIdx}"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
+msgid "volume"
+msgstr ""
+
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Volume"
 msgstr ""
@@ -2778,6 +3191,7 @@ msgstr ""
 msgid "Words"
 msgstr ""
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Year"

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -13,6 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/components/InstanceBackup.tsx
+msgid " — backup from {when} (v{v}, {users} users, {books} books)."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid " — click for sessions"
 msgstr ""
@@ -61,10 +65,15 @@ msgstr ""
 msgid " · {prog}% in"
 msgstr ""
 
+#: src/components/ReadingImport.tsx
+msgid " · {r} stars"
+msgstr ""
+
 #: src/components/stats/BacklogEstimate.tsx
 msgid " · books without a word count use your average for that type"
 msgstr ""
 
+#: src/components/ReadingImport.tsx
 #: src/components/stats/TimelineRibbon.tsx
 #: src/pages/SharePage.tsx
 msgid " · finished {d}"
@@ -76,6 +85,14 @@ msgstr ""
 
 #: src/components/stats/widgets/wordstats.tsx
 msgid " · longest <0>{title}</0> ({words})"
+msgstr ""
+
+#: src/components/ReadingImport.tsx
+msgid " · matched by {via}"
+msgstr ""
+
+#: src/components/ReadingImport.tsx
+msgid " · nothing to fill (already tracked)"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -195,6 +212,11 @@ msgstr ""
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
+msgstr ""
+
+#. placeholder {0}: candidates.length
+#: src/components/CoverPickerModal.tsx
+msgid "{0, plural, one {# cover found — click to apply} other {# covers found — click to apply}}"
 msgstr ""
 
 #. placeholder {0}: hover.b.days.length
@@ -374,6 +396,10 @@ msgstr ""
 msgid "{base} · Vol. {idx}"
 msgstr ""
 
+#: src/lib/goals.ts
+msgid "{behind} behind pace"
+msgstr ""
+
 #: src/pages/HighlightsPage.tsx
 msgid "{books, plural, one {{total} from # book} other {{total} from # books}}"
 msgstr ""
@@ -416,6 +442,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "{deltaStr}% vs last week"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "{diff} ahead of pace"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -466,6 +496,10 @@ msgstr ""
 msgid "{fin} of {st} started · all time"
 msgstr ""
 
+#: src/components/CoverAudit.tsx
+msgid "{flagged} of {scanned} books flagged (low-res = narrower than {minW}px)."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h"
@@ -480,6 +514,10 @@ msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
 msgid "{h}h ago"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "{hit}/7 days this week"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -498,6 +536,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "{label} only"
 msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
@@ -633,6 +675,10 @@ msgstr ""
 msgid "{title} — {dur} between {from} and {to}"
 msgstr ""
 
+#: src/lib/goals.ts
+msgid "{toGo} to go"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{total, plural, one {# volume} other {# volumes}}"
 msgstr ""
@@ -651,6 +697,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "{words} words"
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "{y} Challenge"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -818,6 +868,10 @@ msgstr ""
 msgid "Action failed"
 msgstr ""
 
+#: src/components/CommandPalette.tsx
+msgid "Actions"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Active"
 msgstr ""
@@ -929,6 +983,7 @@ msgstr ""
 msgid "Added to Want to Read"
 msgstr ""
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 msgid "Admin"
@@ -952,6 +1007,10 @@ msgstr ""
 msgid "All {loadedCount} books loaded"
 msgstr ""
 
+#: src/components/CoverAudit.tsx
+msgid "All {scanned} covers look healthy."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "All →"
 msgstr ""
@@ -960,10 +1019,12 @@ msgstr ""
 msgid "All actions"
 msgstr ""
 
+#: src/components/stats/GoalWidget.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "All books"
 msgstr ""
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 msgid "All Books"
 msgstr ""
@@ -1046,12 +1107,25 @@ msgstr ""
 msgid "Applied to volumes you haven’t rated"
 msgstr ""
 
+#: src/components/ReadingImport.tsx
+msgid "Applied: {statuses} statuses, {ratings} ratings, {finishes} finish dates, {reviews} reviews."
+msgstr ""
+
+#: src/components/CoverPickerModal.tsx
 #: src/pages/StatsPage.tsx
 msgid "Apply"
 msgstr ""
 
+#: src/components/ReadingImport.tsx
+msgid "Apply {n} selected"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Apply All ({n})"
+msgstr ""
+
+#: src/components/CoverAudit.tsx
+msgid "Apply the first cover-search candidate"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -1060,6 +1134,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
+msgstr ""
+
+#: src/components/ReadingImport.tsx
+msgid "Applying failed — nothing was changed."
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -1116,12 +1194,20 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
+#: src/components/CommandPalette.tsx
+msgid "Authors"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Auto"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Auto-fit height"
+msgstr ""
+
+#: src/components/CoverAudit.tsx
+msgid "Auto-fix {missingCount} missing"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -1172,6 +1258,10 @@ msgstr ""
 msgid "Backup"
 msgstr ""
 
+#: src/components/InstanceBackup.tsx
+msgid "Backup failed"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Best Day"
 msgstr ""
@@ -1210,6 +1300,7 @@ msgstr ""
 msgid "book"
 msgstr ""
 
+#: src/components/CoverAudit.tsx
 #: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Book"
@@ -1255,6 +1346,11 @@ msgstr ""
 msgid "Book Types"
 msgstr ""
 
+#: src/lib/goals.ts
+msgid "books"
+msgstr ""
+
+#: src/components/CommandPalette.tsx
 #: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -1281,12 +1377,24 @@ msgstr ""
 msgid "Books Started"
 msgstr ""
 
+#: src/lib/goals.ts
+msgid "Books this month"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Books this year"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Books whose pages you revisit"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Books without a series"
+msgstr ""
+
+#: src/components/ReadingImport.tsx
+msgid "Bring your reading history from Goodreads or StoryGraph: upload their CSV export, review what matches your library, apply. Importing only fills gaps — it never overwrites a status, rating, review, or finish date you already have. \"To read\" shelves are skipped (that's what the wishlist is for)."
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1298,7 +1406,10 @@ msgid "Browse your library"
 msgstr ""
 
 #: src/components/EntityModal.tsx
+#: src/components/InstanceBackup.tsx
+#: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
+#: src/components/stats/GoalWidget.tsx
 #: src/components/UploadModal.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -1308,6 +1419,10 @@ msgstr ""
 #: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
+msgstr ""
+
+#: src/components/InstanceBackup.tsx
+msgid "Cancel restore"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -1324,6 +1439,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "ch. 1"
+msgstr ""
+
+#: src/components/CoverPickerModal.tsx
+msgid "Change Cover"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1345,6 +1464,14 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Chart type"
+msgstr ""
+
+#: src/components/ReadingImport.tsx
+msgid "Choose CSV export"
+msgstr ""
+
+#: src/components/CoverPickerModal.tsx
+msgid "Choose file…"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1397,6 +1524,7 @@ msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareShelfModal.tsx
+#: src/components/stats/GoalWidget.tsx
 #: src/components/UploadModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
@@ -1547,12 +1675,20 @@ msgstr ""
 msgid "Core"
 msgstr ""
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Could not create the goal — it may already exist."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Could not link SSO. Please try again."
 msgstr ""
 
 #: src/components/stats/BacklogEstimate.tsx
 msgid "Could not load this scope."
+msgstr ""
+
+#: src/components/ReadingImport.tsx
+msgid "Could not read that file"
 msgstr ""
 
 #: src/components/SeriesFollowButton.tsx
@@ -1571,12 +1707,20 @@ msgstr ""
 msgid "Could not start sync"
 msgstr ""
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Could not update the goal."
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Couldn’t load stats."
 msgstr ""
 
 #: src/components/stats/TimelineRibbon.tsx
 msgid "Couldn't load the timeline."
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Counts"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1655,6 +1799,18 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Custom Stat"
+msgstr ""
+
+#: src/components/CoverPickerModal.tsx
+msgid "Custom URL"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Daily minutes"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Daily pages"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -1837,6 +1993,10 @@ msgstr ""
 msgid "Download as Markdown file"
 msgstr ""
 
+#: src/components/InstanceBackup.tsx
+msgid "Download backup"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Download failed"
@@ -1933,6 +2093,10 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Edit goal"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Edit Library"
 msgstr ""
@@ -2015,6 +2179,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Every widget is already on this board."
+msgstr ""
+
+#: src/components/InstanceBackup.tsx
+msgid "Everything Tome knows in one archive: the database (all users, statuses, sessions, highlights, settings) plus the cover cache. Book files are not included — they live on disk and belong to your own backups. Restoring stages the archive and applies it at the next server restart; the current database is kept alongside as a safety copy."
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -2109,6 +2277,10 @@ msgstr ""
 msgid "Failed to add device"
 msgstr ""
 
+#: src/components/CoverPickerModal.tsx
+msgid "Failed to apply cover"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Failed to authorize"
 msgstr ""
@@ -2132,6 +2304,10 @@ msgstr ""
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "Failed to delete highlight"
+msgstr ""
+
+#: src/components/CoverPickerModal.tsx
+msgid "Failed to fetch candidates"
 msgstr ""
 
 #: src/pages/LoginPage.tsx
@@ -2254,6 +2430,10 @@ msgstr ""
 msgid "Failed to update sharing"
 msgstr ""
 
+#: src/components/CoverPickerModal.tsx
+msgid "Failed to upload cover"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "fantasy, action, romance"
 msgstr ""
@@ -2315,6 +2495,10 @@ msgstr ""
 #: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "First read"
+msgstr ""
+
+#: src/components/CoverAudit.tsx
+msgid "Fixed"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2398,6 +2582,10 @@ msgstr ""
 msgid "Full breakdown →"
 msgstr ""
 
+#: src/components/ReadingImport.tsx
+msgid "fuzzy"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Generate PIN"
 msgstr ""
@@ -2422,6 +2610,18 @@ msgstr ""
 
 #: src/components/SendToDeviceModal.tsx
 msgid "Go to Settings"
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Goal"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Goal reached"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Goal reached today"
 msgstr ""
 
 #: src/components/WhatsNewPanel.tsx
@@ -2501,6 +2701,7 @@ msgstr ""
 msgid "Highlighted {when}"
 msgstr ""
 
+#: src/components/CommandPalette.tsx
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/HighlightsPage.tsx
@@ -2523,6 +2724,7 @@ msgstr ""
 msgid "Hit Edit, then Add tile."
 msgstr ""
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Home"
@@ -2638,12 +2840,25 @@ msgstr ""
 msgid "Incoming"
 msgstr ""
 
+#: src/components/InstanceBackup.tsx
+msgid "Instance backup"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "IP:"
 msgstr ""
 
+#: src/components/ReadingImport.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "ISBN"
+msgstr ""
+
+#: src/components/InstanceBackup.tsx
+msgid "It applies at the next server restart."
+msgstr ""
+
+#: src/components/CommandPalette.tsx
+msgid "Jump to a book, series, author, or page…"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
@@ -2865,6 +3080,7 @@ msgstr ""
 #: src/components/ShareLinksOverview.tsx
 #: src/components/ShareShelfModal.tsx
 #: src/components/stats/BacklogEstimate.tsx
+#: src/components/stats/GoalWidget.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
 #: src/pages/StatsPage.tsx
@@ -2909,6 +3125,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Longest: {d}d"
+msgstr ""
+
+#: src/components/CoverAudit.tsx
+msgid "Low resolution"
 msgstr ""
 
 #: src/components/stats/widgets/taste.tsx
@@ -3004,12 +3224,24 @@ msgstr ""
 msgid "Metric"
 msgstr ""
 
+#: src/lib/goals.ts
+msgid "min"
+msgstr ""
+
 #: src/pages/SetupPage.tsx
 msgid "Minimum 8 characters"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Minutes"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Minutes per day"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Minutes per week"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -3030,6 +3262,10 @@ msgstr ""
 
 #: src/components/stats/HourDowHeatmap.tsx
 msgid "Mon"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Monthly goal"
 msgstr ""
 
 #: src/components/SendButton.tsx
@@ -3104,6 +3340,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "New board"
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "New goal"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -3207,6 +3447,18 @@ msgstr ""
 msgid "No completion data by type."
 msgstr ""
 
+#: src/components/CoverAudit.tsx
+msgid "No cover"
+msgstr ""
+
+#: src/components/CoverPickerModal.tsx
+msgid "No cover candidates found."
+msgstr ""
+
+#: src/components/CoverPickerModal.tsx
+msgid "No covers found — try a different search or use a custom URL below."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
 msgstr ""
@@ -3261,6 +3513,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
+msgstr ""
+
+#: src/components/CommandPalette.tsx
+msgid "No matches."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3448,6 +3704,10 @@ msgstr ""
 msgid "Not found"
 msgstr ""
 
+#: src/components/ReadingImport.tsx
+msgid "Not in your library ({n})"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Not matched"
 msgstr ""
@@ -3535,6 +3795,10 @@ msgstr ""
 msgid "On board"
 msgstr ""
 
+#: src/lib/goals.ts
+msgid "on pace"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "On this day"
@@ -3575,6 +3839,10 @@ msgstr ""
 msgid "Open a book downloaded via OPDS"
 msgstr ""
 
+#: src/components/CoverAudit.tsx
+msgid "Open book (pick a cover by eye)"
+msgstr ""
+
 #: src/components/AppHeader.tsx
 msgid "Open navigation"
 msgstr ""
@@ -3585,6 +3853,10 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Open selected book"
+msgstr ""
+
+#: src/components/CoverPickerModal.tsx
+msgid "or use a custom source"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -3628,6 +3900,7 @@ msgid "Padding"
 msgstr ""
 
 #: src/components/SeriesReadingStats.tsx
+#: src/lib/goals.ts
 #: src/pages/BookDetailPage.tsx
 msgid "pages"
 msgstr ""
@@ -3644,8 +3917,16 @@ msgstr ""
 msgid "Pages / Hour"
 msgstr ""
 
+#: src/lib/goals.ts
+msgid "Pages per day"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Pages per minute over time"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Pages per week"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -3705,6 +3986,10 @@ msgstr ""
 msgid "Pick"
 msgstr ""
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Pick a rhythm — progress counts automatically."
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Pick a start & end"
 msgstr ""
@@ -3745,6 +4030,7 @@ msgstr ""
 msgid "Preparing..."
 msgstr ""
 
+#: src/components/InstanceBackup.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Preparing…"
 msgstr ""
@@ -3779,6 +4065,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Private library"
+msgstr ""
+
+#: src/components/CoverAudit.tsx
+msgid "Problem"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -4023,6 +4313,7 @@ msgstr ""
 msgid "Reading Speed Trend"
 msgstr ""
 
+#: src/components/CommandPalette.tsx
 #: src/components/SeriesReadingStats.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/SetupPage.tsx
@@ -4066,6 +4357,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Recently Imported"
+msgstr ""
+
+#: src/components/ReadingImport.tsx
+msgid "Recognized a <0>{dialect}</0> export: {matched} matched, {unmatched} not in your library, {skipped} to-read rows skipped."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -4145,6 +4440,10 @@ msgstr ""
 msgid "request failed"
 msgstr ""
 
+#: src/components/CoverAudit.tsx
+msgid "Rescan"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Rescan the bindery folder"
 msgstr ""
@@ -4163,6 +4462,14 @@ msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
 msgid "Restore"
+msgstr ""
+
+#: src/components/InstanceBackup.tsx
+msgid "Restore from backup…"
+msgstr ""
+
+#: src/components/InstanceBackup.tsx
+msgid "Restore staged"
 msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
@@ -4235,6 +4542,7 @@ msgstr ""
 
 #: src/components/EntityModal.tsx
 #: src/components/Sidebar.tsx
+#: src/components/stats/GoalWidget.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Save"
@@ -4302,6 +4610,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Scanner"
+msgstr ""
+
+#: src/components/CoverAudit.tsx
+msgid "Scanning covers…"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -4456,6 +4768,7 @@ msgstr ""
 msgid "Sent {sent}/{total}. {failedN} failed."
 msgstr ""
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -4534,8 +4847,24 @@ msgstr ""
 msgid "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
 msgstr ""
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Set a goal"
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Set a reading goal"
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Set a target and watch the ring fill as you read."
+msgstr ""
+
 #: src/components/UploadModal.tsx
 msgid "Set all to"
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Set goal"
 msgstr ""
 
 #: src/components/ForcePasswordChange.tsx
@@ -4554,6 +4883,7 @@ msgstr ""
 msgid "Set your password"
 msgstr ""
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Settings"
@@ -4685,6 +5015,7 @@ msgstr ""
 msgid "Single Sign-On"
 msgstr ""
 
+#: src/components/CoverAudit.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Size"
 msgstr ""
@@ -4699,6 +5030,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "SMTP Status"
+msgstr ""
+
+#: src/components/CoverAudit.tsx
+msgid "Some books had no usable candidate or failed to apply — open them and use the cover picker."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -4743,6 +5078,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "SSO sign-in linked to your account."
+msgstr ""
+
+#: src/components/InstanceBackup.tsx
+msgid "Stage restore"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -4854,6 +5193,10 @@ msgstr ""
 msgid "Tags (comma-separated)"
 msgstr ""
 
+#: src/components/stats/GoalWidget.tsx
+msgid "Target"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Taste"
 msgstr ""
@@ -4880,6 +5223,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "That file is not a Tome board export."
+msgstr ""
+
+#: src/components/InstanceBackup.tsx
+msgid "That file was rejected"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -4939,6 +5286,14 @@ msgstr ""
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
 msgstr ""
 
+#: src/components/InstanceBackup.tsx
+msgid "This replaces <0>the entire database</0> at the next restart. Type <1>RESTORE</1> to arm it."
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "this week"
+msgstr ""
+
 #: src/components/stats/HourDowHeatmap.tsx
 msgid "Thu"
 msgstr ""
@@ -4985,6 +5340,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Timeline"
+msgstr ""
+
+#: src/components/ReadingImport.tsx
+msgid "title"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -5137,6 +5496,10 @@ msgstr ""
 msgid "Unread"
 msgstr ""
 
+#: src/components/CoverAudit.tsx
+msgid "Unreadable file"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Unserialized"
 msgstr ""
@@ -5179,6 +5542,10 @@ msgstr ""
 
 #: src/components/UploadModal.tsx
 msgid "Upload failed"
+msgstr ""
+
+#: src/components/CoverPickerModal.tsx
+msgid "Upload from device"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -5338,6 +5705,14 @@ msgstr ""
 msgid "Wed"
 msgstr ""
 
+#: src/lib/goals.ts
+msgid "Weekly minutes"
+msgstr ""
+
+#: src/lib/goals.ts
+msgid "Weekly pages"
+msgstr ""
+
 #: src/pages/LoginPage.tsx
 msgid "Welcome back"
 msgstr ""
@@ -5399,6 +5774,7 @@ msgstr ""
 msgid "Wish removed"
 msgstr ""
 
+#: src/components/CommandPalette.tsx
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/WishlistPage.tsx
@@ -5435,6 +5811,10 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
+#: src/lib/goals.ts
+msgid "Year Challenge"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Year in Review"
 msgstr ""
@@ -5448,6 +5828,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "You"
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "You already have this goal — edit it from its tile instead."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -136,6 +136,11 @@ msgstr ""
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 msgstr ""
 
+#. placeholder {0}: status.syncedDocuments
+#: src/components/SyncStatusBadge.tsx
+msgid "{0, plural, one {# book tracked} other {# books tracked}}"
+msgstr ""
+
 #. placeholder {0}: data.totals.books
 #. placeholder {0}: s.book_count
 #: src/pages/DashboardPage.tsx
@@ -246,6 +251,11 @@ msgstr ""
 msgid "{0, plural, one {In library · # vol} other {In library · # vols}}"
 msgstr ""
 
+#. placeholder {0}: status.syncedDocuments
+#: src/components/SyncStatusBadge.tsx
+msgid "{0, plural, one {Last sync from {lastDevice} · # book tracked} other {Last sync from {lastDevice} · # books tracked}}"
+msgstr ""
+
 #. placeholder {0}: confirmReject?.length ?? 0
 #: src/pages/BinderyPage.tsx
 msgid "{0, plural, one {Permanently delete # file from the bindery? This cannot be undone.} other {Permanently delete # files from the bindery? This cannot be undone.}}"
@@ -295,6 +305,7 @@ msgid "{d}d ago"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 #: src/pages/WishlistPage.tsx
@@ -372,11 +383,16 @@ msgstr ""
 msgid "{h}h {m}m"
 msgstr ""
 
+#: src/components/PositionHistoryModal.tsx
+msgid "{h}h ago"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "{hours}h ago"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
 msgid "{hrs}h ago"
 msgstr ""
@@ -389,6 +405,10 @@ msgstr ""
 msgid "{inc, plural, one {# file waiting for review} other {# files waiting for review}}"
 msgstr ""
 
+#: src/components/PositionHistoryModal.tsx
+msgid "{m} min ago"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{m}m"
@@ -399,6 +419,7 @@ msgid "{mergeCount, plural, one {merge # group} other {merge # groups}}"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
 msgid "{mins}m ago"
 msgstr ""
@@ -447,6 +468,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "{name} copy"
+msgstr ""
+
+#: src/components/ThemeToggle.tsx
+msgid "{name} theme"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -789,7 +814,12 @@ msgstr ""
 msgid "All-time hours, pages, books, streak"
 msgstr ""
 
+#: src/components/SendButton.tsx
+msgid "Already in your KOReader inbox"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Amber"
 msgstr ""
 
@@ -939,6 +969,10 @@ msgstr ""
 msgid "Best-Rated Series"
 msgstr ""
 
+#: src/components/SendButton.tsx
+msgid "Beta"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Bindery"
@@ -949,6 +983,7 @@ msgid "Bindery flow explained — open docs"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Black"
 msgstr ""
 
@@ -1138,6 +1173,7 @@ msgstr ""
 msgid "Click for details"
 msgstr ""
 
+#: src/components/PositionHistoryModal.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/StatsPage.tsx
@@ -1286,6 +1322,10 @@ msgstr ""
 msgid "Could not link SSO. Please try again."
 msgstr ""
 
+#: src/components/SeriesFollowButton.tsx
+msgid "Could not resolve this series on Hardcover"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Could not set match"
 msgstr ""
@@ -1351,6 +1391,7 @@ msgstr ""
 msgid "Cumulative finishes over time"
 msgstr ""
 
+#: src/components/PositionHistoryModal.tsx
 #: src/pages/StatsPage.tsx
 msgid "current"
 msgstr ""
@@ -1384,6 +1425,7 @@ msgid "Danger Zone"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Dark"
 msgstr ""
 
@@ -1680,6 +1722,7 @@ msgid "Email delivery is not set up yet."
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Ember"
 msgstr ""
 
@@ -1881,6 +1924,10 @@ msgstr ""
 msgid "Failed to log session"
 msgstr ""
 
+#: src/components/SendButton.tsx
+msgid "Failed to queue for KOReader"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Failed to register"
 msgstr ""
@@ -1990,12 +2037,21 @@ msgstr ""
 msgid "Focus search"
 msgstr ""
 
+#: src/components/SeriesFollowButton.tsx
+msgid "Follow"
+msgstr ""
+
 #: src/pages/WishlistPage.tsx
 msgid "Follow a series — search Hardcover…"
 msgstr ""
 
+#: src/components/SeriesFollowButton.tsx
 #: src/pages/WishlistPage.tsx
 msgid "Following"
+msgstr ""
+
+#: src/components/SeriesFollowButton.tsx
+msgid "Following \"{seriesName}\" — you'll hear when a new volume is out"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -2057,6 +2113,10 @@ msgstr ""
 msgid "Genres"
 msgstr ""
 
+#: src/components/SeriesFollowButton.tsx
+msgid "Get notified when a new volume is released"
+msgstr ""
+
 #: src/pages/WishlistPage.tsx
 msgid "Get notified when a new volume of a followed series is released."
 msgstr ""
@@ -2112,6 +2172,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Hide details"
+msgstr ""
+
+#: src/components/stats/widgets/taste.tsx
+msgid "Highest"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -2278,6 +2342,10 @@ msgstr ""
 msgid "Just now"
 msgstr ""
 
+#: src/components/SyncStatusBadge.tsx
+msgid "Just synced"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Keep this one"
 msgstr ""
@@ -2300,6 +2368,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "KOReader sync linked"
+msgstr ""
+
+#: src/components/SyncStatusBadge.tsx
+msgid "KOReader sync: {label}. {tooltip}"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2347,6 +2419,10 @@ msgstr ""
 
 #: src/pages/WishlistPage.tsx
 msgid "Latest: vol {v}"
+msgstr ""
+
+#: src/components/SeriesFollowButton.tsx
+msgid "Latest: Vol {v} · {d}"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2407,6 +2483,7 @@ msgid "Lifetime words read, by year"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Light"
 msgstr ""
 
@@ -2459,6 +2536,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
+#: src/components/PositionHistoryModal.tsx
 #: src/components/ShareLinksOverview.tsx
 #: src/pages/HardcoverPage.tsx
 #: src/pages/SharePage.tsx
@@ -2499,6 +2577,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Longest: {d}d"
+msgstr ""
+
+#: src/components/stats/widgets/taste.tsx
+msgid "Lowest"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2614,6 +2696,10 @@ msgstr ""
 msgid "Mo"
 msgstr ""
 
+#: src/components/SendButton.tsx
+msgid "More send options"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Morning vs evening reader?"
 msgstr ""
@@ -2659,6 +2745,7 @@ msgstr ""
 msgid "Native KOReader plugin — tracks reading sessions and syncs by book ID. More reliable than KOSync."
 msgstr ""
 
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Never"
 msgstr ""
@@ -2729,6 +2816,10 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next page"
+msgstr ""
+
+#: src/components/SeriesFollowButton.tsx
+msgid "Next: Vol {v} · {d}"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2849,6 +2940,26 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "No PINs yet. Generate one to use with OPDS clients."
+msgstr ""
+
+#: src/components/PositionHistoryModal.tsx
+msgid "No position changes recorded yet — history starts with the next sync."
+msgstr ""
+
+#: src/components/stats/widgets/taste.tsx
+msgid "No rated books with reading time yet."
+msgstr ""
+
+#: src/components/stats/widgets/taste.tsx
+msgid "No rated books yet."
+msgstr ""
+
+#: src/components/stats/widgets/taste.tsx
+msgid "No rated series yet."
+msgstr ""
+
+#: src/components/stats/widgets/taste.tsx
+msgid "No ratings yet."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3214,6 +3325,10 @@ msgstr ""
 msgid "Port"
 msgstr ""
 
+#: src/components/PositionHistoryModal.tsx
+msgid "Position history"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Position history — restore a bad sync"
 msgstr ""
@@ -3300,6 +3415,10 @@ msgstr ""
 msgid "Queue: not a duplicate — never show this group again"
 msgstr ""
 
+#: src/components/SendButton.tsx
+msgid "Queued {n} to KOReader — arrives next time KOReader syncs"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Quick Accept"
 msgstr ""
@@ -3323,6 +3442,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Range follows the page's range picker; days show the newest slice of it."
+msgstr ""
+
+#: src/components/stats/widgets/taste.tsx
+msgid "Rate a few books to see a trend."
 msgstr ""
 
 #: src/components/SeriesRating.tsx
@@ -3620,6 +3743,14 @@ msgstr ""
 msgid "Restart KOReader"
 msgstr ""
 
+#: src/components/PositionHistoryModal.tsx
+msgid "Restore"
+msgstr ""
+
+#: src/components/PositionHistoryModal.tsx
+msgid "Restoring sets the live position (and read status) back to that point; devices pick it up on their next sync. Restoring below 100% un-finishes a falsely completed book."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
 msgstr ""
@@ -3846,8 +3977,17 @@ msgstr ""
 msgid "Send test email"
 msgstr ""
 
+#: src/components/SendButton.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Send to Device"
+msgstr ""
+
+#: src/components/SendButton.tsx
+msgid "Send to KOReader"
+msgstr ""
+
+#: src/components/SendButton.tsx
+msgid "Send via email…"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -4162,6 +4302,10 @@ msgstr ""
 msgid "Status: {filterStatusLabel}"
 msgstr ""
 
+#: src/components/SeriesFollowButton.tsx
+msgid "Stop following this series"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Streak"
 msgstr ""
@@ -4263,6 +4407,7 @@ msgid "the sync password set above"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/components/ThemeToggle.tsx
 msgid "Theme"
 msgstr ""
 
@@ -4374,6 +4519,10 @@ msgstr ""
 msgid "Toggle only-notes filter"
 msgstr ""
 
+#: src/components/ThemeToggle.tsx
+msgid "Toggle theme"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Token name"
 msgstr ""
@@ -4470,6 +4619,7 @@ msgstr ""
 msgid "Unknown author"
 msgstr ""
 
+#: src/components/PositionHistoryModal.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "unknown device"
 msgstr ""
@@ -4742,6 +4892,7 @@ msgstr ""
 msgid "Year in Review"
 msgstr ""
 
+#: src/components/SyncStatusBadge.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/WishlistPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -335,6 +335,10 @@ msgstr ""
 msgid "{failedN} of {totalN} failed — {firstErr}"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "{fin} of {st} started"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h"
@@ -418,6 +422,10 @@ msgstr ""
 msgid "{name} · Vol. {start_index}–{end_index}"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "{name} copy"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "{othersCount, plural, one {Delete # other} other {Delete # others}}"
 msgstr ""
@@ -495,6 +503,50 @@ msgstr ""
 msgid "~{at}% in · not read"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "12 mo"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "14d"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "1y"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "24 mo"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "30d"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "365 d"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "7d"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "90d"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "A 24-hour radial of when you read"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "A bit"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "A lot"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
 msgstr ""
@@ -505,6 +557,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "A while ago"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "A year of reading, heatmap"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -557,8 +613,16 @@ msgstr ""
 msgid "Add a review"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Add a widget"
+msgstr ""
+
 #: src/pages/WishlistPage.tsx
 msgid "Add a wish"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Add board"
 msgstr ""
 
 #: src/pages/WishlistPage.tsx
@@ -580,6 +644,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Add Theme"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Add tile"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -627,8 +695,13 @@ msgstr ""
 msgid "Admin access required."
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "all"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/HardcoverPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "All"
 msgstr ""
 
@@ -652,6 +725,10 @@ msgstr ""
 msgid "All Books"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "All Books by Reading Time"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "All Devices"
 msgstr ""
@@ -671,6 +748,14 @@ msgstr ""
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "All users"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "All your reading goals — rings fill as you read, managed in place"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "All-time hours, pages, books, streak"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -697,6 +782,10 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Apply"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Apply All ({n})"
 msgstr ""
@@ -707,6 +796,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Are you getting faster?"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -759,8 +852,32 @@ msgstr ""
 msgid "Authorizing..."
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Auto"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Auto-fit height"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "average pace"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Average rating per book type"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "avg {avg}"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "avg session"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Avg Session"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -771,12 +888,20 @@ msgstr ""
 msgid "Backup"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Best Day"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Best match applied to {matched} of {totalN} files — no match for the rest"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Best match applied to all {matched} files"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Best-Rated Series"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -812,6 +937,10 @@ msgstr ""
 msgid "Book Detail"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Book Length"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Book not found"
 msgstr ""
@@ -841,8 +970,28 @@ msgstr ""
 msgid "Books"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Books completed"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Books Finished"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Books in progress, with covers"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Books Started"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Books whose pages you revisit"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -866,6 +1015,14 @@ msgstr ""
 #: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Category Breakdown"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Category mix over the year"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -893,12 +1050,17 @@ msgstr ""
 msgid "Chapters"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Chart type"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Choose icon"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Clear"
 msgstr ""
 
@@ -942,6 +1104,7 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HardcoverPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Close"
 msgstr ""
 
@@ -1007,6 +1170,18 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Complete series: {title}"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Completion"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Completion Estimates"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Configure"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1083,6 +1258,10 @@ msgstr ""
 msgid "Could not start sync"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Couldn’t load stats."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr ""
@@ -1124,8 +1303,40 @@ msgstr ""
 msgid "Creating..."
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Cumulative Books Added — Last 24 Months"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Cumulative finishes over time"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "current"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Current & longest daily streak"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Current password"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Currently Reading"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Custom"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Custom Stat"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Daily sessions on a 24h track"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1174,8 +1385,16 @@ msgstr ""
 msgid "Delete \"{title}\"?"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Delete {name}"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Delete all {count} cached cover files ({mb} MB). Covers will be re-extracted on next access."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Delete board"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1195,6 +1414,10 @@ msgstr ""
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "Delete this highlight"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Deleted board “{name}”"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -1247,6 +1470,7 @@ msgstr ""
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Dismiss"
 msgstr ""
 
@@ -1262,12 +1486,17 @@ msgstr ""
 msgid "Dismissed"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Do you rate books you spend longer on higher?"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Docs"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Done"
 msgstr ""
 
@@ -1300,6 +1529,10 @@ msgstr ""
 msgid "Download the plugin"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Download the plugin from Settings"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Download your entire library catalog — all titles, authors, series, tags and formats."
 msgstr ""
@@ -1316,8 +1549,20 @@ msgstr ""
 msgid "Drop files in the incoming folder to get started"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Duplicate “{name}”"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Duplicate {title}"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Duplicate Detection"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Duplicate tile"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1351,6 +1596,7 @@ msgstr ""
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Edit"
 msgstr ""
 
@@ -1397,6 +1643,14 @@ msgstr ""
 msgid "Ember"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Empty board"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "EPUB vs CBZ time split"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Error"
 msgstr ""
@@ -1407,6 +1661,14 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Every session — paginated, deletable"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Every widget is already on this board."
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -1455,6 +1717,7 @@ msgstr ""
 
 #: src/pages/HighlightsPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Export"
 msgstr ""
 
@@ -1464,6 +1727,10 @@ msgstr ""
 
 #: src/pages/HighlightsPage.tsx
 msgid "Export failed"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Export this board as a JSON file (share or back up)"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1632,12 +1899,21 @@ msgstr ""
 msgid "Filters"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Finish rate by book type"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Finish Rate per Book Category"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "finished"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Finished"
 msgstr ""
 
@@ -1677,6 +1953,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Format: {filterFormatUpper}"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Fr"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1748,12 +2028,20 @@ msgstr ""
 msgid "Guest"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Habits"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Hardcover"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
 msgid "Hardcover sync is disabled on this server."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Height auto-fits the content — only width is resizable"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1763,6 +2051,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Hide details"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Highest & Lowest Rated"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1792,6 +2084,10 @@ msgstr ""
 msgid "Highlights you made on this day in past years"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Hit Edit, then Add tile."
+msgstr ""
+
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Home"
@@ -1801,8 +2097,24 @@ msgstr ""
 msgid "Host"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Hours & finishes, last 12 months"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "How far through each series"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "How far through the book you'd read by each date."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "How long the books you finish are"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "How much of what you own you’ve read"
 msgstr ""
 
 #: src/pages/LoginPage.tsx
@@ -1813,6 +2125,10 @@ msgstr ""
 msgid "How to set it up"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "How you spread your 1–5 stars"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 msgid "Icon"
@@ -1820,6 +2136,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Impersonation failed"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Import board…"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -1836,6 +2156,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Import reading history"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Imported board"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -1955,6 +2279,10 @@ msgstr ""
 msgid "Last used"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Latest finishes, newest first"
+msgstr ""
+
 #: src/pages/WishlistPage.tsx
 msgid "Latest: vol {v}"
 msgstr ""
@@ -1988,11 +2316,32 @@ msgstr ""
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Library"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Library Completion"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Library size over time"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Library: {filterLibraryChipName}"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "lifetime"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Lifetime Totals"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Lifetime words read, by year"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -2071,6 +2420,22 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Longest Session"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Longest session, biggest day, most pages"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Longest Streak"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Longest: {d}d"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2158,6 +2523,10 @@ msgstr ""
 msgid "Metadata Suggestions"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Metric"
+msgstr ""
+
 #: src/pages/SetupPage.tsx
 msgid "Minimum 8 characters"
 msgstr ""
@@ -2166,12 +2535,32 @@ msgstr ""
 msgid "Minutes"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Minutes read per day"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Missing"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Missing: {filterMissingLabel}"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Mo"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Morning vs evening reader?"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Most-read authors"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Most-read books by time"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2218,6 +2607,10 @@ msgstr ""
 msgid "never used"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "New board"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "New key"
 msgstr ""
@@ -2262,6 +2655,10 @@ msgstr ""
 msgid "Next book"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Next month"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next page"
 msgstr ""
@@ -2292,6 +2689,10 @@ msgstr ""
 
 #: src/pages/HardcoverPage.tsx
 msgid "No books in this view."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "No comparison data."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2370,8 +2771,20 @@ msgstr ""
 msgid "No reading activity yet. Records appear when users start reading books."
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "No reading data yet"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "No reading logged yet. Track time by hand — handy for a paper copy or a device that isn't synced."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "No reading sessions in this range — session-based tiles will be empty."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "no reading yet"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -2392,6 +2805,14 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "No series found — add series metadata to your books."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "No series with reading progress yet."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "no sessions yet"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2415,13 +2836,26 @@ msgstr ""
 msgid "No users have added devices yet."
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "No widgets match “{q}”."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "No widgets on this board yet."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "None"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Not configured"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Not enough reading history yet."
 msgstr ""
 
 #: src/pages/SharePage.tsx
@@ -2430,6 +2864,10 @@ msgstr ""
 
 #: src/pages/HardcoverPage.tsx
 msgid "Not matched"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Not on board"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2483,6 +2921,10 @@ msgstr ""
 msgid "Notifications"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Number of reading sessions"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "of {totalPages} pages"
 msgstr ""
@@ -2491,9 +2933,21 @@ msgstr ""
 msgid "On a device where you're already signed in, go to <0>Settings → Security → Quick Connect</0> and enter this code."
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "on board"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "On board"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "On this day"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "One series front and center — you pick which"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2554,6 +3008,14 @@ msgstr ""
 msgid "Other volumes"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "over {days} days"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Overview"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Owner"
 msgstr ""
@@ -2562,12 +3024,36 @@ msgstr ""
 msgid "pace"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Pace by Format"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Padding"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "pages"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Pages · 30d"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Pages / Day"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Pages / Hour"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Pages per minute over time"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Pages Turned"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2599,8 +3085,20 @@ msgstr ""
 msgid "Per-file details"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Period Comparison"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Personal Records"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Pick"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Pick a start & end"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2609,6 +3107,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Pick which book to keep and an action per group — Merge, Delete Others, or Dismiss — then apply everything at once."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Pick your own metric — avg session, pages/day, best day…"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2649,6 +3151,10 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Previous book"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Previous month"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -2718,6 +3224,14 @@ msgstr ""
 msgid "Quick Connect"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Range"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Range follows the page's range picker; days show the newest slice of it."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Rate this book"
 msgstr ""
@@ -2742,8 +3256,24 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Rating Distribution"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Rating Trend"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Rating vs Time Spent"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Re-match"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Re-reads"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2800,21 +3330,94 @@ msgstr ""
 msgid "Reading"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Reading Activity — Last 365 Days"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading by Category — Last 12 Months"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading by Language"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading by Weekday"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Clock"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Reading days"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading DNA"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Goals"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Hours & Books Finished — Last 12 Months"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Reading intensity"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Reading Intensity by Hour and Day"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Reading Log"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Reading Pace"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Speed"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Speed Trend"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/SetupPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Reading Stats"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading stats appear once sessions arrive — synced from the TomeSync KOReader plugin, logged by hand on a book page, or imported from a KOReader statistics file."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Time"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Time per Day"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading time split by language"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reading Timeline"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Recent Sessions"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2822,6 +3425,7 @@ msgid "Recently Added"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Recently Finished"
 msgstr ""
 
@@ -2858,6 +3462,10 @@ msgstr ""
 msgid "Reject imported book"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Remove {title}"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
 msgstr ""
@@ -2878,8 +3486,28 @@ msgstr ""
 msgid "Remove wish"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Removed “{title}”"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Removed a tile? Add it back — or add another copy."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Rename {name}"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Rename board"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Rescan the bindery folder"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Reset"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2930,6 +3558,10 @@ msgstr ""
 msgid "Roles guide"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Sa"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Same ISBN"
 msgstr ""
@@ -2944,6 +3576,10 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Save board as image"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Save changes"
 msgstr ""
@@ -2953,6 +3589,7 @@ msgid "Save Changes"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Save failed"
 msgstr ""
 
@@ -2963,6 +3600,18 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Save the library first, then reopen it to share with users."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Save this board as an image"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Saved"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Saving"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -3042,6 +3691,10 @@ msgstr ""
 msgid "Search to find more icons"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Search widgets…"
+msgstr ""
+
 #: src/pages/HighlightsPage.tsx
 msgid "Search your highlights…"
 msgstr ""
@@ -3097,6 +3750,7 @@ msgstr ""
 #: src/components/Sidebar.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Series"
 msgstr ""
 
@@ -3106,6 +3760,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Series applied to {n} files"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Series Completion"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -3122,8 +3780,16 @@ msgstr ""
 msgid "Series Progress"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Series ranked by your rating"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Series review"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Series Spotlight"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -3134,8 +3800,16 @@ msgstr ""
 msgid "Server"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Session Timeline"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "sessions"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Sessions"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3256,6 +3930,10 @@ msgstr ""
 msgid "Show this help"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Shrink/grow this tile to fit its content. Off: set the height yourself (content scrolls)."
+msgstr ""
+
 #: src/pages/LoginPage.tsx
 msgid "Sign in"
 msgstr ""
@@ -3296,8 +3974,16 @@ msgstr ""
 msgid "Sort Order"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Sortable table of every book"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Source"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Speed by book format"
 msgstr ""
 
 #: src/pages/LoginPage.tsx
@@ -3336,12 +4022,20 @@ msgstr ""
 msgid "Start {volLabel}"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Start from default"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Start matching this book again"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Start reading and your progress will show up here"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Started vs finished ratio"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -3357,8 +4051,16 @@ msgstr ""
 msgid "Status: {filterStatusLabel}"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Streak"
+msgstr ""
+
 #: src/pages/SetupPage.tsx
 msgid "Strong enough"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Su"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3413,12 +4115,28 @@ msgstr ""
 msgid "Tags (comma-separated)"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Taste"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Taste by Genre"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Test"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Test email sent successfully."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Th"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "That file is not a Tome board export."
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -3445,12 +4163,32 @@ msgstr ""
 msgid "Theme name is required"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "This board is empty."
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "This is a whole-series wish — it stays open as volumes arrive."
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "This is the only time you will see this token. Store it somewhere safe — it cannot be recovered."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "This Month"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "This month, read days filled"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "This page is yours — every tile can be moved, resized, swapped or removed, per board. Hit <0>Edit</0> to start. Reset always brings the defaults back."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "This period vs the last"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -3461,12 +4199,40 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Time / Day"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Time by Format"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Time left on books in progress"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Time of Day Split"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Time per chapter"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Time per chapter, line view"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Time split across categories"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Timeframe"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Timeline"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -3514,6 +4280,22 @@ msgstr ""
 msgid "TomeSync Plugin"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Top Authors by Reading Time"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Top Books by Reading Time"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Total pages turned"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Total time read + avg session"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Translations are community-maintained. Anything not yet translated is shown in English."
 msgstr "翻译由社区维护。尚未翻译的内容将以英文显示。"
@@ -3528,6 +4310,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Try editing the title or series fields"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Tu"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -3545,6 +4331,7 @@ msgid "Unassigned"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/StatsPage.tsx
 msgid "Undo"
 msgstr ""
 
@@ -3623,6 +4410,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "URL"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Use “Add tile” to build your {name} board."
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -3727,6 +4518,10 @@ msgstr ""
 msgid "Warm"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "We"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Web"
 msgstr ""
@@ -3747,8 +4542,16 @@ msgstr ""
 msgid "What did you think? (optional, saved automatically)"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "What do these mean? — read the stats docs"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books."
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "When you read — hour × weekday"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3757,6 +4560,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Where you read"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Which weekday you read most"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3794,10 +4601,18 @@ msgstr ""
 msgid "Words"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Words Read"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Year"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Year in Review"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3826,6 +4641,10 @@ msgstr ""
 msgid "Your account is not permitted to sign in to Tome."
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Your highest & lowest rated books"
+msgstr ""
+
 #: src/pages/SetupPage.tsx
 msgid "Your library"
 msgstr ""
@@ -3843,6 +4662,18 @@ msgstr ""
 msgid "Your note — syncs back to KOReader on the next sync"
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "Your ratings over time"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Your reading life — every book a bar in time"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Your real reading speed — words ÷ time"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Your server admin needs to set SMTP environment variables:"
 msgstr ""
@@ -3857,4 +4688,8 @@ msgstr ""
 
 #: src/pages/WishlistPage.tsx
 msgid "Your wishlist is empty"
+msgstr ""
+
+#: src/pages/StatsPage.tsx
+msgid "Your year, at a glance (1y/All)"
 msgstr ""

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -543,6 +543,10 @@ msgstr ""
 msgid "{books, plural, one {{total} from # book} other {{total} from # books}}"
 msgstr ""
 
+#: src/components/stats/widgets/habits.tsx
+msgid "{bt} — {st} to {en} ({dur})"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "{clearResult} covers deleted."
 msgstr ""
@@ -2154,6 +2158,7 @@ msgid "Copied {n} highlights as Markdown"
 msgstr ""
 
 #: src/pages/HighlightsPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Copy"
 msgstr ""
 
@@ -2161,8 +2166,13 @@ msgstr ""
 msgid "Copy all as Markdown"
 msgstr ""
 
+#: src/components/ShareLinksOverview.tsx
 #: src/components/ShareShelfModal.tsx
 msgid "Copy link"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copy this book’s highlights as Markdown"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -2450,13 +2460,33 @@ msgstr ""
 msgid "Delete Others"
 msgstr ""
 
+#: src/components/stats/widgets/overview.tsx
+msgid "Delete session"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Delete sync record"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Delete theme"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Delete this book from the library? The file will be removed and this cannot be undone."
+msgstr ""
+
+#: src/components/stats/GoalWidget.tsx
+msgid "Delete this goal"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 msgid "Delete this highlight"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
+msgid "Delete this imported sitting"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -3174,6 +3204,14 @@ msgstr ""
 msgid "First read"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Fit page height (W)"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Fit page width (W)"
+msgstr ""
+
 #: src/components/CoverAudit.tsx
 msgid "Fixed"
 msgstr ""
@@ -3382,6 +3420,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Hide details"
+msgstr ""
+
+#: src/components/stats/widgets/library.tsx
+msgid "Hide sessions"
 msgstr ""
 
 #: src/components/stats/widgets/taste.tsx
@@ -4878,6 +4920,10 @@ msgstr ""
 msgid "Page {n}"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Page thumbnails (T)"
+msgstr ""
+
 #: src/components/SeriesReadingStats.tsx
 #: src/lib/goals.ts
 #: src/pages/BookDetailPage.tsx
@@ -4988,6 +5034,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Pick a start & end"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Pick different candidate"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -5135,6 +5185,10 @@ msgid "Queue: fold the other copies into the kept book"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+msgid "Queue: keep the selected book and delete the others — their files are removed from disk"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
 msgid "Queue: not a duplicate — never show this group again"
 msgstr ""
 
@@ -5277,6 +5331,10 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Reader"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Reader settings"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -5439,6 +5497,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Reject imported book"
+msgstr ""
+
+#: src/components/UploadModal.tsx
+msgid "Remove"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -5613,6 +5675,7 @@ msgstr ""
 msgid "Revoke"
 msgstr ""
 
+#: src/components/ShareLinksOverview.tsx
 #: src/components/ShareShelfModal.tsx
 msgid "Revoke link"
 msgstr ""
@@ -5682,6 +5745,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Save Changes"
+msgstr ""
+
+#: src/components/SaveFilterButton.tsx
+msgid "Save current filters as a shelf"
 msgstr ""
 
 #: src/components/ManageSeriesModal.tsx
@@ -5854,6 +5921,10 @@ msgstr ""
 #: src/components/MetadataFetchModal.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Searching…"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "See all in-progress books"
 msgstr ""
 
 #: src/components/AppShell.tsx
@@ -6203,6 +6274,10 @@ msgstr ""
 msgid "Show more ({left} remaining)"
 msgstr ""
 
+#: src/components/stats/widgets/library.tsx
+msgid "Show sessions"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
 msgstr ""
@@ -6229,6 +6304,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Similar Title"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Single page (S)"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -6411,6 +6490,22 @@ msgstr ""
 msgid "Sun"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Switch to fit height"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Switch to fit width"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Switch to page mode"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Switch to webtoon (scroll) mode"
+msgstr ""
+
 #: src/components/HardcoverSync.tsx
 msgid "Sync automatically"
 msgstr ""
@@ -6473,6 +6568,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Synopsis or description"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Table of contents"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -6601,6 +6700,10 @@ msgstr ""
 msgid "This series has no volumes with a numeric index yet. Add volumes before defining arcs."
 msgstr ""
 
+#: src/pages/StatsPage.tsx
+msgid "This tile uses a fixed window and ignores the range picker"
+msgstr ""
+
 #: src/components/WishlistModal.tsx
 msgid "This volume"
 msgstr ""
@@ -6710,6 +6813,10 @@ msgstr ""
 msgid "Toggle only-notes filter"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Toggle RTL (manga) mode"
+msgstr ""
+
 #: src/components/stats/widgets/overview.tsx
 msgid "Toggle sort order"
 msgstr ""
@@ -6784,6 +6891,10 @@ msgid "Trim"
 msgstr ""
 
 #: src/components/stats/widgets/overview.tsx
+msgid "Trim session"
+msgstr ""
+
+#: src/components/stats/widgets/overview.tsx
 msgid "Trimming only shortens this session's length and end time — page turns, progress and every other session stay untouched, and the previous duration is kept in the audit log. The suggestion re-prices this session's page turns at your usual reading pace."
 msgstr ""
 
@@ -6806,6 +6917,10 @@ msgstr ""
 #: src/components/stats/HourDowHeatmap.tsx
 #: src/components/stats/widgets/habits.tsx
 msgid "Tue"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Two-page spread (S)"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -7047,6 +7162,10 @@ msgstr ""
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Volume"
+msgstr ""
+
+#: src/components/SeriesCoverageStrip.tsx
+msgid "Volume {n} — not in the library"
 msgstr ""
 
 #: src/components/home/FocusMode.tsx
@@ -7345,6 +7464,14 @@ msgstr ""
 msgid "Zoom in"
 msgstr ""
 
+#: src/pages/ReaderPage.tsx
+msgid "Zoom in (+)"
+msgstr ""
+
 #: src/components/stats/TimelineRibbon.tsx
 msgid "Zoom out"
+msgstr ""
+
+#: src/pages/ReaderPage.tsx
+msgid "Zoom out (-)"
 msgstr ""

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -1498,10 +1498,11 @@ msgid "Apply to all"
 msgstr ""
 
 #: src/components/MetadataManager.tsx
-msgid "Applying {done}/{total}..."
-msgstr ""
+#~ msgid "Applying {done}/{total}..."
+#~ msgstr ""
 
 #: src/components/BulkMetadataReviewModal.tsx
+#: src/components/MetadataManager.tsx
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
 msgstr ""
@@ -2463,9 +2464,10 @@ msgid "Deleted board “{name}”"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
-msgid "Deleting..."
-msgstr ""
+#~ msgid "Deleting..."
+#~ msgstr ""
 
+#: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Deleting…"
 msgstr ""
@@ -3511,10 +3513,11 @@ msgid "Imported board"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
-msgid "Importing..."
-msgstr ""
+#~ msgid "Importing..."
+#~ msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/BinderyPage.tsx
 msgid "Importing…"
 msgstr ""
 
@@ -3822,8 +3825,8 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 #: src/pages/SettingsPage.tsx
-msgid "Loading..."
-msgstr ""
+#~ msgid "Loading..."
+#~ msgstr ""
 
 #: src/components/HardcoverSync.tsx
 #: src/components/PositionHistoryModal.tsx
@@ -3831,7 +3834,9 @@ msgstr ""
 #: src/components/ShareShelfModal.tsx
 #: src/components/stats/BacklogEstimate.tsx
 #: src/components/stats/GoalWidget.tsx
+#: src/pages/BinderyPage.tsx
 #: src/pages/HardcoverPage.tsx
+#: src/pages/SettingsPage.tsx
 #: src/pages/SharePage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Loading…"
@@ -5022,8 +5027,8 @@ msgid "Prefix"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
-msgid "Preparing..."
-msgstr ""
+#~ msgid "Preparing..."
+#~ msgstr ""
 
 #: src/components/InstanceBackup.tsx
 #: src/pages/SettingsPage.tsx
@@ -5707,12 +5712,13 @@ msgid "Saving"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
-msgid "Saving..."
-msgstr ""
+#~ msgid "Saving..."
+#~ msgstr ""
 
 #: src/components/ForcePasswordChange.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Saving…"
 msgstr ""
 
@@ -5742,9 +5748,10 @@ msgid "Scanning covers…"
 msgstr ""
 
 #: src/components/LibraryHealth.tsx
-msgid "Scanning..."
-msgstr ""
+#~ msgid "Scanning..."
+#~ msgstr ""
 
+#: src/components/LibraryHealth.tsx
 #: src/pages/AdminPage.tsx
 msgid "Scanning…"
 msgstr ""
@@ -5922,7 +5929,12 @@ msgstr ""
 
 #: src/components/SendToDeviceModal.tsx
 #: src/pages/AdminPage.tsx
-msgid "Sending..."
+#~ msgid "Sending..."
+#~ msgstr ""
+
+#: src/components/SendToDeviceModal.tsx
+#: src/pages/AdminPage.tsx
+msgid "Sending…"
 msgstr ""
 
 #: src/pages/AdminPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -370,6 +370,11 @@ msgstr ""
 msgid "{0, plural, one {# result — click to fill form} other {# results — click to fill form}}"
 msgstr ""
 
+#. placeholder {0}: candidates.length
+#: src/components/MetadataFetchModal.tsx
+msgid "{0, plural, one {# result — pick one to review} other {# results — pick one to review}}"
+msgstr ""
+
 #. placeholder {0}: follows.length
 #: src/pages/WishlistPage.tsx
 msgid "{0, plural, one {# series} other {# series}}"
@@ -786,8 +791,20 @@ msgstr ""
 msgid "{name} copy"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
+msgid "{name} errored"
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
+msgid "{name} is rate-limited — try again in a minute"
+msgstr ""
+
 #: src/components/ThemeToggle.tsx
 msgid "{name} theme"
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
+msgid "{name} timed out"
 msgstr ""
 
 #: src/components/BulkMetadataReviewModal.tsx
@@ -929,6 +946,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "← Back to library"
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
+msgid "← Back to results"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1396,6 +1417,14 @@ msgstr ""
 msgid "Apply Approved"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Apply failed"
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
+msgid "Apply Selected"
+msgstr ""
+
 #: src/components/CoverAudit.tsx
 msgid "Apply the first cover-search candidate"
 msgstr ""
@@ -1445,6 +1474,7 @@ msgstr ""
 msgid "Auth"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/components/stats/widgets/library.tsx
 #: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
@@ -1731,6 +1761,7 @@ msgstr ""
 #: src/components/InstanceBackup.tsx
 #: src/components/LibraryHealth.tsx
 #: src/components/ManageSeriesModal.tsx
+#: src/components/MetadataFetchModal.tsx
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
 #: src/components/stats/GoalWidget.tsx
@@ -2092,6 +2123,7 @@ msgstr ""
 msgid "Counts"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr ""
@@ -2148,6 +2180,10 @@ msgstr ""
 #: src/components/PositionHistoryModal.tsx
 #: src/pages/StatsPage.tsx
 msgid "current"
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
+msgid "Current"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -2301,6 +2337,7 @@ msgid "Deleting…"
 msgstr ""
 
 #: src/components/ManageSeriesModal.tsx
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2885,12 +2922,17 @@ msgid "Fetch failed"
 msgstr ""
 
 #: src/components/BulkMetadataReviewModal.tsx
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Fetching metadata..."
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
+msgid "Field"
 msgstr ""
 
 #: src/components/LibraryHealth.tsx
@@ -3127,6 +3169,10 @@ msgstr ""
 msgid "Hardcover sync is disabled on this server."
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Has cover"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Height auto-fits the content — only width is resizable"
 msgstr ""
@@ -3305,6 +3351,7 @@ msgstr ""
 msgid "Include"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Incoming"
 msgstr ""
@@ -3317,6 +3364,7 @@ msgstr ""
 msgid "IP:"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/components/ReadingImport.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "ISBN"
@@ -3394,6 +3442,7 @@ msgstr ""
 msgid "Label (e.g. KOReader)"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -3874,6 +3923,10 @@ msgstr ""
 msgid "New board"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
+msgid "New cover"
+msgstr ""
+
 #: src/components/stats/widgets/overview.tsx
 msgid "New duration"
 msgstr ""
@@ -4008,7 +4061,12 @@ msgid "No completion data by type."
 msgstr ""
 
 #: src/components/CoverAudit.tsx
+#: src/components/MetadataFetchModal.tsx
 msgid "No cover"
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
+msgid "No cover available"
 msgstr ""
 
 #: src/components/CoverPickerModal.tsx
@@ -4204,6 +4262,10 @@ msgstr ""
 msgid "no recent reading, so no day estimate"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
+msgid "No results — but some sources were unavailable (see below); retrying may help."
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "No results — try a different query."
 msgstr ""
@@ -4218,6 +4280,10 @@ msgstr ""
 
 #: src/components/WishlistModal.tsx
 msgid "No results found."
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
+msgid "No results found. Try a different search query."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -4541,6 +4607,10 @@ msgstr ""
 msgid "over {days} days"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Override search query (optional)…"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Overview"
 msgstr ""
@@ -4718,6 +4788,7 @@ msgstr ""
 msgid "Preparing…"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Preview"
 msgstr ""
@@ -4784,6 +4855,7 @@ msgstr ""
 msgid "Publication status"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
@@ -5425,6 +5497,7 @@ msgstr ""
 msgid "Scroll right"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Search"
 msgstr ""
@@ -5437,6 +5510,7 @@ msgstr ""
 msgid "Search books… (/)"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Search failed"
 msgstr ""
@@ -5493,6 +5567,11 @@ msgstr ""
 msgid "Searching {n} books…"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Searching for: <0>{title}</0>"
+msgstr ""
+
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Searching…"
 msgstr ""
@@ -5517,6 +5596,7 @@ msgstr ""
 msgid "Select a book first."
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Select all"
 msgstr ""
@@ -5582,6 +5662,7 @@ msgstr ""
 
 #: src/components/CommandPalette.tsx
 #: src/components/ManageSeriesModal.tsx
+#: src/components/MetadataFetchModal.tsx
 #: src/components/Sidebar.tsx
 #: src/components/WishlistModal.tsx
 #: src/pages/BinderyPage.tsx
@@ -5590,6 +5671,7 @@ msgstr ""
 msgid "Series"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 msgid "Series #"
 msgstr ""
@@ -6079,6 +6161,10 @@ msgstr ""
 msgid "Tag: {filterTag}"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
+msgid "Tags"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Tags (comma-separated)"
 msgstr ""
@@ -6258,6 +6344,7 @@ msgstr ""
 msgid "title"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/components/stats/widgets/library.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
@@ -6805,6 +6892,7 @@ msgstr ""
 msgid "Words Read"
 msgstr ""
 
+#: src/components/MetadataFetchModal.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -37,6 +37,10 @@ msgstr ""
 msgid " · {n} read"
 msgstr ""
 
+#: src/pages/WishlistPage.tsx
+msgid " · {n} volumes"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
 msgstr ""
@@ -47,6 +51,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid " · reviewed"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid " · you have vol {v}"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -147,6 +155,11 @@ msgstr ""
 msgid "{0, plural, one {# result — click to fill form} other {# results — click to fill form}}"
 msgstr ""
 
+#. placeholder {0}: follows.length
+#: src/pages/WishlistPage.tsx
+msgid "{0, plural, one {# series} other {# series}}"
+msgstr ""
+
 #. placeholder {0}: data.reread_bins
 #: src/pages/BookDetailPage.tsx
 msgid "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
@@ -237,8 +250,16 @@ msgstr ""
 msgid "{added} added · {skipped} skipped"
 msgstr ""
 
+#: src/pages/HighlightsPage.tsx
+msgid "{books, plural, one {{total} from # book} other {{total} from # books}}"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "{clearResult} covers deleted."
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "{color} highlight"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -252,6 +273,7 @@ msgstr ""
 #: src/components/NotificationBell.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "{days}d ago"
 msgstr ""
 
@@ -349,6 +371,7 @@ msgid "{minutes}m ago"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "{months}mo ago"
 msgstr ""
 
@@ -446,6 +469,7 @@ msgid "{words} words"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "{years}y ago"
 msgstr ""
 
@@ -507,11 +531,20 @@ msgid "Add"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Add a note"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Add a review"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Add a wish"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Add books you'd like to see in the library."
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -806,6 +839,7 @@ msgstr ""
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/HighlightsPage.tsx
 #: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
@@ -915,8 +949,16 @@ msgstr ""
 msgid "Code was already authorized."
 msgstr ""
 
+#: src/pages/HighlightsPage.tsx
+msgid "Collapse"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Collapse / expand all books"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Collapse all"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -971,6 +1013,22 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Continue Reading"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copied {n} from “{title}”"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copied {n} highlights as Markdown"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copy"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Copy all as Markdown"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1076,6 +1134,7 @@ msgstr ""
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Delete"
 msgstr ""
 
@@ -1102,6 +1161,7 @@ msgid "Delete this book from the library? The file will be removed and this cann
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Delete this highlight"
 msgstr ""
 
@@ -1183,6 +1243,10 @@ msgstr ""
 msgid "Download a JSON snapshot of <0>your personal data</0>: reading status, every reading session, sync positions, shelves, and your local preferences. Book files themselves are not included — Tome only references them on disk. API tokens and KOReader keys are also excluded so the file isn't a credential."
 msgstr ""
 
+#: src/pages/HighlightsPage.tsx
+msgid "Download as Markdown file"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Download failed"
@@ -1210,6 +1274,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Download ZIP"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Downloaded {n} highlights"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -1263,6 +1331,7 @@ msgid "Edit Metadata"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Edit note"
 msgstr ""
 
@@ -1316,6 +1385,14 @@ msgstr ""
 msgid "Exit selection mode"
 msgstr ""
 
+#: src/pages/HighlightsPage.tsx
+msgid "Expand"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Expand all"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Expand sidebar"
 msgstr ""
@@ -1324,12 +1401,17 @@ msgstr ""
 msgid "Expires in {timeLeft}"
 msgstr ""
 
+#: src/pages/HighlightsPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Export"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Export {label}"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Export failed"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1367,6 +1449,7 @@ msgid "Failed to create token"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Failed to delete highlight"
 msgstr ""
 
@@ -1376,6 +1459,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to link sync document"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Failed to load"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -1398,6 +1485,10 @@ msgstr ""
 msgid "Failed to load libraries"
 msgstr ""
 
+#: src/pages/HighlightsPage.tsx
+msgid "Failed to load more"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Failed to load server stats"
 msgstr ""
@@ -1411,6 +1502,7 @@ msgid "Failed to load users"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Failed to load wishlist"
 msgstr ""
 
@@ -1420,6 +1512,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Failed to register"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Failed to remove wish"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1505,6 +1601,14 @@ msgstr ""
 msgid "Focus search"
 msgstr ""
 
+#: src/pages/WishlistPage.tsx
+msgid "Follow a series — search Hardcover…"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Following"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "for {targetLabel} — click a file to switch"
 msgstr ""
@@ -1540,6 +1644,7 @@ msgid "Fulfill: {title}"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Fulfilled"
 msgstr ""
 
@@ -1555,8 +1660,13 @@ msgstr ""
 msgid "Genres"
 msgstr ""
 
+#: src/pages/WishlistPage.tsx
+msgid "Get notified when a new volume of a followed series is released."
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Go back"
 msgstr ""
 
@@ -1594,16 +1704,30 @@ msgid "Hide details"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Highlight deleted"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Highlighted {when}"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 #: src/components/Sidebar.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Highlights"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Highlights & Notes"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Highlights and notes you make in KOReader sync here automatically. Highlight a passage on your device, then sync — it’ll show up in this commonplace book."
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Highlights you made on this day in past years"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1765,8 +1889,13 @@ msgstr ""
 msgid "Last used"
 msgstr ""
 
+#: src/pages/WishlistPage.tsx
+msgid "Latest: vol {v}"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Learn more"
 msgstr ""
 
@@ -1834,6 +1963,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "List view"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Load more ({left} left)"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -1916,6 +2049,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Member"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Members can add books to their wishlist."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2086,6 +2223,14 @@ msgstr ""
 msgid "No fulfilled wishes."
 msgstr ""
 
+#: src/pages/HighlightsPage.tsx
+msgid "No highlights match your search."
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "No highlights yet"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "No libraries"
 msgstr ""
@@ -2185,15 +2330,25 @@ msgid "Note on KOSync coexistence"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Note removed"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Note saved — syncs to your devices"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Note: {note}"
 msgstr ""
 
 #: src/pages/SharePage.tsx
 msgid "Nothing here yet."
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Nothing highlighted on this day — yet."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2218,6 +2373,7 @@ msgid "On a device where you're already signed in, go to <0>Settings → Securit
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "On this day"
 msgstr ""
 
@@ -2230,11 +2386,20 @@ msgstr ""
 msgid "Only filled fields will be updated. Leave blank to keep existing values."
 msgstr ""
 
+#: src/pages/HighlightsPage.tsx
+msgid "Only highlights that carry one of your notes"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Only notes"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "OPDS Catalog"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Open"
 msgstr ""
 
@@ -2578,6 +2743,10 @@ msgstr ""
 msgid "Remove from library"
 msgstr ""
 
+#: src/pages/WishlistPage.tsx
+msgid "Remove wish"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Rescan the bindery folder"
 msgstr ""
@@ -2657,6 +2826,7 @@ msgid "Save failed"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Save note"
 msgstr ""
 
@@ -2669,6 +2839,7 @@ msgid "Saving..."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Saving…"
 msgstr ""
 
@@ -2722,6 +2893,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Search to find more icons"
+msgstr ""
+
+#: src/pages/HighlightsPage.tsx
+msgid "Search your highlights…"
 msgstr ""
 
 #: src/components/AppShell.tsx
@@ -3046,6 +3221,10 @@ msgstr ""
 msgid "Synced document"
 msgstr ""
 
+#: src/pages/HighlightsPage.tsx
+msgid "Synced to Tome {when}"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Synopsis or description"
 msgstr ""
@@ -3134,6 +3313,7 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Today"
 msgstr ""
 
@@ -3196,8 +3376,20 @@ msgstr ""
 msgid "Undo"
 msgstr ""
 
+#: src/pages/WishlistPage.tsx
+msgid "Unfollow"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Unfollow {name}"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Ungrouped files"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Unknown author"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3296,6 +3488,7 @@ msgid "Verify it's working"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "View book"
 msgstr ""
 
@@ -3387,11 +3580,25 @@ msgid "Where you read"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Whole series"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Wish"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Wish added"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Wish removed"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Wishlist"
 msgstr ""
 
@@ -3415,6 +3622,7 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/WishlistPage.tsx
 msgid "Yesterday"
 msgstr ""
 
@@ -3451,6 +3659,7 @@ msgid "Your library is empty"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/HighlightsPage.tsx
 msgid "Your note — syncs back to KOReader on the next sync"
 msgstr ""
 
@@ -3464,4 +3673,8 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "your Tome password"
+msgstr ""
+
+#: src/pages/WishlistPage.tsx
+msgid "Your wishlist is empty"
 msgstr ""

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -25,12 +25,24 @@ msgstr ""
 msgid " · {dups} duplicates"
 msgstr ""
 
+#: src/pages/SharePage.tsx
+msgid " · {dur} read time"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid " · {errs} error(s)"
 msgstr ""
 
+#: src/pages/SharePage.tsx
+msgid " · {n} read"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
+msgstr ""
+
+#: src/pages/SharePage.tsx
+msgid " · finished {d}"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -61,6 +73,18 @@ msgstr ""
 msgid "· {n} docs"
 msgstr ""
 
+#: src/pages/SharePage.tsx
+msgid "· a shared book"
+msgstr ""
+
+#: src/pages/SharePage.tsx
+msgid "· a shared series"
+msgstr ""
+
+#: src/pages/SharePage.tsx
+msgid "· a shared shelf"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "· p. {page} of {totalPages}"
 msgstr ""
@@ -81,13 +105,20 @@ msgstr ""
 msgid "(not set)"
 msgstr ""
 
+#. placeholder {0}: b.stats.reading_days
+#: src/pages/SharePage.tsx
+msgid "{0, plural, one {{dur} over # day} other {{dur} over # days}}"
+msgstr ""
+
 #. placeholder {0}: res.errors.length
 #: src/pages/AdminPage.tsx
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 msgstr ""
 
+#. placeholder {0}: data.totals.books
 #. placeholder {0}: s.book_count
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
 msgstr ""
 
@@ -131,6 +162,11 @@ msgstr ""
 msgid "{0, plural, one {# user} other {# users}}"
 msgstr ""
 
+#. placeholder {0}: data.totals.books
+#: src/pages/SharePage.tsx
+msgid "{0, plural, one {# volume} other {# volumes}}"
+msgstr ""
+
 #. placeholder {0}: group.files.length
 #: src/pages/BinderyPage.tsx
 msgid "{0, plural, one {Accept # volume} other {Accept # volumes}}"
@@ -160,6 +196,11 @@ msgstr ""
 #. placeholder {0}: selectedIds.size
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Deleting # book...} other {Deleting # books...}}"
+msgstr ""
+
+#. placeholder {0}: b.highlights.length
+#: src/pages/SharePage.tsx
+msgid "{0, plural, one {Description & # highlight} other {Description & # highlights}}"
 msgstr ""
 
 #. placeholder {0}: selected.size
@@ -263,10 +304,12 @@ msgid "{failedN} of {totalN} failed — {firstErr}"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "{h}h"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
 msgstr ""
 
@@ -288,6 +331,7 @@ msgid "{inc, plural, one {# file waiting for review} other {# files waiting for 
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "{m}m"
 msgstr ""
 
@@ -351,6 +395,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "{readCount} read · {readingCount} reading · {unreadCount} unread"
+msgstr ""
+
+#: src/pages/SharePage.tsx
+msgid "{readN} read · {unreadN} unread"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -647,6 +695,10 @@ msgstr ""
 msgid "Authorize"
 msgstr ""
 
+#: src/pages/LoginPage.tsx
+msgid "Authorize this code from another device"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Authorizing..."
 msgstr ""
@@ -754,6 +806,7 @@ msgstr ""
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Cancel"
 msgstr ""
@@ -838,6 +891,10 @@ msgstr ""
 msgid "Close navigation"
 msgstr ""
 
+#: src/pages/LoginPage.tsx
+msgid "Code expired. Try again."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Code from new device"
 msgstr ""
@@ -900,6 +957,10 @@ msgstr ""
 msgid "Confirm new password"
 msgstr ""
 
+#: src/pages/SetupPage.tsx
+msgid "Confirm password"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Content"
 msgstr ""
@@ -955,6 +1016,14 @@ msgstr ""
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Create"
+msgstr ""
+
+#: src/pages/SetupPage.tsx
+msgid "Create admin account"
+msgstr ""
+
+#: src/pages/SetupPage.tsx
+msgid "Create your admin account to get started"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1047,6 +1116,7 @@ msgstr ""
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "Description"
 msgstr ""
 
@@ -1210,6 +1280,7 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Email"
 msgstr ""
 
@@ -1247,6 +1318,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Expand sidebar"
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "Expires in {timeLeft}"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1293,6 +1368,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to delete highlight"
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "Failed to generate code. Try again."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1402,6 +1481,7 @@ msgid "Filters"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "finished"
 msgstr ""
 
@@ -1505,6 +1585,7 @@ msgid "Hardcover"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "hiatus"
 msgstr ""
 
@@ -1536,6 +1617,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "How far through the book you'd read by each date."
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "How to authorize"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1633,6 +1718,10 @@ msgstr ""
 msgid "Kindle users"
 msgstr ""
 
+#: src/pages/SetupPage.tsx
+msgid "KOReader Sync"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "KOReader sync linked"
 msgstr ""
@@ -1679,6 +1768,14 @@ msgstr ""
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Learn more"
+msgstr ""
+
+#: src/pages/SharePage.tsx
+msgid "Less"
+msgstr ""
+
+#: src/pages/SetupPage.tsx
+msgid "librarian"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1744,6 +1841,10 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
+#: src/pages/SharePage.tsx
+msgid "Loading…"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Log in as this user"
 msgstr ""
@@ -1754,6 +1855,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Log session"
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "Login failed"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1827,6 +1932,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Metadata Suggestions"
+msgstr ""
+
+#: src/pages/SetupPage.tsx
+msgid "Minimum 8 characters"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2037,6 +2146,10 @@ msgstr ""
 msgid "No suggested match yet — search for the book to link, or upload it first."
 msgstr ""
 
+#: src/pages/LoginPage.tsx
+msgid "No Tome account is linked to this identity, and self-signup is disabled."
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "No type"
@@ -2059,6 +2172,10 @@ msgstr ""
 msgid "Not configured"
 msgstr ""
 
+#: src/pages/SharePage.tsx
+msgid "Not found"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "not read"
 msgstr ""
@@ -2073,6 +2190,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Note saved — syncs to your devices"
+msgstr ""
+
+#: src/pages/SharePage.tsx
+msgid "Nothing here yet."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2092,11 +2213,16 @@ msgstr ""
 msgid "of {totalPages} pages"
 msgstr ""
 
+#: src/pages/LoginPage.tsx
+msgid "On a device where you're already signed in, go to <0>Settings → Security → Quick Connect</0> and enter this code."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "On this day"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "ongoing"
 msgstr ""
 
@@ -2140,6 +2266,10 @@ msgstr ""
 msgid "Other providers"
 msgstr ""
 
+#: src/pages/SharePage.tsx
+msgid "Other volumes"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Owner"
 msgstr ""
@@ -2161,11 +2291,14 @@ msgid "password"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
+#: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Password"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Password must be at least 8 characters"
 msgstr ""
 
@@ -2174,6 +2307,7 @@ msgid "Password updated successfully"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Passwords do not match"
 msgstr ""
 
@@ -2291,6 +2425,7 @@ msgstr ""
 msgid "Quick Accept: {done}/{total} done"
 msgstr ""
 
+#: src/pages/LoginPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Quick Connect"
 msgstr ""
@@ -2327,6 +2462,7 @@ msgstr ""
 #: src/components/BookCard.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "Read"
 msgstr ""
 
@@ -2368,6 +2504,7 @@ msgid "reading"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SharePage.tsx
 msgid "Reading"
 msgstr ""
 
@@ -2384,6 +2521,7 @@ msgid "Reading Log"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Reading Stats"
 msgstr ""
 
@@ -2699,6 +2837,10 @@ msgstr ""
 msgid "Settings"
 msgstr ""
 
+#: src/pages/SetupPage.tsx
+msgid "Setup failed"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Setup instructions"
 msgstr ""
@@ -2726,6 +2868,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Shared fields — applies to all {n} items"
+msgstr ""
+
+#: src/pages/SharePage.tsx
+msgid "Shared from a self-hosted Tome library"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -2783,8 +2929,20 @@ msgstr ""
 msgid "Show this help"
 msgstr ""
 
+#: src/pages/LoginPage.tsx
+msgid "Sign in"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Sign in on a new device without entering your password. On the new device, tap \"Quick Connect\" on the login screen to get a 6-character code, then enter it here."
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "Sign in to your library"
+msgstr ""
+
+#: src/pages/OidcCallbackPage.tsx
+msgid "Signing you in…"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -2815,6 +2973,30 @@ msgstr ""
 msgid "Source"
 msgstr ""
 
+#: src/pages/LoginPage.tsx
+msgid "SSO is misconfigured on the server (redirect URL). Contact your admin."
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "SSO is not enabled."
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "SSO sign-in could not be completed. Please try again."
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "SSO sign-in did not complete. Please try again."
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "SSO sign-in failed: no identity information was returned."
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "SSO sign-in failed. Please try again."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "SSO sign-in linked to your account."
 msgstr ""
@@ -2842,6 +3024,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Status: {filterStatusLabel}"
+msgstr ""
+
+#: src/pages/SetupPage.tsx
+msgid "Strong enough"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2963,6 +3149,11 @@ msgstr ""
 msgid "Token name"
 msgstr ""
 
+#: src/pages/LoginPage.tsx
+#: src/pages/SetupPage.tsx
+msgid "Tome · Your personal library"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "TomeSync and KOSync can both be active. TomeSync tracks full reading sessions; KOSync only stores your last position."
 msgstr ""
@@ -2977,6 +3168,10 @@ msgstr "翻译由社区维护。尚未翻译的内容将以英文显示。"
 
 #: src/pages/DashboardPage.tsx
 msgid "Try adjusting your filters"
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "Try again"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -3084,7 +3279,12 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
+#: src/pages/SetupPage.tsx
 msgid "Username"
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "Username or email"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3107,6 +3307,10 @@ msgstr ""
 msgid "Vol {idx}"
 msgstr ""
 
+#: src/pages/SharePage.tsx
+msgid "Vol. {a}–{b}"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Vol. {idx}"
@@ -3127,6 +3331,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Volumes"
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "Waiting for authorization…"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -3156,6 +3364,14 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Web reader"
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "Welcome back"
+msgstr ""
+
+#: src/pages/SetupPage.tsx
+msgid "Welcome to Tome"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3218,6 +3434,18 @@ msgstr ""
 msgid "Your account is linked to SSO — you can sign in with your identity provider."
 msgstr ""
 
+#: src/pages/LoginPage.tsx
+msgid "Your account is not permitted to sign in to Tome."
+msgstr ""
+
+#: src/pages/SetupPage.tsx
+msgid "Your library"
+msgstr ""
+
+#: src/pages/SetupPage.tsx
+msgid "Your Library"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Your library is empty"
 msgstr ""
@@ -3228,6 +3456,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Your server admin needs to set SMTP environment variables:"
+msgstr ""
+
+#: src/pages/LoginPage.tsx
+msgid "Your Tome account is disabled."
 msgstr ""
 
 #: src/pages/SettingsPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -33,8 +33,16 @@ msgstr ""
 msgid "…and {more} more not shown"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "· {n} docs"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "· p. {page} of {totalPages}"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "(enables dark: variants)"
 msgstr ""
 
 #. placeholder {0}: s.book_count
@@ -91,6 +99,7 @@ msgid "{d}d ago"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
+#: src/pages/SettingsPage.tsx
 msgid "{days}d ago"
 msgstr ""
 
@@ -126,6 +135,10 @@ msgstr ""
 msgid "{h}h {m}m"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "{hours}h ago"
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 msgid "{hrs}h ago"
 msgstr ""
@@ -136,6 +149,10 @@ msgstr ""
 
 #: src/components/NotificationBell.tsx
 msgid "{mins}m ago"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "{minutes}m ago"
 msgstr ""
 
 #: src/components/AppShell.tsx
@@ -215,8 +232,20 @@ msgstr ""
 msgid "~{at}% in · not read"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "A newer release is available — the link opens the release notes. Update by pulling the new image and restarting the container."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "A while ago"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "About"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Account & Security"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -224,6 +253,7 @@ msgid "Activity"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Add"
 msgstr ""
 
@@ -235,6 +265,10 @@ msgstr ""
 msgid "Add a review"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Add custom theme"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Add tag…"
@@ -244,12 +278,24 @@ msgstr ""
 msgid "Add Tags"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Add Theme"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Add to library"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Add to Library"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Add your e-reader or personal email. Books are sent as attachments — works with Kindle, Kobo, or any email address."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Add your SMTP sender address to Amazon's <0>Approved Personal Document E-mail List</0>, or emails will be silently dropped."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -281,6 +327,7 @@ msgid "All readers: {dur} · {days} · {readers}"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "All users"
 msgstr ""
 
@@ -290,6 +337,26 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Any"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "API Keys"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "API Tokens"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "App-specific PINs"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Appearance"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Ask your server admin if you don't manage the Tome installation yourself."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -305,8 +372,20 @@ msgstr ""
 msgid "Author: {filterAuthor}"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Authorize"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Authorizing..."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "avg session"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Backup"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -333,8 +412,16 @@ msgstr ""
 msgid "Books"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Books without a series"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Browse and download your library from KOReader or any OPDS client."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -344,6 +431,7 @@ msgstr ""
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Cancel"
 msgstr ""
 
@@ -353,6 +441,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "ch. 1"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Change Password"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -397,12 +489,36 @@ msgstr ""
 msgid "Clearing…"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Click \"Download plugin ZIP\" above. An API key is automatically created and baked into the plugin — no manual configuration needed."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Close"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "Close navigation"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Code from new device"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Code has expired. Ask the other device to generate a new one."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Code must be 6 characters"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Code not found. Check the code and try again."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Code was already authorized."
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -413,12 +529,20 @@ msgstr ""
 msgid "Collapse sidebar"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Colors <0>(10 hex values, comma-separated)</0>"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Command palette — jump to a book, series, author, or page"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Confirm"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Confirm new password"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -429,6 +553,26 @@ msgstr ""
 msgid "Continue Reading"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Copy to KOReader"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Copy token"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Core"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Could not link SSO. Please try again."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Could not start SSO linking."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Cover"
 msgstr ""
@@ -437,8 +581,28 @@ msgstr ""
 msgid "Cover size"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Create"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Created"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Creating..."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Current password"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Dark"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Dark theme"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -490,6 +654,14 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Device authorized — the new device is now signed in."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Device name"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device."
 msgstr ""
@@ -503,7 +675,12 @@ msgid "Docs"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Done"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Download a JSON snapshot of <0>your personal data</0>: reading status, every reading session, sync positions, shelves, and your local preferences. Book files themselves are not included — Tome only references them on disk. API tokens and KOReader keys are also excluded so the file isn't a credential."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -515,8 +692,32 @@ msgstr ""
 msgid "Download Markdown export"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Download my data"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Download plugin ZIP"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Download the plugin"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Download your entire library catalog — all titles, authors, series, tags and formats."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Download ZIP"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "E-Reader Devices"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "e.g. scribe-laptop"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -544,6 +745,18 @@ msgstr ""
 msgid "Edit Shelf"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Email"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Email address"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Email delivery is not set up yet."
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Ember"
 msgstr ""
@@ -568,8 +781,36 @@ msgstr ""
 msgid "Expand sidebar"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Export"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Export {label}"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Exporting..."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Failed"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Failed to add device"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Failed to authorize"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Failed to change password"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Failed to create token"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -596,7 +837,12 @@ msgstr ""
 msgid "Failed to log session"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Failed to register"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Failed to save"
 msgstr ""
 
@@ -673,6 +919,14 @@ msgstr ""
 msgid "From your highlights"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Full access"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Generate PIN"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Genres"
 msgstr ""
@@ -731,8 +985,32 @@ msgstr ""
 msgid "How far through the book you'd read by each date."
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "How to set it up"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Icon"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Import reading history"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "In KOReader: main menu -> TomeSync -> \"Test connection\" to confirm the plugin can reach your Tome server."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "In KOReader: Search → OPDS catalog → add catalog with the URL above."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "In KOReader: Settings > Device > Restart KOReader. The plugin loads automatically."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "In KOReader: Tools → Progress sync → Custom sync server."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -743,12 +1021,32 @@ msgstr ""
 msgid "just now"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Just now"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Key created — copy it now, it won't be shown again."
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Keyboard Shortcuts"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Kindle users"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "KOReader sync linked"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "KOSync registered successfully"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Label (e.g. KOReader)"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -765,6 +1063,18 @@ msgstr ""
 msgid "Last read"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Last sync: {d}"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Last used"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Learn more"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Libraries"
@@ -772,6 +1082,7 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Library"
 msgstr ""
 
@@ -791,6 +1102,22 @@ msgstr ""
 msgid "Link KOReader sync…"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Link SSO"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Link your identity provider to this account so you can sign in with SSO. Your existing login and password keep working."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Link your identity provider to this account so you can sign in with SSO. Your existing login keeps working."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Linked"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Linking…"
 msgstr ""
@@ -799,12 +1126,20 @@ msgstr ""
 msgid "List view"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Loading..."
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Log out"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Log session"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -852,16 +1187,48 @@ msgstr ""
 msgid "Missing: {filterMissingLabel}"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Must be exactly 10 comma-separated hex values (e.g. #1E1E2E)"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "My Books"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "My Kindle"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "My Rating"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "My Theme"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Name"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Name…"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Native KOReader plugin — tracks reading sessions and syncs by book ID. More reliable than KOSync."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Never"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "never used"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "New key"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -872,8 +1239,16 @@ msgstr ""
 msgid "New Library"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "New password"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "new this week"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "New Token"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -884,8 +1259,20 @@ msgstr ""
 msgid "Next page"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "No API keys. Download the plugin to auto-create one."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "No API tokens yet. Create one to use Scribe or scripts against Tome."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "No devices yet. Add one to start sending books."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -898,6 +1285,10 @@ msgstr ""
 
 #: src/components/Sidebar.tsx
 msgid "No other users to share with."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "No PINs yet. Generate one to use with OPDS clients."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -933,6 +1324,10 @@ msgstr ""
 msgid "not read"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Note on KOSync coexistence"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Note removed"
 msgstr ""
@@ -950,6 +1345,7 @@ msgid "Nothing matched “{search}”"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Notifications"
 msgstr ""
 
@@ -969,6 +1365,14 @@ msgstr ""
 msgid "Only filled fields will be updated. Leave blank to keep existing values."
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "OPDS Catalog"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Open a book downloaded via OPDS"
+msgstr ""
+
 #: src/components/AppHeader.tsx
 msgid "Open navigation"
 msgstr ""
@@ -979,6 +1383,18 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Open selected book"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Other providers"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Owner"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -993,12 +1409,52 @@ msgstr ""
 msgid "Pages · 30d"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Password"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Password must be at least 8 characters"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Password updated successfully"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Passwords do not match"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Pick up where you left off"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "PIN created — copy it now, it won't be shown again."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Position history — restore a bad sync"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Prefix"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Preparing..."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Preparing…"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Preview"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Preview:"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -1017,6 +1473,10 @@ msgstr ""
 msgid "Private library"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Profile updated"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Progress"
 msgstr ""
@@ -1025,12 +1485,20 @@ msgstr ""
 msgid "Progress % <0>(optional)</0>"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Progress Sync"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Public library"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Quick Connect"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1091,6 +1559,10 @@ msgstr ""
 msgid "Read book"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Read-only"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Reader"
 msgstr ""
@@ -1127,21 +1599,53 @@ msgstr ""
 msgid "Recently Finished"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Register"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Remove all of this book's imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Remove device"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Remove from library"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Restart KOReader"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Revoke"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Revoke this token? Any scripts or tools using it will stop working immediately."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Revoke token"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Revoked"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Save"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Save changes"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1160,8 +1664,16 @@ msgstr ""
 msgid "Save the library first, then reopen it to share with users."
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Saving..."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Saving…"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Scope"
 msgstr ""
 
 #: src/components/AppHeader.tsx
@@ -1190,6 +1702,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Select all"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Send to Device"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1222,13 +1738,30 @@ msgstr ""
 msgid "Sessions ({n})"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Set <0>TOME_SMTP_HOST</0>, <1>TOME_SMTP_PORT</1>, <2>TOME_SMTP_USER</2>, and <3>TOME_SMTP_PASSWORD</3>."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Set sync password"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/SettingsPage.tsx
 msgid "Settings"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Setup instructions"
 msgstr ""
 
 #: src/components/Sidebar.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Share"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Share links"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1264,6 +1797,10 @@ msgstr ""
 msgid "Shelves"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Short app-specific passwords for OPDS — easier to type on an e-reader than your full password."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Show another highlight"
 msgstr ""
@@ -1288,6 +1825,18 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Show this help"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Sign in on a new device without entering your password. On the new device, tap \"Quick Connect\" on the login screen to get a 6-character code, then enter it here."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Single Sign-On"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "SSO sign-in linked to your account."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1318,6 +1867,10 @@ msgstr ""
 msgid "Subtitle (optional)"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Sync reading position between KOReader and Tome."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Synced document"
 msgstr ""
@@ -1330,8 +1883,28 @@ msgstr ""
 msgid "Tag: {filterTag}"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "That SSO identity is already linked to another account."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "the sync password set above"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Theme"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Theme name"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Theme name is required"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "This is the only time you will see this token. Store it somewhere safe — it cannot be recovered."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -1361,6 +1934,18 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Toggle only-notes filter"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Token name"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "TomeSync and KOSync can both be active. TomeSync tracks full reading sessions; KOSync only stores your last position."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "TomeSync Plugin"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1400,6 +1985,26 @@ msgstr ""
 msgid "Unserialized"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Update"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Update password"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Update sync password"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Update to v{v}"
+msgstr ""
+
 #: src/components/AppHeader.tsx
 msgid "Upload"
 msgstr ""
@@ -1416,8 +2021,32 @@ msgstr ""
 msgid "Uploader: {filterUploaderName}"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "URL"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Use a <0>Google App Password</0>, not your regular password."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Use this as the OPDS password in KOReader (username stays the same)."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "used {d}"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "User menu"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Username"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Verify it's working"
 msgstr ""
 
 #: src/components/ImpersonationBanner.tsx
@@ -1448,6 +2077,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Want to Read — queue this book up next"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Warm"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1487,10 +2120,26 @@ msgstr ""
 msgid "You rated this {rating}/5"
 msgstr ""
 
+#: src/pages/SettingsPage.tsx
+msgid "You're signed in via SSO. Manage your credentials at your identity provider — there's no Tome password to change."
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Your account is linked to SSO — you can sign in with your identity provider."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Your library is empty"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Your note — syncs back to KOReader on the next sync"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "Your server admin needs to set SMTP environment variables:"
+msgstr ""
+
+#: src/pages/SettingsPage.tsx
+msgid "your Tome password"
 msgstr ""

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -17,12 +17,28 @@ msgstr ""
 msgid " — click for sessions"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid " — MISSING"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid " · {dups} duplicates"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid " · {errs} error(s)"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid " · {prog}% in"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid ", {n} failed"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -45,9 +61,31 @@ msgstr ""
 msgid "(enables dark: variants)"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "(last 100)"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "(leave blank to keep)"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "(not set)"
+msgstr ""
+
+#. placeholder {0}: res.errors.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
+msgstr ""
+
 #. placeholder {0}: s.book_count
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {# book} other {# books}}"
+msgstr ""
+
+#. placeholder {0}: groups.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
 msgstr ""
 
 #. placeholder {0}: aggregate.distinct_readers
@@ -60,14 +98,34 @@ msgstr ""
 msgid "{0, plural, one {# reading day} other {# reading days}}"
 msgstr ""
 
+#. placeholder {0}: records.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# record} other {# records}}"
+msgstr ""
+
 #. placeholder {0}: data.reread_bins
 #: src/pages/BookDetailPage.tsx
 msgid "{0, plural, one {# stretch re-read} other {# stretches re-read}}"
 msgstr ""
 
+#. placeholder {0}: wish.suggested_book_ids.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# suggested match} other {# suggested matches}}"
+msgstr ""
+
+#. placeholder {0}: users.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {# user} other {# users}}"
+msgstr ""
+
 #. placeholder {0}: selected.size
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Added # book to library} other {Added # books to library}}"
+msgstr ""
+
+#. placeholder {0}: applyResult.applied
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {Applied # group} other {Applied # groups}}"
 msgstr ""
 
 #. placeholder {0}: selectedIds.size
@@ -85,9 +143,22 @@ msgstr ""
 msgid "{0, plural, one {Edit Metadata for # Book} other {Edit Metadata for # Books}}"
 msgstr ""
 
+#. placeholder {0}: suggestedBooks.length
+#: src/pages/AdminPage.tsx
+msgid "{0, plural, one {Suggested match:} other {Suggested matches:}}"
+msgstr ""
+
 #. placeholder {0}: selected.size
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Updated metadata for # book} other {Updated metadata for # books}}"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "{added} added · {skipped} skipped"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "{clearResult} covers deleted."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -99,6 +170,7 @@ msgid "{d}d ago"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "{days}d ago"
 msgstr ""
@@ -107,12 +179,20 @@ msgstr ""
 msgid "{dayStr}: {mins}m"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "{deleteBookCount, plural, one {delete # book (removes files)} other {delete # books (removes files)}}"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{deleted, plural, one {Deleted # book} other {Deleted # books}}"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "{deltaStr}% vs last week"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "{dismissCount, plural, one {dismiss # group} other {dismiss # groups}}"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -140,6 +220,7 @@ msgid "{hours}h ago"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
+#: src/pages/AdminPage.tsx
 msgid "{hrs}h ago"
 msgstr ""
 
@@ -147,12 +228,29 @@ msgstr ""
 msgid "{m}m"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "{mergeCount, plural, one {merge # group} other {merge # groups}}"
+msgstr ""
+
 #: src/components/NotificationBell.tsx
+#: src/pages/AdminPage.tsx
 msgid "{mins}m ago"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "{minutes}m ago"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "{months}mo ago"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "{n, plural, one {# matching volume currently in the library.} other {# matching volumes currently in the library.}}"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "{n, plural, one {Confirm — apply # decision} other {Confirm — apply # decisions}}"
 msgstr ""
 
 #: src/components/AppShell.tsx
@@ -166,6 +264,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "{name} · Vol. {start_index}–{end_index}"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "{othersCount, plural, one {Delete # other} other {Delete # others}}"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -220,6 +322,10 @@ msgstr ""
 msgid "{words} words"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "{years}y ago"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "← Back to library"
 msgstr ""
@@ -246,6 +352,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Account & Security"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Active"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -290,6 +400,10 @@ msgstr ""
 msgid "Add to Library"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Add Type"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Add your e-reader or personal email. Books are sent as attachments — works with Kindle, Kobo, or any email address."
 msgstr ""
@@ -298,12 +412,21 @@ msgstr ""
 msgid "Add your SMTP sender address to Amazon's <0>Approved Personal Document E-mail List</0>, or emails will be silently dropped."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Added"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Added to Want to Read"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 msgid "Admin"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Admin access required."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -318,8 +441,16 @@ msgstr ""
 msgid "All →"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "All actions"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "All Books"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "All Devices"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -355,12 +486,32 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Apply All ({n})"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Applying {done}/{total}…"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Ask your server admin if you don't manage the Tome installation yourself."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Assign type to new books"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Attach progress synced from a KOReader-compatible app to this book"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Audit Log"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Auth"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -396,6 +547,10 @@ msgstr ""
 msgid "Black"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Book"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Book deleted"
 msgstr ""
@@ -408,6 +563,11 @@ msgstr ""
 msgid "Book not found"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Book Types"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Books"
 msgstr ""
@@ -429,6 +589,7 @@ msgid "Browse your library"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -459,6 +620,7 @@ msgstr ""
 msgid "Choose icon"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Clear"
 msgstr ""
@@ -469,6 +631,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Clear all filters"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Clear cover cache"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -529,6 +695,10 @@ msgstr ""
 msgid "Collapse sidebar"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Color"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Colors <0>(10 hex values, comma-separated)</0>"
 msgstr ""
@@ -537,6 +707,19 @@ msgstr ""
 msgid "Command palette — jump to a book, series, author, or page"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Complete"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Complete series: {title}"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Configured"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Confirm"
 msgstr ""
@@ -581,6 +764,11 @@ msgstr ""
 msgid "Cover size"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Covers"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Create"
 msgstr ""
@@ -597,6 +785,10 @@ msgstr ""
 msgid "Current password"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Danger Zone"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Dark"
 msgstr ""
@@ -610,6 +802,14 @@ msgstr ""
 msgid "Dashboard"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Data"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Database"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Date Added"
 msgstr ""
@@ -619,6 +819,7 @@ msgid "Day streak"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete"
@@ -628,9 +829,18 @@ msgstr ""
 msgid "Delete \"{title}\"?"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Delete all {count} cached cover files ({mb} MB). Covers will be re-extracted on next access."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Delete failed"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Delete Others"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -654,6 +864,14 @@ msgstr ""
 msgid "Details"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Details:"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Device"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Device authorized — the new device is now signed in."
 msgstr ""
@@ -666,8 +884,25 @@ msgstr ""
 msgid "Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Directories"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Dismiss"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Dismiss failed"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Dismiss wish"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Dismissed"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -712,8 +947,20 @@ msgstr ""
 msgid "Download ZIP"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Duplicate Detection"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Duplicates"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "E-Reader Devices"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "e.g. Novel"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -721,6 +968,7 @@ msgid "e.g. scribe-laptop"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Edit"
 msgstr ""
@@ -745,6 +993,11 @@ msgstr ""
 msgid "Edit Shelf"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Edit User"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Email"
 msgstr ""
@@ -767,6 +1020,10 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Everywhere"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Exact Match"
 msgstr ""
 
 #: src/components/ImpersonationBanner.tsx
@@ -793,6 +1050,7 @@ msgstr ""
 msgid "Exporting..."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Failed"
 msgstr ""
@@ -807,6 +1065,14 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Failed to change password"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to clear covers"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to complete series"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -825,12 +1091,32 @@ msgstr ""
 msgid "Failed to load books"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Failed to load duplicates"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to load facets"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to load libraries"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to load server stats"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to load sync status"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to load users"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to load wishlist"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -842,6 +1128,7 @@ msgid "Failed to register"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Failed to save"
 msgstr ""
@@ -856,6 +1143,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to save review"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Failed to save role"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -876,6 +1167,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "File is missing from disk"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -915,8 +1210,28 @@ msgstr ""
 msgid "Format: {filterFormatUpper}"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "From"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "From your highlights"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Fulfill"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Fulfill failed"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Fulfill: {title}"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Fulfilled"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -932,6 +1247,7 @@ msgid "Genres"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
+#: src/pages/AdminPage.tsx
 msgid "Go back"
 msgstr ""
 
@@ -949,6 +1265,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Group volumes by series"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Guest"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -981,6 +1301,10 @@ msgstr ""
 msgid "Home"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Host"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "How far through the book you'd read by each date."
 msgstr ""
@@ -990,11 +1314,32 @@ msgid "How to set it up"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 msgid "Icon"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Impersonation failed"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Import complete"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Import from Incoming"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Import Now"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Import reading history"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Importing…"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1013,16 +1358,33 @@ msgstr ""
 msgid "In KOReader: Tools → Progress sync → Custom sync server."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Inactive"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Incoming"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "IP:"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "ISBN"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
+#: src/pages/AdminPage.tsx
 msgid "just now"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Just now"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Keep this one"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1043,6 +1405,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "KOSync registered successfully"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Label"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1067,19 +1433,26 @@ msgstr ""
 msgid "Last sync: {d}"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Last Synced"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Last used"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Learn more"
 msgstr ""
 
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Libraries"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -1130,6 +1503,10 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Log in as this user"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Log out"
 msgstr ""
@@ -1159,6 +1536,14 @@ msgstr ""
 msgid "Mark all read"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Mark complete"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Mark it complete when you consider the series fully available; the requester will be notified."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Marked as read"
 msgstr ""
@@ -1169,6 +1554,18 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Marked unread — reading progress cleared"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Member"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Merge"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Metadata"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1251,6 +1648,18 @@ msgstr ""
 msgid "New Token"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "New Type"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "New User"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Next"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Next book"
 msgstr ""
@@ -1267,6 +1676,22 @@ msgstr ""
 msgid "No API tokens yet. Create one to use Scribe or scripts against Tome."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "No audit entries yet."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "No book types yet."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "No books found. Upload the book first, then fulfill."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "No books have been sent yet."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
 msgstr ""
@@ -1275,12 +1700,32 @@ msgstr ""
 msgid "No devices yet. Add one to start sending books."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "No dismissed wishes."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "No duplicates found. Your library looks clean."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "No fulfilled wishes."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "No matching volumes in the library yet."
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 msgid "No notifications yet"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "No open wishes."
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1289,6 +1734,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "No PINs yet. Generate one to use with OPDS clients."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "No reading activity yet. Records appear when users start reading books."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1311,13 +1760,29 @@ msgstr ""
 msgid "No series found — add series metadata to your books."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "No suggested match yet — search for the book to link, or upload it first."
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "No type"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "No type (staging / admin only)"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "No users have added devices yet."
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "None"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Not configured"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1369,6 +1834,10 @@ msgstr ""
 msgid "OPDS Catalog"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Open"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Open a book downloaded via OPDS"
 msgstr ""
@@ -1409,6 +1878,11 @@ msgstr ""
 msgid "Pages · 30d"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "password"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Password"
 msgstr ""
@@ -1429,8 +1903,16 @@ msgstr ""
 msgid "Pick up where you left off"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Pick which book to keep and an action per group — Merge, Delete Others, or Dismiss — then apply everything at once."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "PIN created — copy it now, it won't be shown again."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Port"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1457,6 +1939,10 @@ msgstr ""
 msgid "Preview:"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Previous"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Previous book"
 msgstr ""
@@ -1473,10 +1959,15 @@ msgstr ""
 msgid "Private library"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Process files dropped into the <0>incoming/</0> directory and move them into the library."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Profile updated"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Progress"
 msgstr ""
@@ -1495,6 +1986,14 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Queue: fold the other copies into the kept book"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Queue: not a duplicate — never show this group again"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1525,6 +2024,7 @@ msgstr ""
 msgid "Rating"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "read"
 msgstr ""
@@ -1567,6 +2067,7 @@ msgstr ""
 msgid "Reader"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "reading"
 msgstr ""
@@ -1599,6 +2100,10 @@ msgstr ""
 msgid "Recently Finished"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Refresh"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Register"
 msgstr ""
@@ -1613,6 +2118,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Remove from library"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Resource:"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1639,7 +2148,24 @@ msgstr ""
 msgid "Revoked"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Role"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Roles guide"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Same ISBN"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Same Series Volume"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Save"
 msgstr ""
@@ -1672,6 +2198,26 @@ msgstr ""
 msgid "Saving…"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Scan complete"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Scan Library"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Scan Now"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Scanner"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Scanning…"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Scope"
 msgstr ""
@@ -1682,6 +2228,14 @@ msgstr ""
 
 #: src/components/AppHeader.tsx
 msgid "Search books… (/)"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Search for a book in the library…"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Search for a different book…"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1700,12 +2254,36 @@ msgstr ""
 msgid "Select"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Select a book first."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Select all"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Send failed"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Send History"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Send test email"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Send to Device"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Sending..."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Sent"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1726,6 +2304,10 @@ msgstr ""
 msgid "Series: {filterSeries}"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Server"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "sessions"
 msgstr ""
@@ -1744,6 +2326,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Set sync password"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Set the following environment variables to enable Send to Device:"
 msgstr ""
 
 #: src/components/Sidebar.tsx
@@ -1778,6 +2364,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Shared Library"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "shelved"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1831,8 +2421,24 @@ msgstr ""
 msgid "Sign in on a new device without entering your password. On the new device, tap \"Quick Connect\" on the login screen to get a 6-character code, then enter it here."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Similar Title"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Single Sign-On"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "SMTP Status"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Sort Order"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Source"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1855,6 +2461,7 @@ msgstr ""
 msgid "Stats"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Status"
 msgstr ""
@@ -1871,6 +2478,10 @@ msgstr ""
 msgid "Sync reading position between KOReader and Tome."
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Sync Status"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Synced document"
 msgstr ""
@@ -1881,6 +2492,14 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Tag: {filterTag}"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Test"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Test email sent successfully."
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1903,12 +2522,20 @@ msgstr ""
 msgid "Theme name is required"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "This is a whole-series wish — it stays open as volumes arrive."
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "This is the only time you will see this token. Store it somewhere safe — it cannot be recovered."
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "This permanently removes the selected books and their files from disk. This cannot be undone."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Time"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -1924,6 +2551,7 @@ msgstr ""
 msgid "Title"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Today"
 msgstr ""
@@ -1961,6 +2589,10 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Types"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Unassigned"
 msgstr ""
@@ -1973,6 +2605,7 @@ msgstr ""
 msgid "unknown device"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "unread"
 msgstr ""
@@ -2037,16 +2670,29 @@ msgstr ""
 msgid "used {d}"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "User"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "User menu"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Username"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Users"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Verify it's working"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "View book"
 msgstr ""
 
 #: src/components/ImpersonationBanner.tsx
@@ -2070,6 +2716,14 @@ msgstr ""
 msgid "Volumes"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Walk the library directory and add any new book files found."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "want to read"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Want to Read"
@@ -2081,6 +2735,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Warm"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Web"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2099,8 +2757,21 @@ msgstr ""
 msgid "Where you read"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Whole series"
+msgstr ""
+
 #: src/components/Sidebar.tsx
+#: src/pages/AdminPage.tsx
 msgid "Wishlist"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Without a type, new books are only visible to admins until assigned."
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Word Counts"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2112,8 +2783,13 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Yesterday"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "You"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -82,6 +82,14 @@ msgstr ""
 msgid " · {n} want to read"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid " · {needsReview} needs review"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid " · {noMatch} no match"
+msgstr ""
+
 #: src/components/stats/widgets/overview.tsx
 msgid " · {pages} pages"
 msgstr ""
@@ -136,8 +144,20 @@ msgstr ""
 msgid " · you have vol {v}"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid " {n} had no confident match."
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid " in {n} folders"
+msgstr ""
+
 #: src/components/stats/widgets/habits.tsx
 msgid " vs previous: <0>{prev}</0>"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "— {n} books"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -156,6 +176,10 @@ msgstr ""
 msgid ", {failedN} failed"
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid ", {n} errors"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid ", {n} failed"
 msgstr ""
@@ -166,6 +190,10 @@ msgstr ""
 
 #: src/components/UploadModal.tsx
 msgid ", {skipped} already in library"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid ", removed {n} empty folders"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -245,6 +273,11 @@ msgstr ""
 msgid "{0, plural, one {# book could not be deleted} other {# books could not be deleted}}"
 msgstr ""
 
+#. placeholder {0}: missingResult.removed_books.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# book entry removed} other {# book entries removed}}"
+msgstr ""
+
 #. placeholder {0}: d.books_finished
 #: src/components/stats/widgets/habits.tsx
 msgid "{0, plural, one {# book finished} other {# books finished}}"
@@ -284,9 +317,29 @@ msgstr ""
 msgid "{0, plural, one {# duplicate group found.} other {# duplicate groups found.}}"
 msgstr ""
 
+#. placeholder {0}: healthData.missing_count
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# entry is missing from disk} other {# entries are missing from disk}}"
+msgstr ""
+
+#. placeholder {0}: missingResult.removed_file_rows
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# file entry removed} other {# file entries removed}}"
+msgstr ""
+
+#. placeholder {0}: healthData.missing.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# file in the database but missing from disk} other {# files in the database but missing from disk}}"
+msgstr ""
+
 #. placeholder {0}: items.length
 #: src/components/UploadModal.tsx
 msgid "{0, plural, one {# file selected} other {# files selected}}"
+msgstr ""
+
+#. placeholder {0}: group.issues.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {# file} other {# files}}"
 msgstr ""
 
 #. placeholder {0}: row.unestimated
@@ -380,6 +433,11 @@ msgstr ""
 msgid "{0, plural, one {Applied # group} other {Applied # groups}}"
 msgstr ""
 
+#. placeholder {0}: healthData.missing.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {Confirm — remove # entry} other {Confirm — remove # entries}}"
+msgstr ""
+
 #. placeholder {0}: selectedIds.size
 #: src/pages/DashboardPage.tsx
 msgid "{0, plural, one {Delete # book} other {Delete # books}}"
@@ -418,6 +476,11 @@ msgstr ""
 #. placeholder {0}: result.rejected
 #: src/pages/BinderyPage.tsx
 msgid "{0, plural, one {Rejected # file} other {Rejected # files}}"
+msgstr ""
+
+#. placeholder {0}: purgeResult.length
+#: src/components/LibraryHealth.tsx
+msgid "{0, plural, one {Removed # empty folder.} other {Removed # empty folders.}}"
 msgstr ""
 
 #. placeholder {0}: books.length
@@ -643,6 +706,10 @@ msgstr ""
 msgid "{m}m {rem}s"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "{matched} matched"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "{mergeCount, plural, one {merge # group} other {merge # groups}}"
 msgstr ""
@@ -655,6 +722,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "{minutes}m ago"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "{misplaced} of {total} files need reorganization"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -691,6 +762,10 @@ msgstr ""
 msgid "{n} selected — Clear"
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "{n} skipped (file exists on disk)"
+msgstr ""
+
 #: src/components/HardcoverSync.tsx
 msgid "{n} synced"
 msgstr ""
@@ -713,6 +788,10 @@ msgstr ""
 
 #: src/components/ThemeToggle.tsx
 msgid "{name} theme"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "{ok} of {total} approved"
 msgstr ""
 
 #: src/components/UploadModal.tsx
@@ -1180,6 +1259,10 @@ msgstr ""
 msgid "All {scanned} covers look healthy."
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "All {total} files are correctly placed."
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "All →"
 msgstr ""
@@ -1204,6 +1287,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "All Devices"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "All files are correctly placed."
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -1276,6 +1363,10 @@ msgstr ""
 msgid "Application token (required)"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Applied metadata to {n} books."
+msgstr ""
+
 #: src/components/SeriesRating.tsx
 msgid "Applied to volumes you haven’t rated"
 msgstr ""
@@ -1289,12 +1380,20 @@ msgstr ""
 msgid "Apply"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Apply {n} Approved"
+msgstr ""
+
 #: src/components/ReadingImport.tsx
 msgid "Apply {n} selected"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Apply All ({n})"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Apply Approved"
 msgstr ""
 
 #: src/components/CoverAudit.tsx
@@ -1305,6 +1404,7 @@ msgstr ""
 msgid "Apply to all"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
 #: src/pages/AdminPage.tsx
 msgid "Applying {done}/{total}…"
 msgstr ""
@@ -1364,6 +1464,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Author: {filterAuthor}"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Author: {name}"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -1454,6 +1558,10 @@ msgstr ""
 msgid "Backup failed"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Batch complete"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Best Day"
 msgstr ""
@@ -1514,6 +1622,10 @@ msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Book Detail"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "book entry will be removed"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -1614,8 +1726,10 @@ msgstr ""
 msgid "Can't find it? Add manually"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
 #: src/components/EntityModal.tsx
 #: src/components/InstanceBackup.tsx
+#: src/components/LibraryHealth.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/ReadingImport.tsx
 #: src/components/Sidebar.tsx
@@ -1742,6 +1856,7 @@ msgstr ""
 msgid "Click for details"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
 #: src/components/ManageSeriesModal.tsx
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareShelfModal.tsx
@@ -1841,6 +1956,10 @@ msgstr ""
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Confirm"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Confirm & Reorganize"
 msgstr ""
 
 #: src/components/ForcePasswordChange.tsx
@@ -1963,6 +2082,10 @@ msgstr ""
 
 #: src/components/WordCount.tsx
 msgid "Counted"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Counting… {done} / {total}"
 msgstr ""
 
 #: src/components/stats/GoalWidget.tsx
@@ -2113,6 +2236,10 @@ msgstr ""
 msgid "days at ~{mpd} min a day (last {win} days)"
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "Dead entries removed"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -2215,6 +2342,7 @@ msgstr ""
 msgid "Directories"
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
 #: src/components/WhatsNewPanel.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -2305,6 +2433,14 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Drop files in the incoming folder to get started"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Dry Run All"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Dry Run Preview — {n} files would be moved"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -2744,6 +2880,11 @@ msgstr ""
 msgid "Fastest"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Fetch failed"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Fetch Metadata"
 msgstr ""
@@ -2752,12 +2893,24 @@ msgstr ""
 msgid "Fetching metadata..."
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "File {id}: {err}"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "file entry only"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "File is missing from disk"
 msgstr ""
 
 #: src/components/SendToDeviceModal.tsx
 msgid "File size: {size}"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Fill missing fields only"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -3325,6 +3478,10 @@ msgstr ""
 msgid "Library Completion"
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "Library Health"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Library size over time"
 msgstr ""
@@ -3654,6 +3811,10 @@ msgstr ""
 msgid "Most-read books by time"
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "Moved {n} files"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Must be exactly 10 comma-separated hex values (e.g. #1E1E2E)"
 msgstr ""
@@ -3886,6 +4047,10 @@ msgstr ""
 msgid "No duplicates found. Your library looks clean."
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "No empty folders found."
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "No files in the bindery"
 msgstr ""
@@ -3918,6 +4083,10 @@ msgstr ""
 msgid "No library growth data."
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "No match found"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "No matches"
 msgstr ""
@@ -3932,6 +4101,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "No metadata found"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "no new fields"
 msgstr ""
 
 #: src/components/NotificationBell.tsx
@@ -4235,6 +4408,10 @@ msgstr ""
 msgid "Nothing shared yet. Use the share icon on a shelf, a series page, or a book page."
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "Nothing to remove."
+msgstr ""
+
 #: src/components/NotificationBell.tsx
 #: src/pages/SettingsPage.tsx
 msgid "Notifications"
@@ -4338,6 +4515,14 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Orphaned entries"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Other"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -4602,6 +4787,18 @@ msgstr ""
 #: src/pages/BinderyPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Publisher"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Purge Empty Folders"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Purge failed"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Purging..."
 msgstr ""
 
 #: src/components/NotificationChannels.tsx
@@ -4935,8 +5132,16 @@ msgstr ""
 msgid "Remove channel"
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "Remove Dead Entries"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Remove device"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Remove folders that contain only hidden files (.DS_Store, etc.)"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -4959,12 +5164,40 @@ msgstr ""
 msgid "Removed a tile? Add it back — or add another copy."
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "Removes the database entries only — no files are touched"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Removing dead entries failed"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Removing..."
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Rename {name}"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "Rename board"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Reorganization complete"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Reorganize All"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Reorganize failed"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Reorganize Selected ({n})"
 msgstr ""
 
 #: src/components/NotificationChannels.tsx
@@ -5025,6 +5258,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "Review"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Review {n} Uncertain"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -5146,6 +5383,11 @@ msgstr ""
 msgid "Scan complete"
 msgstr ""
 
+#: src/components/LibraryHealth.tsx
+msgid "Scan failed"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
 #: src/pages/AdminPage.tsx
 msgid "Scan Library"
 msgstr ""
@@ -5160,6 +5402,10 @@ msgstr ""
 
 #: src/components/CoverAudit.tsx
 msgid "Scanning covers…"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Scanning..."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -5223,6 +5469,10 @@ msgstr ""
 msgid "Search icons…"
 msgstr ""
 
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Search manually"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "Search query..."
 msgstr ""
@@ -5237,6 +5487,10 @@ msgstr ""
 
 #: src/pages/HighlightsPage.tsx
 msgid "Search your highlights…"
+msgstr ""
+
+#: src/components/BulkMetadataReviewModal.tsx
+msgid "Searching {n} books…"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
@@ -5385,6 +5639,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Series: {filterSeries}"
+msgstr ""
+
+#: src/components/LibraryHealth.tsx
+msgid "Series: {name}"
 msgstr ""
 
 #: src/pages/AdminPage.tsx

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -41,6 +41,14 @@ msgstr ""
 msgid " · {errs} error(s)"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid " · {n} ahead in this series"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid " · {n} errors"
+msgstr ""
+
 #: src/components/stats/SeriesCompletionGrid.tsx
 msgid " · {n} in progress"
 msgstr ""
@@ -51,6 +59,10 @@ msgstr ""
 
 #: src/components/stats/BacklogEstimate.tsx
 msgid " · {n} not estimated yet"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid " · {n} not matched"
 msgstr ""
 
 #: src/pages/SharePage.tsx
@@ -130,6 +142,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "— keep existing —"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "— manage →"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -462,6 +478,10 @@ msgstr ""
 msgid "{count} sittings · {from} – {to}"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "{d} days ago"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "{d}d ago"
 msgstr ""
@@ -554,6 +574,10 @@ msgstr ""
 msgid "{flagged} of {scanned} books flagged (low-res = narrower than {minW}px)."
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "{h} hours ago"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h"
@@ -565,6 +589,10 @@ msgstr ""
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{h}h {m}m"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "{h}h {mm}m"
 msgstr ""
 
 #: src/components/PositionHistoryModal.tsx
@@ -601,6 +629,7 @@ msgstr ""
 msgid "{label} only"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
 #: src/components/PositionHistoryModal.tsx
 msgid "{m} min ago"
 msgstr ""
@@ -608,6 +637,10 @@ msgstr ""
 #: src/pages/DashboardPage.tsx
 #: src/pages/SharePage.tsx
 msgid "{m}m"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "{m}m {rem}s"
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -658,6 +691,10 @@ msgstr ""
 msgid "{n} selected — Clear"
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
+msgid "{n} synced"
+msgstr ""
+
 #: src/components/stats/TimelineRibbon.tsx
 msgid "{n} vols · "
 msgstr ""
@@ -702,6 +739,10 @@ msgstr ""
 msgid "{pct}% more reading this period"
 msgstr ""
 
+#: src/components/WordCount.tsx
+msgid "{pending, plural, one {Count # EPUB} other {Count # EPUBs}}"
+msgstr ""
+
 #: src/components/stats/widgets/habits.tsx
 msgid "{ppm} pages/min"
 msgstr ""
@@ -724,6 +765,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "{recent} in the last 7 days vs {prior} the week before"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "{s}s"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -799,6 +844,10 @@ msgstr ""
 msgid "{years}y ago"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "← Back to current"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "← Back to library"
 msgstr ""
@@ -853,6 +902,10 @@ msgstr ""
 
 #: src/components/ShareShelfModal.tsx
 msgid "1 day"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "1 hour ago"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -923,6 +976,7 @@ msgstr ""
 msgid "A share link is a read-only page anyone with the link can open — no account needed. It shows covers, titles, tags, descriptions, and your ratings and highlights for this book. It never exposes files: no downloads, no reading, no way in. Revoke it any time and the link dies instantly."
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "A sync is already running"
 msgstr ""
@@ -1179,6 +1233,10 @@ msgstr ""
 
 #: src/pages/StatsPage.tsx
 msgid "All-time hours, pages, books, streak"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Already counted"
 msgstr ""
 
 #: src/components/SendButton.tsx
@@ -1544,6 +1602,10 @@ msgstr ""
 msgid "Browse and download your library from KOReader or any OPDS client."
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "Browse library"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Browse your library"
 msgstr ""
@@ -1798,6 +1860,10 @@ msgstr ""
 msgid "Content Type"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "Continue reading"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Continue Reading"
 msgstr ""
@@ -1838,12 +1904,20 @@ msgstr ""
 msgid "Could not create the goal — it may already exist."
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
+msgid "Could not link Hardcover account"
+msgstr ""
+
 #: src/pages/SettingsPage.tsx
 msgid "Could not link SSO. Please try again."
 msgstr ""
 
 #: src/components/stats/BacklogEstimate.tsx
 msgid "Could not load this scope."
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Could not parse ({n})"
 msgstr ""
 
 #: src/components/ReadingImport.tsx
@@ -1862,8 +1936,17 @@ msgstr ""
 msgid "Could not start SSO linking."
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Could not start sync"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "Could not unlink"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "Could not update sync setting"
 msgstr ""
 
 #: src/components/stats/GoalWidget.tsx
@@ -1876,6 +1959,10 @@ msgstr ""
 
 #: src/components/stats/TimelineRibbon.tsx
 msgid "Couldn't load the timeline."
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Counted"
 msgstr ""
 
 #: src/components/stats/GoalWidget.tsx
@@ -1946,6 +2033,14 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Current password"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Current:"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "Currently reading"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -2148,6 +2243,7 @@ msgstr ""
 msgid "Docs"
 msgstr ""
 
+#: src/components/WordCount.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/SettingsPage.tsx
 #: src/pages/StatsPage.tsx
@@ -2299,6 +2395,10 @@ msgstr ""
 msgid "Edit User"
 msgstr ""
 
+#: src/components/WordCount.tsx
+msgid "Elapsed {el} · ~{eta} left"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 #: src/pages/SettingsPage.tsx
 #: src/pages/SetupPage.tsx
@@ -2334,6 +2434,10 @@ msgstr ""
 msgid "EPUB vs CBZ time split"
 msgstr ""
 
+#: src/components/WordCount.tsx
+msgid "EPUBs"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Error"
 msgstr ""
@@ -2348,6 +2452,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Est. remaining"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Every EPUB is counted"
 msgstr ""
 
 #: src/components/ShareLinksOverview.tsx
@@ -2448,6 +2556,7 @@ msgstr ""
 msgid "failed"
 msgstr ""
 
+#: src/components/WordCount.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
 #: src/pages/DashboardPage.tsx
@@ -2548,6 +2657,10 @@ msgstr ""
 msgid "Failed to load wishlist"
 msgstr ""
 
+#: src/components/WordCount.tsx
+msgid "Failed to load word-count status"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to log session"
 msgstr ""
@@ -2593,6 +2706,10 @@ msgstr ""
 
 #: src/components/SendToDeviceModal.tsx
 msgid "Failed to send"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Failed to start"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -2791,6 +2908,10 @@ msgstr ""
 
 #: src/pages/WishlistPage.tsx
 msgid "Get notified when a new volume of a followed series is released."
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "Get token"
 msgstr ""
 
 #: src/components/KeyboardShortcutsModal.tsx
@@ -3056,6 +3177,7 @@ msgstr ""
 msgid "Jump to a book, series, author, or page…"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
 #: src/components/NotificationBell.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BinderyPage.tsx
@@ -3066,6 +3188,7 @@ msgstr ""
 msgid "Just now"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
 #: src/components/stats/widgets/habits.tsx
 msgid "Just started"
 msgstr ""
@@ -3140,6 +3263,10 @@ msgstr ""
 
 #: src/pages/AdminPage.tsx
 msgid "Last Synced"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "last synced {when}"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -3228,6 +3355,10 @@ msgstr ""
 msgid "Link"
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
+msgid "Link account"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Link KOReader sync…"
 msgstr ""
@@ -3250,6 +3381,14 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Linked"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "Linked as @{username} — initial sync started"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "Linked as <0>@{username}</0>"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -3277,6 +3416,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
 #: src/components/PositionHistoryModal.tsx
 #: src/components/ShareLinksOverview.tsx
 #: src/components/ShareShelfModal.tsx
@@ -3642,6 +3782,10 @@ msgstr ""
 msgid "Next: Vol {v} · {d}"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "Next: Vol {v} →"
+msgstr ""
+
 #: src/components/stats/HourDowHeatmap.tsx
 msgid "No activity"
 msgstr ""
@@ -3720,6 +3864,10 @@ msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "No description"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "No description yet for this volume."
 msgstr ""
 
 #: src/components/SendToDeviceModal.tsx
@@ -4024,6 +4172,10 @@ msgstr ""
 msgid "not read"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "Not started yet"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Not synced yet"
 msgstr ""
@@ -4070,6 +4222,7 @@ msgstr ""
 msgid "Nothing highlighted on this day — yet."
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
 #: src/pages/DashboardPage.tsx
 msgid "Nothing in progress"
 msgstr ""
@@ -4262,6 +4415,10 @@ msgstr ""
 msgid "Pages Turned"
 msgstr ""
 
+#: src/components/WordCount.tsx
+msgid "Parse each EPUB to store its word count. New uploads get this automatically — this backfills books added before the feature. It only reads the files and writes one number per book; nothing on disk is modified. Word counts power words-read and reading-speed stats. PDF and CBZ are skipped."
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "password"
 msgstr ""
@@ -4293,6 +4450,10 @@ msgstr ""
 
 #: src/components/ForcePasswordChange.tsx
 msgid "Passwords do not match."
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "Paste your Hardcover API token"
 msgstr ""
 
 #: src/components/NotificationChannels.tsx
@@ -4416,6 +4577,7 @@ msgstr ""
 msgid "Profile updated"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "Progress"
@@ -4444,6 +4606,10 @@ msgstr ""
 
 #: src/components/NotificationChannels.tsx
 msgid "Push Tome's notifications (wish fulfilled, new volume detected, reading goals) to ntfy, Gotify, or any webhook the moment they happen — the bell above only rings when you visit. Each channel can be tested, paused, or removed; tokens are stored server-side and never shown again."
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "Push your ratings and reading progress to your Hardcover profile — nothing is ever deleted there. Your Hardcover Want to Read shelf syncs both ways. Needs your personal API token (separate from the server's metadata token)."
 msgstr ""
 
 #: src/pages/AdminPage.tsx
@@ -4531,6 +4697,14 @@ msgstr ""
 msgid "Rating vs Time Spent"
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
+msgid "Ratings push shortly after you change them; progress goes out in batches."
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "Re-link"
+msgstr ""
+
 #: src/pages/HardcoverPage.tsx
 msgid "Re-match"
 msgstr ""
@@ -4573,6 +4747,10 @@ msgstr ""
 
 #: src/components/BookCard.tsx
 msgid "Read book"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "Read on the web"
 msgstr ""
 
 #: src/pages/SettingsPage.tsx
@@ -4835,6 +5013,14 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Resume {volLabel}"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "Resume reading"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Retry {n} failed"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -5490,12 +5676,20 @@ msgstr ""
 msgid "Start {volLabel}"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "Start a book and Focus mode will pick up where you left off"
+msgstr ""
+
 #: src/pages/StatsPage.tsx
 msgid "Start from default"
 msgstr ""
 
 #: src/pages/HardcoverPage.tsx
 msgid "Start matching this book again"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "Start reading"
 msgstr ""
 
 #: src/pages/DashboardPage.tsx
@@ -5521,6 +5715,10 @@ msgstr ""
 
 #: src/pages/DashboardPage.tsx
 msgid "Status: {filterStatusLabel}"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Stop"
 msgstr ""
 
 #: src/components/SeriesFollowButton.tsx
@@ -5552,6 +5750,11 @@ msgstr ""
 msgid "Sun"
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
+msgid "Sync automatically"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Sync now"
 msgstr ""
@@ -5564,10 +5767,15 @@ msgstr ""
 msgid "Sync started"
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
+msgid "Sync started — pushing ratings and progress, syncing Want to Read both ways"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Sync Status"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Synced"
 msgstr ""
@@ -5576,10 +5784,27 @@ msgstr ""
 msgid "Synced document"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "Synced from {device}"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "Synced from Kindle"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "Synced from Kobo"
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "Synced from KOReader"
+msgstr ""
+
 #: src/pages/HighlightsPage.tsx
 msgid "Synced to Tome {when}"
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
 #: src/pages/HardcoverPage.tsx
 msgid "Syncing…"
 msgstr ""
@@ -5798,6 +6023,10 @@ msgstr ""
 msgid "Title is required."
 msgstr ""
 
+#: src/components/WordCount.tsx
+msgid "To count"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 #: src/pages/DashboardPage.tsx
 #: src/pages/WishlistPage.tsx
@@ -5835,6 +6064,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "TomeSync Plugin"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Took {dur}"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -5958,6 +6191,10 @@ msgstr ""
 msgid "unknown device"
 msgstr ""
 
+#: src/components/HardcoverSync.tsx
+msgid "Unlink"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "unread"
@@ -5981,6 +6218,10 @@ msgstr ""
 
 #: src/pages/SettingsPage.tsx
 msgid "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install."
+msgstr ""
+
+#: src/components/home/FocusMode.tsx
+msgid "Up next"
 msgstr ""
 
 #: src/components/UpcomingReleases.tsx
@@ -6134,6 +6375,10 @@ msgstr ""
 msgid "Volume"
 msgstr ""
 
+#: src/components/home/FocusMode.tsx
+msgid "Volume <0>{v}</0>"
+msgstr ""
+
 #: src/pages/DashboardPage.tsx
 msgid "Volumes"
 msgstr ""
@@ -6270,12 +6515,32 @@ msgstr ""
 msgid "Word count at your measured {wpm} wpm"
 msgstr ""
 
+#: src/components/WordCount.tsx
+msgid "Word count complete"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Word count failed"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Word count stopped"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Word counts"
+msgstr ""
+
 #: src/pages/AdminPage.tsx
 msgid "Word Counts"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
 msgid "Words"
+msgstr ""
+
+#: src/components/WordCount.tsx
+msgid "Words found"
 msgstr ""
 
 #: src/pages/StatsPage.tsx
@@ -6333,6 +6598,10 @@ msgstr ""
 
 #: src/lib/backlog.ts
 msgid "Your average time per finished book of this type (no word count)"
+msgstr ""
+
+#: src/components/HardcoverSync.tsx
+msgid "Your Hardcover token expired (they reset every January 1). Paste a fresh one to resume syncing."
 msgstr ""
 
 #: src/pages/StatsPage.tsx

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,20 @@
 import './index.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { I18nProvider } from '@lingui/react'
 import App from './App.tsx'
+import { i18n, activateLocale, detectLocale } from './lib/i18n'
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+// Activate the UI language before the first render so nothing flashes English
+// for a user who picked another language. activateLocale never rejects: a
+// missing catalog renders the source strings.
+activateLocale(detectLocale())
+  .then(() => {
+    createRoot(document.getElementById('root')!).render(
+      <StrictMode>
+        <I18nProvider i18n={i18n}>
+          <App />
+        </I18nProvider>
+      </StrictMode>,
+    )
+  })

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -17,6 +17,9 @@ import { InstanceBackup } from '@/components/InstanceBackup'
 import { WordCountTab } from '@/components/WordCount'
 import { SeriesCoverageStrip } from '@/components/SeriesCoverageStrip'
 import { useAuth, isAdmin } from '@/contexts/AuthContext'
+import { Trans, useLingui, Plural } from '@lingui/react/macro'
+import { t, plural, msg } from '@lingui/core/macro'
+import type { MessageDescriptor } from '@lingui/core'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
 import { IconPicker } from '@/components/Sidebar'
@@ -68,6 +71,7 @@ function UserModal({ user, onClose, onSaved }: {
   onClose: () => void
   onSaved: (u: UserData) => void
 }) {
+  const { t } = useLingui()
   const { user: me } = useAuth()
   const [username, setUsername] = useState(user?.username ?? '')
   const [email, setEmail] = useState(user?.email ?? '')
@@ -89,50 +93,50 @@ function UserModal({ user, onClose, onSaved }: {
         : await api.post<UserData>('/users', { username, email, password, role, is_admin: role === 'admin' })
       onSaved(saved)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to save')
+      setError(err instanceof Error ? err.message : t`Failed to save`)
     } finally {
       setSaving(false)
     }
   }
 
   const roles: { value: 'admin' | 'member' | 'guest'; label: string; Icon: typeof Shield }[] = [
-    { value: 'guest', label: 'Guest', Icon: Eye },
-    { value: 'member', label: 'Member', Icon: User },
-    { value: 'admin', label: 'Admin', Icon: Shield },
+    { value: 'guest', label: t`Guest`, Icon: Eye },
+    { value: 'member', label: t`Member`, Icon: User },
+    { value: 'admin', label: t`Admin`, Icon: Shield },
   ]
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/40 backdrop-blur-sm">
       <div className="bg-card border border-border rounded-2xl shadow-xl shadow-accent-soft w-full max-w-md">
         <div className="flex items-center justify-between p-4 border-b border-border">
-          <h2 className="text-sm font-semibold">{user ? 'Edit User' : 'New User'}</h2>
+          <h2 className="text-sm font-semibold">{user ? t`Edit User` : t`New User`}</h2>
           <button onClick={onClose} className="p-1 rounded hover:bg-accent transition-colors">
             <X className="w-4 h-4" />
           </button>
         </div>
         <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-3">
           <div className="flex flex-col gap-1">
-            <label className="text-xs font-medium text-muted-foreground">Username</label>
+            <label className="text-xs font-medium text-muted-foreground"><Trans>Username</Trans></label>
             <input value={username} onChange={e => setUsername(e.target.value)} required
               className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               placeholder="username" />
           </div>
           <div className="flex flex-col gap-1">
-            <label className="text-xs font-medium text-muted-foreground">Email</label>
+            <label className="text-xs font-medium text-muted-foreground"><Trans>Email</Trans></label>
             <input type="email" value={email} onChange={e => setEmail(e.target.value)} required
               className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
               placeholder="user@example.com" />
           </div>
           <div className="flex flex-col gap-1">
             <label className="text-xs font-medium text-muted-foreground">
-              Password {user && <span className="text-muted-foreground/60">(leave blank to keep)</span>}
+              <Trans>Password</Trans> {user && <span className="text-muted-foreground/60"><Trans>(leave blank to keep)</Trans></span>}
             </label>
             <input type="password" value={password} onChange={e => setPassword(e.target.value)} required={!user}
               className="h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-              placeholder={user ? '••••••••' : 'password'} />
+              placeholder={user ? '••••••••' : t`password`} />
           </div>
           <div className="flex flex-col gap-1">
-            <label className="text-xs font-medium text-muted-foreground">Role</label>
+            <label className="text-xs font-medium text-muted-foreground"><Trans>Role</Trans></label>
             <div className="flex rounded-lg border border-border overflow-hidden">
               {roles.map(({ value, label, Icon }) => (
                 <button
@@ -159,17 +163,17 @@ function UserModal({ user, onClose, onSaved }: {
                   isActive ? 'bg-primary border-primary' : 'border-border')}>
                 {isActive && <Check className="w-3 h-3 text-primary-foreground" />}
               </div>
-              <span className="text-sm">Active</span>
+              <span className="text-sm"><Trans>Active</Trans></span>
             </label>
           )}
           {error && <p className="text-xs text-destructive">{error}</p>}
           <div className="flex justify-end gap-2 mt-1">
             <button type="button" onClick={onClose}
-              className="px-3 py-1.5 text-sm rounded-md border border-border hover:bg-accent transition-colors">Cancel</button>
+              className="px-3 py-1.5 text-sm rounded-md border border-border hover:bg-accent transition-colors"><Trans>Cancel</Trans></button>
             <button type="submit" disabled={saving}
               className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors flex items-center gap-1.5 disabled:opacity-50">
               {saving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-              {user ? 'Save' : 'Create'}
+              {user ? t`Save` : t`Create`}
             </button>
           </div>
         </form>
@@ -181,6 +185,7 @@ function UserModal({ user, onClose, onSaved }: {
 // ── UsersTab ──────────────────────────────────────────────────────────────
 
 function UsersTab() {
+  const { t, i18n } = useLingui()
   const { user: me, impersonate } = useAuth()
   const navigate = useNavigate()
   const [users, setUsers] = useState<UserData[]>([])
@@ -195,7 +200,7 @@ function UsersTab() {
   const [impersonating, setImpersonating] = useState<number | null>(null)
 
   useEffect(() => {
-    api.get<UserData[]>('/users').then(setUsers).catch(() => setError('Failed to load users')).finally(() => setLoading(false))
+    api.get<UserData[]>('/users').then(setUsers).catch(() => setError(t`Failed to load users`)).finally(() => setLoading(false))
   }, [])
 
   function handleSaved(saved: UserData) {
@@ -213,7 +218,7 @@ function UsersTab() {
       await impersonate(userId)
       navigate('/')
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Impersonation failed')
+      setError(e instanceof Error ? e.message : t`Impersonation failed`)
     } finally { setImpersonating(null) }
   }
 
@@ -224,7 +229,7 @@ function UsersTab() {
       setUsers(prev => prev.filter(u => u.id !== userId))
       setDeleteConfirm(null)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Delete failed')
+      setError(e instanceof Error ? e.message : t`Delete failed`)
     } finally { setDeleting(null) }
   }
 
@@ -234,7 +239,7 @@ function UsersTab() {
       const saved = await api.put<UserData>(`/users/${userId}`, { role, is_admin: role === 'admin' })
       setUsers(prev => prev.map(x => x.id === userId ? saved : x))
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to save role')
+      setError(e instanceof Error ? e.message : t`Failed to save role`)
     } finally { setPermSaving(null) }
   }
 
@@ -248,19 +253,19 @@ function UsersTab() {
       )}
       <div className="flex items-center justify-between mb-4 gap-3">
         <div className="flex items-center gap-3 min-w-0">
-          <p className="text-sm text-muted-foreground">{users.length} user{users.length !== 1 ? 's' : ''}</p>
+          <p className="text-sm text-muted-foreground"><Plural value={users.length} one="# user" other="# users" /></p>
           <a
             href={docsLink(DOCS.usersAndRoles)}
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
           >
-            Roles guide <ExternalLink className="w-3 h-3" />
+            <Trans>Roles guide</Trans> <ExternalLink className="w-3 h-3" />
           </a>
         </div>
         <button onClick={() => { setModalUser(null); setModalOpen(true) }}
           className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors">
-          <Plus className="w-3.5 h-3.5" /> New User
+          <Plus className="w-3.5 h-3.5" /> <Trans>New User</Trans>
         </button>
       </div>
 
@@ -283,34 +288,34 @@ function UsersTab() {
                       <span className="text-sm font-medium truncate">{u.username}</span>
                       {u.role === 'admin' && (
                         <span className="flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded-full bg-primary/10 text-primary border border-primary/20">
-                          <Shield className="w-2.5 h-2.5" /> Admin
+                          <Shield className="w-2.5 h-2.5" /> <Trans>Admin</Trans>
                         </span>
                       )}
                       {!u.is_active && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-destructive/10 text-destructive border border-destructive/20">Inactive</span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-destructive/10 text-destructive border border-destructive/20"><Trans>Inactive</Trans></span>
                       )}
                       {u.id === me?.id && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground border border-border">You</span>
+                        <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-muted text-muted-foreground border border-border"><Trans>You</Trans></span>
                       )}
                     </div>
                     <p className="text-xs text-muted-foreground truncate">{u.email}</p>
                   </div>
                 </div>
                 <div className="hidden sm:block text-xs text-muted-foreground shrink-0">
-                  {new Date(u.created_at).toLocaleDateString()}
+                  {new Date(u.created_at).toLocaleDateString(i18n.locale)}
                 </div>
                 <div className="flex items-center gap-1 shrink-0">
                   <button onClick={() => setExpandedId(expandedId === u.id ? null : u.id)}
-                    className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-foreground" title="Role">
+                    className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-foreground" title={t`Role`}>
                     {expandedId === u.id ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
                   </button>
                   <button onClick={() => { setModalUser(u); setModalOpen(true) }}
-                    className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-foreground" title="Edit">
+                    className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-foreground" title={t`Edit`}>
                     <Pencil className="w-3.5 h-3.5" />
                   </button>
                   {u.id !== me?.id && (
                     <button onClick={() => handleImpersonate(u.id)} disabled={impersonating === u.id}
-                      className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-warning" title="Log in as this user">
+                      className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-warning" title={t`Log in as this user`}>
                       {impersonating === u.id
                         ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
                         : <LogIn className="w-3.5 h-3.5" />}
@@ -321,7 +326,7 @@ function UsersTab() {
                       <div className="flex items-center gap-1">
                         <button onClick={() => handleDelete(u.id)} disabled={deleting === u.id}
                           className="px-2 py-1 text-xs rounded bg-destructive text-destructive-foreground hover:bg-destructive/90 flex items-center gap-1">
-                          {deleting === u.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />} Confirm
+                          {deleting === u.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />} <Trans>Confirm</Trans>
                         </button>
                         <button onClick={() => setDeleteConfirm(null)}
                           className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground">
@@ -330,7 +335,7 @@ function UsersTab() {
                       </div>
                     ) : (
                       <button onClick={() => setDeleteConfirm(u.id)}
-                        className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-destructive" title="Delete">
+                        className="p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground hover:text-destructive" title={t`Delete`}>
                         <Trash2 className="w-3.5 h-3.5" />
                       </button>
                     )
@@ -340,12 +345,12 @@ function UsersTab() {
               {expandedId === u.id && (
                 <div className="border-t border-border px-4 py-3 bg-muted/30">
                   <div className="flex items-center gap-3">
-                    <span className="text-xs text-muted-foreground shrink-0">Role</span>
+                    <span className="text-xs text-muted-foreground shrink-0"><Trans>Role</Trans></span>
                     <div className="flex rounded-lg border border-border overflow-hidden">
                       {([
-                        { value: 'guest', label: 'Guest', Icon: Eye },
-                        { value: 'member', label: 'Member', Icon: User },
-                        { value: 'admin', label: 'Admin', Icon: Shield },
+                        { value: 'guest', label: t`Guest`, Icon: Eye },
+                        { value: 'member', label: t`Member`, Icon: User },
+                        { value: 'admin', label: t`Admin`, Icon: Shield },
                       ] as { value: 'admin' | 'member' | 'guest'; label: string; Icon: typeof Shield }[]).map(({ value, label, Icon }) => (
                         <button
                           key={value}
@@ -379,6 +384,7 @@ function UsersTab() {
 // ── ScannerTab ────────────────────────────────────────────────────────────
 
 function ScannerTab() {
+  const { t } = useLingui()
   const [scanning, setScanning] = useState(false)
   const [importing, setImporting] = useState(false)
   const [defaultTypeId, setDefaultTypeId] = useState<number | ''>('')
@@ -409,20 +415,20 @@ function ScannerTab() {
 
   const typeSelector = (
     <div className="mt-3">
-      <label className="block text-xs text-muted-foreground mb-1">Assign type to new books</label>
+      <label className="block text-xs text-muted-foreground mb-1"><Trans>Assign type to new books</Trans></label>
       <select
         value={defaultTypeId}
         onChange={e => setDefaultTypeId(e.target.value ? Number(e.target.value) : '')}
         className="tome-select w-full text-sm bg-background border border-border rounded-lg px-3 py-1.5 text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
       >
-        <option value="">No type (staging / admin only)</option>
+        <option value="">{t`No type (staging / admin only)`}</option>
         {bookTypes.map(t => (
           <option key={t.id} value={t.id}>{t.label}</option>
         ))}
       </select>
       {!defaultTypeId && (
         <p className="text-xs text-warning mt-1">
-          Without a type, new books are only visible to admins until assigned.
+          <Trans>Without a type, new books are only visible to admins until assigned.</Trans>
         </p>
       )}
     </div>
@@ -432,16 +438,16 @@ function ScannerTab() {
     <div className="flex flex-col gap-4 max-w-xl mx-auto w-full">
       <div className="border border-border rounded-xl bg-card overflow-hidden">
         <div className="px-4 py-3 border-b border-border">
-          <h3 className="text-sm font-semibold">Scan Library</h3>
+          <h3 className="text-sm font-semibold"><Trans>Scan Library</Trans></h3>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Walk the library directory and add any new book files found.
+            <Trans>Walk the library directory and add any new book files found.</Trans>
           </p>
         </div>
         <div className="px-4 py-3">
           {scanning ? (
             <div className="flex flex-col items-center justify-center py-4 gap-2">
               <BookAnimation variant="refresh" className="block w-12 h-12 text-primary" />
-              <p className="text-sm text-muted-foreground">Scanning…</p>
+              <p className="text-sm text-muted-foreground"><Trans>Scanning…</Trans></p>
             </div>
           ) : (
             <>
@@ -449,7 +455,7 @@ function ScannerTab() {
               <button onClick={handleScan} disabled={scanning || importing}
                 className="mt-3 flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 transition-colors disabled:opacity-50">
                 <RefreshCw className="w-4 h-4" />
-                Scan Now
+                <Trans>Scan Now</Trans>
               </button>
             </>
           )}
@@ -458,9 +464,9 @@ function ScannerTab() {
 
       <div className="border border-border rounded-xl bg-card overflow-hidden">
         <div className="px-4 py-3 border-b border-border">
-          <h3 className="text-sm font-semibold">Import from Incoming</h3>
+          <h3 className="text-sm font-semibold"><Trans>Import from Incoming</Trans></h3>
           <p className="text-xs text-muted-foreground mt-0.5">
-            Process files dropped into the <code className="text-[11px] bg-muted px-1 rounded">incoming/</code> directory and move them into the library.
+            <Trans>Process files dropped into the <code className="text-[11px] bg-muted px-1 rounded">incoming/</code> directory and move them into the library.</Trans>
           </p>
         </div>
         <div className="px-4 py-3">
@@ -468,7 +474,7 @@ function ScannerTab() {
           <button onClick={handleImport} disabled={importing || scanning}
             className="mt-3 flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm hover:bg-primary/90 transition-colors disabled:opacity-50">
             {importing ? <RefreshCw className="w-4 h-4 animate-spin" /> : <FolderInput className="w-4 h-4" />}
-            {importing ? 'Importing…' : 'Import Now'}
+            {importing ? t`Importing…` : t`Import Now`}
           </button>
         </div>
       </div>
@@ -476,12 +482,16 @@ function ScannerTab() {
       {lastResult && (
         <div className="border border-success/30 bg-success/5 rounded-xl px-4 py-3 text-sm">
           <p className="font-medium text-foreground mb-1">
-            {lastResult.type === 'scan' ? 'Scan' : 'Import'} complete
+            {lastResult.type === 'scan' ? t`Scan complete` : t`Import complete`}
           </p>
           <p className="text-muted-foreground text-xs">
-            {lastResult.result.added} added · {lastResult.result.skipped} skipped
-            {lastResult.result.duplicates ? ` · ${lastResult.result.duplicates} duplicates` : ''}
-            {lastResult.result.errors ? ` · ${lastResult.result.errors} error(s)` : ''}
+            {(() => {
+              const r = lastResult.result
+              const added = r.added, skipped = r.skipped, dups = r.duplicates, errs = r.errors
+              return t`${added} added · ${skipped} skipped` +
+                (dups ? t` · ${dups} duplicates` : '') +
+                (errs ? t` · ${errs} error(s)` : '')
+            })()}
           </p>
         </div>
       )}
@@ -492,6 +502,7 @@ function ScannerTab() {
 // ── ServerTab ─────────────────────────────────────────────────────────────
 
 function ServerTab() {
+  const { t } = useLingui()
   const [stats, setStats] = useState<AdminStats | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -500,7 +511,7 @@ function ServerTab() {
   const [confirmClear, setConfirmClear] = useState(false)
 
   useEffect(() => {
-    api.get<AdminStats>('/admin/stats').then(setStats).catch(() => setError('Failed to load server stats')).finally(() => setLoading(false))
+    api.get<AdminStats>('/admin/stats').then(setStats).catch(() => setError(t`Failed to load server stats`)).finally(() => setLoading(false))
   }, [])
 
   async function handleClearCovers() {
@@ -512,7 +523,7 @@ function ServerTab() {
       setStats(prev => prev ? { ...prev, covers_count: 0, covers_size_mb: 0 } : prev)
       setConfirmClear(false)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to clear covers')
+      setError(e instanceof Error ? e.message : t`Failed to clear covers`)
     } finally { setClearing(false) }
   }
 
@@ -529,10 +540,10 @@ function ServerTab() {
       {/* Stats */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {[
-          { icon: BookOpen, label: 'Books', value: stats?.book_count ?? 0 },
-          { icon: Users, label: 'Users', value: stats?.user_count ?? 0 },
-          { icon: Database, label: 'Database', value: `${stats?.db_size_mb ?? 0} MB` },
-          { icon: HardDrive, label: 'Covers', value: `${stats?.covers_size_mb ?? 0} MB` },
+          { icon: BookOpen, label: t`Books`, value: stats?.book_count ?? 0 },
+          { icon: Users, label: t`Users`, value: stats?.user_count ?? 0 },
+          { icon: Database, label: t`Database`, value: `${stats?.db_size_mb ?? 0} MB` },
+          { icon: HardDrive, label: t`Covers`, value: `${stats?.covers_size_mb ?? 0} MB` },
         ].map(({ icon: Icon, label, value }) => (
           <div key={label} className="border border-border rounded-xl bg-card px-4 py-3">
             <div className="flex items-center gap-1.5 text-muted-foreground mb-1">
@@ -547,13 +558,13 @@ function ServerTab() {
       {/* Paths */}
       <div className="border border-border rounded-xl bg-card overflow-hidden">
         <div className="px-4 py-3 border-b border-border">
-          <h3 className="text-sm font-semibold">Directories</h3>
+          <h3 className="text-sm font-semibold"><Trans>Directories</Trans></h3>
         </div>
         <div className="divide-y divide-border">
           {[
-            { label: 'Library', path: stats?.library_dir },
-            { label: 'Data', path: stats?.data_dir },
-            { label: 'Incoming', path: stats?.incoming_dir },
+            { label: t`Library`, path: stats?.library_dir },
+            { label: t`Data`, path: stats?.data_dir },
+            { label: t`Incoming`, path: stats?.incoming_dir },
           ].map(({ label, path }) => (
             <div key={label} className="flex items-start gap-3 px-4 py-2.5">
               <Folder className="w-4 h-4 text-muted-foreground shrink-0 mt-0.5" />
@@ -569,18 +580,20 @@ function ServerTab() {
       {/* Danger zone */}
       <div className="border border-destructive/30 rounded-xl bg-card overflow-hidden">
         <div className="px-4 py-3 border-b border-destructive/20">
-          <h3 className="text-sm font-semibold text-destructive">Danger Zone</h3>
+          <h3 className="text-sm font-semibold text-destructive"><Trans>Danger Zone</Trans></h3>
         </div>
         <div className="px-4 py-3">
           <div className="flex items-start justify-between gap-4">
             <div>
-              <p className="text-sm font-medium">Clear cover cache</p>
+              <p className="text-sm font-medium"><Trans>Clear cover cache</Trans></p>
+              {(() => { const count = stats?.covers_count ?? 0; const mb = stats?.covers_size_mb ?? 0; return (
               <p className="text-xs text-muted-foreground mt-0.5">
-                Delete all {stats?.covers_count ?? 0} cached cover files ({stats?.covers_size_mb ?? 0} MB).
-                Covers will be re-extracted on next access.
+                <Trans>Delete all {count} cached cover files ({mb} MB).
+                Covers will be re-extracted on next access.</Trans>
               </p>
+              ) })()}
               {clearResult != null && (
-                <p className="text-xs text-success mt-1">{clearResult} covers deleted.</p>
+                <p className="text-xs text-success mt-1"><Trans>{clearResult} covers deleted.</Trans></p>
               )}
               {error && (
                 <p className="text-xs text-destructive mt-1">{error}</p>
@@ -591,7 +604,7 @@ function ServerTab() {
                 <button onClick={handleClearCovers} disabled={clearing}
                   className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md bg-destructive text-destructive-foreground hover:bg-destructive/90 transition-colors disabled:opacity-50">
                   {clearing ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Trash className="w-3.5 h-3.5" />}
-                  Confirm
+                  <Trans>Confirm</Trans>
                 </button>
                 <button onClick={() => setConfirmClear(false)}
                   className="p-1.5 rounded-md hover:bg-accent text-muted-foreground transition-colors">
@@ -601,7 +614,7 @@ function ServerTab() {
             ) : (
               <button onClick={() => setConfirmClear(true)}
                 className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border border-destructive/40 text-destructive hover:bg-destructive/10 transition-colors">
-                <Trash className="w-3.5 h-3.5" /> Clear
+                <Trash className="w-3.5 h-3.5" /> <Trans>Clear</Trans>
               </button>
             )}
           </div>
@@ -610,7 +623,8 @@ function ServerTab() {
 
       {stats && (
         <p className="text-xs text-muted-foreground text-center pt-1">
-          Tome v{stats.tome_version} · Python {stats.python_version}
+          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- version line */}
+          {`Tome v${stats.tome_version} · Python ${stats.python_version}`}
         </p>
       )}
     </div>
@@ -645,6 +659,7 @@ function defaultForm(): TypeFormState {
 }
 
 function TypesTab() {
+  const { t } = useLingui()
   const [types, setTypes] = useState<BookType[]>([])
   const [loading, setLoading] = useState(true)
   const [showAdd, setShowAdd] = useState(false)
@@ -679,7 +694,7 @@ function TypesTab() {
       setAddForm(defaultForm())
       setShowAdd(false)
     } catch (e) {
-      setAddError(e instanceof Error ? e.message : 'Failed')
+      setAddError(e instanceof Error ? e.message : t`Failed`)
     } finally {
       setAddSaving(false)
     }
@@ -701,7 +716,7 @@ function TypesTab() {
       load()
       setEditId(null)
     } catch (e) {
-      setEditError(e instanceof Error ? e.message : 'Failed')
+      setEditError(e instanceof Error ? e.message : t`Failed`)
     } finally {
       setEditSaving(false)
     }
@@ -715,7 +730,7 @@ function TypesTab() {
       load()
       setDeleteConfirmId(null)
     } catch (e) {
-      setDeleteError(e instanceof Error ? e.message : 'Failed')
+      setDeleteError(e instanceof Error ? e.message : t`Failed`)
     }
   }
 
@@ -723,32 +738,32 @@ function TypesTab() {
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold flex items-center gap-2">
-          <Tag className="w-4 h-4 text-muted-foreground" /> Book Types
+          <Tag className="w-4 h-4 text-muted-foreground" /> <Trans>Book Types</Trans>
         </h2>
         <button
           onClick={() => { setShowAdd(a => !a); setAddError(null) }}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-card hover:bg-muted transition-all"
         >
-          <Plus className="w-3.5 h-3.5" /> Add Type
+          <Plus className="w-3.5 h-3.5" /> <Trans>Add Type</Trans>
         </button>
       </div>
 
       {/* Add form */}
       {showAdd && (
         <div className="border border-border rounded-xl bg-card p-4 space-y-3">
-          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">New Type</h3>
+          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide"><Trans>New Type</Trans></h3>
           <div className="grid grid-cols-2 gap-3">
             <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Label</label>
+              <label className="text-xs text-muted-foreground mb-1 block"><Trans>Label</Trans></label>
               <input
                 value={addForm.label}
                 onChange={e => setAddForm(f => ({ ...f, label: e.target.value }))}
-                placeholder="e.g. Novel"
+                placeholder={t`e.g. Novel`}
                 className="tome-select w-full px-3 py-1.5 text-sm rounded-lg border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring"
               />
             </div>
             <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Color</label>
+              <label className="text-xs text-muted-foreground mb-1 block"><Trans>Color</Trans></label>
               <select
                 value={addForm.color}
                 onChange={e => setAddForm(f => ({ ...f, color: e.target.value as ColorOption }))}
@@ -758,11 +773,11 @@ function TypesTab() {
               </select>
             </div>
             <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Icon</label>
+              <label className="text-xs text-muted-foreground mb-1 block"><Trans>Icon</Trans></label>
               <IconPicker value={addForm.icon} onChange={v => setAddForm(f => ({ ...f, icon: v }))} />
             </div>
             <div>
-              <label className="text-xs text-muted-foreground mb-1 block">Sort Order</label>
+              <label className="text-xs text-muted-foreground mb-1 block"><Trans>Sort Order</Trans></label>
               <input
                 type="number"
                 value={addForm.sort_order}
@@ -773,14 +788,14 @@ function TypesTab() {
           </div>
           {addError && <p className="text-xs text-destructive">{addError}</p>}
           <div className="flex items-center gap-2 justify-end">
-            <button onClick={() => setShowAdd(false)} className="px-3 py-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">Cancel</button>
+            <button onClick={() => setShowAdd(false)} className="px-3 py-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"><Trans>Cancel</Trans></button>
             <button
               onClick={handleAdd}
               disabled={addSaving || !addForm.label.trim()}
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
             >
               {addSaving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
-              Save
+              <Trans>Save</Trans>
             </button>
           </div>
         </div>
@@ -790,7 +805,7 @@ function TypesTab() {
       {loading ? (
         <div className="flex justify-center py-8"><Loader2 className="w-5 h-5 animate-spin text-muted-foreground" /></div>
       ) : types.length === 0 ? (
-        <p className="text-sm text-muted-foreground text-center py-8">No book types yet.</p>
+        <p className="text-sm text-muted-foreground text-center py-8"><Trans>No book types yet.</Trans></p>
       ) : (
         <div className="border border-border rounded-xl bg-card overflow-hidden divide-y divide-border">
           {types.map(bt => (
@@ -799,7 +814,7 @@ function TypesTab() {
                 <div className="p-4 space-y-3">
                   <div className="grid grid-cols-2 gap-3">
                     <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Label</label>
+                      <label className="text-xs text-muted-foreground mb-1 block"><Trans>Label</Trans></label>
                       <input
                         value={editForm.label}
                         onChange={e => setEditForm(f => ({ ...f, label: e.target.value }))}
@@ -807,7 +822,7 @@ function TypesTab() {
                       />
                     </div>
                     <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Color</label>
+                      <label className="text-xs text-muted-foreground mb-1 block"><Trans>Color</Trans></label>
                       <select
                         value={editForm.color}
                         onChange={e => setEditForm(f => ({ ...f, color: e.target.value as ColorOption }))}
@@ -817,11 +832,11 @@ function TypesTab() {
                       </select>
                     </div>
                     <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Icon</label>
+                      <label className="text-xs text-muted-foreground mb-1 block"><Trans>Icon</Trans></label>
                       <IconPicker value={editForm.icon} onChange={v => setEditForm(f => ({ ...f, icon: v }))} />
                     </div>
                     <div>
-                      <label className="text-xs text-muted-foreground mb-1 block">Sort Order</label>
+                      <label className="text-xs text-muted-foreground mb-1 block"><Trans>Sort Order</Trans></label>
                       <input
                         type="number"
                         value={editForm.sort_order}
@@ -832,14 +847,14 @@ function TypesTab() {
                   </div>
                   {editError && <p className="text-xs text-destructive">{editError}</p>}
                   <div className="flex items-center gap-2 justify-end">
-                    <button onClick={() => setEditId(null)} className="px-3 py-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors">Cancel</button>
+                    <button onClick={() => setEditId(null)} className="px-3 py-1.5 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"><Trans>Cancel</Trans></button>
                     <button
                       onClick={handleEdit}
                       disabled={editSaving || !editForm.label.trim()}
                       className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
                     >
                       {editSaving ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Check className="w-3.5 h-3.5" />}
-                      Save
+                      <Trans>Save</Trans>
                     </button>
                   </div>
                 </div>
@@ -856,7 +871,7 @@ function TypesTab() {
                         onClick={() => handleDelete(bt.id)}
                         className="flex items-center gap-1 px-2 py-1 text-xs rounded-md bg-destructive text-destructive-foreground hover:opacity-90 transition-colors"
                       >
-                        <Trash2 className="w-3 h-3" /> Confirm
+                        <Trash2 className="w-3 h-3" /> <Trans>Confirm</Trans>
                       </button>
                       <button
                         onClick={() => { setDeleteConfirmId(null); setDeleteError(null) }}
@@ -870,14 +885,14 @@ function TypesTab() {
                       <button
                         onClick={() => startEdit(bt)}
                         className="p-1.5 rounded-md hover:bg-muted transition-colors text-muted-foreground hover:text-foreground"
-                        title="Edit"
+                        title={t`Edit`}
                       >
                         <Pencil className="w-3.5 h-3.5" />
                       </button>
                       <button
                         onClick={() => { setDeleteConfirmId(bt.id); setDeleteError(null) }}
                         className="p-1.5 rounded-md hover:bg-muted transition-colors text-muted-foreground hover:text-destructive"
-                        title="Delete"
+                        title={t`Delete`}
                       >
                         <Trash2 className="w-3.5 h-3.5" />
                       </button>
@@ -895,14 +910,15 @@ function TypesTab() {
 
 // ── AuditTab ──────────────────────────────────────────────────────────────
 
-const ACTION_CATEGORIES = [
-  { value: '', label: 'All actions' },
-  { value: 'auth', label: 'Auth' },
-  { value: 'books', label: 'Books' },
-  { value: 'users', label: 'Users' },
-  { value: 'libraries', label: 'Libraries' },
+const ACTION_CATEGORIES: { value: string; label: MessageDescriptor }[] = [
+  { value: '', label: msg`All actions` },
+  { value: 'auth', label: msg`Auth` },
+  { value: 'books', label: msg`Books` },
+  { value: 'users', label: msg`Users` },
+  { value: 'libraries', label: msg`Libraries` },
 ]
 
+/* eslint-disable lingui/no-unlocalized-strings -- Tailwind class map */
 const ACTION_COLORS: Record<string, string> = {
   'auth.login': 'bg-success/10 text-success border-success/20',
   'auth.login_failed': 'bg-destructive/10 text-destructive border-destructive/20',
@@ -921,6 +937,7 @@ const ACTION_COLORS: Record<string, string> = {
   'libraries.updated': 'bg-info/10 text-info border-info/20',
   'libraries.deleted': 'bg-destructive/10 text-destructive border-destructive/20',
 }
+/* eslint-enable lingui/no-unlocalized-strings */
 
 interface AuditEntry {
   id: number
@@ -936,6 +953,7 @@ interface AuditEntry {
 }
 
 function AuditTab() {
+  const { i18n } = useLingui()
   const [items, setItems] = useState<AuditEntry[]>([])
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
@@ -968,11 +986,11 @@ function AuditTab() {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold">Audit Log</h2>
+        <h2 className="text-sm font-semibold"><Trans>Audit Log</Trans></h2>
         <div className="flex items-center gap-2 flex-wrap">
           <select value={filterAction} onChange={e => { setFilterAction(e.target.value); setPage(1) }}
             className="tome-select text-xs border border-border rounded-lg px-2 py-1.5 bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-primary">
-            {ACTION_CATEGORIES.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
+            {ACTION_CATEGORIES.map(c => <option key={c.value} value={c.value}>{i18n._(c.label)}</option>)}
           </select>
           <input type="date" value={fromDate} onChange={e => { setFromDate(e.target.value); setPage(1) }}
             className="text-xs border border-border rounded-lg px-2 py-1.5 bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-primary" />
@@ -986,10 +1004,11 @@ function AuditTab() {
           <BookAnimation variant="refresh" className="block w-10 h-10 text-primary" />
         </div>
       ) : items.length === 0 ? (
-        <div className="text-center py-16 text-muted-foreground text-sm">No audit entries yet.</div>
+        <div className="text-center py-16 text-muted-foreground text-sm"><Trans>No audit entries yet.</Trans></div>
       ) : (
         <div className="flex flex-col gap-1">
           {items.map(entry => {
+            // eslint-disable-next-line lingui/no-unlocalized-strings -- Tailwind classes
             const colorClass = ACTION_COLORS[entry.action] ?? 'bg-muted text-muted-foreground border-border'
             const isExpanded = expandedId === entry.id
             const parsed = entry.details ? (() => { try { return JSON.parse(entry.details) } catch { return null } })() : null
@@ -1019,13 +1038,13 @@ function AuditTab() {
                 </button>
                 {isExpanded && (
                   <div className="px-4 pb-3 pt-0 border-t border-border bg-muted/30 text-xs text-muted-foreground flex flex-col gap-1.5">
-                    {entry.ip_address && <div><span className="font-medium text-foreground">IP:</span> {entry.ip_address}</div>}
+                    {entry.ip_address && <div><span className="font-medium text-foreground"><Trans>IP:</Trans></span> {entry.ip_address}</div>}
                     {entry.resource_type && entry.resource_id && (
-                      <div><span className="font-medium text-foreground">Resource:</span> {entry.resource_type} #{entry.resource_id}</div>
+                      <div><span className="font-medium text-foreground"><Trans>Resource:</Trans></span> {entry.resource_type} #{entry.resource_id}</div>
                     )}
                     {parsed && (
                       <div>
-                        <span className="font-medium text-foreground">Details:</span>
+                        <span className="font-medium text-foreground"><Trans>Details:</Trans></span>
                         <pre className="mt-1 p-2 rounded bg-background text-[10px] overflow-x-auto border border-border">
                           {JSON.stringify(parsed, null, 2)}
                         </pre>
@@ -1044,12 +1063,12 @@ function AuditTab() {
         <div className="flex items-center justify-center gap-2 pt-2">
           <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}
             className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-accent disabled:opacity-40 transition-colors">
-            Previous
+            <Trans>Previous</Trans>
           </button>
           <span className="text-xs text-muted-foreground">{page} / {totalPages}</span>
           <button onClick={() => setPage(p => Math.min(totalPages, p + 1))} disabled={page === totalPages}
             className="px-3 py-1.5 text-xs rounded-lg border border-border hover:bg-accent disabled:opacity-40 transition-colors">
-            Next
+            <Trans>Next</Trans>
           </button>
         </div>
       )}
@@ -1080,42 +1099,54 @@ function relativeTime(iso: string | null): string {
   if (!iso) return '—'
   const diff = Date.now() - new Date(iso).getTime()
   const mins = Math.floor(diff / 60_000)
-  if (mins < 1) return 'just now'
-  if (mins < 60) return `${mins}m ago`
+  if (mins < 1) return t`just now`
+  if (mins < 60) return t`${mins}m ago`
   const hrs = Math.floor(mins / 60)
-  if (hrs < 24) return `${hrs}h ago`
+  if (hrs < 24) return t`${hrs}h ago`
   const days = Math.floor(hrs / 24)
-  if (days < 30) return `${days}d ago`
+  if (days < 30) return t`${days}d ago`
   return new Date(iso).toLocaleDateString(undefined, { dateStyle: 'medium' })
 }
 
+const SYNC_STATUS_LABELS: Record<string, MessageDescriptor> = {
+  unread: msg`unread`, reading: msg`reading`, read: msg`read`,
+  shelved: msg`shelved`, want_to_read: msg`want to read`,
+}
+
 function StatusBadge({ status }: { status: SyncRecord['status'] }) {
+  const { i18n } = useLingui()
+  /* eslint-disable lingui/no-unlocalized-strings -- Tailwind classes */
   const cls =
     status === 'read'
       ? 'bg-success/10 text-success border-success/20'
       : status === 'reading'
         ? 'bg-info/10 text-info border-info/20'
         : 'bg-muted text-muted-foreground border-border'
+  /* eslint-enable lingui/no-unlocalized-strings */
   return (
     <span className={cn('text-[10px] font-medium px-1.5 py-0.5 rounded border whitespace-nowrap', cls)}>
-      {status}
+      {SYNC_STATUS_LABELS[status] ? i18n._(SYNC_STATUS_LABELS[status]) : status}
     </span>
   )
 }
 
 function SourceBadge({ source }: { source: SyncRecord['source'] }) {
+  const { t } = useLingui()
+  /* eslint-disable lingui/no-unlocalized-strings -- Tailwind classes */
   const cls =
     source === 'tomesync'
       ? 'bg-primary/10 text-primary border-primary/20'
       : 'bg-muted text-muted-foreground border-border'
+  /* eslint-enable lingui/no-unlocalized-strings */
   return (
     <span className={cn('text-[10px] font-medium px-1.5 py-0.5 rounded border whitespace-nowrap', cls)}>
-      {source === 'tomesync' ? 'TomeSync' : 'Web'}
+      {source === 'tomesync' ? 'TomeSync' : t`Web`}
     </span>
   )
 }
 
 function SyncStatusTab() {
+  const { t } = useLingui()
   const [records, setRecords] = useState<SyncRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -1126,7 +1157,7 @@ function SyncStatusTab() {
   useEffect(() => {
     api.get<SyncRecord[]>('/admin/sync-status')
       .then(setRecords)
-      .catch(() => setError('Failed to load sync status'))
+      .catch(() => setError(t`Failed to load sync status`))
       .finally(() => setLoading(false))
   }, [])
 
@@ -1209,16 +1240,16 @@ function SyncStatusTab() {
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold">Sync Status</h2>
+        <h2 className="text-sm font-semibold"><Trans>Sync Status</Trans></h2>
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
           <Activity className="w-3.5 h-3.5" />
-          <span>{records.length} record{records.length !== 1 ? 's' : ''}</span>
+          <span><Plural value={records.length} one="# record" other="# records" /></span>
         </div>
       </div>
 
       {sorted.length === 0 ? (
         <div className="text-center py-16 text-muted-foreground text-sm">
-          No reading activity yet. Records appear when users start reading books.
+          <Trans>No reading activity yet. Records appear when users start reading books.</Trans>
         </div>
       ) : (
         <div className="border border-border rounded-xl overflow-hidden">
@@ -1226,13 +1257,13 @@ function SyncStatusTab() {
             <table className="w-full text-xs">
               <thead className="border-b border-border bg-muted/40">
                 <tr>
-                  <ColHeader label="Book" col="book_title" />
-                  <ColHeader label="User" col="username" />
-                  <ColHeader label="Status" col="status" />
-                  <ColHeader label="Progress" col="progress_pct" />
-                  <ColHeader label="Last Synced" col="last_synced" />
-                  <ColHeader label="Device" col="device" />
-                  <ColHeader label="Source" col="source" />
+                  <ColHeader label={t`Book`} col="book_title" />
+                  <ColHeader label={t`User`} col="username" />
+                  <ColHeader label={t`Status`} col="status" />
+                  <ColHeader label={t`Progress`} col="progress_pct" />
+                  <ColHeader label={t`Last Synced`} col="last_synced" />
+                  <ColHeader label={t`Device`} col="device" />
+                  <ColHeader label={t`Source`} col="source" />
                   <th className="px-3 py-2.5 w-8" />
                 </tr>
               </thead>
@@ -1317,19 +1348,21 @@ interface DuplicatesResponse {
   groups: DuplicateGroup[]
 }
 
-const MATCH_REASON_LABEL: Record<DuplicateGroup['match_reason'], string> = {
-  content_hash: 'Exact Match',
-  isbn: 'Same ISBN',
-  same_series_volume: 'Same Series Volume',
-  similar_title: 'Similar Title',
+const MATCH_REASON_LABEL: Record<DuplicateGroup['match_reason'], MessageDescriptor> = {
+  content_hash: msg`Exact Match`,
+  isbn: msg`Same ISBN`,
+  same_series_volume: msg`Same Series Volume`,
+  similar_title: msg`Similar Title`,
 }
 
+/* eslint-disable lingui/no-unlocalized-strings -- Tailwind class map */
 const MATCH_REASON_STYLE: Record<DuplicateGroup['match_reason'], string> = {
   content_hash: 'bg-destructive/10 text-destructive border-destructive/20',
   isbn: 'bg-warning/10 text-warning border-warning/20',
   same_series_volume: 'bg-purple-500/10 text-purple-600 border-purple-500/20',
   similar_title: 'bg-info/10 text-info border-info/20',
 }
+/* eslint-enable lingui/no-unlocalized-strings */
 
 function formatBytes(bytes: number | null): string {
   if (bytes == null) return '—'
@@ -1341,6 +1374,7 @@ function formatBytes(bytes: number | null): string {
 type GroupDecision = 'merge' | 'delete' | 'dismiss'
 
 function DuplicatesTab() {
+  const { t, i18n } = useLingui()
   const [groups, setGroups] = useState<DuplicateGroup[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -1368,7 +1402,7 @@ function DuplicatesTab() {
         }
         setKeepIds(defaults)
       })
-      .catch(e => setError(e instanceof Error ? e.message : 'Failed to load duplicates'))
+      .catch(e => setError(e instanceof Error ? e.message : t`Failed to load duplicates`))
       .finally(() => setLoading(false))
   }
 
@@ -1413,14 +1447,14 @@ function DuplicatesTab() {
             { book_ids: removeIds },
           )
           if (res.errors.length) {
-            throw new Error(`${res.errors.length} book${res.errors.length !== 1 ? 's' : ''} could not be deleted`)
+            throw new Error(plural(res.errors.length, { one: '# book could not be deleted', other: '# books could not be deleted' }))
           }
         } else {
           await api.post('/admin/duplicates/dismiss', { book_ids: group.books.map(b => b.id) })
         }
         applied++
       } catch (e) {
-        failed.push({ label, error: e instanceof Error ? e.message : 'Failed' })
+        failed.push({ label, error: e instanceof Error ? e.message : t`Failed` })
       }
       setApplyProgress({ done: i + 1, total: decidedGroups.length })
     }
@@ -1451,14 +1485,14 @@ function DuplicatesTab() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Copy className="w-4 h-4 text-muted-foreground" />
-          <h2 className="text-sm font-semibold">Duplicate Detection</h2>
+          <h2 className="text-sm font-semibold"><Trans>Duplicate Detection</Trans></h2>
         </div>
         <button
           onClick={fetchGroups}
           className="flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-md border border-border hover:bg-accent transition-colors text-muted-foreground"
         >
           <RefreshCw className="w-3.5 h-3.5" />
-          Refresh
+          <Trans>Refresh</Trans>
         </button>
       </div>
 
@@ -1470,8 +1504,8 @@ function DuplicatesTab() {
             : 'border-success/20 bg-success/5',
         )}>
           <p className={cn('font-medium', applyResult.failed.length ? 'text-warning' : 'text-success')}>
-            Applied {applyResult.applied} group{applyResult.applied !== 1 ? 's' : ''}
-            {applyResult.failed.length > 0 && `, ${applyResult.failed.length} failed`}
+            <Plural value={applyResult.applied} one="Applied # group" other="Applied # groups" />
+            {applyResult.failed.length > 0 && (() => { const n = applyResult.failed.length; return t`, ${n} failed` })()}
           </p>
           {applyResult.failed.length > 0 && (
             <ul className="space-y-0.5 text-muted-foreground">
@@ -1483,12 +1517,13 @@ function DuplicatesTab() {
 
       {groups.length === 0 ? (
         <div className="text-center py-16 text-muted-foreground text-sm">
-          No duplicates found. Your library looks clean.
+          <Trans>No duplicates found. Your library looks clean.</Trans>
         </div>
       ) : (
         <div className="flex flex-col gap-4">
           <p className="text-xs text-muted-foreground">
-            {groups.length} duplicate group{groups.length !== 1 ? 's' : ''} found. Pick which book to keep and an action per group — Merge, Delete Others, or Dismiss — then apply everything at once.
+            {plural(groups.length, { one: '# duplicate group found.', other: '# duplicate groups found.' })}{' '}
+            <Trans>Pick which book to keep and an action per group — Merge, Delete Others, or Dismiss — then apply everything at once.</Trans>
           </p>
           {groups.map(group => {
             const decision = decisions[group.group_id]
@@ -1504,7 +1539,7 @@ function DuplicatesTab() {
                     'text-[10px] font-medium px-2 py-0.5 rounded border',
                     MATCH_REASON_STYLE[group.match_reason],
                   )}>
-                    {MATCH_REASON_LABEL[group.match_reason]}
+                    {i18n._(MATCH_REASON_LABEL[group.match_reason])}
                   </span>
                   <div className="flex items-center gap-2">
                     <button
@@ -1516,10 +1551,10 @@ function DuplicatesTab() {
                           ? 'bg-accent text-foreground border-primary/40'
                           : 'border-border hover:bg-accent text-muted-foreground',
                       )}
-                      title="Queue: not a duplicate — never show this group again"
+                      title={t`Queue: not a duplicate — never show this group again`}
                     >
                       <X className="w-3.5 h-3.5" />
-                      Dismiss
+                      <Trans>Dismiss</Trans>
                     </button>
                     <button
                       onClick={() => toggleDecision(group.group_id, 'merge')}
@@ -1530,10 +1565,10 @@ function DuplicatesTab() {
                           ? 'bg-primary text-primary-foreground border-primary'
                           : 'border-border hover:bg-accent text-muted-foreground',
                       )}
-                      title="Queue: fold the other copies into the kept book"
+                      title={t`Queue: fold the other copies into the kept book`}
                     >
                       <GitMerge className="w-3.5 h-3.5" />
-                      Merge
+                      <Trans>Merge</Trans>
                     </button>
                     <button
                       onClick={() => toggleDecision(group.group_id, 'delete')}
@@ -1547,7 +1582,7 @@ function DuplicatesTab() {
                       title="Queue: keep the selected book and delete the others — their files are removed from disk"
                     >
                       <Trash2 className="w-3.5 h-3.5" />
-                      {decision === 'delete' ? `Delete ${othersCount} other${othersCount !== 1 ? 's' : ''}` : 'Delete Others'}
+                      {decision === 'delete' ? plural(othersCount, { one: 'Delete # other', other: 'Delete # others' }) : t`Delete Others`}
                     </button>
                   </div>
                 </div>
@@ -1610,16 +1645,16 @@ function DuplicatesTab() {
                                     ? 'bg-muted text-muted-foreground border-border'
                                     : 'bg-destructive/10 text-destructive border-destructive/20',
                                 )}
-                                title={f.path_exists ? undefined : 'File is missing from disk'}
+                                title={f.path_exists ? undefined : t`File is missing from disk`}
                               >
                                 {f.format.toUpperCase()} {formatBytes(f.file_size)}
-                                {!f.path_exists && ' — MISSING'}
+                                {!f.path_exists && t` — MISSING`}
                               </span>
                             ))}
                           </div>
                         )}
                         {isKeep && (
-                          <span className="text-[10px] font-medium text-primary">Keep this one</span>
+                          <span className="text-[10px] font-medium text-primary"><Trans>Keep this one</Trans></span>
                         )}
                       </label>
                     )
@@ -1634,9 +1669,9 @@ function DuplicatesTab() {
               {/* bottom-16 below sm clears the fixed keyboard-shortcuts FAB */}
               <span className="text-xs text-muted-foreground min-w-0">
                 {[
-                  mergeCount > 0 ? `merge ${mergeCount} group${mergeCount !== 1 ? 's' : ''}` : null,
-                  deleteBookCount > 0 ? `delete ${deleteBookCount} book${deleteBookCount !== 1 ? 's' : ''} (removes files)` : null,
-                  dismissCount > 0 ? `dismiss ${dismissCount} group${dismissCount !== 1 ? 's' : ''}` : null,
+                  mergeCount > 0 ? plural(mergeCount, { one: 'merge # group', other: 'merge # groups' }) : null,
+                  deleteBookCount > 0 ? plural(deleteBookCount, { one: 'delete # book (removes files)', other: 'delete # books (removes files)' }) : null,
+                  dismissCount > 0 ? plural(dismissCount, { one: 'dismiss # group', other: 'dismiss # groups' }) : null,
                 ].filter(Boolean).join(' · ')}
               </span>
               <div className="flex items-center gap-2 shrink-0 ml-auto">
@@ -1645,7 +1680,7 @@ function DuplicatesTab() {
                     onClick={() => setConfirmApply(false)}
                     className="px-3 py-1.5 text-xs rounded-md border border-border hover:bg-accent transition-colors text-muted-foreground"
                   >
-                    Cancel
+                    <Trans>Cancel</Trans>
                   </button>
                 )}
                 <button
@@ -1653,7 +1688,7 @@ function DuplicatesTab() {
                   disabled={applying}
                   className="px-3 py-1.5 text-xs rounded-md border border-border hover:bg-accent transition-colors text-muted-foreground disabled:opacity-50"
                 >
-                  Clear
+                  <Trans>Clear</Trans>
                 </button>
                 <button
                   onClick={() => confirmApply ? applyAll() : setConfirmApply(true)}
@@ -1666,11 +1701,16 @@ function DuplicatesTab() {
                   )}
                 >
                   {applying && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-                  {applying
-                    ? `Applying ${applyProgress?.done ?? 0}/${applyProgress?.total ?? decidedGroups.length}…`
-                    : confirmApply
-                    ? `Confirm — apply ${decidedGroups.length} decision${decidedGroups.length !== 1 ? 's' : ''}`
-                    : `Apply All (${decidedGroups.length})`}
+                  {(() => {
+                    const done = applyProgress?.done ?? 0
+                    const total = applyProgress?.total ?? decidedGroups.length
+                    const n = decidedGroups.length
+                    return applying
+                      ? t`Applying ${done}/${total}…`
+                      : confirmApply
+                      ? plural(n, { one: 'Confirm — apply # decision', other: 'Confirm — apply # decisions' })
+                      : t`Apply All (${n})`
+                  })()}
                 </button>
               </div>
             </div>
@@ -1697,12 +1737,13 @@ interface BookSearchResult {
 function wishAgeLabel(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
   const days = Math.floor(diff / 86_400_000)
-  if (days === 0) return 'Today'
-  if (days === 1) return 'Yesterday'
-  if (days < 30) return `${days}d ago`
+  if (days === 0) return t`Today`
+  if (days === 1) return t`Yesterday`
+  if (days < 30) return t`${days}d ago`
   const months = Math.floor(days / 30)
-  if (months < 12) return `${months}mo ago`
-  return `${Math.floor(months / 12)}y ago`
+  if (months < 12) return t`${months}mo ago`
+  const years = Math.floor(months / 12)
+  return t`${years}y ago`
 }
 
 function FulfillPicker({
@@ -1714,6 +1755,7 @@ function FulfillPicker({
   onFulfill: (bookId: number | null) => Promise<void>
   onCancel: () => void
 }) {
+  const { t } = useLingui()
   const isWholeSeries = !!wish.series && wish.series_index == null
   const [suggestedBooks, setSuggestedBooks] = useState<BookSearchResult[]>([])
   const [searchQuery, setSearchQuery] = useState('')
@@ -1758,13 +1800,13 @@ function FulfillPicker({
   }
 
   async function handleSubmit() {
-    if (!selectedId) { setError('Select a book first.'); return }
+    if (!selectedId) { setError(t`Select a book first.`); return }
     setFulfilling(true)
     setError(null)
     try {
       await onFulfill(selectedId)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Fulfill failed')
+      setError(e instanceof Error ? e.message : t`Fulfill failed`)
       setFulfilling(false)
     }
   }
@@ -1775,7 +1817,7 @@ function FulfillPicker({
     try {
       await onFulfill(null)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to complete series')
+      setError(e instanceof Error ? e.message : t`Failed to complete series`)
       setFulfilling(false)
     }
   }
@@ -1789,22 +1831,22 @@ function FulfillPicker({
     return (
       <div className="border border-primary/20 bg-primary/5 rounded-xl p-4 space-y-3">
         <div className="flex items-center justify-between">
-          <p className="text-xs font-semibold text-foreground">Complete series: {wish.title}</p>
+          {(() => { const title = wish.title; return <p className="text-xs font-semibold text-foreground"><Trans>Complete series: {title}</Trans></p> })()}
           <button onClick={onCancel} className="p-1 rounded hover:bg-accent text-muted-foreground transition-colors">
             <X className="w-3.5 h-3.5" />
           </button>
         </div>
         <p className="text-xs text-muted-foreground leading-relaxed">
-          This is a whole-series wish — it stays open as volumes arrive.{' '}
+          <Trans>This is a whole-series wish — it stays open as volumes arrive.</Trans>{' '}
           {n > 0
-            ? `${n} matching volume${n > 1 ? 's' : ''} currently in the library.`
-            : 'No matching volumes in the library yet.'}{' '}
-          Mark it complete when you consider the series fully available; the requester will be notified.
+            ? plural(n, { one: '# matching volume currently in the library.', other: '# matching volumes currently in the library.' })
+            : t`No matching volumes in the library yet.`}{' '}
+          <Trans>Mark it complete when you consider the series fully available; the requester will be notified.</Trans>
         </p>
         {error && <p className="text-xs text-destructive">{error}</p>}
         <div className="flex items-center justify-end gap-2 pt-1">
           <button onClick={onCancel} className="px-2.5 py-1 text-xs rounded-md border border-border hover:bg-accent transition-colors text-muted-foreground">
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
           <button
             onClick={handleComplete}
@@ -1812,7 +1854,7 @@ function FulfillPicker({
             className="flex items-center gap-1 px-3 py-1 text-xs rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-50"
           >
             {fulfilling ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
-            Mark complete
+            <Trans>Mark complete</Trans>
           </button>
         </div>
       </div>
@@ -1822,7 +1864,7 @@ function FulfillPicker({
   return (
     <div className="border border-primary/20 bg-primary/5 rounded-xl p-4 space-y-3">
       <div className="flex items-center justify-between">
-        <p className="text-xs font-semibold text-foreground">Fulfill: {wish.title}</p>
+        {(() => { const title = wish.title; return <p className="text-xs font-semibold text-foreground"><Trans>Fulfill: {title}</Trans></p> })()}
         <button onClick={onCancel} className="p-1 rounded hover:bg-accent text-muted-foreground transition-colors">
           <X className="w-3.5 h-3.5" />
         </button>
@@ -1834,7 +1876,7 @@ function FulfillPicker({
         <input
           value={searchQuery}
           onChange={e => handleSearchChange(e.target.value)}
-          placeholder={suggestedBooks.length > 0 ? 'Search for a different book…' : 'Search for a book in the library…'}
+          placeholder={suggestedBooks.length > 0 ? t`Search for a different book…` : t`Search for a book in the library…`}
           className="w-full h-8 pl-7 pr-3 text-xs rounded-lg border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {searching && <Loader2 className="absolute right-2.5 top-1/2 -translate-y-1/2 w-3 h-3 text-muted-foreground animate-spin" />}
@@ -1842,7 +1884,7 @@ function FulfillPicker({
 
       {/* Suggested / search results */}
       {!searchQuery && suggestedBooks.length > 0 && (
-        <p className="text-[10px] text-muted-foreground">Suggested match{suggestedBooks.length > 1 ? 'es' : ''}:</p>
+        <p className="text-[10px] text-muted-foreground"><Plural value={suggestedBooks.length} one="Suggested match:" other="Suggested matches:" /></p>
       )}
       {displayBooks.length > 0 && (
         <div className="space-y-1.5 max-h-48 overflow-y-auto">
@@ -1874,17 +1916,17 @@ function FulfillPicker({
       )}
 
       {!searchQuery && suggestedBooks.length === 0 && !searching && (
-        <p className="text-xs text-muted-foreground">No suggested match yet — search for the book to link, or upload it first.</p>
+        <p className="text-xs text-muted-foreground"><Trans>No suggested match yet — search for the book to link, or upload it first.</Trans></p>
       )}
       {searchQuery && !searching && searchResults.length === 0 && (
-        <p className="text-xs text-muted-foreground">No books found. Upload the book first, then fulfill.</p>
+        <p className="text-xs text-muted-foreground"><Trans>No books found. Upload the book first, then fulfill.</Trans></p>
       )}
 
       {error && <p className="text-xs text-destructive">{error}</p>}
 
       <div className="flex items-center justify-end gap-2 pt-1">
         <button onClick={onCancel} className="px-2.5 py-1 text-xs rounded-md border border-border hover:bg-accent transition-colors text-muted-foreground">
-          Cancel
+          <Trans>Cancel</Trans>
         </button>
         <button
           onClick={handleSubmit}
@@ -1892,7 +1934,7 @@ function FulfillPicker({
           className="flex items-center gap-1 px-3 py-1 text-xs rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-50"
         >
           {fulfilling && <Loader2 className="w-3 h-3 animate-spin" />}
-          Fulfill
+          <Trans>Fulfill</Trans>
         </button>
       </div>
     </div>
@@ -1900,6 +1942,7 @@ function FulfillPicker({
 }
 
 function WishlistTab() {
+  const { t } = useLingui()
   const [statusFilter, setStatusFilter] = useState<WishStatus>('open')
   const [wishes, setWishes] = useState<WishAdminOut[]>([])
   const [loading, setLoading] = useState(true)
@@ -1914,7 +1957,7 @@ function WishlistTab() {
     setError(null)
     adminListWishes({ status: statusFilter })
       .then(setWishes)
-      .catch(e => setError(e instanceof Error ? e.message : 'Failed to load wishlist'))
+      .catch(e => setError(e instanceof Error ? e.message : t`Failed to load wishlist`))
       .finally(() => setLoading(false))
   }
 
@@ -1926,7 +1969,7 @@ function WishlistTab() {
       setFulfillingId(null)
       load()
     } catch (e) {
-      setActionError(prev => ({ ...prev, [wishId]: e instanceof Error ? e.message : 'Fulfill failed' }))
+      setActionError(prev => ({ ...prev, [wishId]: e instanceof Error ? e.message : t`Fulfill failed` }))
       throw e
     }
   }
@@ -1939,16 +1982,16 @@ function WishlistTab() {
       setDismissConfirmId(null)
       load()
     } catch (e) {
-      setActionError(prev => ({ ...prev, [wishId]: e instanceof Error ? e.message : 'Dismiss failed' }))
+      setActionError(prev => ({ ...prev, [wishId]: e instanceof Error ? e.message : t`Dismiss failed` }))
     } finally {
       setDismissing(null)
     }
   }
 
   const STATUS_TABS: { id: WishStatus; label: string }[] = [
-    { id: 'open', label: 'Open' },
-    { id: 'fulfilled', label: 'Fulfilled' },
-    { id: 'dismissed', label: 'Dismissed' },
+    { id: 'open', label: t`Open` },
+    { id: 'fulfilled', label: t`Fulfilled` },
+    { id: 'dismissed', label: t`Dismissed` },
   ]
 
   return (
@@ -1956,14 +1999,14 @@ function WishlistTab() {
       <div className="flex items-center justify-between flex-wrap gap-2">
         <div className="flex items-center gap-2">
           <Sparkles className="w-4 h-4 text-muted-foreground" />
-          <h2 className="text-sm font-semibold">Wishlist</h2>
+          <h2 className="text-sm font-semibold"><Trans>Wishlist</Trans></h2>
           <a
             href={docsLink(DOCS.wishlist)}
             target="_blank"
             rel="noopener noreferrer"
             className="shrink-0 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
           >
-            Learn more <ExternalLink className="w-3 h-3" />
+            <Trans>Learn more</Trans> <ExternalLink className="w-3 h-3" />
           </a>
         </div>
         <div className="flex items-center gap-1">
@@ -1999,7 +2042,9 @@ function WishlistTab() {
         </div>
       ) : wishes.length === 0 ? (
         <div className="text-center py-16 text-muted-foreground text-sm">
-          No {statusFilter} wishes.
+          {statusFilter === 'open' ? <Trans>No open wishes.</Trans>
+            : statusFilter === 'fulfilled' ? <Trans>No fulfilled wishes.</Trans>
+            : <Trans>No dismissed wishes.</Trans>}
         </div>
       ) : (
         <div className="flex flex-col gap-2">
@@ -2034,7 +2079,7 @@ function WishlistTab() {
                       {wish.series && wish.series_index == null && (
                         <span className="mt-0.5 self-start inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-muted border border-border text-muted-foreground font-medium">
                           <Layers className="w-2.5 h-2.5" />
-                          Whole series
+                          <Trans>Whole series</Trans>
                         </span>
                       )}
                       {wish.note && (
@@ -2058,7 +2103,7 @@ function WishlistTab() {
                                 className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-destructive text-destructive-foreground hover:opacity-90 transition-colors disabled:opacity-50"
                               >
                                 {dismissing === wish.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Check className="w-3 h-3" />}
-                                Confirm
+                                <Trans>Confirm</Trans>
                               </button>
                               <button
                                 onClick={() => setDismissConfirmId(null)}
@@ -2071,10 +2116,10 @@ function WishlistTab() {
                             <button
                               onClick={() => { setDismissConfirmId(wish.id); setFulfillingId(null) }}
                               className="flex items-center gap-1 px-2 py-1.5 text-xs rounded-md border border-border hover:bg-accent transition-colors text-muted-foreground"
-                              title="Dismiss wish"
+                              title={t`Dismiss wish`}
                             >
                               <X className="w-3 h-3" />
-                              Dismiss
+                              <Trans>Dismiss</Trans>
                             </button>
                           )}
                           <button
@@ -2086,7 +2131,7 @@ function WishlistTab() {
                             className="flex items-center gap-1 px-2 py-1.5 text-xs rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-all"
                           >
                             <Check className="w-3 h-3" />
-                            {wish.series && wish.series_index == null ? 'Complete' : 'Fulfill'}
+                            {wish.series && wish.series_index == null ? t`Complete` : t`Fulfill`}
                           </button>
                         </>
                       )}
@@ -2095,7 +2140,7 @@ function WishlistTab() {
                           to={`/books/${wish.fulfilled_book_id}`}
                           className="text-xs text-primary hover:underline"
                         >
-                          View book
+                          <Trans>View book</Trans>
                         </Link>
                       )}
                     </div>
@@ -2109,7 +2154,7 @@ function WishlistTab() {
                   {wish.suggested_book_ids && wish.suggested_book_ids.length > 0 && wish.status === 'open' && fulfillingId !== wish.id && !(wish.series && wish.series_index == null) && (
                     <div className="mt-1.5 flex items-center gap-1.5">
                       <span className="text-[10px] px-1.5 py-0.5 rounded bg-warning/10 text-warning border border-warning/20 font-medium">
-                        {wish.suggested_book_ids.length} suggested match{wish.suggested_book_ids.length > 1 ? 'es' : ''}
+                        <Plural value={wish.suggested_book_ids.length} one="# suggested match" other="# suggested matches" />
                       </span>
                     </div>
                   )}
@@ -2143,6 +2188,7 @@ function WishlistTab() {
 type Tab = 'users' | 'scanner' | 'server' | 'types' | 'audit' | 'metadata' | 'library' | 'wordcount' | 'sync' | 'duplicates' | 'covers' | 'email' | 'wishlist'
 
 export function AdminPage() {
+  const { t } = useLingui()
   const { user } = useAuth()
   const [tab, setTab] = useState<Tab>('users')
   // Keep the active tab visible in the scrollable bar (no-op when it all fits)
@@ -2154,26 +2200,26 @@ export function AdminPage() {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen gap-3">
         <Shield className="w-10 h-10 text-muted-foreground" />
-        <p className="text-sm text-muted-foreground">Admin access required.</p>
-        <Link to="/" className="text-sm text-primary hover:underline">Go back</Link>
+        <p className="text-sm text-muted-foreground"><Trans>Admin access required.</Trans></p>
+        <Link to="/" className="text-sm text-primary hover:underline"><Trans>Go back</Trans></Link>
       </div>
     )
   }
 
   const tabs: { id: Tab; label: string }[] = [
-    { id: 'users', label: 'Users' },
-    { id: 'scanner', label: 'Scanner' },
-    { id: 'server', label: 'Server' },
-    { id: 'types', label: 'Types' },
-    { id: 'audit', label: 'Audit Log' },
-    { id: 'metadata', label: 'Metadata' },
-    { id: 'library', label: 'Library' },
-    { id: 'wordcount', label: 'Word Counts' },
-    { id: 'sync', label: 'Sync Status' },
-    { id: 'duplicates', label: 'Duplicates' },
-    { id: 'covers', label: 'Covers' },
-    { id: 'email', label: 'Email' },
-    { id: 'wishlist', label: 'Wishlist' },
+    { id: 'users', label: t`Users` },
+    { id: 'scanner', label: t`Scanner` },
+    { id: 'server', label: t`Server` },
+    { id: 'types', label: t`Types` },
+    { id: 'audit', label: t`Audit Log` },
+    { id: 'metadata', label: t`Metadata` },
+    { id: 'library', label: t`Library` },
+    { id: 'wordcount', label: t`Word Counts` },
+    { id: 'sync', label: t`Sync Status` },
+    { id: 'duplicates', label: t`Duplicates` },
+    { id: 'covers', label: t`Covers` },
+    { id: 'email', label: t`Email` },
+    { id: 'wishlist', label: t`Wishlist` },
   ]
 
   return (
@@ -2186,7 +2232,7 @@ export function AdminPage() {
             </Link>
             <div className="flex items-center gap-2">
               <Shield className="w-4 h-4 text-muted-foreground" />
-              <span className="text-sm font-semibold">Admin</span>
+              <span className="text-sm font-semibold"><Trans>Admin</Trans></span>
             </div>
           </div>
         </div>
@@ -2258,6 +2304,7 @@ interface SendHistoryEntry {
 }
 
 function EmailTab() {
+  const { t, i18n } = useLingui()
   const [smtpStatus, setSmtpStatus] = useState<SmtpStatusDetail | null>(null)
   const [allDevices, setAllDevices] = useState<AdminDevice[]>([])
   const [history, setHistory] = useState<SendHistoryEntry[]>([])
@@ -2288,7 +2335,7 @@ function EmailTab() {
       await api.post('/admin/smtp-test', { email: testEmail.trim() })
       setTestResult({ ok: true })
     } catch (err) {
-      setTestResult({ ok: false, error: err instanceof Error ? err.message : 'Send failed' })
+      setTestResult({ ok: false, error: err instanceof Error ? err.message : t`Send failed` })
     } finally {
       setTestSending(false)
     }
@@ -2309,10 +2356,10 @@ function EmailTab() {
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2">
             <Mail className="w-4 h-4 text-muted-foreground" />
-            <h3 className="text-sm font-semibold text-foreground">SMTP Status</h3>
+            <h3 className="text-sm font-semibold text-foreground"><Trans>SMTP Status</Trans></h3>
           </div>
           <a href={docsLink(DOCS.sendToDevice)} target="_blank" rel="noopener noreferrer" className="shrink-0 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors">
-            Learn more <ExternalLink className="w-3 h-3" />
+            <Trans>Learn more</Trans> <ExternalLink className="w-3 h-3" />
           </a>
         </div>
 
@@ -2320,27 +2367,27 @@ function EmailTab() {
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <div className="w-2 h-2 rounded-full bg-success" />
-              <span className="text-xs font-medium text-success">Configured</span>
+              <span className="text-xs font-medium text-success"><Trans>Configured</Trans></span>
             </div>
             <div className="rounded-lg bg-muted/60 border border-border text-xs divide-y divide-border/50">
               <div className="flex items-center gap-3 px-3 py-2">
-                <span className="text-muted-foreground w-20 shrink-0">Host</span>
+                <span className="text-muted-foreground w-20 shrink-0"><Trans>Host</Trans></span>
                 <span className="font-mono text-foreground">{smtpStatus.host}</span>
               </div>
               <div className="flex items-center gap-3 px-3 py-2">
-                <span className="text-muted-foreground w-20 shrink-0">Port</span>
+                <span className="text-muted-foreground w-20 shrink-0"><Trans>Port</Trans></span>
                 <span className="font-mono text-foreground">{smtpStatus.port}</span>
               </div>
               <div className="flex items-center gap-3 px-3 py-2">
-                <span className="text-muted-foreground w-20 shrink-0">From</span>
-                <span className="font-mono text-foreground">{smtpStatus.from_address || '(not set)'}</span>
+                <span className="text-muted-foreground w-20 shrink-0"><Trans>From</Trans></span>
+                <span className="font-mono text-foreground">{smtpStatus.from_address || t`(not set)`}</span>
               </div>
             </div>
 
             {/* Test email */}
             <form onSubmit={handleTestEmail} className="flex items-end gap-2">
               <div className="flex-1">
-                <label className="block text-xs font-medium text-muted-foreground mb-1">Send test email</label>
+                <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Send test email</Trans></label>
                 <input
                   type="email"
                   value={testEmail}
@@ -2355,20 +2402,20 @@ function EmailTab() {
                 className="flex items-center gap-1.5 h-9 px-3 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40 shrink-0"
               >
                 {testSending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
-                {testSending ? 'Sending...' : 'Test'}
+                {testSending ? t`Sending...` : t`Test`}
               </button>
             </form>
-            {testResult?.ok && <p className="text-xs text-success">Test email sent successfully.</p>}
+            {testResult?.ok && <p className="text-xs text-success"><Trans>Test email sent successfully.</Trans></p>}
             {testResult && !testResult.ok && <p className="text-xs text-destructive">{testResult.error}</p>}
           </div>
         ) : (
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               <div className="w-2 h-2 rounded-full bg-warning" />
-              <span className="text-xs font-medium text-warning dark:text-warning">Not configured</span>
+              <span className="text-xs font-medium text-warning dark:text-warning"><Trans>Not configured</Trans></span>
             </div>
             <p className="text-xs text-muted-foreground">
-              Set the following environment variables to enable Send to Device:
+              <Trans>Set the following environment variables to enable Send to Device:</Trans>
             </p>
             <code className="block text-xs font-mono bg-muted rounded-lg px-3 py-2 text-muted-foreground whitespace-pre-wrap">TOME_SMTP_HOST{'\n'}TOME_SMTP_USER{'\n'}TOME_SMTP_PASSWORD</code>
           </div>
@@ -2379,29 +2426,29 @@ function EmailTab() {
       <div className="rounded-xl border border-border bg-card p-5 space-y-4">
         <div className="flex items-center gap-2">
           <Send className="w-4 h-4 text-muted-foreground" />
-          <h3 className="text-sm font-semibold text-foreground">All Devices</h3>
+          <h3 className="text-sm font-semibold text-foreground"><Trans>All Devices</Trans></h3>
           <span className="text-xs text-muted-foreground">({allDevices.length})</span>
         </div>
 
         {allDevices.length > 0 ? (
           <div className="rounded-lg border border-border overflow-hidden text-xs divide-y divide-border">
             <div className="hidden sm:grid grid-cols-[8rem_1fr_1fr_7rem] px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground bg-muted/40">
-              <span>User</span>
-              <span>Device</span>
-              <span>Email</span>
-              <span>Added</span>
+              <span><Trans>User</Trans></span>
+              <span><Trans>Device</Trans></span>
+              <span><Trans>Email</Trans></span>
+              <span><Trans>Added</Trans></span>
             </div>
             {allDevices.map(d => (
               <div key={d.id} className="flex sm:grid sm:grid-cols-[8rem_1fr_1fr_7rem] items-center gap-2 sm:gap-0 px-3 py-2.5 hover:bg-muted/30 transition-colors">
                 <span className="text-foreground font-medium truncate">{d.username}</span>
                 <span className="text-foreground truncate">{d.device_name}</span>
                 <span className="text-muted-foreground font-mono truncate">{d.device_email}</span>
-                <span className="text-muted-foreground hidden sm:block">{new Date(d.created_at).toLocaleDateString()}</span>
+                <span className="text-muted-foreground hidden sm:block">{new Date(d.created_at).toLocaleDateString(i18n.locale)}</span>
               </div>
             ))}
           </div>
         ) : (
-          <p className="text-xs text-muted-foreground">No users have added devices yet.</p>
+          <p className="text-xs text-muted-foreground"><Trans>No users have added devices yet.</Trans></p>
         )}
       </div>
 
@@ -2409,23 +2456,23 @@ function EmailTab() {
       <div className="rounded-xl border border-border bg-card p-5 space-y-4">
         <div className="flex items-center gap-2">
           <Activity className="w-4 h-4 text-muted-foreground" />
-          <h3 className="text-sm font-semibold text-foreground">Send History</h3>
-          <span className="text-xs text-muted-foreground">(last 100)</span>
+          <h3 className="text-sm font-semibold text-foreground"><Trans>Send History</Trans></h3>
+          <span className="text-xs text-muted-foreground"><Trans>(last 100)</Trans></span>
         </div>
 
         {history.length > 0 ? (
           <div className="rounded-lg border border-border overflow-hidden text-xs divide-y divide-border">
             <div className="hidden sm:grid grid-cols-[10rem_6rem_1fr_1fr_5rem] px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground bg-muted/40">
-              <span>Time</span>
-              <span>User</span>
-              <span>Book</span>
-              <span>Device</span>
-              <span>Status</span>
+              <span><Trans>Time</Trans></span>
+              <span><Trans>User</Trans></span>
+              <span><Trans>Book</Trans></span>
+              <span><Trans>Device</Trans></span>
+              <span><Trans>Status</Trans></span>
             </div>
             {history.map(h => (
               <div key={h.id} className="flex sm:grid sm:grid-cols-[10rem_6rem_1fr_1fr_5rem] items-center gap-2 sm:gap-0 px-3 py-2 hover:bg-muted/30 transition-colors">
                 <span className="text-muted-foreground shrink-0">
-                  {new Date(h.created_at).toLocaleString(undefined, {
+                  {new Date(h.created_at).toLocaleString(i18n.locale, {
                     month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
                   })}
                 </span>
@@ -2436,13 +2483,13 @@ function EmailTab() {
                   'text-xs font-medium',
                   h.status === 'ok' ? 'text-success' : 'text-destructive'
                 )}>
-                  {h.status === 'ok' ? 'Sent' : 'Failed'}
+                  {h.status === 'ok' ? t`Sent` : t`Failed`}
                 </span>
               </div>
             ))}
           </div>
         ) : (
-          <p className="text-xs text-muted-foreground">No books have been sent yet.</p>
+          <p className="text-xs text-muted-foreground"><Trans>No books have been sent yet.</Trans></p>
         )}
       </div>
     </div>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -1303,7 +1303,7 @@ function SyncStatusTab() {
                         onClick={() => handleDelete(r)}
                         disabled={isDeleting}
                         className="p-1 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40"
-                        title="Delete sync record"
+                        title={t`Delete sync record`}
                       >
                         {isDeleting
                           ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -1579,7 +1579,7 @@ function DuplicatesTab() {
                           ? 'bg-destructive text-destructive-foreground border-destructive'
                           : 'border-border hover:bg-accent text-muted-foreground',
                       )}
-                      title="Queue: keep the selected book and delete the others — their files are removed from disk"
+                      title={t`Queue: keep the selected book and delete the others — their files are removed from disk`}
                     >
                       <Trash2 className="w-3.5 h-3.5" />
                       {decision === 'delete' ? plural(othersCount, { one: 'Delete # other', other: 'Delete # others' }) : t`Delete Others`}
@@ -2024,7 +2024,7 @@ function WishlistTab() {
               {t.label}
             </button>
           ))}
-          <button onClick={load} className="ml-1 p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground" title="Refresh">
+          <button onClick={load} className="ml-1 p-1.5 rounded-md hover:bg-accent transition-colors text-muted-foreground" title={t`Refresh`}>
             <RefreshCw className="w-3.5 h-3.5" />
           </button>
         </div>

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -2402,7 +2402,7 @@ function EmailTab() {
                 className="flex items-center gap-1.5 h-9 px-3 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40 shrink-0"
               >
                 {testSending ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
-                {testSending ? t`Sending...` : t`Test`}
+                {testSending ? t`Sending…` : t`Test`}
               </button>
             </form>
             {testResult?.ok && <p className="text-xs text-success"><Trans>Test email sent successfully.</Trans></p>}

--- a/frontend/src/pages/BinderyPage.tsx
+++ b/frontend/src/pages/BinderyPage.tsx
@@ -1779,14 +1779,14 @@ export function BinderyPage() {
                           <button
                             onClick={e => { e.stopPropagation(); acceptUnreviewed(book.id) }}
                             className="p-1.5 rounded-md text-primary hover:bg-primary/10 transition-colors"
-                            title="Accept"
+                            title={t`Accept`}
                           >
                             <Check className="h-3.5 w-3.5" />
                           </button>
                           <button
                             onClick={e => { e.stopPropagation(); setConfirmRejectUnreviewed(book.id) }}
                             className="p-1.5 rounded-md text-destructive hover:bg-destructive/10 transition-colors"
-                            title="Reject"
+                            title={t`Reject`}
                           >
                             <Trash2 className="h-3.5 w-3.5" />
                           </button>

--- a/frontend/src/pages/BinderyPage.tsx
+++ b/frontend/src/pages/BinderyPage.tsx
@@ -10,6 +10,9 @@ import { DOCS, docsLink } from '@/lib/docs'
 import { api } from '@/lib/api'
 import { useBookTypes } from '@/lib/bookTypes'
 import { useToast } from '@/contexts/ToastContext'
+import { Trans, useLingui, Plural } from '@lingui/react/macro'
+import { plural, msg } from '@lingui/core/macro'
+import type { MessageDescriptor } from '@lingui/core'
 import type { MetadataCandidate, BookType } from '@/lib/books'
 import { formatBytes } from '@/lib/books'
 import { cn } from '@/lib/utils'
@@ -156,6 +159,7 @@ function formToAcceptFile(path: string, form: ItemForm): BinderyAcceptFile {
 
 function FormatBadge({ format }: { format: string }) {
   const f = format.toLowerCase()
+  /* eslint-disable lingui/no-unlocalized-strings -- Tailwind class map */
   const colorMap: Record<string, string> = {
     epub: 'bg-blue-500/10 text-blue-600 dark:text-blue-400 border-blue-500/20',
     pdf: 'bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20',
@@ -164,6 +168,7 @@ function FormatBadge({ format }: { format: string }) {
     mobi: 'bg-green-500/10 text-green-600 dark:text-green-400 border-green-500/20',
   }
   const cls = colorMap[f] ?? 'bg-muted text-muted-foreground border-border'
+  /* eslint-enable lingui/no-unlocalized-strings */
   return (
     <span className={cn('text-[10px] font-medium px-1.5 py-0.5 rounded border uppercase tracking-wide', cls)}>
       {format}
@@ -171,7 +176,10 @@ function FormatBadge({ format }: { format: string }) {
   )
 }
 
+const CONTENT_TYPE_LABELS: Record<string, MessageDescriptor> = { volume: msg`volume`, chapter: msg`chapter` }
+
 function ContentTypeBadge({ type }: { type: string }) {
+  const { i18n } = useLingui()
   const isChapter = type === 'chapter'
   return (
     <span className={cn(
@@ -180,16 +188,18 @@ function ContentTypeBadge({ type }: { type: string }) {
         ? 'bg-warning/10 text-warning border-warning/20'
         : 'bg-sky-500/10 text-sky-600 dark:text-sky-400 border-sky-500/20'
     )}>
-      {type}
+      {CONTENT_TYPE_LABELS[type] ? i18n._(CONTENT_TYPE_LABELS[type]) : type}
     </span>
   )
 }
 
 function SourceBadge({ source }: { source: string }) {
+  /* eslint-disable lingui/no-unlocalized-strings -- provider names */
   const label =
     source === 'hardcover' ? 'Hardcover'
     : source === 'google_books' ? 'Google'
     : 'OpenLib'
+  /* eslint-enable lingui/no-unlocalized-strings */
   return (
     <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded border border-border text-muted-foreground bg-muted">
       {label}
@@ -214,13 +224,15 @@ interface LibraryOption {
   can_edit: boolean
 }
 
-function LibrariesSelect({ value, onChange, libraries, className, placeholder = 'No libraries' }: {
+function LibrariesSelect({ value, onChange, libraries, className, placeholder }: {
   value: number[]
   onChange: (ids: number[]) => void
   libraries: LibraryOption[]
   className?: string
   placeholder?: string
 }) {
+  const { t } = useLingui()
+  const resolvedPlaceholder = placeholder ?? t`No libraries`
   const [open, setOpen] = useState(false)
   const ref = useRef<HTMLDivElement>(null)
   useEffect(() => {
@@ -252,7 +264,7 @@ function LibrariesSelect({ value, onChange, libraries, className, placeholder = 
         <span className="flex-1 truncate">
           {value.length > 0
             ? editable.filter(l => value.includes(l.id)).map(l => l.name).join(', ')
-            : placeholder}
+            : resolvedPlaceholder}
         </span>
         <ChevronDown className="w-3.5 h-3.5 shrink-0 opacity-60" />
       </button>
@@ -344,108 +356,109 @@ interface MetadataFormProps {
 }
 
 function MetadataForm({ form, onChange, bookTypes, libraries }: MetadataFormProps) {
+  const { t } = useLingui()
   return (
     <div className="space-y-3">
       <div className="grid grid-cols-1 gap-3">
         <div>
-          <label className={LABEL_CLS}>Title *</label>
+          <label className={LABEL_CLS}><Trans>Title *</Trans></label>
           <input
             className={INPUT_CLS}
             value={form.title}
             onChange={e => onChange('title', e.target.value)}
-            placeholder="Book title"
+            placeholder={t`Book title`}
           />
         </div>
         <div>
-          <label className={LABEL_CLS}>Author</label>
+          <label className={LABEL_CLS}><Trans>Author</Trans></label>
           <input
             className={INPUT_CLS}
             value={form.author}
             onChange={e => onChange('author', e.target.value)}
-            placeholder="Author name"
+            placeholder={t`Author name`}
           />
         </div>
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className={LABEL_CLS}>Series</label>
+          <label className={LABEL_CLS}><Trans>Series</Trans></label>
           <input
             className={INPUT_CLS}
             value={form.series}
             onChange={e => onChange('series', e.target.value)}
-            placeholder="Series name"
+            placeholder={t`Series name`}
           />
         </div>
         <div>
-          <label className={LABEL_CLS}>Series #</label>
+          <label className={LABEL_CLS}><Trans>Series #</Trans></label>
           <input
             className={INPUT_CLS}
             type="number"
             step="0.1"
             value={form.series_index}
             onChange={e => onChange('series_index', e.target.value)}
-            placeholder="e.g. 1"
+            placeholder={t`e.g. 1`}
           />
         </div>
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className={LABEL_CLS}>Content Type</label>
+          <label className={LABEL_CLS}><Trans>Content Type</Trans></label>
           <SelectMenu
             value={form.content_type}
             onChange={v => onChange('content_type', v)}
-            options={[{ value: 'volume', label: 'Volume' }, { value: 'chapter', label: 'Chapter' }]}
+            options={[{ value: 'volume', label: t`Volume` }, { value: 'chapter', label: t`Chapter` }]}
           />
         </div>
         <div>
-          <label className={LABEL_CLS}>Book Type</label>
+          <label className={LABEL_CLS}><Trans>Book Type</Trans></label>
           <SelectMenu
             value={form.book_type_id}
             onChange={v => onChange('book_type_id', v)}
-            options={[{ value: '', label: 'No type' },
+            options={[{ value: '', label: t`No type` },
                       ...bookTypes.map(bt => ({ value: String(bt.id), label: bt.label }))]}
           />
         </div>
       </div>
       <div>
-        <label className={LABEL_CLS}>Libraries</label>
+        <label className={LABEL_CLS}><Trans>Libraries</Trans></label>
         <LibrariesSelect
           value={form.library_ids}
           onChange={ids => onChange('library_ids', ids)}
           libraries={libraries}
         />
         <p className="mt-1 text-[11px] text-muted-foreground">
-          The book type's own library is always added automatically.
+          <Trans>The book type's own library is always added automatically.</Trans>
         </p>
       </div>
       <div>
-        <label className={LABEL_CLS}>Description</label>
+        <label className={LABEL_CLS}><Trans>Description</Trans></label>
         <textarea
           className={TEXTAREA_CLS}
           rows={3}
           value={form.description}
           onChange={e => onChange('description', e.target.value)}
-          placeholder="Synopsis or description"
+          placeholder={t`Synopsis or description`}
         />
       </div>
       <div className="grid grid-cols-2 gap-3">
         <div>
-          <label className={LABEL_CLS}>Publisher</label>
+          <label className={LABEL_CLS}><Trans>Publisher</Trans></label>
           <input
             className={INPUT_CLS}
             value={form.publisher}
             onChange={e => onChange('publisher', e.target.value)}
-            placeholder="Publisher"
+            placeholder={t`Publisher`}
           />
         </div>
         <div>
-          <label className={LABEL_CLS}>Year</label>
+          <label className={LABEL_CLS}><Trans>Year</Trans></label>
           <input
             className={INPUT_CLS}
             type="number"
             value={form.year}
             onChange={e => onChange('year', e.target.value)}
-            placeholder="e.g. 2023"
+            placeholder={t`e.g. 2023`}
           />
         </div>
       </div>
@@ -460,26 +473,26 @@ function MetadataForm({ form, onChange, bookTypes, libraries }: MetadataFormProp
           />
         </div>
         <div>
-          <label className={LABEL_CLS}>Language</label>
+          <label className={LABEL_CLS}><Trans>Language</Trans></label>
           <input
             className={INPUT_CLS}
             value={form.language}
             onChange={e => onChange('language', e.target.value)}
-            placeholder="e.g. en"
+            placeholder={t`e.g. en`}
           />
         </div>
       </div>
       <div>
-        <label className={LABEL_CLS}>Tags (comma-separated)</label>
+        <label className={LABEL_CLS}><Trans>Tags (comma-separated)</Trans></label>
         <input
           className={INPUT_CLS}
           value={form.tags}
           onChange={e => onChange('tags', e.target.value)}
-          placeholder="fantasy, action, romance"
+          placeholder={t`fantasy, action, romance`}
         />
       </div>
       <div>
-        <label className={LABEL_CLS}>Cover URL</label>
+        <label className={LABEL_CLS}><Trans>Cover URL</Trans></label>
         <input
           className={INPUT_CLS}
           value={form.cover_url}
@@ -489,7 +502,7 @@ function MetadataForm({ form, onChange, bookTypes, libraries }: MetadataFormProp
         {form.cover_url && (
           <img
             src={form.cover_url}
-            alt="Cover preview"
+            alt={t`Cover preview`}
             className="mt-2 h-24 w-16 object-cover rounded border border-border"
             onError={e => { (e.target as HTMLImageElement).style.display = 'none' }}
           />
@@ -515,13 +528,14 @@ interface CandidatePanelProps {
 }
 
 function CandidatePanel({ candidates, loading, searchQuery, onSearchQueryChange, onSearch, onSelect, appliedId, targetLabel }: CandidatePanelProps) {
+  const { t } = useLingui()
   return (
     <div className="flex flex-col h-full">
       <div className="mb-3">
-        <span className="text-sm font-medium">Metadata Suggestions</span>
+        <span className="text-sm font-medium"><Trans>Metadata Suggestions</Trans></span>
         {targetLabel && (
           <span className="block text-xs text-muted-foreground truncate">
-            for {targetLabel} — click a file to switch
+            <Trans>for {targetLabel} — click a file to switch</Trans>
           </span>
         )}
       </div>
@@ -533,7 +547,7 @@ function CandidatePanel({ candidates, loading, searchQuery, onSearchQueryChange,
           className="flex-1 h-8 rounded-md border border-border bg-transparent px-2.5 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
           value={searchQuery}
           onChange={e => onSearchQueryChange(e.target.value)}
-          placeholder="Search query..."
+          placeholder={t`Search query...`}
         />
         <button
           type="submit"
@@ -551,14 +565,14 @@ function CandidatePanel({ candidates, loading, searchQuery, onSearchQueryChange,
       {!loading && candidates.length === 0 && (
         <div className="flex-1 flex flex-col items-center justify-center py-12 text-center">
           <BookOpen className="h-8 w-8 text-muted-foreground/40 mb-2" />
-          <p className="text-sm text-muted-foreground">No metadata found</p>
-          <p className="text-xs text-muted-foreground/60 mt-1">Try editing the title or series fields</p>
+          <p className="text-sm text-muted-foreground"><Trans>No metadata found</Trans></p>
+          <p className="text-xs text-muted-foreground/60 mt-1"><Trans>Try editing the title or series fields</Trans></p>
         </div>
       )}
       {!loading && candidates.length > 0 && (
         <div className="space-y-2 overflow-y-auto flex-1">
           <p className="text-xs text-muted-foreground mb-1">
-            {candidates.length} result{candidates.length !== 1 ? 's' : ''} — click to fill form
+            <Plural value={candidates.length} one="# result — click to fill form" other="# results — click to fill form" />
           </p>
           {candidates.map(c => (
             <button
@@ -626,6 +640,7 @@ function SeriesGroupCard({ group, bookTypes, libraries, busy, onAccept }: {
   busy: boolean
   onAccept: (form: { series: string; author: string; book_type_id: string; library_ids: number[] }) => void
 }) {
+  const { t } = useLingui()
   const [series, setSeries] = useState(group.series ?? '')
   const [author, setAuthor] = useState(group.author ?? '')
   const [typeId, setTypeId] = useState(group.book_type_id != null ? String(group.book_type_id) : '')
@@ -639,21 +654,21 @@ function SeriesGroupCard({ group, bookTypes, libraries, busy, onAccept }: {
           <div className="flex items-center gap-2 flex-wrap">
             <Layers className="w-4 h-4 text-primary/70 shrink-0" />
             <span className="text-sm font-semibold text-foreground truncate">
-              {series || 'Ungrouped files'}
+              {series || t`Ungrouped files`}
             </span>
             {group.library_match && (
               <span
                 className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-success/10 text-success text-[10px] font-medium"
-                title={`Matches "${group.library_match.series}" already in your library — name, author, type and libraries adopted from it`}
+                title={(() => { const name = group.library_match.series; return t`Matches "${name}" already in your library — name, author, type and libraries adopted from it` })()}
               >
                 <Check className="w-3 h-3" />
-                In library · {group.library_match.volume_count} vol{group.library_match.volume_count === 1 ? '' : 's'}
-                {group.library_match.from_reviewed ? ' · reviewed' : ''}
+                {plural(group.library_match.volume_count, { one: 'In library · # vol', other: 'In library · # vols' })}
+                {group.library_match.from_reviewed ? t` · reviewed` : ''}
               </span>
             )}
             {!group.library_match && group.series && (
               <span className="px-2 py-0.5 rounded-full bg-muted text-muted-foreground text-[10px] font-medium">
-                New series
+                <Trans>New series</Trans>
               </span>
             )}
           </div>
@@ -669,7 +684,7 @@ function SeriesGroupCard({ group, bookTypes, libraries, busy, onAccept }: {
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all shrink-0"
         >
           {busy ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
-          Accept {group.files.length} volume{group.files.length === 1 ? '' : 's'}
+          <Plural value={group.files.length} one="Accept # volume" other="Accept # volumes" />
         </button>
       </div>
 
@@ -678,19 +693,19 @@ function SeriesGroupCard({ group, bookTypes, libraries, busy, onAccept }: {
         <input
           value={series}
           onChange={e => setSeries(e.target.value)}
-          placeholder="Series"
+          placeholder={t`Series`}
           className="w-full px-2.5 py-1.5 text-xs rounded-lg border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring"
         />
         <input
           value={author}
           onChange={e => setAuthor(e.target.value)}
-          placeholder="Author"
+          placeholder={t`Author`}
           className="w-full px-2.5 py-1.5 text-xs rounded-lg border border-border bg-background focus:outline-none focus:ring-1 focus:ring-ring"
         />
         <SelectMenu
           value={typeId}
           onChange={setTypeId}
-          options={[{ value: '', label: 'No type' }, ...bookTypes.map(bt => ({ value: String(bt.id), label: bt.label }))]}
+          options={[{ value: '', label: t`No type` }, ...bookTypes.map(bt => ({ value: String(bt.id), label: bt.label }))]}
           className="[&>button]:py-1.5 [&>button]:text-xs"
         />
         <LibrariesSelect
@@ -709,7 +724,7 @@ function SeriesGroupCard({ group, bookTypes, libraries, busy, onAccept }: {
             title={`${f.filename} → ${f.dest_preview}`}
             className="inline-flex items-center gap-1 px-2 py-1 rounded-md bg-muted/60 text-[11px] text-foreground"
           >
-            {f.series_index != null ? `Vol ${f.series_index}` : (f.title || f.filename)}
+            {(() => { const idx = f.series_index; return idx != null ? t`Vol ${idx}` : (f.title || f.filename) })()}
             <span className="text-muted-foreground uppercase text-[9px]">{f.format}</span>
           </span>
         ))}
@@ -718,8 +733,10 @@ function SeriesGroupCard({ group, bookTypes, libraries, busy, onAccept }: {
   )
 }
 
-function ConfirmDialog({ open, title, message, confirmLabel = 'Confirm', destructive, onConfirm, onCancel }: ConfirmDialogProps) {
+function ConfirmDialog({ open, title, message, confirmLabel, destructive, onConfirm, onCancel }: ConfirmDialogProps) {
+  const { t } = useLingui()
   if (!open) return null
+  const resolvedConfirmLabel = confirmLabel ?? t`Confirm`
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onCancel} />
@@ -731,7 +748,7 @@ function ConfirmDialog({ open, title, message, confirmLabel = 'Confirm', destruc
             onClick={onCancel}
             className="px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
           <button
             onClick={onConfirm}
@@ -742,7 +759,7 @@ function ConfirmDialog({ open, title, message, confirmLabel = 'Confirm', destruc
                 : 'bg-primary text-primary-foreground hover:opacity-90'
             )}
           >
-            {confirmLabel}
+            {resolvedConfirmLabel}
           </button>
         </div>
       </div>
@@ -755,6 +772,7 @@ function ConfirmDialog({ open, title, message, confirmLabel = 'Confirm', destruc
 // ---------------------------------------------------------------------------
 
 export function BinderyPage() {
+  const { t } = useLingui()
   const { toast } = useToast()
   const bookTypes = useBookTypes()
   const navigate = useNavigate()
@@ -862,7 +880,7 @@ export function BinderyPage() {
       setItems(data)
       setGroups(grouped)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Failed to load bindery')
+      toast.error(err instanceof Error ? err.message : t`Failed to load bindery`)
     } finally {
       setLoading(false)
     }
@@ -902,13 +920,18 @@ export function BinderyPage() {
       const res = await api.post<{ accepted: unknown[]; errors: { path: string; error: string }[] }>(
         '/bindery/accept', { files })
       if (res.errors?.length) {
-        toast.error(`${res.errors.length} of ${files.length} failed — ${res.errors[0].error}`)
+        { const failedN = res.errors.length, totalN = files.length, firstErr = res.errors[0].error; toast.error(t`${failedN} of ${totalN} failed — ${firstErr}`) }
       } else {
-        toast.success(`Accepted ${files.length} volume${files.length === 1 ? '' : 's'}${form.series ? ` of ${form.series}` : ''}`)
+        {
+          const n = files.length, seriesName = form.series
+          toast.success(seriesName
+            ? plural(n, { one: `Accepted # volume of ${seriesName}`, other: `Accepted # volumes of ${seriesName}` })
+            : plural(n, { one: 'Accepted # volume', other: 'Accepted # volumes' }))
+        }
       }
       await fetchAll()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Accept failed')
+      toast.error(err instanceof Error ? err.message : t`Accept failed`)
     } finally {
       setAcceptingGroup(null)
     }
@@ -1052,9 +1075,9 @@ export function BinderyPage() {
       setMatchingAll(null)
     }
     if (matched === reviewItems.length) {
-      toast.success(`Best match applied to all ${matched} files`)
+      toast.success(t`Best match applied to all ${matched} files`)
     } else {
-      toast.success(`Best match applied to ${matched} of ${reviewItems.length} files — no match for the rest`)
+      { const totalN = reviewItems.length; toast.success(t`Best match applied to ${matched} of ${totalN} files — no match for the rest`) }
     }
   }
 
@@ -1168,7 +1191,7 @@ export function BinderyPage() {
       }
       return next
     })
-    toast.success(`Series applied to ${reviewItems.length} files`)
+    { const n = reviewItems.length; toast.success(t`Series applied to ${n} files`) }
   }
 
   function applyBatchAuthor() {
@@ -1179,7 +1202,7 @@ export function BinderyPage() {
       }
       return next
     })
-    toast.success(`Author applied to ${reviewItems.length} files`)
+    { const n = reviewItems.length; toast.success(t`Author applied to ${n} files`) }
   }
 
   function applyBatchBookType() {
@@ -1190,7 +1213,7 @@ export function BinderyPage() {
       }
       return next
     })
-    toast.success(`Book type applied to ${reviewItems.length} files`)
+    { const n = reviewItems.length; toast.success(t`Book type applied to ${n} files`) }
   }
 
   function applyBatchLibraries() {
@@ -1201,7 +1224,7 @@ export function BinderyPage() {
       }
       return next
     })
-    toast.success(`Libraries applied to ${reviewItems.length} files`)
+    { const n = reviewItems.length; toast.success(t`Libraries applied to ${n} files`) }
   }
 
   // ---------------------------------------------------------------------------
@@ -1212,7 +1235,7 @@ export function BinderyPage() {
     const form = formData[path]
     if (!form) return
     if (!form.title.trim()) {
-      toast.error('Title is required')
+      toast.error(t`Title is required`)
       return
     }
     setAccepting(true)
@@ -1224,7 +1247,7 @@ export function BinderyPage() {
       if (result.errors.length > 0) {
         toast.error(result.errors[0].error)
       } else {
-        toast.success(`Accepted: ${result.accepted[0]?.title ?? 'book'}`)
+        { const title = result.accepted[0]?.title ?? t`book`; toast.success(t`Accepted: ${title}`) }
         setAcceptFlash(true)
         setTimeout(() => {
           setAcceptFlash(false)
@@ -1234,7 +1257,7 @@ export function BinderyPage() {
         }, 400)
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Accept failed')
+      toast.error(err instanceof Error ? err.message : t`Accept failed`)
     } finally {
       setAccepting(false)
     }
@@ -1247,7 +1270,7 @@ export function BinderyPage() {
     })
     const invalid = files.find(f => !f.title?.trim())
     if (invalid) {
-      toast.error('All items must have a title')
+      toast.error(t`All items must have a title`)
       return
     }
     setAccepting(true)
@@ -1261,14 +1284,14 @@ export function BinderyPage() {
         toast.error(`${result.errors.length} error(s): ${msgs}`)
       }
       if (result.accepted.length > 0) {
-        toast.success(`Accepted ${result.accepted.length} book${result.accepted.length !== 1 ? 's' : ''}`)
+        toast.success(plural(result.accepted.length, { one: 'Accepted # book', other: 'Accepted # books' }))
         const acceptedPaths = new Set(result.accepted.map((_, i) => files[i]?.path).filter(Boolean))
         setItems(prev => prev.filter(i => !acceptedPaths.has(i.path)))
         transitionTo('list')
         setSelected(new Set())
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Accept failed')
+      toast.error(err instanceof Error ? err.message : t`Accept failed`)
     } finally {
       setAccepting(false)
     }
@@ -1346,14 +1369,14 @@ export function BinderyPage() {
           updateStatus(path, 'error', result.errors[0].error)
         }
       } catch (err) {
-        updateStatus(path, 'error', err instanceof Error ? err.message : 'Failed')
+        updateStatus(path, 'error', err instanceof Error ? err.message : t`Failed`)
       }
     }
 
     // Clean up
     setListLibraryIds([])
     if (acceptedPaths.length > 0) {
-      toast.success(`Accepted ${acceptedPaths.length} book${acceptedPaths.length !== 1 ? 's' : ''}`)
+      toast.success(plural(acceptedPaths.length, { one: 'Accepted # book', other: 'Accepted # books' }))
       setItems(prev => prev.filter(i => !acceptedPaths.includes(i.path)))
       setSelected(new Set())
     }
@@ -1372,7 +1395,7 @@ export function BinderyPage() {
         { paths }
       )
       if (result.rejected > 0) {
-        toast.success(`Rejected ${result.rejected} file${result.rejected !== 1 ? 's' : ''}`)
+        toast.success(plural(result.rejected, { one: 'Rejected # file', other: 'Rejected # files' }))
         setItems(prev => prev.filter(i => !paths.includes(i.path)))
         setSelected(prev => {
           const next = new Set(prev)
@@ -1384,7 +1407,7 @@ export function BinderyPage() {
         toast.error(`${result.errors.length} error(s)`)
       }
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Reject failed')
+      toast.error(err instanceof Error ? err.message : t`Reject failed`)
     } finally {
       setRejecting(false)
       setConfirmReject(null)
@@ -1399,9 +1422,9 @@ export function BinderyPage() {
     try {
       await api.put(`/bindery/review/${bookId}`)
       setUnreviewed(prev => prev.filter(b => b.id !== bookId))
-      toast.success('Book accepted')
+      toast.success(t`Book accepted`)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Accept failed')
+      toast.error(err instanceof Error ? err.message : t`Accept failed`)
     }
   }
 
@@ -1410,9 +1433,9 @@ export function BinderyPage() {
     try {
       await api.delete(`/bindery/reject/${bookId}`)
       setUnreviewed(prev => prev.filter(b => b.id !== bookId))
-      toast.success('Book rejected and removed')
+      toast.success(t`Book rejected and removed`)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Reject failed')
+      toast.error(err instanceof Error ? err.message : t`Reject failed`)
     } finally {
       setRejectingUnreviewed(false)
       setConfirmRejectUnreviewed(null)
@@ -1424,9 +1447,9 @@ export function BinderyPage() {
     try {
       await api.put('/bindery/review-all')
       setUnreviewed([])
-      toast.success('All imported books accepted')
+      toast.success(t`All imported books accepted`)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Review all failed')
+      toast.error(err instanceof Error ? err.message : t`Review all failed`)
     } finally {
       setReviewingAll(false)
     }
@@ -1533,18 +1556,19 @@ export function BinderyPage() {
           <button
             onClick={fetchAll}
             disabled={loading || unreviewedLoading}
-            title="Rescan the bindery folder"
+            title={t`Rescan the bindery folder`}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-muted transition-colors disabled:opacity-50"
           >
             <RefreshCw className={cn('h-3.5 w-3.5', (loading || unreviewedLoading) && 'animate-spin')} />
             {/* Label stays at every size — collapsed to a bare icon it sat next
                 to the global sync indicator as two identical circular-arrow
                 glyphs (UX sweep finding). */}
-            <span>Refresh</span>
+            <span><Trans>Refresh</Trans></span>
           </button>
         }
       >
       <div className={cn('flex flex-col h-full transition-opacity duration-150', viewTransition ? 'opacity-0' : 'opacity-100')}>
+        {/* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS */}
         <style>{`
           @keyframes fade-in-up {
             from { opacity: 0; transform: translateY(8px); }
@@ -1559,19 +1583,20 @@ export function BinderyPage() {
         {/* Header */}
         <div className="sticky top-0 z-20 bg-background/80 backdrop-blur-sm border-b border-border px-4 pt-4 pb-4">
           <div className="flex items-center gap-3">
-            <h1 className="font-display text-xl text-foreground">Bindery</h1>
+            <h1 className="font-display text-xl text-foreground"><Trans>Bindery</Trans></h1>
             <p className="text-xs text-muted-foreground hidden md:block">
-              {loading || unreviewedLoading
-                ? 'Loading...'
-                : unreviewed.length > 0
-                  ? `${unreviewed.length} imported + ${items.length} incoming`
-                  : `${items.length} file${items.length !== 1 ? 's' : ''} waiting for review`}
+              {(() => {
+                if (loading || unreviewedLoading) return t`Loading...`
+                const inc = items.length, imp = unreviewed.length
+                if (imp > 0) return t`${imp} imported + ${inc} incoming`
+                return plural(inc, { one: '# file waiting for review', other: '# files waiting for review' })
+              })()}
             </p>
             <a
               href={docsLink(DOCS.bindery)}
               target="_blank"
               rel="noopener noreferrer"
-              title="Bindery flow explained — open docs"
+              title={t`Bindery flow explained — open docs`}
               className="p-1.5 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
             >
               <HelpCircle className="w-3.5 h-3.5" />
@@ -1585,7 +1610,7 @@ export function BinderyPage() {
                 onClick={hasSelection ? clearSelection : selectAll}
                 className="px-2.5 py-1.5 rounded-lg text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted border border-border transition-colors"
               >
-                {hasSelection ? `${selectedArr.length} selected — Clear` : 'Select All'}
+                {(() => { const n = selectedArr.length; return hasSelection ? t`${n} selected — Clear` : t`Select All` })()}
               </button>
 
               {hasSelection && (
@@ -1595,7 +1620,7 @@ export function BinderyPage() {
                     onClick={() => enterReview(selectedArr)}
                     className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
                   >
-                    <Eye className="h-3 w-3" /> Review
+                    <Eye className="h-3 w-3" /> <Trans>Review</Trans>
                   </button>
                   <button
                     onClick={() => quickAccept(selectedArr)}
@@ -1603,13 +1628,13 @@ export function BinderyPage() {
                     className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border text-foreground hover:bg-muted disabled:opacity-50 transition-all"
                   >
                     {accepting ? <Loader2 className="h-3 w-3 animate-spin" /> : <Zap className="h-3 w-3" />}
-                    Quick Accept
+                    <Trans>Quick Accept</Trans>
                   </button>
                   <button
                     onClick={() => setConfirmReject(selectedArr)}
                     className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-destructive hover:bg-destructive/10 border border-destructive/30 transition-all"
                   >
-                    <Trash2 className="h-3 w-3" /> Reject
+                    <Trash2 className="h-3 w-3" /> <Trans>Reject</Trans>
                   </button>
                   {libraries.some(l => l.can_edit) && (
                     <>
@@ -1619,7 +1644,7 @@ export function BinderyPage() {
                         onChange={setListLibraryIds}
                         libraries={libraries}
                         className="w-56 [&>button]:py-1.5 [&>button]:text-xs"
-                        placeholder="Add to libraries…"
+                        placeholder={t`Add to libraries…`}
                       />
                     </>
                   )}
@@ -1635,7 +1660,7 @@ export function BinderyPage() {
         {!loading && groups.some(g => g.files.length > 1 || g.library_match) && (
           <div className="px-4 py-3 border-b border-border bg-muted/20 flex flex-col gap-3">
             <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-              Series review
+              <Trans>Series review</Trans>
             </p>
             {groups
               .filter(g => g.files.length > 1 || g.library_match)
@@ -1656,12 +1681,12 @@ export function BinderyPage() {
         {items.length > 0 && (
           <div className="flex items-center gap-3 px-4 py-2 bg-muted/30 border-b border-border text-[10px] font-medium text-muted-foreground uppercase tracking-wide">
             <span className="w-4 shrink-0" />
-            <span className="flex-1">Title</span>
+            <span className="flex-1"><Trans>Title</Trans></span>
             <div className="flex items-center gap-2 shrink-0">
-              <span className="w-10">Format</span>
-              <span className="w-14">Type</span>
-              <span className="w-24 text-right hidden sm:block">Series</span>
-              <span className="w-16 text-right hidden md:block">Size</span>
+              <span className="w-10"><Trans>Format</Trans></span>
+              <span className="w-14"><Trans>Type</Trans></span>
+              <span className="w-24 text-right hidden sm:block"><Trans>Series</Trans></span>
+              <span className="w-16 text-right hidden md:block"><Trans>Size</Trans></span>
               <span className="w-3.5" />
             </div>
           </div>
@@ -1681,9 +1706,9 @@ export function BinderyPage() {
                 className="h-12 w-12 text-muted-foreground/30 mb-3"
                 style={{ animation: 'gentle-pulse 3s ease-in-out infinite' }}
               />
-              <p className="text-base font-medium text-muted-foreground">No files in the bindery</p>
+              <p className="text-base font-medium text-muted-foreground"><Trans>No files in the bindery</Trans></p>
               <p className="text-sm text-muted-foreground/60 mt-1">
-                Drop files in the incoming folder to get started
+                <Trans>Drop files in the incoming folder to get started</Trans>
               </p>
             </div>
           )}
@@ -1694,7 +1719,7 @@ export function BinderyPage() {
               {/* Section header */}
               <div className="flex items-center justify-between px-4 py-2.5 bg-muted/30 border-b border-border">
                 <div className="flex items-center gap-2">
-                  <span className="font-display text-sm text-foreground">Recently Imported</span>
+                  <span className="font-display text-sm text-foreground"><Trans>Recently Imported</Trans></span>
                   <span className="text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-primary/10 text-primary">
                     {unreviewed.length}
                   </span>
@@ -1705,7 +1730,7 @@ export function BinderyPage() {
                   className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium text-primary hover:bg-primary/10 transition-colors disabled:opacity-50"
                 >
                   {reviewingAll ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
-                  Accept All
+                  <Trans>Accept All</Trans>
                 </button>
               </div>
               {/* Cards grid */}
@@ -1716,13 +1741,14 @@ export function BinderyPage() {
                   const diffMs = Date.now() - addedAt.getTime()
                   const diffHrs = Math.floor(diffMs / 1000 / 60 / 60)
                   const diffMins = Math.floor(diffMs / 1000 / 60)
+                  const diffDays = Math.floor(diffHrs / 24)
                   const timeAgo = diffHrs >= 24
-                    ? `${Math.floor(diffHrs / 24)}d ago`
+                    ? t`${diffDays}d ago`
                     : diffHrs >= 1
-                      ? `${diffHrs}h ago`
+                      ? t`${diffHrs}h ago`
                       : diffMins >= 1
-                        ? `${diffMins}m ago`
-                        : 'just now'
+                        ? t`${diffMins}m ago`
+                        : t`just now`
 
                   return (
                     <div
@@ -1744,7 +1770,7 @@ export function BinderyPage() {
                         {book.author && (
                           <p className="text-xs text-muted-foreground truncate">{book.author}</p>
                         )}
-                        <p className="text-[10px] text-muted-foreground/60 mt-0.5">Added {timeAgo}</p>
+                        <p className="text-[10px] text-muted-foreground/60 mt-0.5"><Trans>Added {timeAgo}</Trans></p>
                       </div>
                       {/* Badges + Actions */}
                       <div className="shrink-0 flex flex-col items-end gap-1.5">
@@ -1822,7 +1848,7 @@ export function BinderyPage() {
                   {folders.length > 0 && (
                     <div className="flex items-center gap-2 px-4 py-2 bg-muted/50 border-b border-border">
                       <span className="w-4 shrink-0" />
-                      <span className="text-sm font-medium text-muted-foreground">Other files</span>
+                      <span className="text-sm font-medium text-muted-foreground"><Trans>Other files</Trans></span>
                       <span className="text-xs text-muted-foreground">({ungrouped.length})</span>
                     </div>
                   )}
@@ -1851,17 +1877,17 @@ export function BinderyPage() {
                 <>
                   <div className="flex items-center justify-between mb-1.5">
                     <span className="text-xs font-medium">
-                      Quick Accept: {done}/{total} done{errors > 0 ? `, ${errors} failed` : ''}
+                      {t`Quick Accept: ${done}/${total} done` + (errors > 0 ? t`, ${errors} failed` : '')}
                     </span>
                     {qaProgress.items.every(i => i.status === 'done' || i.status === 'error') ? (
                       <button
                         onClick={e => { e.stopPropagation(); setQaProgress(null); setQaModalOpen(false) }}
                         className="text-xs text-muted-foreground hover:text-foreground transition-colors"
                       >
-                        Dismiss
+                        <Trans>Dismiss</Trans>
                       </button>
                     ) : (
-                      <span className="text-[10px] text-muted-foreground">Click for details</span>
+                      <span className="text-[10px] text-muted-foreground"><Trans>Click for details</Trans></span>
                     )}
                   </div>
                   <div className="h-1.5 bg-muted rounded-full overflow-hidden flex">
@@ -1890,7 +1916,7 @@ export function BinderyPage() {
             <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={() => setQaModalOpen(false)} />
             <div className="relative z-10 bg-background border border-border rounded-2xl shadow-xl shadow-accent-soft w-full max-w-md mx-4 max-h-[70vh] flex flex-col">
               <div className="flex items-center justify-between px-5 py-3 border-b border-border">
-                <span className="text-sm font-semibold">Quick Accept Progress</span>
+                <span className="text-sm font-semibold"><Trans>Quick Accept Progress</Trans></span>
                 <button onClick={() => setQaModalOpen(false)} className="text-muted-foreground hover:text-foreground transition-colors">
                   <X className="h-4 w-4" />
                 </button>
@@ -1916,7 +1942,7 @@ export function BinderyPage() {
                       )}
                     </div>
                     <span className="text-[10px] text-muted-foreground shrink-0 capitalize">
-                      {item.status === 'fetching' ? 'Fetching metadata...' : item.status === 'accepting' ? 'Importing...' : ''}
+                      {item.status === 'fetching' ? t`Fetching metadata...` : item.status === 'accepting' ? t`Importing...` : ''}
                     </span>
                   </div>
                 ))}
@@ -1928,9 +1954,9 @@ export function BinderyPage() {
         {/* Confirm reject dialog for raw files */}
         <ConfirmDialog
           open={confirmReject !== null}
-          title="Reject files"
-          message={`Permanently delete ${confirmReject?.length ?? 0} file${(confirmReject?.length ?? 0) !== 1 ? 's' : ''} from the bindery? This cannot be undone.`}
-          confirmLabel={rejecting ? 'Deleting...' : 'Delete'}
+          title={t`Reject files`}
+          message={plural(confirmReject?.length ?? 0, { one: 'Permanently delete # file from the bindery? This cannot be undone.', other: 'Permanently delete # files from the bindery? This cannot be undone.' })}
+          confirmLabel={rejecting ? t`Deleting...` : t`Delete`}
           destructive
           onConfirm={() => confirmReject && doReject(confirmReject)}
           onCancel={() => setConfirmReject(null)}
@@ -1939,9 +1965,9 @@ export function BinderyPage() {
         {/* Confirm reject dialog for unreviewed (imported) books */}
         <ConfirmDialog
           open={confirmRejectUnreviewed !== null}
-          title="Reject imported book"
-          message="Delete this book from the library? The file will be removed and this cannot be undone."
-          confirmLabel={rejectingUnreviewed ? 'Deleting...' : 'Delete'}
+          title={t`Reject imported book`}
+          message={t`Delete this book from the library? The file will be removed and this cannot be undone.`}
+          confirmLabel={rejectingUnreviewed ? t`Deleting...` : t`Delete`}
           destructive
           onConfirm={() => confirmRejectUnreviewed !== null && doRejectUnreviewed(confirmRejectUnreviewed)}
           onCancel={() => setConfirmRejectUnreviewed(null)}
@@ -1969,12 +1995,12 @@ export function BinderyPage() {
             onClick={() => transitionTo('list')}
             className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
           >
-            <ArrowLeft className="h-4 w-4" /> Back to list
+            <ArrowLeft className="h-4 w-4" /> <Trans>Back to list</Trans>
           </button>
           <span className="text-muted-foreground/40">/</span>
           <span className="text-sm font-medium">
             {isBatch
-              ? `Reviewing ${reviewItems.length} files`
+              ? (() => { const n = reviewItems.length; return t`Reviewing ${n} files` })()
               : currentItem?.filename ?? ''}
           </span>
         </div>
@@ -2015,19 +2041,19 @@ export function BinderyPage() {
                 className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
               >
                 {accepting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
-                Accept
+                <Trans>Accept</Trans>
               </button>
               <button
                 onClick={skipItem}
                 className="px-4 py-2 rounded-lg text-sm font-medium border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
               >
-                Skip
+                <Trans>Skip</Trans>
               </button>
               <button
                 onClick={rejectCurrentAndAdvance}
                 className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium border border-destructive/30 text-destructive hover:bg-destructive/5 transition-all ml-auto"
               >
-                <Trash2 className="h-3.5 w-3.5" /> Reject
+                <Trash2 className="h-3.5 w-3.5" /> <Trans>Reject</Trans>
               </button>
             </div>
           </div>
@@ -2054,63 +2080,63 @@ export function BinderyPage() {
           <div className="lg:w-3/5 overflow-y-auto p-6 border-r border-border space-y-5">
             {/* Shared fields */}
             <div className="rounded-lg border border-border p-4 space-y-3">
-              <h3 className="text-sm font-semibold">Shared fields — applies to all {reviewItems.length} items</h3>
+              {(() => { const n = reviewItems.length; return <h3 className="text-sm font-semibold"><Trans>Shared fields — applies to all {n} items</Trans></h3> })()}
               <div className="space-y-3">
                 <div>
-                  <label className={LABEL_CLS}>Series</label>
+                  <label className={LABEL_CLS}><Trans>Series</Trans></label>
                   <div className="flex gap-2">
                     <input
                       className={cn(INPUT_CLS, 'flex-1')}
                       value={batchSeries}
                       onChange={e => setBatchSeries(e.target.value)}
-                      placeholder="Series name"
+                      placeholder={t`Series name`}
                     />
                     <button
                       onClick={applyBatchSeries}
                       className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-muted hover:bg-accent transition-colors"
                     >
-                      Apply to all
+                      <Trans>Apply to all</Trans>
                     </button>
                   </div>
                 </div>
                 <div>
-                  <label className={LABEL_CLS}>Author</label>
+                  <label className={LABEL_CLS}><Trans>Author</Trans></label>
                   <div className="flex gap-2">
                     <input
                       className={cn(INPUT_CLS, 'flex-1')}
                       value={batchAuthor}
                       onChange={e => setBatchAuthor(e.target.value)}
-                      placeholder="Author name"
+                      placeholder={t`Author name`}
                     />
                     <button
                       onClick={applyBatchAuthor}
                       className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-muted hover:bg-accent transition-colors"
                     >
-                      Apply to all
+                      <Trans>Apply to all</Trans>
                     </button>
                   </div>
                 </div>
                 <div>
-                  <label className={LABEL_CLS}>Book Type</label>
+                  <label className={LABEL_CLS}><Trans>Book Type</Trans></label>
                   <div className="flex gap-2">
                     <SelectMenu
                       className="flex-1"
                       value={batchBookTypeId}
                       onChange={setBatchBookTypeId}
-                      options={[{ value: '', label: 'No type' },
+                      options={[{ value: '', label: t`No type` },
                                 ...bookTypes.map(bt => ({ value: String(bt.id), label: bt.label }))]}
                     />
                     <button
                       onClick={applyBatchBookType}
                       className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-muted hover:bg-accent transition-colors"
                     >
-                      Apply to all
+                      <Trans>Apply to all</Trans>
                     </button>
                   </div>
                 </div>
                 {libraries.some(l => l.can_edit) && (
                   <div>
-                    <label className={LABEL_CLS}>Libraries</label>
+                    <label className={LABEL_CLS}><Trans>Libraries</Trans></label>
                     <div className="flex gap-2">
                       <LibrariesSelect
                         value={batchLibraryIds}
@@ -2122,7 +2148,7 @@ export function BinderyPage() {
                         onClick={applyBatchLibraries}
                         className="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-muted hover:bg-accent transition-colors"
                       >
-                        Apply to all
+                        <Trans>Apply to all</Trans>
                       </button>
                     </div>
                   </div>
@@ -2133,7 +2159,7 @@ export function BinderyPage() {
             {/* Per-item rows */}
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <h3 className="text-sm font-semibold">Per-file details</h3>
+                <h3 className="text-sm font-semibold"><Trans>Per-file details</Trans></h3>
                 <button
                   onClick={matchAll}
                   disabled={matchingAll !== null || fetchingMeta}
@@ -2142,9 +2168,9 @@ export function BinderyPage() {
                   {matchingAll !== null
                     ? <Loader2 className="h-3 w-3 animate-spin" />
                     : <Zap className="h-3 w-3" />}
-                  {matchingAll !== null
-                    ? `Matching ${matchingAll}/${reviewItems.length}…`
-                    : 'Match all'}
+                  {(() => { const total = reviewItems.length; return matchingAll !== null
+                    ? t`Matching ${matchingAll}/${total}…`
+                    : t`Match all` })()}
                 </button>
               </div>
               {reviewItems.map(item => {
@@ -2191,7 +2217,7 @@ export function BinderyPage() {
                         className="flex-1 h-7 rounded border border-border bg-transparent px-2 text-xs placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
                         value={form.title}
                         onChange={e => updateForm(item.path, 'title', e.target.value)}
-                        placeholder="Title"
+                        placeholder={t`Title`}
                       />
                       <input
                         className="w-16 h-7 rounded border border-border bg-transparent px-2 text-xs text-center placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
@@ -2200,15 +2226,15 @@ export function BinderyPage() {
                         value={form.series_index}
                         onChange={e => updateForm(item.path, 'series_index', e.target.value)}
                         placeholder="#"
-                        title="Series index"
+                        title={t`Series index`}
                       />
                       <select
                         className="h-7 rounded border border-border bg-transparent px-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-ring cursor-pointer"
                         value={form.content_type}
                         onChange={e => updateForm(item.path, 'content_type', e.target.value)}
                       >
-                        <option value="volume">Volume</option>
-                        <option value="chapter">Chapter</option>
+                        <option value="volume">{t`Volume`}</option>
+                        <option value="chapter">{t`Chapter`}</option>
                       </select>
                     </div>
                     {/* Expanded full form */}
@@ -2235,19 +2261,19 @@ export function BinderyPage() {
                 className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
               >
                 {accepting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Check className="h-3.5 w-3.5" />}
-                Accept All
+                <Trans>Accept All</Trans>
               </button>
               <button
                 onClick={() => transitionTo('list')}
                 className="px-4 py-2 rounded-lg text-sm font-medium border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
               >
-                Back to list
+                <Trans>Back to list</Trans>
               </button>
               <button
                 onClick={() => setConfirmReject(reviewItems.map(i => i.path))}
                 className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium border border-destructive/30 text-destructive hover:bg-destructive/5 transition-all ml-auto"
               >
-                <Trash2 className="h-3.5 w-3.5" /> Reject All
+                <Trash2 className="h-3.5 w-3.5" /> <Trans>Reject All</Trans>
               </button>
             </div>
           </div>
@@ -2271,9 +2297,9 @@ export function BinderyPage() {
       {/* Confirm reject dialog */}
       <ConfirmDialog
         open={confirmReject !== null}
-        title="Reject files"
-        message={`Permanently delete ${confirmReject?.length ?? 0} file${(confirmReject?.length ?? 0) !== 1 ? 's' : ''} from the bindery? This cannot be undone.`}
-        confirmLabel={rejecting ? 'Deleting...' : 'Delete'}
+        title={t`Reject files`}
+        message={plural(confirmReject?.length ?? 0, { one: 'Permanently delete # file from the bindery? This cannot be undone.', other: 'Permanently delete # files from the bindery? This cannot be undone.' })}
+        confirmLabel={rejecting ? t`Deleting...` : t`Delete`}
         destructive
         onConfirm={() => {
           if (confirmReject) {

--- a/frontend/src/pages/BinderyPage.tsx
+++ b/frontend/src/pages/BinderyPage.tsx
@@ -1586,7 +1586,7 @@ export function BinderyPage() {
             <h1 className="font-display text-xl text-foreground"><Trans>Bindery</Trans></h1>
             <p className="text-xs text-muted-foreground hidden md:block">
               {(() => {
-                if (loading || unreviewedLoading) return t`Loading...`
+                if (loading || unreviewedLoading) return t`Loading…`
                 const inc = items.length, imp = unreviewed.length
                 if (imp > 0) return t`${imp} imported + ${inc} incoming`
                 return plural(inc, { one: '# file waiting for review', other: '# files waiting for review' })
@@ -1942,7 +1942,7 @@ export function BinderyPage() {
                       )}
                     </div>
                     <span className="text-[10px] text-muted-foreground shrink-0 capitalize">
-                      {item.status === 'fetching' ? t`Fetching metadata...` : item.status === 'accepting' ? t`Importing...` : ''}
+                      {item.status === 'fetching' ? t`Fetching metadata...` : item.status === 'accepting' ? t`Importing…` : ''}
                     </span>
                   </div>
                 ))}
@@ -1956,7 +1956,7 @@ export function BinderyPage() {
           open={confirmReject !== null}
           title={t`Reject files`}
           message={plural(confirmReject?.length ?? 0, { one: 'Permanently delete # file from the bindery? This cannot be undone.', other: 'Permanently delete # files from the bindery? This cannot be undone.' })}
-          confirmLabel={rejecting ? t`Deleting...` : t`Delete`}
+          confirmLabel={rejecting ? t`Deleting…` : t`Delete`}
           destructive
           onConfirm={() => confirmReject && doReject(confirmReject)}
           onCancel={() => setConfirmReject(null)}
@@ -1967,7 +1967,7 @@ export function BinderyPage() {
           open={confirmRejectUnreviewed !== null}
           title={t`Reject imported book`}
           message={t`Delete this book from the library? The file will be removed and this cannot be undone.`}
-          confirmLabel={rejectingUnreviewed ? t`Deleting...` : t`Delete`}
+          confirmLabel={rejectingUnreviewed ? t`Deleting…` : t`Delete`}
           destructive
           onConfirm={() => confirmRejectUnreviewed !== null && doRejectUnreviewed(confirmRejectUnreviewed)}
           onCancel={() => setConfirmRejectUnreviewed(null)}
@@ -2299,7 +2299,7 @@ export function BinderyPage() {
         open={confirmReject !== null}
         title={t`Reject files`}
         message={plural(confirmReject?.length ?? 0, { one: 'Permanently delete # file from the bindery? This cannot be undone.', other: 'Permanently delete # files from the bindery? This cannot be undone.' })}
-        confirmLabel={rejecting ? t`Deleting...` : t`Delete`}
+        confirmLabel={rejecting ? t`Deleting…` : t`Delete`}
         destructive
         onConfirm={() => {
           if (confirmReject) {

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -10,6 +10,8 @@ import {
 } from 'lucide-react'
 import { useAuth, isMember } from '@/contexts/AuthContext'
 import { useToast } from '@/contexts/ToastContext'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 import { ThemeToggle } from '@/components/ThemeToggle'
 import { MetadataFetchModal } from '@/components/MetadataFetchModal'
 import { CoverPickerModal } from '@/components/CoverPickerModal'
@@ -90,6 +92,13 @@ interface ChapterTime {
   sittings: ChapterSitting[]
 }
 
+import { msg } from '@lingui/core/macro'
+import type { MessageDescriptor } from '@lingui/core'
+
+const STATUS_CHIP_LABELS: Record<string, MessageDescriptor> = {
+  unread: msg`unread`, reading: msg`reading`, read: msg`read`,
+}
+
 // When a chapter was actually read, honest about sittings:
 //   one sitting  → "Jun 2, 17:40 – 18:54"
 //   two or three → "Jun 2 17:40–18:10 · Jun 3 21:00–21:34"
@@ -102,12 +111,15 @@ function chapterReadSpan(c: ChapterTime): string {
   const clock = (ts: number) =>
     new Date(ts * 1000).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
   if (s.length === 1) {
-    return `read ${day(s[0].start_ts)}, ${clock(s[0].start_ts)} – ${clock(s[0].end_ts)}`
+    const d = day(s[0].start_ts), from = clock(s[0].start_ts), to = clock(s[0].end_ts)
+    return t`read ${d}, ${from} – ${to}`
   }
   if (s.length <= 3) {
-    return 'read ' + s.map(x => `${day(x.start_ts)} ${clock(x.start_ts)}–${clock(x.end_ts)}`).join(' · ')
+    const span = s.map(x => `${day(x.start_ts)} ${clock(x.start_ts)}–${clock(x.end_ts)}`).join(' · ')
+    return t`read ${span}`
   }
-  return `${s.length} sittings · ${day(s[0].start_ts)} – ${day(s[s.length - 1].end_ts)}`
+  const count = s.length, from = day(s[0].start_ts), to = day(s[s.length - 1].end_ts)
+  return t`${count} sittings · ${from} – ${to}`
 }
 
 // Short variant for the line-chart tooltip (dates only, no clock times).
@@ -118,7 +130,7 @@ function chapterReadSpanShort(c: ChapterTime): string {
     new Date(ts * 1000).toLocaleDateString(undefined, { day: 'numeric', month: 'short' })
   const a = day(s[0].start_ts)
   const b = day(s[s.length - 1].end_ts)
-  return a === b ? `read ${a}` : `read ${a} – ${b}`
+  return a === b ? t`read ${a}` : t`read ${a} – ${b}`
 }
 
 interface ReadingStatsResponse {
@@ -163,6 +175,7 @@ async function downloadFile(book: BookDetail, f: BookFile) {
 }
 
 export function BookDetailPage() {
+  const { t, i18n } = useLingui()
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { user } = useAuth()
@@ -289,9 +302,9 @@ export function BookDetailPage() {
     setAdjacent(null)
     api.get<BookDetail>(`/books/${id}`)
       .then(b => { setBook(b); setDraft(b); setLocalLibIds(b.library_ids ?? []) })
-      .catch(() => setError('Book not found'))
+      .catch(() => setError(t`Book not found`))
       .finally(() => setLoading(false))
-    api.get<LibraryType[]>('/libraries').then(setLibraries).catch(() => toast.error('Failed to load libraries'))
+    api.get<LibraryType[]>('/libraries').then(setLibraries).catch(() => toast.error(t`Failed to load libraries`))
     api.get<BookStatus>(`/books/${id}/status`).then(s => { setBookStatus(s.status); setProgressPct(s.progress_pct); setCfi(s.cfi ?? null); setProgressAnimated(false); setRating(s.rating ?? null); setReview(s.review ?? ''); setEditingReview(false) }).catch(() => {})
     api.get<typeof adjacent>(`/books/${id}/adjacent`).then(setAdjacent).catch(() => {})
     api.get<KosyncStatus>(`/books/${id}/kosync-progress`)
@@ -348,16 +361,16 @@ export function BookDetailPage() {
       const restored = await api.put<BookStatus>(`/books/${id}/status`, prev)
       applyStatus(restored)
     } catch {
-      toast.error('Failed to undo')
+      toast.error(t`Failed to undo`)
     }
   }
 
   const STATUS_LABEL: Record<ReadingStatus, string> = {
-    unread: 'Marked unread — reading progress cleared',
-    reading: 'Marked as reading',
-    read: 'Marked as read',
-    shelved: 'Shelved — kept your progress',
-    want_to_read: 'Added to Want to Read',
+    unread: t`Marked unread — reading progress cleared`,
+    reading: t`Marked as reading`,
+    read: t`Marked as read`,
+    shelved: t`Shelved — kept your progress`,
+    want_to_read: t`Added to Want to Read`,
   }
 
   async function handleStatusChange(s: ReadingStatus) {
@@ -367,9 +380,9 @@ export function BookDetailPage() {
     try {
       const updated = await api.put<BookStatus>(`/books/${id}/status`, { status: s })
       applyStatus(updated)
-      toast.info(STATUS_LABEL[s], { action: { label: 'Undo', onClick: () => restoreStatus(prev) } })
+      toast.info(STATUS_LABEL[s], { action: { label: t`Undo`, onClick: () => restoreStatus(prev) } })
     } catch {
-      toast.error('Failed to update reading status')
+      toast.error(t`Failed to update reading status`)
     } finally {
       setStatusSaving(false)
     }
@@ -389,9 +402,9 @@ export function BookDetailPage() {
       setKosyncUnlinked(!ks.linked && ks.unlinked_documents ? ks.unlinked_documents : [])
       applyStatus(s)
       setKosyncPickerOpen(false)
-      toast.info('KOReader sync linked')
+      toast.info(t`KOReader sync linked`)
     } catch {
-      toast.error('Failed to link sync document')
+      toast.error(t`Failed to link sync document`)
     } finally {
       setKosyncLinking(false)
     }
@@ -405,7 +418,7 @@ export function BookDetailPage() {
       await api.put<BookStatus>(`/books/${id}/rating`, { rating: next })
     } catch {
       setRating(prev)
-      toast.error('Failed to save rating')
+      toast.error(t`Failed to save rating`)
     }
   }
 
@@ -422,7 +435,7 @@ export function BookDetailPage() {
     try {
       await api.put<BookStatus>(`/books/${id}/rating`, { review: next || null })
     } catch {
-      toast.error('Failed to save review')
+      toast.error(t`Failed to save review`)
     }
   }
 
@@ -431,10 +444,10 @@ export function BookDetailPage() {
     setDeleting(true)
     try {
       await api.delete(`/books/${book.id}`)
-      toast.success('Book deleted')
+      toast.success(t`Book deleted`)
       navigate('/')
     } catch (err) {
-      const msg = err instanceof Error ? err.message : 'Delete failed'
+      const msg = err instanceof Error ? err.message : t`Delete failed`
       setError(msg)
       toast.error(msg)
       setDeleting(false)
@@ -448,7 +461,7 @@ export function BookDetailPage() {
     setDraftTags(book.tags.map(t => t.tag))
     setDraftBookTypeId(book.book_type_id ?? null)
     setEditing(true)
-    api.get<Facets>('/books/facets').then(setFacets).catch(() => toast.error('Failed to load facets'))
+    api.get<Facets>('/books/facets').then(setFacets).catch(() => toast.error(t`Failed to load facets`))
   }
   function cancelEdit() {
     if (!book) return
@@ -482,10 +495,10 @@ export function BookDetailPage() {
       setDraftTags(updated.tags.map(t => t.tag))
       setDraftBookTypeId(updated.book_type_id ?? null)
       setEditing(false)
-      toast.success('Metadata saved')
+      toast.success(t`Metadata saved`)
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Save failed')
-      toast.error(err instanceof Error ? err.message : 'Save failed')
+      setError(err instanceof Error ? err.message : t`Save failed`)
+      toast.error(err instanceof Error ? err.message : t`Save failed`)
     } finally {
       setSaving(false)
     }
@@ -507,8 +520,8 @@ export function BookDetailPage() {
   if (error || !book) return (
     <div className="min-h-screen bg-background flex items-center justify-center">
       <div className="text-center gap-3 flex flex-col items-center">
-        <p className="text-muted-foreground">{error ?? 'Book not found'}</p>
-        <Link to="/" className="text-sm text-primary hover:underline">← Back to library</Link>
+        <p className="text-muted-foreground">{error ?? t`Book not found`}</p>
+        <Link to="/" className="text-sm text-primary hover:underline"><Trans>← Back to library</Trans></Link>
       </div>
     </div>
   )
@@ -543,7 +556,7 @@ export function BookDetailPage() {
       className="mt-4 flex items-center justify-center gap-2 w-full px-3 py-2.5 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:bg-primary/90 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md"
     >
       <BookMarked className="w-4 h-4" />
-      Read
+      <Trans>Read</Trans>
     </button>
   ) : null
 
@@ -555,7 +568,7 @@ export function BookDetailPage() {
           onClick={async () => {
             setDownloadingId(f.id)
             try { await downloadFile(book, f) }
-            catch (e) { setError(e instanceof Error ? e.message : 'Download failed') }
+            catch (e) { setError(e instanceof Error ? e.message : t`Download failed`) }
             finally { setDownloadingId(null) }
           }}
           disabled={downloadingId === f.id}
@@ -606,13 +619,13 @@ export function BookDetailPage() {
             value={field('title') ?? ''}
             onChange={e => setField('title', e.target.value)}
             className="w-full text-2xl font-bold text-foreground bg-muted rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-ring mb-1"
-            placeholder="Title"
+            placeholder={t`Title`}
           />
           <input
             value={field('subtitle') ?? ''}
             onChange={e => setField('subtitle', e.target.value)}
             className="w-full text-base text-muted-foreground bg-muted rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-ring mt-1"
-            placeholder="Subtitle (optional)"
+            placeholder={t`Subtitle (optional)`}
           />
         </>
       ) : (
@@ -621,7 +634,7 @@ export function BookDetailPage() {
             <h1 className="text-2xl sm:text-3xl font-bold text-foreground">{book.title}</h1>
             {book.content_type === 'chapter' && (
               <span className="shrink-0 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded bg-muted text-muted-foreground border border-border">
-                Chapter
+                <Trans>Chapter</Trans>
               </span>
             )}
           </div>
@@ -636,7 +649,7 @@ export function BookDetailPage() {
           value={field('author') ?? ''}
           onChange={v => setField('author', v)}
           suggestions={facets.authors}
-          placeholder="Author"
+          placeholder={t`Author`}
           className="w-full text-base bg-muted rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-ring mt-2"
         />
       ) : book.author ? (
@@ -656,7 +669,7 @@ export function BookDetailPage() {
                 value={field('series') ?? ''}
                 onChange={v => setField('series', v)}
                 suggestions={facets.series}
-                placeholder="Series name"
+                placeholder={t`Series name`}
                 className="flex-1 min-w-0 text-sm bg-muted rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-ring"
               />
               <input
@@ -700,7 +713,7 @@ export function BookDetailPage() {
               : 'border-border text-muted-foreground hover:bg-muted hover:text-foreground'
           )}
         >
-          {s}
+          {i18n._(STATUS_CHIP_LABELS[s])}
         </button>
       ))}
       {/* Want to Read + Shelved — set apart from the linear unread→reading→read
@@ -713,7 +726,7 @@ export function BookDetailPage() {
         key={bookStatus === 'want_to_read' ? `want_to_read-${statusPopKey}` : 'want_to_read'}
         disabled={statusSaving}
         onClick={() => handleStatusChange('want_to_read')}
-        title="Want to Read — queue this book up next"
+        title={t`Want to Read — queue this book up next`}
         className={cn(
           'px-2.5 py-1 rounded-md text-xs font-medium border transition-all inline-flex items-center gap-1.5',
           bookStatus === 'want_to_read'
@@ -722,13 +735,13 @@ export function BookDetailPage() {
         )}
       >
         <BookMarked className="w-3.5 h-3.5" />
-        Want to Read
+        <Trans>Want to Read</Trans>
       </button>
       <button
         key={bookStatus === 'shelved' ? `shelved-${statusPopKey}` : 'shelved'}
         disabled={statusSaving}
         onClick={() => handleStatusChange('shelved')}
-        title="Shelved — set aside, keeps your progress"
+        title={t`Shelved — set aside, keeps your progress`}
         className={cn(
           'px-2.5 py-1 rounded-md text-xs font-medium border transition-all inline-flex items-center gap-1.5',
           bookStatus === 'shelved'
@@ -737,7 +750,7 @@ export function BookDetailPage() {
         )}
       >
         <Archive className="w-3.5 h-3.5" />
-        Shelved
+        <Trans>Shelved</Trans>
       </button>
       {statusSaving && <Loader2 className="w-4 h-4 animate-spin text-muted-foreground self-center" />}
       {progressPct != null && progressPct > 0 && bookStatus !== 'unread' && (
@@ -750,13 +763,17 @@ export function BookDetailPage() {
           </div>
           <span className="text-xs text-muted-foreground tabular-nums shrink-0">
             {Math.round(progressPct * 100)}%
-            {book?.hardcover_pages != null && book.hardcover_pages > 0 && (
+            {book?.hardcover_pages != null && book.hardcover_pages > 0 && (() => {
               // Print-edition pagination (from the matched Hardcover edition) —
               // font-size agnostic, unlike the device's reflowed page count.
-              <span className="ml-1 opacity-60">
-                · p. {Math.max(1, Math.round(progressPct * book.hardcover_pages))} of {book.hardcover_pages}
-              </span>
-            )}
+              const page = Math.max(1, Math.round(progressPct * book.hardcover_pages))
+              const totalPages = book.hardcover_pages
+              return (
+                <span className="ml-1 opacity-60">
+                  <Trans>· p. {page} of {totalPages}</Trans>
+                </span>
+              )
+            })()}
             {kosyncDevice && (
               <span className="ml-1 opacity-60">· {kosyncDevice}</span>
             )}
@@ -770,13 +787,13 @@ export function BookDetailPage() {
               type="button"
               onClick={() => { setKosyncPickerOpen(true); setKosyncLinkDoc(kosyncUnlinked[0]?.document ?? '') }}
               className="text-muted-foreground hover:text-foreground underline decoration-dotted underline-offset-2 transition-colors"
-              title="Attach progress synced from a KOReader-compatible app to this book"
+              title={t`Attach progress synced from a KOReader-compatible app to this book`}
             >
-              Link KOReader sync…
+              <Trans>Link KOReader sync…</Trans>
             </button>
           ) : (
             <div className="flex flex-wrap items-center gap-2 rounded bg-muted/40 px-2 py-2">
-              <span className="text-muted-foreground">Synced document</span>
+              <span className="text-muted-foreground"><Trans>Synced document</Trans></span>
               <select
                 value={kosyncLinkDoc}
                 onChange={e => setKosyncLinkDoc(e.target.value)}
@@ -784,7 +801,7 @@ export function BookDetailPage() {
               >
                 {kosyncUnlinked.map(d => (
                   <option key={d.document} value={d.document}>
-                    {d.device || 'unknown device'} · {Math.round(d.percentage * 100)}% · {new Date(d.timestamp * 1000).toLocaleDateString()} · {d.document.slice(0, 8)}
+                    {d.device || t`unknown device`} · {Math.round(d.percentage * 100)}% · {new Date(d.timestamp * 1000).toLocaleDateString(i18n.locale)} · {d.document.slice(0, 8)}
                   </option>
                 ))}
               </select>
@@ -794,14 +811,14 @@ export function BookDetailPage() {
                 onClick={linkKosyncDocument}
                 className="rounded border border-border px-2 py-0.5 text-foreground hover:bg-muted transition-colors disabled:opacity-40"
               >
-                {kosyncLinking ? 'Linking…' : 'Link'}
+                {kosyncLinking ? t`Linking…` : t`Link`}
               </button>
               <button
                 type="button"
                 onClick={() => setKosyncPickerOpen(false)}
                 className="rounded border border-border px-2 py-0.5 text-muted-foreground hover:bg-muted transition-colors"
               >
-                Cancel
+                <Trans>Cancel</Trans>
               </button>
             </div>
           )}
@@ -816,7 +833,7 @@ export function BookDetailPage() {
       <div className="flex items-center gap-2.5">
         <StarRating value={rating} onChange={saveRating} />
         <span className="text-xs text-muted-foreground">
-          {rating ? `You rated this ${rating}/5` : 'Rate this book'}
+          {rating ? t`You rated this ${rating}/5` : t`Rate this book`}
         </span>
         {!review && !editingReview && (
           <button
@@ -824,7 +841,7 @@ export function BookDetailPage() {
             onClick={startEditingReview}
             className="text-xs text-primary hover:underline"
           >
-            Add a review
+            <Trans>Add a review</Trans>
           </button>
         )}
       </div>
@@ -835,7 +852,7 @@ export function BookDetailPage() {
           onBlur={saveReview}
           autoFocus
           rows={3}
-          placeholder="What did you think? (optional, saved automatically)"
+          placeholder={t`What did you think? (optional, saved automatically)`}
           className="mt-2 w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
         />
       ) : review ? (
@@ -844,8 +861,8 @@ export function BookDetailPage() {
           <button
             type="button"
             onClick={startEditingReview}
-            aria-label="Edit review"
-            title="Edit review"
+            aria-label={t`Edit review`}
+            title={t`Edit review`}
             className="absolute right-0 top-0 p-1 text-muted-foreground/50 transition-colors hover:text-foreground"
           >
             <Edit2 className="h-3.5 w-3.5" />
@@ -872,13 +889,13 @@ export function BookDetailPage() {
           aria-expanded={statsOpen}
           className="flex items-center gap-1.5 font-display text-base text-foreground hover:text-primary transition-colors"
         >
-          Reading Stats
+          <Trans>Reading Stats</Trans>
           <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', !statsOpen && '-rotate-90')} />
         </button>
         <button
           type="button"
           onClick={() => setShowPositionHistory(true)}
-          title="Position history — restore a bad sync"
+          title={t`Position history — restore a bad sync`}
           className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
         >
           <HistoryIcon className="w-3.5 h-3.5" />
@@ -910,7 +927,7 @@ export function BookDetailPage() {
                     aria-expanded={sessionsOpen}
                     className="flex items-center gap-1.5 text-sm font-medium text-foreground hover:text-primary transition-colors"
                   >
-                    Sessions ({readingStats.own.sessions})
+                    {(() => { const n = readingStats.own.sessions; return <Trans>Sessions ({n})</Trans> })()}
                     <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', !sessionsOpen && '-rotate-90')} />
                   </button>
                   <SessionLogHint />
@@ -927,7 +944,7 @@ export function BookDetailPage() {
           // No history yet — the manual-tracking entry point (paper / un-synced device).
           <div className="rounded-xl border border-border bg-card px-5 py-4">
             <p className="text-sm text-muted-foreground">
-              No reading logged yet. Track time by hand — handy for a paper copy or a device that isn&apos;t synced.
+              <Trans>No reading logged yet. Track time by hand — handy for a paper copy or a device that isn&apos;t synced.</Trans>
             </p>
             <div className="mt-3">
               <ManualLogControls bookId={Number(id)} onChange={refreshStats} />
@@ -941,7 +958,7 @@ export function BookDetailPage() {
   // Genres block for the left sidebar (variant 1)
   const genresBlock = editing ? (
     <div>
-      <p className="font-display text-base text-foreground mb-2">Genres</p>
+      <p className="font-display text-base text-foreground mb-2"><Trans>Genres</Trans></p>
       <div className="flex flex-wrap gap-1.5 mb-2">
         {draftTags.map(tag => (
           <span key={tag} className="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-muted border border-border text-foreground">
@@ -960,7 +977,7 @@ export function BookDetailPage() {
         value={tagInput}
         onChange={setTagInput}
         suggestions={facets.tags.filter(t => !draftTags.includes(t))}
-        placeholder="Add tag…"
+        placeholder={t`Add tag…`}
         onSelect={tag => {
           if (tag && !draftTags.includes(tag)) {
             setDraftTags(prev => [...prev, tag])
@@ -979,7 +996,7 @@ export function BookDetailPage() {
     </div>
   ) : book.tags.length > 0 ? (
     <div>
-      <p className="font-display text-base text-foreground mb-2">Genres</p>
+      <p className="font-display text-base text-foreground mb-2"><Trans>Genres</Trans></p>
       <div className="flex flex-wrap gap-1.5">
         {book.tags.map(t => (
           <button
@@ -997,25 +1014,25 @@ export function BookDetailPage() {
   // Full-width Details grid for below the description (variant 1)
   const metadataGridFull = (
     <div className="mt-6">
-      <div className="font-display text-base text-foreground mb-3">Details</div>
+      <div className="font-display text-base text-foreground mb-3"><Trans>Details</Trans></div>
       <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-x-6 gap-y-4">
-        <MetaField icon={<Calendar className="w-3.5 h-3.5" />} label="Year"
+        <MetaField icon={<Calendar className="w-3.5 h-3.5" />} label={t`Year`}
           value={field('year') ?? ''} editing={editing}
           onChange={v => setField('year', v)} type="number" placeholder="2024" />
-        <MetaField icon={<Globe className="w-3.5 h-3.5" />} label="Language"
+        <MetaField icon={<Globe className="w-3.5 h-3.5" />} label={t`Language`}
           value={field('language') ?? ''} editing={editing}
           onChange={v => setField('language', v)} placeholder="en" />
-        <MetaField icon={<Hash className="w-3.5 h-3.5" />} label="ISBN"
+        <MetaField icon={<Hash className="w-3.5 h-3.5" />} label={t`ISBN`}
           value={field('isbn') ?? ''} editing={editing}
           onChange={v => setField('isbn', v)} placeholder="978-..." />
-        <MetaField icon={<Building2 className="w-3.5 h-3.5" />} label="Publisher"
+        <MetaField icon={<Building2 className="w-3.5 h-3.5" />} label={t`Publisher`}
           value={field('publisher') ?? ''} editing={editing}
-          onChange={v => setField('publisher', v)} placeholder="Publisher" />
-        <MetaField icon={<FileText className="w-3.5 h-3.5" />} label="Format"
+          onChange={v => setField('publisher', v)} placeholder={t`Publisher`} />
+        <MetaField icon={<FileText className="w-3.5 h-3.5" />} label={t`Format`}
           value={book.files.map(f => f.format.toUpperCase()).join(', ')} editing={false}
           onChange={() => {}} />
-        <MetaField icon={<AlignLeft className="w-3.5 h-3.5" />} label="Words"
-          value={book.word_count != null ? `${book.word_count.toLocaleString()} words` : ''}
+        <MetaField icon={<AlignLeft className="w-3.5 h-3.5" />} label={t`Words`}
+          value={(() => { if (book.word_count == null) return ''; const words = book.word_count.toLocaleString(i18n.locale); return t`${words} words` })()}
           editing={false} onChange={() => {}} />
         {/* How long the whole book would take at your pace (#187). In-progress
             books additionally get "Est. remaining" in the Reading Stats block. */}
@@ -1038,6 +1055,7 @@ export function BookDetailPage() {
           <div className="flex items-start gap-2">
             <span className="text-muted-foreground mt-0.5 shrink-0"><BookMarked className="w-3.5 h-3.5" /></span>
             <div className="flex-1 min-w-0">
+              {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product name */}
               <p className="text-xs text-muted-foreground/70 mb-0.5">Hardcover</p>
               <a
                 href={`https://hardcover.app/books/${book.hardcover_slug}`}
@@ -1053,21 +1071,21 @@ export function BookDetailPage() {
         <div className="flex items-start gap-2">
           <span className="text-muted-foreground mt-0.5 shrink-0"><TagIcon className="w-3.5 h-3.5" /></span>
           <div className="flex-1 min-w-0">
-            <p className="text-xs text-muted-foreground/70 mb-0.5">Type</p>
+            <p className="text-xs text-muted-foreground/70 mb-0.5"><Trans>Type</Trans></p>
             {editing ? (
               <select
                 value={draftBookTypeId ?? ''}
                 onChange={e => setDraftBookTypeId(e.target.value ? Number(e.target.value) : null)}
                 className="w-full text-sm bg-muted rounded-lg px-2 py-1.5 border border-border focus:outline-none focus:ring-2 focus:ring-ring"
               >
-                <option value="">No type</option>
+                <option value="">{t`No type`}</option>
                 {bookTypes.map(bt => (
                   <option key={bt.id} value={bt.id}>{bt.label}</option>
                 ))}
               </select>
             ) : (
               <p className="text-sm text-foreground">
-                {bookTypes.find(bt => bt.id === book.book_type_id)?.label ?? <span className="text-muted-foreground/50 italic">None</span>}
+                {bookTypes.find(bt => bt.id === book.book_type_id)?.label ?? <span className="text-muted-foreground/50 italic">{t`None`}</span>}
               </p>
             )}
           </div>
@@ -1076,18 +1094,18 @@ export function BookDetailPage() {
         <div className="flex items-start gap-2">
           <span className="text-muted-foreground mt-0.5 shrink-0"><FileText className="w-3.5 h-3.5" /></span>
           <div className="flex-1 min-w-0">
-            <p className="text-xs text-muted-foreground/70 mb-0.5">Content</p>
+            <p className="text-xs text-muted-foreground/70 mb-0.5"><Trans>Content</Trans></p>
             {editing ? (
               <select
                 value={draft.content_type ?? 'volume'}
                 onChange={e => setDraft(d => ({ ...d, content_type: e.target.value }))}
                 className="w-full text-sm bg-muted rounded-lg px-2 py-1.5 border border-border focus:outline-none focus:ring-2 focus:ring-ring"
               >
-                <option value="volume">Volume</option>
-                <option value="chapter">Chapter</option>
+                <option value="volume">{t`Volume`}</option>
+                <option value="chapter">{t`Chapter`}</option>
               </select>
             ) : (
-              <p className="text-sm text-foreground capitalize">{book.content_type ?? 'volume'}</p>
+              <p className="text-sm text-foreground">{book.content_type === 'chapter' ? t`Chapter` : t`Volume`}</p>
             )}
           </div>
         </div>
@@ -1097,14 +1115,14 @@ export function BookDetailPage() {
 
   const descriptionBlock = (
     <div className="mt-6">
-      <div className="font-display text-base text-foreground mb-2">Description</div>
+      <div className="font-display text-base text-foreground mb-2"><Trans>Description</Trans></div>
       {editing ? (
         <textarea
           value={field('description') ?? ''}
           onChange={e => setField('description', e.target.value)}
           rows={6}
           className="w-full text-sm text-foreground bg-muted rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-ring resize-none"
-          placeholder="No description"
+          placeholder={t`No description`}
         />
       ) : book.description ? (
         <div>
@@ -1117,12 +1135,12 @@ export function BookDetailPage() {
               onClick={() => setDescExpanded(e => !e)}
               className="mt-1 text-xs font-medium text-primary hover:underline"
             >
-              {descExpanded ? 'Show less' : 'Show more'}
+              {descExpanded ? t`Show less` : t`Show more`}
             </button>
           )}
         </div>
       ) : (
-        <p className="text-sm text-muted-foreground/50 italic">No description</p>
+        <p className="text-sm text-muted-foreground/50 italic"><Trans>No description</Trans></p>
       )}
     </div>
   )
@@ -1132,9 +1150,9 @@ export function BookDetailPage() {
       await api.delete(`/annotations/${annotationId}`)
       setAnnotations(prev => prev.filter(a => a.id !== annotationId))
       setConfirmingHighlight(null)
-      toast.success('Highlight deleted')
+      toast.success(t`Highlight deleted`)
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed to delete highlight')
+      toast.error(e instanceof Error ? e.message : t`Failed to delete highlight`)
     }
   }
 
@@ -1144,9 +1162,9 @@ export function BookDetailPage() {
       await api.put(`/annotations/${annotationId}`, { note })
       setAnnotations(prev => prev.map(a => (a.id === annotationId ? { ...a, note } : a)))
       setEditingNoteId(null)
-      toast.success(note ? 'Note saved — syncs to your devices' : 'Note removed')
+      toast.success(note ? t`Note saved — syncs to your devices` : t`Note removed`)
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed to save note')
+      toast.error(e instanceof Error ? e.message : t`Failed to save note`)
     }
   }
 
@@ -1158,7 +1176,7 @@ export function BookDetailPage() {
         aria-expanded={highlightsOpen}
         className="flex items-center gap-1.5 font-display text-base text-foreground mb-3 hover:text-primary transition-colors"
       >
-        Highlights &amp; Notes
+        <Trans>Highlights &amp; Notes</Trans>
         <span className="text-muted-foreground/50 font-normal text-sm">({annotations.length})</span>
         <ChevronDown className={cn('w-3.5 h-3.5 transition-transform', !highlightsOpen && '-rotate-90')} />
       </button>
@@ -1173,10 +1191,10 @@ export function BookDetailPage() {
                 {confirmingHighlight === a.id ? (
                   <span className="flex items-center gap-1.5 text-[11px] shrink-0">
                     <button onClick={() => deleteHighlight(a.id)} className="font-medium text-destructive hover:underline">
-                      Delete
+                      <Trans>Delete</Trans>
                     </button>
                     <button onClick={() => setConfirmingHighlight(null)} className="text-muted-foreground hover:text-foreground">
-                      Cancel
+                      <Trans>Cancel</Trans>
                     </button>
                   </span>
                 ) : (
@@ -1186,16 +1204,16 @@ export function BookDetailPage() {
                         setEditingNoteDraft(a.note ?? '')
                         setEditingNoteId(prev => (prev === a.id ? null : a.id))
                       }}
-                      title={a.note ? 'Edit note' : 'Add a note'}
-                      aria-label={a.note ? 'Edit note' : 'Add a note'}
+                      title={a.note ? t`Edit note` : t`Add a note`}
+                      aria-label={a.note ? t`Edit note` : t`Add a note`}
                       className="p-1 -mt-1 rounded text-muted-foreground/50 hover:text-foreground transition-all opacity-60 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
                     >
                       <Edit2 className="w-3.5 h-3.5" />
                     </button>
                     <button
                       onClick={() => setConfirmingHighlight(a.id)}
-                      title="Delete this highlight"
-                      aria-label="Delete this highlight"
+                      title={t`Delete this highlight`}
+                      aria-label={t`Delete this highlight`}
                       className="p-1 -mt-1 -mr-1 rounded text-muted-foreground/50 hover:text-destructive transition-all opacity-60 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
                     >
                       <Trash2 className="w-3.5 h-3.5" />
@@ -1215,15 +1233,15 @@ export function BookDetailPage() {
                     onChange={e => setEditingNoteDraft(e.target.value)}
                     autoFocus
                     rows={2}
-                    placeholder="Your note — syncs back to KOReader on the next sync"
+                    placeholder={t`Your note — syncs back to KOReader on the next sync`}
                     className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                   />
                   <span className="flex items-center gap-2 text-xs">
                     <button onClick={() => saveHighlightNote(a.id)} className="font-medium text-primary hover:underline">
-                      Save note
+                      <Trans>Save note</Trans>
                     </button>
                     <button onClick={() => setEditingNoteId(null)} className="text-muted-foreground hover:text-foreground">
-                      Cancel
+                      <Trans>Cancel</Trans>
                     </button>
                   </span>
                 </div>
@@ -1248,13 +1266,13 @@ export function BookDetailPage() {
           <div className="flex items-center gap-1 text-sm text-muted-foreground min-w-0 shrink">
             {/* p-2.5/-m-1.5: the bare 14px icons were the whole tap target on
                 phones (UX sweep finding) — pad the hit area, not the visuals. */}
-            <Link to="/" title="Home" aria-label="Home" className="flex items-center hover:text-foreground transition-colors shrink-0 p-2.5 -m-1.5">
+            <Link to="/" title={t`Home`} aria-label={t`Home`} className="flex items-center hover:text-foreground transition-colors shrink-0 p-2.5 -m-1.5">
               <Home className="w-3.5 h-3.5" />
             </Link>
             <ChevronRight className="w-3.5 h-3.5 opacity-30 shrink-0" />
-            <Link to="/?tab=books" title="Library" className="flex items-center gap-1 hover:text-foreground transition-colors shrink-0 p-2.5 -m-1.5">
+            <Link to="/?tab=books" title={t`Library`} className="flex items-center gap-1 hover:text-foreground transition-colors shrink-0 p-2.5 -m-1.5">
               <Library className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">Library</span>
+              <span className="hidden sm:inline"><Trans>Library</Trans></span>
             </Link>
             {adjacent && (adjacent.prev || adjacent.next) && book && (
               <>
@@ -1271,7 +1289,7 @@ export function BookDetailPage() {
                 )}
                 <ChevronRight className="w-3.5 h-3.5 opacity-30 shrink-0" />
                 <span className="text-foreground font-medium truncate max-w-[100px] sm:max-w-[180px]">
-                  {book.series_index != null ? `Vol. ${book.series_index}` : book.title}
+                  {(() => { const idx = book.series_index; return idx != null ? t`Vol. ${idx}` : book.title })()}
                 </span>
                 <div className="flex items-center gap-0 shrink-0 ml-1">
                   {adjacent.prev ? (
@@ -1304,21 +1322,21 @@ export function BookDetailPage() {
             {canDelete && !editing && (
               confirmDelete ? (
                 <div className="flex items-center gap-1.5 flex-wrap justify-end">
-                  <span className="text-xs text-muted-foreground hidden sm:inline truncate max-w-[120px]">Delete "{book.title}"?</span>
+                  {(() => { const title = book.title; return <span className="text-xs text-muted-foreground hidden sm:inline truncate max-w-[120px]"><Trans>Delete "{title}"?</Trans></span> })()}
                   <button
                     onClick={handleDelete}
                     disabled={deleting}
                     className="flex items-center gap-1.5 px-2.5 py-2.5 sm:py-1.5 rounded-lg text-xs font-medium border border-transparent bg-destructive text-white hover:opacity-90 transition-all disabled:opacity-50"
                   >
                     <Trash2 className="w-3.5 h-3.5" />
-                    {deleting ? 'Deleting…' : 'Confirm'}
+                    {deleting ? t`Deleting…` : t`Confirm`}
                   </button>
                   <button
                     onClick={() => setConfirmDelete(false)}
                     className="flex items-center gap-1.5 px-2.5 py-2.5 sm:py-1.5 rounded-lg text-xs font-medium border border-transparent text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
                   >
                     <X className="w-3.5 h-3.5" />
-                    <span className="hidden sm:inline">Cancel</span>
+                    <span className="hidden sm:inline"><Trans>Cancel</Trans></span>
                   </button>
                 </div>
               ) : (
@@ -1327,7 +1345,7 @@ export function BookDetailPage() {
                   className="flex items-center gap-1.5 px-2.5 py-2.5 sm:py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-muted-foreground hover:text-destructive hover:border-destructive/30 transition-all duration-200"
                 >
                   <Trash2 className="w-3.5 h-3.5" />
-                  <span className="hidden sm:inline">Delete</span>
+                  <span className="hidden sm:inline"><Trans>Delete</Trans></span>
                 </button>
               )
             )}
@@ -1346,7 +1364,7 @@ export function BookDetailPage() {
                       )}
                     >
                       <Library className="w-3.5 h-3.5" />
-                      <span className="hidden sm:inline">Libraries</span>
+                      <span className="hidden sm:inline"><Trans>Libraries</Trans></span>
                       {localLibIds.length > 0 && (
                         <span className="ml-0.5 bg-primary text-primary-foreground rounded-full px-1.5 py-px text-[10px] font-bold leading-none">
                           {localLibIds.length}
@@ -1356,7 +1374,7 @@ export function BookDetailPage() {
                     {libMenuOpen && (
                       <div className="absolute right-0 top-full mt-1 z-40 bg-card border border-border rounded-xl shadow-xl shadow-accent-soft py-1 min-w-48 max-w-[calc(100vw-2rem)]">
                         <p className="px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground border-b border-border mb-1">
-                          Add to library
+                          <Trans>Add to library</Trans>
                         </p>
                         {libraries.filter(l => l.can_edit).map(lib => {
                           const inLib = localLibIds.includes(lib.id)
@@ -1381,7 +1399,7 @@ export function BookDetailPage() {
                                 onClick={() => toggleLibrary(lib.id)}
                                 disabled={pending}
                                 className="shrink-0 p-0.5 rounded hover:bg-accent transition-colors disabled:opacity-60"
-                                title={inLib ? 'Remove from library' : 'Add to library'}
+                                title={inLib ? t`Remove from library` : t`Add to library`}
                               >
                                 {inLib
                                   ? <Check className="w-3.5 h-3.5 text-primary" />
@@ -1397,11 +1415,11 @@ export function BookDetailPage() {
                 )}
                 <button
                   onClick={() => setShowShare(true)}
-                  title="Share this book — a public metadata-only page"
+                  title={t`Share this book — a public metadata-only page`}
                   className="flex items-center gap-1.5 px-2.5 py-2.5 sm:py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted hover:-translate-y-0.5 transition-all duration-200"
                 >
                   <Share2 className="w-3.5 h-3.5" />
-                  <span className="hidden sm:inline">Share</span>
+                  <span className="hidden sm:inline"><Trans>Share</Trans></span>
                 </button>
                 {book.content_type !== 'chapter' && (
                   <button
@@ -1409,7 +1427,7 @@ export function BookDetailPage() {
                     className="flex items-center gap-1.5 px-2.5 py-2.5 sm:py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted hover:-translate-y-0.5 transition-all duration-200"
                   >
                     <Sparkles className="w-3.5 h-3.5" />
-                    <span className="hidden sm:inline">Fetch Metadata</span>
+                    <span className="hidden sm:inline"><Trans>Fetch Metadata</Trans></span>
                   </button>
                 )}
                 <button
@@ -1417,7 +1435,7 @@ export function BookDetailPage() {
                   className="flex items-center gap-1.5 px-2.5 py-2.5 sm:py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted hover:-translate-y-0.5 transition-all duration-200"
                 >
                   <Edit2 className="w-3.5 h-3.5" />
-                  <span className="hidden sm:inline">Edit</span>
+                  <span className="hidden sm:inline"><Trans>Edit</Trans></span>
                 </button>
               </>
             )}
@@ -1429,14 +1447,14 @@ export function BookDetailPage() {
                   className="flex items-center gap-1.5 px-2.5 py-2.5 sm:py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-50"
                 >
                   <Save className="w-3.5 h-3.5" />
-                  {saving ? 'Saving…' : 'Save'}
+                  {saving ? t`Saving…` : t`Save`}
                 </button>
                 <button
                   onClick={cancelEdit}
                   className="flex items-center gap-1.5 px-2.5 py-2.5 sm:py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
                 >
                   <X className="w-3.5 h-3.5" />
-                  <span className="hidden sm:inline">Cancel</span>
+                  <span className="hidden sm:inline"><Trans>Cancel</Trans></span>
                 </button>
               </>
             )}
@@ -1530,6 +1548,7 @@ function ActivityChart({ timeline, bookId, onChange }: {
   bookId?: number
   onChange?: () => void
 }) {
+  const { t, i18n } = useLingui()
   // Click-through: a bar opens that day's sessions for quick trim/delete —
   // e.g. an accidentally imported sitting, without scrolling to the full log.
   const [dayOpen, setDayOpen] = useState<string | null>(null)
@@ -1540,7 +1559,9 @@ function ActivityChart({ timeline, bookId, onChange }: {
   // reading days they rendered as giant full-width slabs. Capped at the last
   // 365 days so a years-long log can't produce more bars than pixels.
   const byDate = new Map(timeline.map(d => [d.date, d]))
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- ISO time suffix
   const startD = new Date(timeline[0].date + 'T00:00:00')
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- ISO time suffix
   const endD = new Date(timeline[timeline.length - 1].date + 'T00:00:00')
   let days: typeof timeline = []
   for (const d = new Date(startD); d <= endD; d.setDate(d.getDate() + 1)) {
@@ -1567,7 +1588,7 @@ function ActivityChart({ timeline, bookId, onChange }: {
     // looked half-finished against the full-width card chrome. Big bars for a
     // short history are fine; the gap-filled axis keeps the spacing honest.
     <div className="flex flex-col">
-      <p className="text-xs text-muted-foreground/70 mb-1.5 shrink-0">Activity</p>
+      <p className="text-xs text-muted-foreground/70 mb-1.5 shrink-0"><Trans>Activity</Trans></p>
       {/* Fixed-height strip: flex-1 fill only works inside a sized flex parent,
           and the hero wraps this in a plain div — flex-1 collapsed to 0px there
           (bars rendered into no vertical space at all) */}
@@ -1579,7 +1600,12 @@ function ActivityChart({ timeline, bookId, onChange }: {
             const pct = d.seconds > 0 ? Math.max(d.seconds / max, 0.06) : 0
             const mins = Math.round(d.seconds / 60)
             const clickable = d.seconds > 0 && bookId != null
-            const tip = `${fmtDay(d.date)}: ${mins}m${d.pages > 0 ? `, ${d.pages} pages` : ''}${d.progress_pct != null ? ` · ${d.progress_pct}% in` : ''}${clickable ? ' — click for sessions' : ''}`
+            const dayStr = fmtDay(d.date)
+            const pages = d.pages, prog = d.progress_pct
+            const tip = t`${dayStr}: ${mins}m` +
+              (pages > 0 ? t`, ${pages} pages` : '') +
+              (prog != null ? t` · ${prog}% in` : '') +
+              (clickable ? t` — click for sessions` : '')
             return (
               <div
                 key={d.date}
@@ -1607,13 +1633,13 @@ function ActivityChart({ timeline, bookId, onChange }: {
               <div className="flex shrink-0 items-center justify-between border-b border-border px-5 py-3.5">
                 <span className="flex items-center gap-1.5">
                   <h2 className="font-display text-sm text-foreground">
-                    Sessions · {new Date(dayOpen + 'T00:00:00').toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' })}
+                    {(() => { const d = new Date(dayOpen + 'T00:00:00').toLocaleDateString(i18n.locale, { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' }); return t`Sessions · ${d}` })()}
                   </h2>
                   <SessionLogHint />
                 </span>
                 <button
                   type="button"
-                  aria-label="Close"
+                  aria-label={t`Close`}
                   onClick={() => setDayOpen(null)}
                   className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 >
@@ -1632,8 +1658,8 @@ function ActivityChart({ timeline, bookId, onChange }: {
         <div className="mt-3">
           <div className="flex items-center justify-between mb-1">
             <span className="flex items-center gap-1">
-              <p className="text-xs text-muted-foreground/70">Progress</p>
-              <InfoHint text="How far through the book you'd read by each date." />
+              <p className="text-xs text-muted-foreground/70"><Trans>Progress</Trans></p>
+              <InfoHint text={t`How far through the book you'd read by each date.`} />
             </span>
             {lastProgress != null && (
               <p className="text-xs tabular-nums text-muted-foreground/60">{Math.round(lastProgress)}%</p>
@@ -1654,8 +1680,9 @@ function ActivityChart({ timeline, bookId, onChange }: {
 
 // Friendly label for a ReadingSession.device value.
 function sourceLabel(device: string): string {
-  if (!device || device === 'web-reader' || device === 'web') return 'Web reader'
-  if (device === 'manual') return 'Manual'
+  if (!device || device === 'web-reader' || device === 'web') return t`Web reader`
+  if (device === 'manual') return t`Manual`
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- product name
   if (device === 'koreader') return 'KOReader'
   return device
 }
@@ -1669,7 +1696,7 @@ function SourceSplit({ sources }: { sources: { device: string; seconds: number; 
   if (total <= 0 || sources.length < 2) return null
   return (
     <div className="mt-4">
-      <p className="text-xs text-muted-foreground/70 mb-1.5">Where you read</p>
+      <p className="text-xs text-muted-foreground/70 mb-1.5"><Trans>Where you read</Trans></p>
       {/* gap-px: adjacent primary shades are close — a hairline seam marks the split */}
       <div className="flex gap-px h-2 rounded-full overflow-hidden bg-muted">
         {sources.map((s, i) => (
@@ -1697,6 +1724,7 @@ function SourceSplit({ sources }: { sources: { device: string; seconds: number; 
 // ── Reading intensity: per-page dwell across the book, from imported KOReader page-stats ─────
 
 function IntensityBlock({ data, bookId, onChange }: { data: BookIntensity; bookId: number; onChange?: () => void }) {
+  const { t } = useLingui()
   const max = Math.max(...data.curve, 1)
   const finished = data.pct_read >= 99
   const [confirmClear, setConfirmClear] = useState(false)
@@ -1712,21 +1740,21 @@ function IntensityBlock({ data, bookId, onChange }: { data: BookIntensity; bookI
     <div className="rounded-xl border border-border bg-card px-5 py-4">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
         <span className="flex items-center gap-1.5">
-          <p className="font-display text-sm text-foreground">Reading intensity</p>
-          <InfoHint text="Where in the book your time went — taller means more time spent on those pages." />
+          <p className="font-display text-sm text-foreground"><Trans>Reading intensity</Trans></p>
+          <InfoHint text={t`Where in the book your time went — taller means more time spent on those pages.`} />
         </span>
         <span className="flex items-center gap-2">
           <p className="text-xs text-muted-foreground">
             <span className="font-medium tabular-nums text-foreground">{data.pages_read.toLocaleString()}</span>
-            {' '}of {data.total_pages.toLocaleString()} pages
+            {' '}{(() => { const totalPages = data.total_pages.toLocaleString(); return <Trans>of {totalPages} pages</Trans> })()}
             {!finished && <span className="tabular-nums"> · {data.pct_read}%</span>}
-            {' · '}{formatDuration(data.total_seconds)} on device
+            {' · '}{(() => { const dur = formatDuration(data.total_seconds); return <Trans>{dur} on device</Trans> })()}
           </p>
           <button
             type="button"
             onClick={() => setConfirmClear(o => !o)}
             className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
-            title="Clear imported history — remove this book's KOReader page data"
+            title={t`Clear imported history — remove this book's KOReader page data`}
           >
             <Trash2 className="w-3.5 h-3.5" />
           </button>
@@ -1735,7 +1763,7 @@ function IntensityBlock({ data, bookId, onChange }: { data: BookIntensity; bookI
       {confirmClear && (
         <div className="mt-3 flex flex-wrap items-center gap-2 rounded bg-muted/40 px-3 py-2 text-xs">
           <span className="text-muted-foreground">
-            Remove all of this book&apos;s imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on.
+            <Trans>Remove all of this book&apos;s imported KOReader history? Web and manual sessions stay. Reading it on the device again will re-import from there on.</Trans>
           </span>
           <button
             type="button"
@@ -1743,14 +1771,14 @@ function IntensityBlock({ data, bookId, onChange }: { data: BookIntensity; bookI
             disabled={clearing}
             className="rounded border border-destructive/40 px-2 py-0.5 text-destructive hover:bg-destructive/10 transition-colors disabled:opacity-40"
           >
-            {clearing ? 'Clearing…' : 'Clear'}
+            {clearing ? t`Clearing…` : t`Clear`}
           </button>
           <button
             type="button"
             onClick={() => setConfirmClear(false)}
             className="rounded border border-border px-2 py-0.5 text-muted-foreground hover:bg-muted transition-colors"
           >
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
         </div>
       )}
@@ -1761,7 +1789,8 @@ function IntensityBlock({ data, bookId, onChange }: { data: BookIntensity; bookI
           {data.curve.map((secs, i) => {
             const pct = secs > 0 ? Math.max(secs / max, 0.04) : 0
             const at = Math.round((i / data.curve.length) * 100)
-            const tip = secs > 0 ? `~${at}% in · ${formatDuration(secs)}` : `~${at}% in · not read`
+            const dur = formatDuration(secs)
+            const tip = secs > 0 ? t`~${at}% in · ${dur}` : t`~${at}% in · not read`
             return (
               <div
                 key={i}
@@ -1774,9 +1803,9 @@ function IntensityBlock({ data, bookId, onChange }: { data: BookIntensity; bookI
         </div>
       </div>
       <div className="flex justify-between text-xs text-muted-foreground/50 mt-1">
-        <span>start</span>
+        <span>{t`start`}</span>
         {data.reread_bins > 0 && (
-          <span className="text-muted-foreground/70">{data.reread_bins} stretch{data.reread_bins !== 1 ? 'es' : ''} re-read</span>
+          <span className="text-muted-foreground/70">{plural(data.reread_bins, { one: '# stretch re-read', other: '# stretches re-read' })}</span>
         )}
         <span>end</span>
       </div>
@@ -1787,6 +1816,7 @@ function IntensityBlock({ data, bookId, onChange }: { data: BookIntensity; bookI
 // ── Time per chapter: page-stat dwell bucketed into the book's TOC boundaries ─────
 
 function ChapterTimesBlock({ chapters }: { chapters: ChapterTime[] }) {
+  const { t } = useLingui()
   const [showDetails, setShowDetails] = useState(false)
   const max = Math.max(...chapters.map(c => c.seconds), 1)
   const total = chapters.reduce((s, c) => s + c.seconds, 0)
@@ -1794,10 +1824,10 @@ function ChapterTimesBlock({ chapters }: { chapters: ChapterTime[] }) {
     <div className="rounded-xl border border-border bg-card px-5 py-4">
       <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
         <span className="flex items-center gap-1.5">
-          <p className="font-display text-sm text-foreground">Time per chapter</p>
-          <InfoHint text="Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device." />
+          <p className="font-display text-sm text-foreground"><Trans>Time per chapter</Trans></p>
+          <InfoHint text={t`Device reading time mapped into the book's chapters. Hover the line for a chapter's time; a flat stretch hasn't been read on a synced device.`} />
         </span>
-        <p className="text-xs text-muted-foreground tabular-nums">{formatDuration(total)} across {chapters.length} chapters</p>
+        {(() => { const dur = formatDuration(total); const n = chapters.length; return <p className="text-xs text-muted-foreground tabular-nums">{t`${dur} across ${n} chapters`}</p> })()}
       </div>
       <ChapterLineChart chapters={chapters} />
       {showDetails && (
@@ -1828,7 +1858,7 @@ function ChapterTimesBlock({ chapters }: { chapters: ChapterTime[] }) {
         onClick={() => setShowDetails(v => !v)}
         className="mt-2.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
       >
-        {showDetails ? 'Hide details' : 'Show details'}
+        {showDetails ? t`Hide details` : t`Show details`}
       </button>
     </div>
   )
@@ -1840,6 +1870,7 @@ function ChapterTimesBlock({ chapters }: { chapters: ChapterTime[] }) {
 // in percent, because the SVG stretches (preserveAspectRatio="none") and
 // would distort anything drawn inside it.
 function ChapterLineChart({ chapters }: { chapters: ChapterTime[] }) {
+  const { t } = useLingui()
   const W = 600, H = 80, PAD = 2
   const n = chapters.length
   const max = Math.max(...chapters.map(c => c.seconds), 1)
@@ -1861,7 +1892,7 @@ function ChapterLineChart({ chapters }: { chapters: ChapterTime[] }) {
   return (
     <div className="mt-3">
       <div className="relative" onMouseMove={onMove} onMouseLeave={() => setHover(null)}>
-        <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-20 block" preserveAspectRatio="none" role="img" aria-label="Time per chapter, line view">
+        <svg viewBox={`0 0 ${W} ${H}`} className="w-full h-20 block" preserveAspectRatio="none" role="img" aria-label={t`Time per chapter, line view`}>
           <line x1={PAD} y1={H - PAD} x2={W - PAD} y2={H - PAD} className="stroke-border/60" strokeWidth="1" />
           <polygon points={area} className="fill-primary/15" />
           <polyline points={pts} className="stroke-primary/70 fill-none" strokeWidth="2" strokeLinejoin="round" vectorEffect="non-scaling-stroke" />
@@ -1882,7 +1913,7 @@ function ChapterLineChart({ chapters }: { chapters: ChapterTime[] }) {
             >
               <span className="text-foreground">{h.title}</span>
               <span className="text-muted-foreground tabular-nums">
-                {' · '}{h.seconds <= 0 ? 'not read' : h.seconds < 60 ? '<1m' : formatDuration(h.seconds)}
+                {' · '}{h.seconds <= 0 ? t`not read` : h.seconds < 60 ? '<1m' : formatDuration(h.seconds)}
                 {chapterReadSpanShort(h) && ` · ${chapterReadSpanShort(h)}`}
               </span>
             </div>
@@ -1890,8 +1921,8 @@ function ChapterLineChart({ chapters }: { chapters: ChapterTime[] }) {
         )}
       </div>
       <div className="flex justify-between text-xs text-muted-foreground/50 mt-1">
-        <span>ch. 1</span>
-        <span>ch. {n}</span>
+        <span><Trans>ch. 1</Trans></span>
+        <span><Trans>ch. {n}</Trans></span>
       </div>
     </div>
   )
@@ -1907,6 +1938,7 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
   onChange: () => void
   exportRows?: { date: string; seconds: number; pages: number; progress_pct: number | null }[]
 }) {
+  const { t } = useLingui()
   const { toast } = useToast()
   const [logging, setLogging] = useState(false)
   const [minutes, setMinutes] = useState('')
@@ -1928,7 +1960,7 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
       setMinutes(''); setPct(''); setLogging(false)
       onChange()
     } catch (e) {
-      toast.error((e as Error).message ?? 'Failed to log session')
+      toast.error((e as Error).message ?? t`Failed to log session`)
     } finally {
       setSaving(false)
     }
@@ -1955,6 +1987,7 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
   }
 
   const canExport = exportRows != null && exportRows.length > 0
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- Tailwind classes
   const chip = 'rounded-md border border-border px-2 py-0.5 text-xs font-medium text-muted-foreground hover:text-foreground hover:border-primary/50 transition-colors'
 
   return (
@@ -1965,7 +1998,7 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
           onClick={() => setLogging(o => !o)}
           className="flex items-center gap-1.5 text-sm font-medium text-foreground hover:text-primary transition-colors"
         >
-          <Plus className="w-4 h-4" /> Log session
+          <Plus className="w-4 h-4" /> <Trans>Log session</Trans>
         </button>
         {canExport && (
           <div className="flex items-center gap-1.5">
@@ -1978,7 +2011,7 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
       {logging && (
         <form onSubmit={submitLog} className="mt-3 flex flex-wrap items-end gap-3">
           <label className="flex flex-col gap-1">
-            <span className="text-xs text-muted-foreground/70">Minutes</span>
+            <span className="text-xs text-muted-foreground/70"><Trans>Minutes</Trans></span>
             <input
               type="number" min="1" step="1" required autoFocus
               value={minutes} onChange={e => setMinutes(e.target.value)}
@@ -1986,7 +2019,7 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
             />
           </label>
           <label className="flex flex-col gap-1">
-            <span className="text-xs text-muted-foreground/70">Progress % <span className="text-muted-foreground/40">(optional)</span></span>
+            <span className="text-xs text-muted-foreground/70"><Trans>Progress % <span className="text-muted-foreground/40">(optional)</span></Trans></span>
             <input
               type="number" min="0" max="100" step="1"
               value={pct} onChange={e => setPct(e.target.value)}
@@ -1997,13 +2030,13 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
             type="submit" disabled={saving || !minutes}
             className="rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
           >
-            {saving ? 'Saving…' : 'Add'}
+            {saving ? t`Saving…` : t`Add`}
           </button>
           <button
             type="button" onClick={() => { setLogging(false); setMinutes(''); setPct('') }}
             className="rounded-md px-3 py-1.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
           >
-            Cancel
+            <Trans>Cancel</Trans>
           </button>
         </form>
       )}
@@ -2012,18 +2045,21 @@ function ManualLogControls({ bookId, onChange, exportRows }: {
 }
 
 function MomentumChip({ momentum }: { momentum: NonNullable<BookReadingStats['momentum']> }) {
+  const { t } = useLingui()
   const Icon = momentum.direction === 'up' ? TrendingUp : momentum.direction === 'down' ? TrendingDown : Minus
   const tone =
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- Tailwind classes
     momentum.direction === 'up' ? 'text-emerald-600 dark:text-emerald-400'
       : momentum.direction === 'down' ? 'text-muted-foreground'
         : 'text-muted-foreground'
+  const deltaStr = momentum.delta_pct != null ? `${momentum.delta_pct > 0 ? '+' : ''}${momentum.delta_pct}` : ''
   const label = momentum.delta_pct != null
-    ? `${momentum.delta_pct > 0 ? '+' : ''}${momentum.delta_pct}% vs last week`
-    : 'new this week'
+    ? t`${deltaStr}% vs last week`
+    : t`new this week`
   return (
     <span
       className={cn('flex items-center gap-1 text-xs font-medium', tone)}
-      title={`${formatDuration(momentum.recent_seconds)} in the last 7 days vs ${formatDuration(momentum.prior_seconds)} the week before`}
+      title={(() => { const recent = formatDuration(momentum.recent_seconds); const prior = formatDuration(momentum.prior_seconds); return t`${recent} in the last 7 days vs ${prior} the week before` })()}
     >
       <Icon className="w-3.5 h-3.5" />
       {label}
@@ -2032,30 +2068,32 @@ function MomentumChip({ momentum }: { momentum: NonNullable<BookReadingStats['mo
 }
 
 function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps) {
+  const { t } = useLingui()
+  const pacePerMin = own.pace_pages_per_min
   const supporting: { label: string; value: string }[] = [
-    { label: 'sessions', value: String(own.sessions) },
-    { label: 'pages', value: own.pages_turned > 0 ? String(own.pages_turned) : '—' },
-    { label: 'avg session', value: formatDuration(own.avg_session_seconds) },
-    ...(own.pace_pages_per_min != null
-      ? [{ label: 'pace', value: `${own.pace_pages_per_min} pg/min` }] : []),
+    { label: t`sessions`, value: String(own.sessions) },
+    { label: t`pages`, value: own.pages_turned > 0 ? String(own.pages_turned) : '—' },
+    { label: t`avg session`, value: formatDuration(own.avg_session_seconds) },
+    ...(pacePerMin != null
+      ? [{ label: t`pace`, value: t`${pacePerMin} pg/min` }] : []),
   ]
 
   const bottomStats: { label: string; value: string }[] = []
   if (own.first_read) {
-    bottomStats.push({ label: 'First read', value: formatDate(own.first_read.slice(0, 10)) })
+    bottomStats.push({ label: t`First read`, value: formatDate(own.first_read.slice(0, 10)) })
   }
   if (own.last_read) {
-    bottomStats.push({ label: 'Last read', value: formatDate(own.last_read.slice(0, 10)) })
+    bottomStats.push({ label: t`Last read`, value: formatDate(own.last_read.slice(0, 10)) })
   }
   if (own.finished_at) {
-    bottomStats.push({ label: 'Finished', value: formatDate(own.finished_at.slice(0, 10)) })
+    bottomStats.push({ label: t`Finished`, value: formatDate(own.finished_at.slice(0, 10)) })
   }
   // Reading days from distinct session days
   if (own.session_timeline.length > 0) {
-    bottomStats.push({ label: 'Reading days', value: String(own.session_timeline.length) })
+    bottomStats.push({ label: t`Reading days`, value: String(own.session_timeline.length) })
   }
   if (own.status === 'reading' && own.estimated_finish_seconds != null) {
-    bottomStats.push({ label: 'Est. remaining', value: formatDuration(own.estimated_finish_seconds) })
+    bottomStats.push({ label: t`Est. remaining`, value: formatDuration(own.estimated_finish_seconds) })
   }
 
   return (
@@ -2066,7 +2104,7 @@ function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps)
           <p className="text-3xl font-semibold tabular-nums text-foreground leading-none">
             {formatDuration(own.total_seconds)}
           </p>
-          <p className="text-sm text-muted-foreground">read</p>
+          <p className="text-sm text-muted-foreground"><Trans>read</Trans></p>
         </div>
         {own.momentum && <MomentumChip momentum={own.momentum} />}
         {/* 2×2 on phones — free wrapping left "pace" orphaned on its own line */}
@@ -2093,7 +2131,7 @@ function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps)
           own.session_timeline.filter(d => d.progress_pct != null).length > 1) && (
         <div className="mt-4">
           <div className="flex items-center justify-between mb-1.5">
-            <span className="text-xs text-muted-foreground/70">Progress</span>
+            <span className="text-xs text-muted-foreground/70"><Trans>Progress</Trans></span>
             <span className="text-xs font-medium tabular-nums text-foreground">{Math.round(own.progress * 100)}%</span>
           </div>
           <div className="h-1.5 rounded-full bg-muted overflow-hidden">
@@ -2117,7 +2155,12 @@ function StatsLayoutHero({ own, aggregate, bookId, onChange }: StatsLayoutProps)
           Still shown when someone ELSE read a book you haven't touched. */}
       {aggregate && (aggregate.distinct_readers > 1 || own.total_seconds === 0) && (
         <p className="text-xs text-muted-foreground/60 mt-3">
-          All readers: {formatDuration(aggregate.total_seconds)} · {aggregate.total_sessions} reading day{aggregate.total_sessions !== 1 ? 's' : ''} · {aggregate.distinct_readers} reader{aggregate.distinct_readers !== 1 ? 's' : ''}
+          {(() => {
+            const dur = formatDuration(aggregate.total_seconds)
+            const days = plural(aggregate.total_sessions, { one: '# reading day', other: '# reading days' })
+            const readers = plural(aggregate.distinct_readers, { one: '# reader', other: '# readers' })
+            return t`All readers: ${dur} · ${days} · ${readers}`
+          })()}
         </p>
       )}
       {/* Log a session by hand · export the log */}

--- a/frontend/src/pages/BookDetailPage.tsx
+++ b/frontend/src/pages/BookDetailPage.tsx
@@ -1040,7 +1040,7 @@ export function BookDetailPage() {
           <div className="flex items-start gap-2">
             <span className="text-muted-foreground mt-0.5 shrink-0"><Timer className="w-3.5 h-3.5" /></span>
             <div className="flex-1 min-w-0">
-              <p className="text-xs text-muted-foreground/70 mb-0.5">Est. read time</p>
+              <p className="text-xs text-muted-foreground/70 mb-0.5"><Trans>Est. read time</Trans></p>
               <p className="text-sm text-foreground" title={describePace(estimate.pace, estimate.method)}>
                 {formatEstimateHours(estimate.seconds)}
                 {estimate.days != null && (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -9,6 +9,9 @@ import {
 } from 'lucide-react'
 import { AppHeader, HeaderSearch } from '@/components/AppHeader'
 import { useAuth, isMember, isAdmin } from '@/contexts/AuthContext'
+import { Trans, useLingui, Plural } from '@lingui/react/macro'
+import { t, plural, msg } from '@lingui/core/macro'
+import type { MessageDescriptor } from '@lingui/core'
 import { useToast } from '@/contexts/ToastContext'
 import { useSidebarLists } from '@/lib/sidebarLists'
 import { BookCard, type ViewMode } from '@/components/BookCard'
@@ -115,8 +118,21 @@ interface HighlightSpotlight {
   } | null
 }
 
-const SORT_LABELS: Record<SortField, string> = {
-  title: 'Title', author: 'Author', year: 'Year', added_at: 'Date Added', rating: 'My Rating',
+const SORT_LABELS: Record<SortField, MessageDescriptor> = {
+  title: msg`Title`, author: msg`Author`, year: msg`Year`, added_at: msg`Date Added`, rating: msg`My Rating`,
+}
+
+// Reading-status + series-status display names, shared by filter buttons and chips.
+const READING_STATUS_LABELS: Record<string, MessageDescriptor> = {
+  unread: msg`Unread`, want_to_read: msg`Want to Read`, reading: msg`Reading`,
+  read: msg`Read`, shelved: msg`Shelved`,
+}
+const MISSING_LABELS: Record<string, MessageDescriptor> = {
+  cover: msg`Cover`, description: msg`Description`, author: msg`Author`,
+  series: msg`Series`, any: msg`Any`,
+}
+const SERIES_STATUS_LABELS: Record<string, MessageDescriptor> = {
+  ongoing: msg`ongoing`, finished: msg`finished`, hiatus: msg`hiatus`,
 }
 
 const VIEW_KEY = 'tome_view'
@@ -138,6 +154,7 @@ interface BulkDeleteModalProps {
 }
 
 function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: BulkDeleteModalProps) {
+  const { t } = useLingui()
   const [deleting, setDeleting] = useState(false)
 
   if (!open) return null
@@ -163,7 +180,7 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
             <div className="flex items-center gap-2">
               <Trash2 className="w-4 h-4 text-destructive" />
               <h2 className="text-base font-semibold text-foreground">
-                Delete {selectedIds.size} book{selectedIds.size !== 1 ? 's' : ''}
+                <Plural value={selectedIds.size} one="Delete # book" other="Delete # books" />
               </h2>
             </div>
             <button
@@ -178,7 +195,7 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
           {/* Warning */}
           <div className="px-6 pb-3 shrink-0">
             <p className="text-xs text-destructive bg-destructive/10 border border-destructive/20 rounded-lg px-3 py-2">
-              This permanently removes the selected books and their files from disk. This cannot be undone.
+              <Trans>This permanently removes the selected books and their files from disk. This cannot be undone.</Trans>
             </p>
           </div>
 
@@ -213,7 +230,7 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
               })}
               {selectedIds.size > selectedBooks.length && (
                 <p className="text-xs text-muted-foreground py-2">
-                  …and {selectedIds.size - selectedBooks.length} more not shown
+                  {(() => { const more = selectedIds.size - selectedBooks.length; return t`…and ${more} more not shown` })()}
                 </p>
               )}
             </div>
@@ -223,7 +240,7 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
           <div className="flex items-center justify-end gap-2 px-6 py-4 border-t border-border shrink-0">
             {deleting && (
               <span className="text-xs text-muted-foreground mr-auto">
-                Deleting {selectedIds.size} book{selectedIds.size !== 1 ? 's' : ''}...
+                <Plural value={selectedIds.size} one="Deleting # book..." other="Deleting # books..." />
               </span>
             )}
             <button
@@ -231,7 +248,7 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
               disabled={deleting}
               className="px-3 py-1.5 rounded-lg text-sm border border-border text-muted-foreground hover:bg-muted disabled:opacity-50 transition-colors"
             >
-              Cancel
+              <Trans>Cancel</Trans>
             </button>
             <button
               onClick={handleDelete}
@@ -239,7 +256,7 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm bg-destructive text-destructive-foreground hover:opacity-90 disabled:opacity-50 transition-all"
             >
               {deleting && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-              Delete {selectedIds.size} book{selectedIds.size !== 1 ? 's' : ''}
+              <Plural value={selectedIds.size} one="Delete # book" other="Delete # books" />
             </button>
           </div>
         </div>
@@ -248,16 +265,18 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
   )
 }
 
+// Duration abbreviations go through the catalog so locales can adapt the units.
 function formatReadingTime(seconds: number): string {
-  if (seconds < 60) return `${seconds}s`
+  if (seconds < 60) return t`${seconds}s`
   const h = Math.floor(seconds / 3600)
   const m = Math.floor((seconds % 3600) / 60)
-  if (h === 0) return `${m}m`
-  if (m === 0) return `${h}h`
-  return `${h}h ${m}m`
+  if (h === 0) return t`${m}m`
+  if (m === 0) return t`${h}h`
+  return t`${h}h ${m}m`
 }
 
 export function DashboardPage() {
+  const { t, i18n } = useLingui()
   const { user } = useAuth()
   const navigate = useNavigate()
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
@@ -406,36 +425,41 @@ export function DashboardPage() {
   }> {
     if (arcs.length === 0) return [{ label: '', description: null, volumes: books }]
     const sorted = [...arcs].sort((a, b) => a.start_index - b.start_index)
-    const sections: Array<{ label: string; description: string | null; volumes: SeriesDetailBook[] }> = sorted.map(arc => ({
-      label: `${arc.name} · Vol. ${arc.start_index}–${arc.end_index}`,
-      description: arc.description ?? null,
-      volumes: books.filter(v =>
-        v.series_index != null &&
-        v.series_index >= arc.start_index &&
-        v.series_index <= arc.end_index
-      ),
-    }))
+    const sections: Array<{ label: string; description: string | null; volumes: SeriesDetailBook[] }> = sorted.map(arc => {
+      const { name, start_index, end_index } = arc
+      return {
+        label: t`${name} · Vol. ${start_index}–${end_index}`,
+        description: arc.description ?? null,
+        volumes: books.filter(v =>
+          v.series_index != null &&
+          v.series_index >= arc.start_index &&
+          v.series_index <= arc.end_index
+        ),
+      }
+    })
     const unassigned = books.filter(v =>
       v.series_index == null ||
       !sorted.some(a => v.series_index! >= a.start_index && v.series_index! <= a.end_index)
     )
     if (unassigned.length > 0) {
-      sections.push({ label: 'Unassigned', description: null, volumes: unassigned })
+      sections.push({ label: t`Unassigned`, description: null, volumes: unassigned })
     }
     return sections.filter(s => s.volumes.length > 0)
   }
 
   function SeriesStatusBadge({ status }: { status: SeriesStatus | undefined }) {
     if (!status || status === 'unknown') return null
+    /* eslint-disable lingui/no-unlocalized-strings -- Tailwind classes */
     const cls =
       status === 'ongoing'
         ? 'bg-warning/15 text-warning'
         : status === 'finished'
         ? 'bg-success/15 text-success'
         : /* hiatus */ 'bg-muted text-muted-foreground'
+    /* eslint-enable lingui/no-unlocalized-strings */
     return (
       <span className={cn('inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide leading-none', cls)}>
-        {status}
+        {SERIES_STATUS_LABELS[status] ? i18n._(SERIES_STATUS_LABELS[status]) : status}
       </span>
     )
   }
@@ -592,7 +616,7 @@ export function DashboardPage() {
       a.remove()
       URL.revokeObjectURL(url)
     } catch (e) {
-      toastError(e instanceof Error ? e.message : 'Download failed')
+      toastError(e instanceof Error ? e.message : t`Download failed`)
     } finally {
       setBulkPending(false)
     }
@@ -603,12 +627,12 @@ export function DashboardPage() {
     setBulkPending(true)
     try {
       await api.post(`/libraries/${libId}/books`, { book_ids: [...selected] })
-      toastSuccess(`Added ${selected.size} book${selected.size !== 1 ? 's' : ''} to library`)
+      toastSuccess(plural(selected.size, { one: 'Added # book to library', other: 'Added # books to library' }))
       clearSelection()
       setBulkLibMenu(false)
       loadLibraries()
     } catch (e) {
-      toastError(e instanceof Error ? e.message : 'Failed')
+      toastError(e instanceof Error ? e.message : t`Failed`)
     } finally {
       setBulkPending(false)
     }
@@ -630,12 +654,12 @@ export function DashboardPage() {
         deleted += res.deleted.length
         failed += res.errors.length
       }
-      toastSuccess(`Deleted ${deleted} book${deleted !== 1 ? 's' : ''}`)
+      toastSuccess(plural(deleted, { one: 'Deleted # book', other: 'Deleted # books' }))
       if (failed) {
-        toastError(`${failed} book${failed !== 1 ? 's' : ''} could not be deleted`)
+        toastError(plural(failed, { one: '# book could not be deleted', other: '# books could not be deleted' }))
       }
     } catch (e) {
-      toastError(e instanceof Error ? e.message : 'Delete failed')
+      toastError(e instanceof Error ? e.message : t`Delete failed`)
     }
     setDeleteModalOpen(false)
     clearSelection()
@@ -653,13 +677,13 @@ export function DashboardPage() {
       if (bulkMetaTagsAdd.length) body.tags_add = bulkMetaTagsAdd
       if (bulkMetaTypeId) body.book_type_id = bulkMetaTypeId
       await api.put('/books/bulk-metadata', body)
-      toastSuccess(`Updated metadata for ${selected.size} book${selected.size !== 1 ? 's' : ''}`)
+      toastSuccess(plural(selected.size, { one: 'Updated metadata for # book', other: 'Updated metadata for # books' }))
       setBulkMetaOpen(false)
       setBulkMetaAuthor(''); setBulkMetaSeries(''); setBulkMetaTagsAdd([]); setBulkMetaTypeId('')
       clearSelection()
       loadBooks(); loadFacets()
     } catch (e) {
-      toastError(e instanceof Error ? e.message : 'Failed to update metadata')
+      toastError(e instanceof Error ? e.message : t`Failed to update metadata`)
     } finally {
       setBulkMetaSaving(false)
     }
@@ -699,6 +723,7 @@ export function DashboardPage() {
         const scale = a.width / b.width
         child.style.transition = 'none'
         child.style.transformOrigin = 'top left'
+        // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS transform
         child.style.transform = `translate(${a.left - b.left}px, ${a.top - b.top}px) scale(${scale})`
         moved.push(child)
       }
@@ -842,7 +867,7 @@ export function DashboardPage() {
       })
       .catch(err => {
         if (err instanceof Error && err.name === 'AbortError') return
-        toastError('Failed to load books')
+        toastError(t`Failed to load books`)
       })
       .finally(() => {
         if (reset) {
@@ -995,19 +1020,25 @@ export function DashboardPage() {
   }, [tab, homeMode, readingDna])
 
   // ── Filter chip helpers ───────────────────────────────────────────────────
+  const filterLibraryChipName = libraries.find(l => l.id === filterLibrary)?.name ?? t`Library`
+  const filterFormatUpper = filterFormat.toUpperCase()
+  const filterLanguageLabel = facets.languages.find(l => l.code === filterLanguage)?.label ?? filterLanguage
+  const filterStatusLabel = READING_STATUS_LABELS[filterReadingStatus] ? i18n._(READING_STATUS_LABELS[filterReadingStatus]) : filterReadingStatus
+  const filterMissingLabel = MISSING_LABELS[filterMissing] ? i18n._(MISSING_LABELS[filterMissing]) : filterMissing
+  const filterUploaderName = userList.find(u => u.id === filterAddedBy)?.username ?? filterAddedBy
   const activeFilterChips: { label: string; key: string }[] = [
-    ...(filterLibrary ? [{ label: `Library: ${libraries.find(l => l.id === filterLibrary)?.name ?? 'Library'}`, key: 'library_id' }] : []),
-    ...(filterSeries ? [{ label: `Series: ${filterSeries}`, key: 'series' }] : []),
-    ...(filterNoSeries ? [{ label: 'No Series', key: 'no_series' }] : []),
-    ...(filterAuthor ? [{ label: `Author: ${filterAuthor}`, key: 'author' }] : []),
-    ...(filterTag ? [{ label: `Tag: ${filterTag}`, key: 'tag' }] : []),
-    ...(filterFormat ? [{ label: `Format: ${filterFormat.toUpperCase()}`, key: 'format' }] : []),
-    ...(filterLanguage ? [{ label: `Language: ${facets.languages.find(l => l.code === filterLanguage)?.label ?? filterLanguage}`, key: 'language' }] : []),
-    ...(filterReadingStatus ? [{ label: `Status: ${filterReadingStatus.charAt(0).toUpperCase() + filterReadingStatus.slice(1)}`, key: 'reading_status' }] : []),
-    ...(filterMinRating ? [{ label: filterMinRating === 5 ? 'Rated: 5 stars' : `Rated: ${filterMinRating}+ stars`, key: 'min_rating' }] : []),
-    ...(filterMissing ? [{ label: `Missing: ${filterMissing.charAt(0).toUpperCase() + filterMissing.slice(1)}`, key: 'missing' }] : []),
-    ...(filterOwnership === 'mine' ? [{ label: 'My Books', key: 'ownership' }] : filterOwnership === 'shared' ? [{ label: 'Shared Library', key: 'ownership' }] : []),
-    ...(filterAddedBy ? [{ label: `Uploader: ${userList.find(u => u.id === filterAddedBy)?.username ?? filterAddedBy}`, key: 'added_by' }] : []),
+    ...(filterLibrary ? [{ label: t`Library: ${filterLibraryChipName}`, key: 'library_id' }] : []),
+    ...(filterSeries ? [{ label: t`Series: ${filterSeries}`, key: 'series' }] : []),
+    ...(filterNoSeries ? [{ label: t`No Series`, key: 'no_series' }] : []),
+    ...(filterAuthor ? [{ label: t`Author: ${filterAuthor}`, key: 'author' }] : []),
+    ...(filterTag ? [{ label: t`Tag: ${filterTag}`, key: 'tag' }] : []),
+    ...(filterFormat ? [{ label: t`Format: ${filterFormatUpper}`, key: 'format' }] : []),
+    ...(filterLanguage ? [{ label: t`Language: ${filterLanguageLabel}`, key: 'language' }] : []),
+    ...(filterReadingStatus ? [{ label: t`Status: ${filterStatusLabel}`, key: 'reading_status' }] : []),
+    ...(filterMinRating ? [{ label: filterMinRating === 5 ? t`Rated: 5 stars` : t`Rated: ${filterMinRating}+ stars`, key: 'min_rating' }] : []),
+    ...(filterMissing ? [{ label: t`Missing: ${filterMissingLabel}`, key: 'missing' }] : []),
+    ...(filterOwnership === 'mine' ? [{ label: t`My Books`, key: 'ownership' }] : filterOwnership === 'shared' ? [{ label: t`Shared Library`, key: 'ownership' }] : []),
+    ...(filterAddedBy ? [{ label: t`Uploader: ${filterUploaderName}`, key: 'added_by' }] : []),
   ]
 
   // Params to pass to SaveFilterButton (excludes library_id — that belongs in sidebar)
@@ -1023,6 +1054,7 @@ export function DashboardPage() {
   // follows the slider value. view-fade covers the grid/list switch.
   const cardView: ViewMode = view === 'list' ? 'list' : gridSize < 150 ? 'small' : 'large'
   const gridClass = view === 'list'
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- Tailwind classes
     ? 'flex flex-col gap-2.5 animate-[view-fade_0.25s_ease-out]'
     : cn(
         'grid transition-[gap] duration-300 ease-out animate-[view-fade_0.25s_ease-out]',
@@ -1032,6 +1064,7 @@ export function DashboardPage() {
   // without it a 180px minimum fits only one track on a 390px screen
   const gridStyle = view === 'list'
     ? undefined
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS grid template
     : { gridTemplateColumns: `repeat(auto-fill, minmax(min(${gridSize}px, 42vw), 1fr))` }
 
   // Active library name for heading
@@ -1041,11 +1074,11 @@ export function DashboardPage() {
   const homeStatItems: { value: string; label: string; icon: ReactNode }[] = homeStats ? [
     // A zero-day streak is a sad opener — only lead with it when it exists
     ...(homeStats.current_streak_days > 0
-      ? [{ value: String(homeStats.current_streak_days), label: 'Day streak', icon: <Flame className="w-5 h-5" /> }]
+      ? [{ value: String(homeStats.current_streak_days), label: t`Day streak`, icon: <Flame className="w-5 h-5" /> }]
       : []),
-    { value: String(homeStats.books_finished_30d), label: 'Finished · 30d', icon: <BookCheck className="w-5 h-5" /> },
-    { value: formatReadingTime(homeStats.reading_seconds_30d), label: 'Read · 30d', icon: <Clock className="w-5 h-5" /> },
-    { value: String(homeStats.pages_turned_30d), label: 'Pages · 30d', icon: <BookOpenCheck className="w-5 h-5" /> },
+    { value: String(homeStats.books_finished_30d), label: t`Finished · 30d`, icon: <BookCheck className="w-5 h-5" /> },
+    { value: formatReadingTime(homeStats.reading_seconds_30d), label: t`Read · 30d`, icon: <Clock className="w-5 h-5" /> },
+    { value: String(homeStats.pages_turned_30d), label: t`Pages · 30d`, icon: <BookOpenCheck className="w-5 h-5" /> },
   ] : []
 
   // Compact Focus / Dashboard switch — placed inline next to the KPI band in
@@ -1053,8 +1086,8 @@ export function DashboardPage() {
   const modeToggle = (
     <div className="flex w-full sm:inline-flex sm:w-auto rounded-lg border border-border bg-card p-0.5 sm:shrink-0">
       {([
-        { id: 'focus', label: 'Focus', icon: <Moon className="w-3.5 h-3.5" /> },
-        { id: 'dashboard', label: 'Dashboard', icon: <LayoutGrid className="w-3.5 h-3.5" /> },
+        { id: 'focus', label: t`Focus`, icon: <Moon className="w-3.5 h-3.5" /> },
+        { id: 'dashboard', label: t`Dashboard`, icon: <LayoutGrid className="w-3.5 h-3.5" /> },
       ] as const).map((m) => (
         <button
           key={m.id}
@@ -1102,7 +1135,10 @@ export function DashboardPage() {
         onDone={() => { loadBooks(); loadFacets() }}
         onWishMatches={(wishIds) => {
           const n = wishIds.length
-          toast.info(`This upload satisfies ${n} wish${n !== 1 ? 'es' : ''} — review in Admin > Wishlist`)
+          toast.info(plural(n, {
+            one: 'This upload satisfies # wish — review in Admin > Wishlist',
+            other: 'This upload satisfies # wishes — review in Admin > Wishlist',
+          }))
         }}
       />
 
@@ -1263,12 +1299,12 @@ export function DashboardPage() {
                 return (
                   <section className="px-5 py-4">
                     <header className="flex items-center justify-between mb-2">
-                      <h2 className="text-base text-foreground">Pick up where you left off</h2>
+                      <h2 className="text-base text-foreground"><Trans>Pick up where you left off</Trans></h2>
                       <button
                         onClick={dismiss}
                         className="text-xs text-muted-foreground hover:text-foreground transition-colors"
                       >
-                        Dismiss
+                        <Trans>Dismiss</Trans>
                       </button>
                     </header>
                     <HScrollRow className="gap-3 pb-1" controlsTop="top-[60px]">
@@ -1289,7 +1325,7 @@ export function DashboardPage() {
                             {b.title}
                           </p>
                           <p className="text-[10px] text-muted-foreground">
-                            {b.days_ago != null ? `${b.days_ago}d ago` : 'A while ago'}
+                            {(() => { const d = b.days_ago; return d != null ? t`${d}d ago` : t`A while ago` })()}
                           </p>
                         </a>
                       ))}
@@ -1300,18 +1336,18 @@ export function DashboardPage() {
 
               {/* ── Continue Reading ──────────────────────────────────────── */}
               <section className="flex flex-col gap-3 px-5 py-5">
-                <h2 className="text-base font-semibold text-foreground">Continue Reading</h2>
+                <h2 className="text-base font-semibold text-foreground"><Trans>Continue Reading</Trans></h2>
                 {continueReading.length === 0 ? (
                   <div className="flex flex-col items-center justify-center py-24 gap-4 text-center">
                     <div className="w-16 h-16 rounded-2xl bg-primary/10 flex items-center justify-center">
                       <BookOpen className="w-8 h-8 text-primary/40" />
                     </div>
                     <div>
-                      <p className="text-base font-medium text-foreground">Nothing in progress</p>
-                      <p className="text-sm text-muted-foreground mt-1">Start reading and your progress will show up here</p>
+                      <p className="text-base font-medium text-foreground"><Trans>Nothing in progress</Trans></p>
+                      <p className="text-sm text-muted-foreground mt-1"><Trans>Start reading and your progress will show up here</Trans></p>
                     </div>
                     <button onClick={() => setTab('books')} className="text-sm text-primary hover:underline">
-                      Browse your library
+                      <Trans>Browse your library</Trans>
                     </button>
                   </div>
                 ) : (
@@ -1363,7 +1399,7 @@ export function DashboardPage() {
                 if (rows.length === 0) return null
                 return (
                   <div className="flex flex-col gap-3 px-5 py-5">
-                    <h2 className="text-base font-semibold text-foreground">Series Progress</h2>
+                    <h2 className="text-base font-semibold text-foreground"><Trans>Series Progress</Trans></h2>
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
                       {rows.map(({ book, read, total, pct }) => (
                         <button
@@ -1394,7 +1430,7 @@ export function DashboardPage() {
               {/* ── Recently Finished ─────────────────────────────────────── */}
               {recentlyFinished.length > 0 && (
                 <section className="flex flex-col gap-3 px-5 py-5">
-                  <h2 className="text-base font-semibold text-foreground">Recently Finished</h2>
+                  <h2 className="text-base font-semibold text-foreground"><Trans>Recently Finished</Trans></h2>
                   <HScrollRow className="gap-3 pb-1 px-1" wrapClassName="-mx-1" controlsTop="top-[72px]">
                     {recentlyFinished.map(book => (
                       <div key={book.id} className="shrink-0 w-24">
@@ -1416,7 +1452,7 @@ export function DashboardPage() {
               {/* ── Recently Added ────────────────────────────────────────── */}
               {recentlyAdded.length > 0 && (
                 <section className="flex flex-col gap-3 px-5 py-5">
-                  <h2 className="text-base font-semibold text-foreground">Recently Added</h2>
+                  <h2 className="text-base font-semibold text-foreground"><Trans>Recently Added</Trans></h2>
                   <HScrollRow className="gap-3 pb-1 px-1" wrapClassName="-mx-1" controlsTop="top-[72px]">
                     {recentlyAdded.map(book => (
                       <div key={book.id} className="shrink-0 w-24">
@@ -1439,7 +1475,7 @@ export function DashboardPage() {
               {/* ── Reading Log ───────────────────────────────────────────── */}
               {activityLog.length > 0 && (
                 <div className="flex flex-col gap-3 px-5 py-5">
-                  <h2 className="text-base font-semibold text-foreground">Reading Log</h2>
+                  <h2 className="text-base font-semibold text-foreground"><Trans>Reading Log</Trans></h2>
                   <div className="flex flex-col gap-1">
                     {(() => {
                       // Back-to-back sessions of the same book collapse into one row
@@ -1451,9 +1487,9 @@ export function DashboardPage() {
                         const today = new Date()
                         const yesterday = new Date(today)
                         yesterday.setDate(today.getDate() - 1)
-                        if (d.toDateString() === today.toDateString()) return 'Today'
-                        if (d.toDateString() === yesterday.toDateString()) return 'Yesterday'
-                        return d.toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' })
+                        if (d.toDateString() === today.toDateString()) return t`Today`
+                        if (d.toDateString() === yesterday.toDateString()) return t`Yesterday`
+                        return d.toLocaleDateString(i18n.locale, { weekday: 'short', month: 'short', day: 'numeric' })
                       }
                       type LogRow = { entry: ActivityEntry; sessions: number; seconds: number }
                       const days: { label: string; first: string; rows: LogRow[] }[] = []
@@ -1492,9 +1528,10 @@ export function DashboardPage() {
                               <div className="min-w-0 flex-1">
                                 <p className="text-xs font-medium text-foreground truncate">{entry.book_title}</p>
                                 <p className="text-[10px] text-muted-foreground">
-                                  {sessions > 1
-                                    ? `${sessions} sessions · ${formatReadingTime(seconds)}`
-                                    : formatReadingTime(seconds)}
+                                  {(() => {
+                                    const time = formatReadingTime(seconds)
+                                    return sessions > 1 ? t`${sessions} sessions · ${time}` : time
+                                  })()}
                                 </p>
                               </div>
                               <span className="text-[10px] text-muted-foreground shrink-0">
@@ -1527,7 +1564,7 @@ export function DashboardPage() {
                     <header className="flex items-center justify-between mb-2.5">
                       <h2 className="flex items-center gap-1.5 text-sm font-semibold text-foreground">
                         <Quote className="w-4 h-4 text-primary/60" />
-                        {spotlight.on_this_day ? 'On this day' : 'From your highlights'}
+                        {spotlight.on_this_day ? t`On this day` : t`From your highlights`}
                       </h2>
                       <div className="flex items-center gap-2">
                         <button
@@ -1537,14 +1574,14 @@ export function DashboardPage() {
                               `/annotations/spotlight${cur ? `?exclude=${cur}` : ''}`
                             ).then(setSpotlight).catch(() => {})
                           }}
-                          title="Show another highlight"
-                          aria-label="Show another highlight"
+                          title={t`Show another highlight`}
+                          aria-label={t`Show another highlight`}
                           className="p-1 rounded text-muted-foreground hover:text-foreground transition-colors"
                         >
                           <Shuffle className="w-3.5 h-3.5" />
                         </button>
                         <a href="/highlights" className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-                          All →
+                          <Trans>All →</Trans>
                         </a>
                       </div>
                     </header>
@@ -1574,7 +1611,7 @@ export function DashboardPage() {
                 className="flex items-center gap-1 hover:text-foreground transition-colors shrink-0"
               >
                 <Home className="w-3.5 h-3.5" />
-                <span className="hidden sm:inline">Library</span>
+                <span className="hidden sm:inline"><Trans>Library</Trans></span>
               </button>
               <ChevronRight className="w-3.5 h-3.5 opacity-30 shrink-0" />
               {expandedSeries ? (
@@ -1583,13 +1620,13 @@ export function DashboardPage() {
                     onClick={() => { setExpandedSeries(null); setSeriesDetail(null) }}
                     className="hover:text-foreground transition-colors"
                   >
-                    Series
+                    <Trans>Series</Trans>
                   </button>
                   <ChevronRight className="w-3.5 h-3.5 opacity-30 shrink-0" />
                   <span className="font-medium text-foreground truncate max-w-[200px] sm:max-w-[300px]">{expandedSeries}</span>
                 </>
               ) : (
-                <span className="font-medium text-foreground">Series</span>
+                <span className="font-medium text-foreground"><Trans>Series</Trans></span>
               )}
             </div>
             {seriesLoading ? (
@@ -1599,7 +1636,7 @@ export function DashboardPage() {
             ) : seriesList.length === 0 ? (
               <div className="flex flex-col items-center justify-center py-24 gap-3 text-muted-foreground">
                 <BookOpen className="w-12 h-12 opacity-20" />
-                <p className="text-sm">No series found — add series metadata to your books.</p>
+                <p className="text-sm"><Trans>No series found — add series metadata to your books.</Trans></p>
               </div>
             ) : (
               <div className="flex flex-col gap-4">
@@ -1621,7 +1658,7 @@ export function DashboardPage() {
                               {seriesDetail.name !== '__unserialized__' && (
                                 <button
                                   onClick={() => setShareSeries(seriesDetail.name)}
-                                  title="Share this series — a public metadata-only page"
+                                  title={t`Share this series — a public metadata-only page`}
                                   className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                                 >
                                   <Share2 className="w-4 h-4" />
@@ -1644,8 +1681,10 @@ export function DashboardPage() {
                               return (
                                 <div className="mt-3">
                                   <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
-                                    <span>{readCount} read &middot; {readingCount} reading &middot; {total - readCount - readingCount} unread</span>
-                                    <span>{total} volumes</span>
+                                    {(() => { const unreadCount = total - readCount - readingCount; return (
+                                      <span><Trans>{readCount} read &middot; {readingCount} reading &middot; {unreadCount} unread</Trans></span>
+                                    ) })()}
+                                    <span><Plural value={total} one="# volume" other="# volumes" /></span>
                                   </div>
                                   {seriesDetail.backlog && seriesDetail.backlog.estimated > 0 && (
                                     <p className="text-[10px] text-muted-foreground mb-1.5" title={describePace(seriesDetail.backlog.pace, seriesDetail.backlog.by_type.some(t => t.type_avg > 0) ? 'type_avg' : 'words')}>
@@ -1674,7 +1713,7 @@ export function DashboardPage() {
                                     onClick={() => setSeriesDescExpanded(v => !v)}
                                     className="text-xs font-medium text-primary hover:opacity-80 mt-1 transition-opacity"
                                   >
-                                    {seriesDescExpanded ? 'Show less' : 'Show more'}
+                                    {seriesDescExpanded ? t`Show less` : t`Show more`}
                                   </button>
                                 )}
                               </div>
@@ -1684,7 +1723,8 @@ export function DashboardPage() {
                             {(() => {
                               const continueBook = getContinueBook(seriesDetail.books)
                               if (!continueBook) return null
-                              const volLabel = continueBook.series_index != null ? `Vol. ${continueBook.series_index}` : continueBook.title
+                              const volIdx = continueBook.series_index
+                              const volLabel = volIdx != null ? t`Vol. ${volIdx}` : continueBook.title
                               const isResuming = continueBook.reading_status === 'reading'
                               return (
                                 <button
@@ -1692,7 +1732,7 @@ export function DashboardPage() {
                                   className="flex items-center gap-2 px-4 py-2 rounded-lg bg-primary text-primary-foreground text-sm font-medium hover:opacity-90 transition-opacity"
                                 >
                                   <Play className="w-3.5 h-3.5" />
-                                  {isResuming ? `Resume ${volLabel}` : `Start ${volLabel}`}
+                                  {isResuming ? t`Resume ${volLabel}` : t`Start ${volLabel}`}
                                 </button>
                               )
                             })()}
@@ -1702,16 +1742,16 @@ export function DashboardPage() {
                               className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-card text-sm font-medium text-foreground hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed transition-all"
                             >
                               {markingAllRead ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <CheckCheck className="w-3.5 h-3.5" />}
-                              Mark all read
+                              <Trans>Mark all read</Trans>
                             </button>
                             {isAdmin(user) && (
                               <button
                                 onClick={() => setManageSeriesOpen(true)}
                                 className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-card text-sm font-medium text-foreground hover:bg-muted transition-all"
-                                title="Manage series"
+                                title={t`Manage series`}
                               >
                                 <Settings2 className="w-3.5 h-3.5" />
-                                Manage
+                                <Trans>Manage</Trans>
                               </button>
                             )}
                             <SeriesFollowButton seriesName={seriesDetail.name} />
@@ -1763,8 +1803,8 @@ export function DashboardPage() {
                                           <button
                                             onClick={e => { e.stopPropagation(); navigate(`/reader/${vol.id}`) }}
                                             className="absolute top-1 left-1 opacity-0 group-hover:opacity-100 transition-opacity z-10"
-                                            title="Read"
-                                            aria-label="Read"
+                                            title={t`Read`}
+                                            aria-label={t`Read`}
                                           >
                                             <div className="w-5 h-5 rounded-full bg-white/90 flex items-center justify-center shadow">
                                               <Play className="w-2.5 h-2.5 text-black fill-black ml-px" />
@@ -1780,9 +1820,11 @@ export function DashboardPage() {
                                           {/* Volume number overlay */}
                                           {vol.series_index != null && (
                                             <div className="absolute bottom-0 inset-x-0 bg-black/60 px-1 py-0.5">
+                                              {(() => { const idx = vol.series_index; return (
                                               <span className="text-[9px] font-bold text-white leading-none">
-                                                Vol. {vol.series_index}
+                                                <Trans>Vol. {idx}</Trans>
                                               </span>
+                                              ) })()}
                                             </div>
                                           )}
                                         </div>
@@ -1823,19 +1865,19 @@ export function DashboardPage() {
                           <div className="relative aspect-[2/3] bg-muted overflow-hidden">
                             <CoverImage
                               src={s.cover_book_id ? `/api/books/${s.cover_book_id}/cover` : null}
-                              alt={isUnserialized ? 'Unserialized' : s.name}
+                              alt={isUnserialized ? t`Unserialized` : s.name}
                               imgClassName="group-hover:scale-105"
                             />
                             <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/70 to-transparent px-2 pt-6 pb-2">
                               <span className="text-[10px] font-semibold text-white/90">
-                                {s.book_count} {s.book_count === 1 ? 'book' : 'books'}
+                                <Plural value={s.book_count} one="# book" other="# books" />
                               </span>
                             </div>
                           </div>
                           <div className="px-3 py-2.5 flex flex-col gap-0.5 min-w-0">
                             <div className="flex items-start gap-1.5 flex-wrap">
                               <span className="text-xs font-semibold text-foreground leading-tight line-clamp-2">
-                                {isUnserialized ? 'No Series' : s.name}
+                                {isUnserialized ? t`No Series` : s.name}
                               </span>
                               {!isUnserialized && <SeriesStatusBadge status={seriesMetaMap[s.name]} />}
                             </div>
@@ -1847,7 +1889,7 @@ export function DashboardPage() {
                               <p className="text-[10px] text-muted-foreground leading-snug line-clamp-2 mt-0.5">{s.description}</p>
                             )}
                             {isUnserialized && (
-                              <p className="text-[10px] text-muted-foreground leading-snug mt-0.5">Books without a series</p>
+                              <p className="text-[10px] text-muted-foreground leading-snug mt-0.5"><Trans>Books without a series</Trans></p>
                             )}
                             {!isUnserialized && s.book_count > 0 && (s.read_count > 0 || s.reading_count > 0) && (
                               <div className="mt-1.5 h-1 rounded-full bg-muted overflow-hidden flex">
@@ -1882,7 +1924,7 @@ export function DashboardPage() {
                     'flex items-center gap-1 px-2.5 py-1 rounded-md text-xs font-medium transition-all',
                     sort === f ? 'bg-primary/10 text-primary shadow-sm' : 'text-muted-foreground hover:text-foreground'
                   )}>
-                  {SORT_LABELS[f]}
+                  {i18n._(SORT_LABELS[f])}
                   {sort === f && (order === 'asc' ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />)}
                 </button>
               ))}
@@ -1897,7 +1939,7 @@ export function DashboardPage() {
                   : 'border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted'
               )}>
               <SlidersHorizontal className="w-3.5 h-3.5" />
-              Filters
+              <Trans>Filters</Trans>
               {hasFilters && (
                 <span className="ml-0.5 w-4 h-4 rounded-full bg-primary text-primary-foreground text-[9px] flex items-center justify-center font-bold">
                   {activeFilterChips.length}
@@ -1919,7 +1961,7 @@ export function DashboardPage() {
 
             {(hasFilters || filterLibrary) && (
               <button onClick={clearFilters} className="text-xs text-muted-foreground hover:text-foreground transition-colors ml-1">
-                Clear all
+                <Trans>Clear all</Trans>
               </button>
             )}
 
@@ -1930,18 +1972,23 @@ export function DashboardPage() {
                 : (() => {
                     // Grouped rows are series stacks + standalones — "titles", not the
                     // ambiguous "entries" (which read like a book count and never matched it).
-                    const noun = (n: number) => groupActive ? (n === 1 ? 'title' : 'titles') : (n === 1 ? 'book' : 'books')
-                    return totalCount !== null && totalCount > books.length
-                      ? `${books.length} of ${totalCount} ${noun(totalCount)}`
-                      : `${books.length} ${noun(books.length)}`
+                    const shown = books.length
+                    if (totalCount !== null && totalCount > shown) {
+                      return groupActive
+                        ? plural(totalCount, { one: `${shown} of # title`, other: `${shown} of # titles` })
+                        : plural(totalCount, { one: `${shown} of # book`, other: `${shown} of # books` })
+                    }
+                    return groupActive
+                      ? plural(shown, { one: '# title', other: '# titles' })
+                      : plural(shown, { one: '# book', other: '# books' })
                   })()}
             </span>
 
             {/* Group by series toggle */}
             <button
               onClick={() => persistGroup(!groupBySeries)}
-              title={groupBySeries ? 'Show individual volumes' : 'Group volumes by series'}
-              aria-label="Group by series"
+              title={groupBySeries ? t`Show individual volumes` : t`Group volumes by series`}
+              aria-label={t`Group by series`}
               aria-pressed={groupBySeries}
               className={cn(
                 'flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border transition-all',
@@ -1951,7 +1998,7 @@ export function DashboardPage() {
               )}
             >
               <Layers className="w-3.5 h-3.5" />
-              <span className="hidden sm:inline">Group series</span>
+              <span className="hidden sm:inline"><Trans>Group series</Trans></span>
             </button>
 
             {/* Select mode toggle — selection operates on individual books, hidden while grouped */}
@@ -1977,16 +2024,16 @@ export function DashboardPage() {
                 >
                   {selectionMode
                     ? selected.size > 0
-                      ? <><XSquare className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Deselect all</span></>
-                      : <><CheckSquare className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Select all</span></>
-                    : <><CheckSquare className="w-3.5 h-3.5" /><span className="hidden sm:inline"> Select</span></>
+                      ? <><XSquare className="w-3.5 h-3.5" /><span className="hidden sm:inline"> <Trans>Deselect all</Trans></span></>
+                      : <><CheckSquare className="w-3.5 h-3.5" /><span className="hidden sm:inline"> <Trans>Select all</Trans></span></>
+                    : <><CheckSquare className="w-3.5 h-3.5" /><span className="hidden sm:inline"> <Trans>Select</Trans></span></>
                   }
                 </button>
                 {selectionMode && (
                   <button
                     onClick={exitSelectionMode}
-                    title="Exit selection mode"
-                    aria-label="Exit selection mode"
+                    title={t`Exit selection mode`}
+                    aria-label={t`Exit selection mode`}
                     className="p-1.5 rounded-lg border border-border bg-card text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
                   >
                     <X className="w-3.5 h-3.5" />
@@ -2003,8 +2050,8 @@ export function DashboardPage() {
                 step={10}
                 value={gridSize}
                 onChange={e => persistGridSize(Number(e.target.value))}
-                title="Cover size"
-                aria-label="Cover size"
+                title={t`Cover size`}
+                aria-label={t`Cover size`}
                 tabIndex={view === 'grid' ? 0 : -1}
                 className={cn(
                   'cover-slider transition-all duration-200',
@@ -2017,8 +2064,8 @@ export function DashboardPage() {
                 }}
               />
               {([
-                { mode: 'grid' as ViewPref, Icon: LayoutGrid, title: 'Grid view' },
-                { mode: 'list' as ViewPref, Icon: List, title: 'List view' },
+                { mode: 'grid' as ViewPref, Icon: LayoutGrid, title: t`Grid view` },
+                { mode: 'list' as ViewPref, Icon: List, title: t`List view` },
               ]).map(({ mode, Icon, title }) => (
                 <button key={mode} onClick={() => persistView(mode)} title={title} aria-label={title}
                   className={cn('p-1.5 rounded-md transition-all',
@@ -2033,7 +2080,7 @@ export function DashboardPage() {
           {filterOpen && (
             <div className="mb-4 p-4 rounded-xl border border-border bg-card flex flex-col gap-4">
               <div className="flex items-center justify-between sm:hidden">
-                <span className="text-xs font-medium text-muted-foreground">Filters</span>
+                <span className="text-xs font-medium text-muted-foreground"><Trans>Filters</Trans></span>
                 <button
                   onClick={() => setFilterOpen(false)}
                   className="p-1 text-muted-foreground hover:text-foreground"
@@ -2042,16 +2089,16 @@ export function DashboardPage() {
                 </button>
               </div>
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
-                <FilterSelect label="Series" value={filterSeries} options={facets.series} onChange={v => setFilter('series', v)} />
-                <FilterSelect label="Author" value={filterAuthor} options={facets.authors} onChange={v => setFilter('author', v)} />
-                <FilterSelect label="Tag" value={filterTag} options={facets.tags} onChange={v => setFilter('tag', v)} />
-                <FilterSelect label="Format" value={filterFormat} options={facets.formats.map(f => f.toUpperCase())} onChange={v => setFilter('format', v.toLowerCase())} />
+                <FilterSelect label={t`Series`} value={filterSeries} options={facets.series} onChange={v => setFilter('series', v)} />
+                <FilterSelect label={t`Author`} value={filterAuthor} options={facets.authors} onChange={v => setFilter('author', v)} />
+                <FilterSelect label={t`Tag`} value={filterTag} options={facets.tags} onChange={v => setFilter('tag', v)} />
+                <FilterSelect label={t`Format`} value={filterFormat} options={facets.formats.map(f => f.toUpperCase())} onChange={v => setFilter('format', v.toLowerCase())} />
                 {facets.languages.length > 1 && (
-                  <FilterSelect label="Language" value={filterLanguage} options={facets.languages.map(l => ({ value: l.code, label: l.label }))} onChange={v => setFilter('language', v)} />
+                  <FilterSelect label={t`Language`} value={filterLanguage} options={facets.languages.map(l => ({ value: l.code, label: l.label }))} onChange={v => setFilter('language', v)} />
                 )}
               </div>
               <div className="flex items-center gap-2 flex-wrap">
-                <span className="text-xs text-muted-foreground font-medium w-14">Status</span>
+                <span className="text-xs text-muted-foreground font-medium w-14"><Trans>Status</Trans></span>
                 {(['', 'unread', 'want_to_read', 'reading', 'read', 'shelved'] as const).map(s => (
                   <button
                     key={s}
@@ -2063,19 +2110,19 @@ export function DashboardPage() {
                         : 'border-border bg-card text-muted-foreground hover:text-foreground'
                     )}
                   >
-                    {s === '' ? 'All' : s === 'want_to_read' ? 'Want to Read' : s.charAt(0).toUpperCase() + s.slice(1)}
+                    {s === '' ? t`All` : i18n._(READING_STATUS_LABELS[s])}
                   </button>
                 ))}
               </div>
               <div className="flex items-center gap-2 flex-wrap">
-                <span className="text-xs text-muted-foreground font-medium w-14">Rating</span>
+                <span className="text-xs text-muted-foreground font-medium w-14"><Trans>Rating</Trans></span>
                 {([
-                  { value: '', label: 'All' },
-                  { value: '1', label: 'Rated' },
-                  { value: '3', label: '3+' },
-                  { value: '4', label: '4+' },
-                  { value: '5', label: '5' },
-                ]).map(({ value, label }) => (
+                  { value: '', label: t`All`, starless: true },
+                  { value: '1', label: t`Rated`, starless: true },
+                  { value: '3', label: '3+', starless: false },
+                  { value: '4', label: '4+', starless: false },
+                  { value: '5', label: '5', starless: false },
+                ]).map(({ value, label, starless }) => (
                   <button
                     key={value}
                     onClick={() => setFilter('min_rating', value)}
@@ -2086,20 +2133,20 @@ export function DashboardPage() {
                         : 'border-border bg-card text-muted-foreground hover:text-foreground'
                     )}
                   >
-                    {label !== 'All' && label !== 'Rated' && <Star className="w-3 h-3 fill-current" />}
+                    {!starless && <Star className="w-3 h-3 fill-current" />}
                     {label}
                   </button>
                 ))}
               </div>
               <div className="flex items-center gap-2 flex-wrap">
-                <span className="text-xs text-muted-foreground font-medium w-14">Missing</span>
+                <span className="text-xs text-muted-foreground font-medium w-14"><Trans>Missing</Trans></span>
                 {([
-                  { value: '', label: 'None' },
-                  { value: 'cover', label: 'Cover' },
-                  { value: 'description', label: 'Description' },
-                  { value: 'author', label: 'Author' },
-                  { value: 'series', label: 'Series' },
-                  { value: 'any', label: 'Any' },
+                  { value: '', label: t`None` },
+                  { value: 'cover', label: t`Cover` },
+                  { value: 'description', label: t`Description` },
+                  { value: 'author', label: t`Author` },
+                  { value: 'series', label: t`Series` },
+                  { value: 'any', label: t`Any` },
                 ]).map(({ value, label }) => (
                   <button
                     key={value}
@@ -2118,11 +2165,11 @@ export function DashboardPage() {
               {/* Ownership filter — members only (not admin) */}
               {isMember(user) && !isAdmin(user) && (
                 <div className="flex items-center gap-2 flex-wrap">
-                  <span className="text-xs text-muted-foreground font-medium w-14">Books</span>
+                  <span className="text-xs text-muted-foreground font-medium w-14"><Trans>Books</Trans></span>
                   {([
-                    { value: '', label: 'All' },
-                    { value: 'mine', label: 'My Books' },
-                    { value: 'shared', label: 'Shared Library' },
+                    { value: '', label: t`All` },
+                    { value: 'mine', label: t`My Books` },
+                    { value: 'shared', label: t`Shared Library` },
                   ] as const).map(({ value, label }) => (
                     <button
                       key={value}
@@ -2142,13 +2189,13 @@ export function DashboardPage() {
               {/* Uploader filter — admins only */}
               {isAdmin(user) && userList.length > 0 && (
                 <div className="flex items-center gap-2 flex-wrap">
-                  <span className="text-xs text-muted-foreground font-medium w-14">Uploader</span>
+                  <span className="text-xs text-muted-foreground font-medium w-14"><Trans>Uploader</Trans></span>
                   <select
                     value={filterAddedBy ?? ''}
                     onChange={e => setFilter('added_by', e.target.value)}
                     className="text-xs rounded-lg border border-border bg-background px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-ring"
                   >
-                    <option value="">All users</option>
+                    <option value="">{t`All users`}</option>
                     {userList.map(u => (
                       <option key={u.id} value={u.id}>{u.username} ({u.role})</option>
                     ))}
@@ -2156,15 +2203,15 @@ export function DashboardPage() {
                 </div>
               )}
               <div className="flex items-center gap-2 flex-wrap">
-                <span className="text-xs text-muted-foreground font-medium w-14">Type</span>
+                <span className="text-xs text-muted-foreground font-medium w-14"><Trans>Type</Trans></span>
                 <select
                   value={contentType}
                   onChange={e => setContentType(e.target.value)}
                   className="text-xs rounded-lg border border-border bg-background px-2 py-1.5 focus:outline-none focus:ring-1 focus:ring-ring"
                 >
-                  <option value="volume">Volumes</option>
-                  <option value="chapter">Chapters</option>
-                  <option value="">All</option>
+                  <option value="volume">{t`Volumes`}</option>
+                  <option value="chapter">{t`Chapters`}</option>
+                  <option value="">{t`All`}</option>
                 </select>
               </div>
             </div>
@@ -2173,7 +2220,7 @@ export function DashboardPage() {
           {/* ── Bulk action bar ──────────────────────────────────────────── */}
           {selectionMode && (
             <div className="mb-3 flex items-center gap-2 px-3 py-2 rounded-xl bg-primary/5 border border-primary/20">
-              <span className="text-xs font-medium text-primary">{selected.size} selected</span>
+              <span className="text-xs font-medium text-primary">{(() => { const n = selected.size; return t`${n} selected` })()}</span>
               <div className="flex-1" />
               <button
                 onClick={bulkDownload}
@@ -2181,7 +2228,7 @@ export function DashboardPage() {
                 className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted disabled:opacity-50 transition-all"
               >
                 <Download className="w-3.5 h-3.5" />
-                Download ZIP
+                <Trans>Download ZIP</Trans>
               </button>
               {isMember(user) && (
                 <SendButton
@@ -2196,7 +2243,7 @@ export function DashboardPage() {
                 className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-border bg-card text-foreground hover:bg-muted disabled:opacity-50 transition-all"
               >
                 <Pencil className="w-3.5 h-3.5" />
-                Edit Metadata
+                <Trans>Edit Metadata</Trans>
               </button>
               {libraries.some(l => l.can_edit) && (
                 <div className="relative">
@@ -2206,7 +2253,7 @@ export function DashboardPage() {
                     className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
                   >
                     <LibraryIcon className="w-3.5 h-3.5" />
-                    Add to Library
+                    <Trans>Add to Library</Trans>
                   </button>
                   {bulkLibMenu && (
                     <>
@@ -2233,10 +2280,10 @@ export function DashboardPage() {
                 className="flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium border border-destructive/30 bg-destructive/10 text-destructive hover:bg-destructive/20 disabled:opacity-50 transition-all"
               >
                 <Trash2 className="w-3.5 h-3.5" />
-                Delete
+                <Trans>Delete</Trans>
               </button>
               <button onClick={exitSelectionMode} className="text-xs text-muted-foreground hover:text-foreground transition-colors">
-                Done
+                <Trans>Done</Trans>
               </button>
             </div>
           )}
@@ -2245,8 +2292,8 @@ export function DashboardPage() {
           {search && !loading && totalCount !== null && (
             <p className="text-sm text-muted-foreground mb-3">
               {totalCount === 0
-                ? `No results for "${search}"`
-                : `${totalCount} result${totalCount !== 1 ? 's' : ''} for "${search}"`}
+                ? t`No results for "${search}"`
+                : plural(totalCount, { one: `# result for "${search}"`, other: `# results for "${search}"` })}
             </p>
           )}
 
@@ -2263,28 +2310,28 @@ export function DashboardPage() {
               {search ? (
                 <>
                   <div>
-                    <p className="text-base font-medium text-foreground">No results found</p>
-                    <p className="text-sm text-muted-foreground mt-1">Nothing matched &ldquo;{search}&rdquo;</p>
+                    <p className="text-base font-medium text-foreground"><Trans>No results found</Trans></p>
+                    <p className="text-sm text-muted-foreground mt-1"><Trans>Nothing matched &ldquo;{search}&rdquo;</Trans></p>
                   </div>
                   <button
                     onClick={() => { setSearchInput(''); setFilter('q', '') }}
                     className="text-sm text-primary hover:underline"
                   >
-                    Clear search
+                    <Trans>Clear search</Trans>
                   </button>
                 </>
               ) : (hasFilters || filterLibrary) ? (
                 <>
                   <div>
-                    <p className="text-base font-medium text-foreground">No matches</p>
-                    <p className="text-sm text-muted-foreground mt-1">Try adjusting your filters</p>
+                    <p className="text-base font-medium text-foreground"><Trans>No matches</Trans></p>
+                    <p className="text-sm text-muted-foreground mt-1"><Trans>Try adjusting your filters</Trans></p>
                   </div>
-                  <button onClick={clearFilters} className="text-sm text-primary hover:underline">Clear all filters</button>
+                  <button onClick={clearFilters} className="text-sm text-primary hover:underline"><Trans>Clear all filters</Trans></button>
                 </>
               ) : (
                 <div>
-                  <p className="text-base font-medium text-foreground">Your library is empty</p>
-                  <p className="text-sm text-muted-foreground mt-1">Upload or scan a folder to get started</p>
+                  <p className="text-base font-medium text-foreground"><Trans>Your library is empty</Trans></p>
+                  <p className="text-sm text-muted-foreground mt-1"><Trans>Upload or scan a folder to get started</Trans></p>
                 </div>
               )}
             </div>
@@ -2329,11 +2376,14 @@ export function DashboardPage() {
               <Loader2 className="w-5 h-5 animate-spin text-muted-foreground" />
             </div>
           )}
-          {!hasMore && booksRef.current.length >= PAGE_SIZE && (
-            <p className="text-center text-xs text-muted-foreground py-4">
-              All {booksRef.current.length} books loaded
-            </p>
-          )}
+          {!hasMore && booksRef.current.length >= PAGE_SIZE && (() => {
+            const loadedCount = booksRef.current.length
+            return (
+              <p className="text-center text-xs text-muted-foreground py-4">
+                <Trans>All {loadedCount} books loaded</Trans>
+              </p>
+            )
+          })()}
           </>
           )}
         </main>
@@ -2359,7 +2409,7 @@ export function DashboardPage() {
             <div className="pointer-events-auto w-full max-w-md bg-card border border-border rounded-2xl shadow-2xl p-6">
               <div className="flex items-start justify-between mb-1">
                 <h2 className="text-base font-semibold text-foreground">
-                  Edit Metadata for {selected.size} Book{selected.size !== 1 ? 's' : ''}
+                  <Plural value={selected.size} one="Edit Metadata for # Book" other="Edit Metadata for # Books" />
                 </h2>
                 <button
                   onClick={() => setBulkMetaOpen(false)}
@@ -2370,33 +2420,33 @@ export function DashboardPage() {
                 </button>
               </div>
               <p className="text-xs text-muted-foreground mb-4">
-                Only filled fields will be updated. Leave blank to keep existing values.
+                <Trans>Only filled fields will be updated. Leave blank to keep existing values.</Trans>
               </p>
 
               <div className="space-y-3">
                 <div>
-                  <label className="text-xs font-medium text-muted-foreground mb-1 block">Author</label>
+                  <label className="text-xs font-medium text-muted-foreground mb-1 block"><Trans>Author</Trans></label>
                   <AutocompleteInput
                     value={bulkMetaAuthor}
                     onChange={setBulkMetaAuthor}
                     suggestions={facets.authors}
-                    placeholder="Author"
+                    placeholder={t`Author`}
                     className="w-full text-sm bg-muted rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                 </div>
                 <div>
-                  <label className="text-xs font-medium text-muted-foreground mb-1 block">Series</label>
+                  <label className="text-xs font-medium text-muted-foreground mb-1 block"><Trans>Series</Trans></label>
                   <AutocompleteInput
                     value={bulkMetaSeries}
                     onChange={setBulkMetaSeries}
                     suggestions={facets.series}
-                    placeholder="Series name"
+                    placeholder={t`Series name`}
                     className="w-full text-sm bg-muted rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-ring"
                   />
                 </div>
 
                 <div>
-                  <label className="text-xs font-medium text-muted-foreground mb-1 block">Add Tags</label>
+                  <label className="text-xs font-medium text-muted-foreground mb-1 block"><Trans>Add Tags</Trans></label>
                   <div className="flex flex-wrap gap-1.5 mb-2">
                     {bulkMetaTagsAdd.map(tag => (
                       <span key={tag} className="flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-muted border border-border text-foreground">
@@ -2415,7 +2465,7 @@ export function DashboardPage() {
                     value={bulkMetaTagInput}
                     onChange={setBulkMetaTagInput}
                     suggestions={facets.tags.filter(t => !bulkMetaTagsAdd.includes(t))}
-                    placeholder="Add tag…"
+                    placeholder={t`Add tag…`}
                     onSelect={tag => {
                       if (tag && !bulkMetaTagsAdd.includes(tag)) {
                         setBulkMetaTagsAdd(prev => [...prev, tag])
@@ -2434,13 +2484,13 @@ export function DashboardPage() {
                 </div>
 
                 <div>
-                  <label className="text-xs font-medium text-muted-foreground mb-1 block">Type</label>
+                  <label className="text-xs font-medium text-muted-foreground mb-1 block"><Trans>Type</Trans></label>
                   <select
                     value={bulkMetaTypeId}
                     onChange={e => setBulkMetaTypeId(e.target.value ? Number(e.target.value) : '')}
                     className="w-full text-sm bg-muted rounded-lg px-3 py-1.5 focus:outline-none focus:ring-2 focus:ring-ring text-foreground"
                   >
-                    <option value="">— keep existing —</option>
+                    <option value="">{t`— keep existing —`}</option>
                     {bookTypes.map(t => (
                       <option key={t.id} value={t.id}>{t.label}</option>
                     ))}
@@ -2454,7 +2504,7 @@ export function DashboardPage() {
                   disabled={bulkMetaSaving}
                   className="px-3 py-1.5 rounded-lg text-sm border border-border text-muted-foreground hover:bg-muted transition-colors"
                 >
-                  Cancel
+                  <Trans>Cancel</Trans>
                 </button>
                 <button
                   onClick={bulkSaveMetadata}
@@ -2462,7 +2512,7 @@ export function DashboardPage() {
                   className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 transition-all"
                 >
                   {bulkMetaSaving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-                  Save Changes
+                  <Trans>Save Changes</Trans>
                 </button>
               </div>
             </div>
@@ -2476,13 +2526,14 @@ export function DashboardPage() {
 function FilterSelect({ label, value, options, onChange }: {
   label: string; value: string; options: (string | { value: string; label: string })[]; onChange: (v: string) => void
 }) {
+  const { t } = useLingui()
   const opts = options.map(o => typeof o === 'string' ? { value: o, label: o } : o)
   return (
     <div className="flex flex-col gap-1">
       <label className="text-xs font-medium text-muted-foreground">{label}</label>
       <select value={value} onChange={e => onChange(e.target.value)}
         className="h-8 rounded-md border border-border bg-background px-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring text-foreground">
-        <option value="">All</option>
+        <option value="">{t`All`}</option>
         {opts.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
       </select>
     </div>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1688,9 +1688,11 @@ export function DashboardPage() {
                                   </div>
                                   {seriesDetail.backlog && seriesDetail.backlog.estimated > 0 && (
                                     <p className="text-[10px] text-muted-foreground mb-1.5" title={describePace(seriesDetail.backlog.pace, seriesDetail.backlog.by_type.some(t => t.type_avg > 0) ? 'type_avg' : 'words')}>
-                                      <span className="text-foreground font-medium tabular-nums">{formatEstimateHours(seriesDetail.backlog.seconds)}</span> left in this series
-                                      {seriesDetail.backlog.days != null && <> &middot; {formatEstimateDays(seriesDetail.backlog.days)} at your pace</>}
-                                      {seriesDetail.backlog.unestimated > 0 && <> &middot; {seriesDetail.backlog.unestimated} not estimated</>}
+                                      {(() => { const dur = formatEstimateHours(seriesDetail.backlog.seconds); return (
+                                        <Trans><span className="text-foreground font-medium tabular-nums">{dur}</span> left in this series</Trans>
+                                      ) })()}
+                                      {seriesDetail.backlog.days != null && (() => { const d = formatEstimateDays(seriesDetail.backlog.days); return <Trans> &middot; {d} at your pace</Trans> })()}
+                                      {seriesDetail.backlog.unestimated > 0 && (() => { const n = seriesDetail.backlog.unestimated; return <Trans> &middot; {n} not estimated</Trans> })()}
                                     </p>
                                   )}
                                   <div className="h-2 rounded-full bg-muted overflow-hidden flex">

--- a/frontend/src/pages/HardcoverPage.tsx
+++ b/frontend/src/pages/HardcoverPage.tsx
@@ -10,6 +10,10 @@ import type { Book } from '@/lib/books'
 import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
 import { cn } from '@/lib/utils'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { t, plural, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 
 interface HardcoverStatus {
   linked: boolean
@@ -51,12 +55,12 @@ interface Candidate {
 
 type Filter = 'all' | 'matched' | 'unmatched' | 'excluded' | 'errors'
 
-const FILTERS: { key: Filter; label: string }[] = [
-  { key: 'all', label: 'All' },
-  { key: 'matched', label: 'Synced' },
-  { key: 'unmatched', label: 'Not matched' },
-  { key: 'excluded', label: 'Excluded' },
-  { key: 'errors', label: 'Errors' },
+const FILTERS: { key: Filter; label: MessageDescriptor }[] = [
+  { key: 'all', label: msg`All` },
+  { key: 'matched', label: msg`Synced` },
+  { key: 'unmatched', label: msg`Not matched` },
+  { key: 'excluded', label: msg`Excluded` },
+  { key: 'errors', label: msg`Errors` },
 ]
 
 function displayTitle(b: HcBook): string {
@@ -67,16 +71,17 @@ function displayTitle(b: HcBook): string {
     const idx = String(b.series_index)
     const alreadyThere = new RegExp(`vol(?:ume)?\\.?\\s*0*${idx.replace('.', '\\.')}\\b`, 'i').test(b.title)
     if (alreadyThere) return b.title
-    return `${b.title === b.series ? b.series : b.title} · Vol. ${idx}`
+    const base = b.title === b.series ? b.series : b.title
+    return t`${base} · Vol. ${idx}`
   }
   return b.title
 }
 
-const STATE_LABEL: Record<HcBook['state'], string> = {
-  matched: 'Synced',
-  unmatched: 'Not matched',
-  excluded: 'Excluded',
-  pending: 'Not synced yet',
+const STATE_LABEL: Record<HcBook['state'], MessageDescriptor> = {
+  matched: msg`Synced`,
+  unmatched: msg`Not matched`,
+  excluded: msg`Excluded`,
+  pending: msg`Not synced yet`,
 }
 
 const GROUP_KEY = 'tome_hardcover_group'
@@ -110,6 +115,7 @@ type Cell =
   | { kind: 'stack'; volumes: HcBook[] }
 
 export function HardcoverPage() {
+  const { t } = useLingui()
   const { toast } = useToast()
   const [status, setStatus] = useState<HardcoverStatus | null>(null)
   const [unavailable, setUnavailable] = useState(false)
@@ -218,10 +224,10 @@ export function HardcoverPage() {
   async function syncNow() {
     try {
       const r = await api.post<{ started: boolean }>('/hardcover/sync-now', {})
-      toast.info(r.started ? 'Sync started' : 'A sync is already running')
+      toast.info(r.started ? t`Sync started` : t`A sync is already running`)
       setStatus(s => s ? { ...s, sync_running: true } : s)
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Could not start sync')
+      toast.error(err instanceof Error ? err.message : t`Could not start sync`)
     }
   }
 
@@ -229,17 +235,18 @@ export function HardcoverPage() {
     try {
       await api.post(`/hardcover/books/${b.book_id}/rematch`, { mode })
       toast.info(mode === 'retry'
-        ? 'Match cleared — re-matching on the next sync'
-        : 'Excluded from Hardcover sync')
+        ? t`Match cleared — re-matching on the next sync`
+        : t`Excluded from Hardcover sync`)
       await load()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Action failed')
+      toast.error(err instanceof Error ? err.message : t`Action failed`)
     }
   }
 
   async function openPicker(b: HcBook) {
     setPickFor(b)
     const base = b.series && b.series_index != null
+      // eslint-disable-next-line lingui/no-unlocalized-strings -- search query, not copy
       ? `${b.series} Vol. ${b.series_index}` : b.title
     const q = b.author ? `${base} ${b.author}` : base
     setPickQuery(q)
@@ -252,7 +259,7 @@ export function HardcoverPage() {
     try {
       setPickResults(await api.get<Candidate[]>(`/hardcover/search?q=${encodeURIComponent(q)}`))
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Search failed')
+      toast.error(err instanceof Error ? err.message : t`Search failed`)
       setPickResults([])
     } finally {
       setPickBusy(false)
@@ -264,11 +271,11 @@ export function HardcoverPage() {
     setPickBusy(true)
     try {
       await api.post(`/hardcover/books/${pickFor.book_id}/match`, { hardcover_book_id: c.hardcover_book_id })
-      toast.success(`Matched to “${c.title}”`)
+      { const title = c.title; toast.success(t`Matched to “${title}”`) }
       setPickFor(null)
       await load()
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : 'Could not set match')
+      toast.error(err instanceof Error ? err.message : t`Could not set match`)
     } finally {
       setPickBusy(false)
     }
@@ -277,7 +284,7 @@ export function HardcoverPage() {
   if (unavailable) {
     return (
       <AppShell>
-        <div className="p-8 text-sm text-muted-foreground">Hardcover sync is disabled on this server.</div>
+        <div className="p-8 text-sm text-muted-foreground"><Trans>Hardcover sync is disabled on this server.</Trans></div>
       </AppShell>
     )
   }
@@ -287,23 +294,24 @@ export function HardcoverPage() {
       <div className="p-4 sm:p-6 lg:p-8 max-w-6xl mx-auto">
         <div className="flex items-center gap-3 mb-1">
           <BookMarked className="w-5 h-5 text-primary" />
+          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product name */}
           <h1 className="font-display text-2xl text-foreground">Hardcover</h1>
         </div>
         <p className="text-sm text-muted-foreground mb-6">
-          What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books.
+          <Trans>What your books sync to on Hardcover — audit matches, fix wrong ones, exclude books.</Trans>
         </p>
 
         {!status ? (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
-            <Loader2 className="w-4 h-4 animate-spin" /> Loading…
+            <Loader2 className="w-4 h-4 animate-spin" /> <Trans>Loading…</Trans>
           </div>
         ) : !status.linked ? (
           <div className="rounded-xl border border-border bg-card p-6 text-sm text-foreground/90 max-w-xl">
-            <p className="mb-2">No Hardcover account linked yet.</p>
+            <p className="mb-2"><Trans>No Hardcover account linked yet.</Trans></p>
             <p className="text-muted-foreground">
-              Link your personal API token in{' '}
+              <Trans>Link your personal API token in{' '}
               <Link to="/settings" className="text-primary hover:underline">Settings → Hardcover</Link>{' '}
-              — syncing starts right after.
+              — syncing starts right after.</Trans>
             </p>
           </div>
         ) : (
@@ -315,16 +323,16 @@ export function HardcoverPage() {
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-border text-sm font-medium text-foreground hover:bg-muted transition-colors disabled:opacity-50"
               >
                 <RefreshCw className={cn('w-4 h-4', status.sync_running && 'animate-spin')} />
-                {status.sync_running ? 'Syncing…' : 'Sync now'}
+                {status.sync_running ? t`Syncing…` : t`Sync now`}
               </button>
               <span className="text-xs text-muted-foreground mr-2">
                 @{status.username}
-                {status.last_synced_at && ` · last synced ${new Date(status.last_synced_at + 'Z').toLocaleString()}`}
+                {status.last_synced_at && (() => { const when = new Date(status.last_synced_at + 'Z').toLocaleString(i18n.locale); return t` · last synced ${when}` })()}
               </span>
               <div className="flex items-center gap-1 ml-auto">
                 <button
                   onClick={() => persistGroup(!grouped)}
-                  title={grouped ? 'Show individual volumes' : 'Group volumes by series'}
+                  title={grouped ? t`Show individual volumes` : t`Group volumes by series`}
                   aria-pressed={grouped}
                   className={cn(
                     'flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium border transition-all mr-1',
@@ -334,7 +342,7 @@ export function HardcoverPage() {
                   )}
                 >
                   <Layers className="w-3.5 h-3.5" />
-                  <span className="hidden sm:inline">Group series</span>
+                  <span className="hidden sm:inline"><Trans>Group series</Trans></span>
                 </button>
                 {FILTERS.map(f => {
                   const n = counts[f.key]
@@ -350,7 +358,7 @@ export function HardcoverPage() {
                           : 'border-border text-muted-foreground hover:text-foreground hover:bg-muted'
                       )}
                     >
-                      {f.label} <span className="opacity-60">{n}</span>
+                      {i18n._(f.label)} <span className="opacity-60">{n}</span>
                     </button>
                   )
                 })}
@@ -360,7 +368,7 @@ export function HardcoverPage() {
                 <input
                   value={query}
                   onChange={e => setQuery(e.target.value)}
-                  placeholder="Filter…"
+                  placeholder={t`Filter…`}
                   className="pl-7 pr-2 py-1.5 w-40 rounded-md border border-border bg-background text-xs text-foreground placeholder:text-muted-foreground/60 focus:border-primary focus:outline-none"
                 />
               </div>
@@ -372,7 +380,7 @@ export function HardcoverPage() {
                   onClick={() => setExpandedSeries(null)}
                   className="inline-flex items-center gap-1 px-2 py-1 rounded-md border border-border text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
                 >
-                  <ChevronLeft className="w-3.5 h-3.5" /> All books
+                  <ChevronLeft className="w-3.5 h-3.5" /> <Trans>All books</Trans>
                 </button>
                 <span className="text-sm font-medium text-foreground">{expandedSeries}</span>
               </div>
@@ -380,10 +388,10 @@ export function HardcoverPage() {
 
             {books == null ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Loader2 className="w-4 h-4 animate-spin" /> Loading books…
+                <Loader2 className="w-4 h-4 animate-spin" /> <Trans>Loading books…</Trans>
               </div>
             ) : cells.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No books in this view.</p>
+              <p className="text-sm text-muted-foreground"><Trans>No books in this view.</Trans></p>
             ) : (
               <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
                 {cells.map(cell => cell.kind === 'stack' ? (
@@ -410,7 +418,7 @@ export function HardcoverPage() {
                           : b.state === 'excluded' ? 'bg-muted-foreground/80 text-black'
                           : 'bg-black/60 text-white'
                       )}>
-                        {b.error ? 'Error' : STATE_LABEL[b.state]}
+                        {b.error ? t`Error` : i18n._(STATE_LABEL[b.state])}
                       </span>
                     </Link>
                     <div className="p-2.5 flex flex-col gap-1 grow">
@@ -426,7 +434,7 @@ export function HardcoverPage() {
                         </a>
                       ) : (
                         <p className="text-[11px] text-muted-foreground truncate">
-                          {b.state === 'excluded' ? 'not syncing' : b.isbn ?? 'no ISBN'}
+                          {b.state === 'excluded' ? t`not syncing` : b.isbn ?? t`no ISBN`}
                         </p>
                       )}
                       {b.error && (
@@ -439,34 +447,34 @@ export function HardcoverPage() {
                         <button
                           onClick={() => void openPicker(b)}
                           className="text-primary hover:underline"
-                          title="Search Hardcover and pick the record yourself"
+                          title={t`Search Hardcover and pick the record yourself`}
                         >
-                          Pick
+                          <Trans>Pick</Trans>
                         </button>
                         {b.state === 'matched' && (
                           <button
                             onClick={() => void rematch(b, 'retry')}
                             className="text-muted-foreground hover:text-foreground"
-                            title="Remove our entry from Hardcover and re-match automatically"
+                            title={t`Remove our entry from Hardcover and re-match automatically`}
                           >
-                            Re-match
+                            <Trans>Re-match</Trans>
                           </button>
                         )}
                         {b.state === 'excluded' ? (
                           <button
                             onClick={() => void rematch(b, 'retry')}
                             className="text-muted-foreground hover:text-foreground"
-                            title="Start matching this book again"
+                            title={t`Start matching this book again`}
                           >
-                            Include
+                            <Trans>Include</Trans>
                           </button>
                         ) : (
                           <button
                             onClick={() => void rematch(b, 'exclude')}
                             className="text-muted-foreground hover:text-destructive"
-                            title="Never sync this book"
+                            title={t`Never sync this book`}
                           >
-                            Exclude
+                            <Trans>Exclude</Trans>
                           </button>
                         )}
                       </div>
@@ -492,9 +500,9 @@ export function HardcoverPage() {
             <div className="p-4 border-b border-border">
               <div className="flex items-center justify-between gap-2 mb-3">
                 <p className="text-sm font-medium text-foreground truncate">
-                  Match “{displayTitle(pickFor)}” to…
+                  {(() => { const title = displayTitle(pickFor); return <Trans>Match “{title}” to…</Trans> })()}
                 </p>
-                <button onClick={() => setPickFor(null)} aria-label="Close"
+                <button onClick={() => setPickFor(null)} aria-label={t`Close`}
                         className="text-muted-foreground hover:text-foreground">
                   <X className="w-4 h-4" />
                 </button>
@@ -505,7 +513,7 @@ export function HardcoverPage() {
                   onChange={e => setPickQuery(e.target.value)}
                   onKeyDown={e => { if (e.key === 'Enter') void runPickSearch(pickQuery) }}
                   autoFocus
-                  placeholder="Search Hardcover…"
+                  placeholder={t`Search Hardcover…`}
                   className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:border-primary focus:outline-none"
                 />
                 <button
@@ -513,17 +521,17 @@ export function HardcoverPage() {
                   disabled={pickBusy}
                   className="px-3 py-2 rounded-md border border-border text-sm text-foreground hover:bg-muted disabled:opacity-50"
                 >
-                  Search
+                  <Trans>Search</Trans>
                 </button>
               </div>
             </div>
             <div className="max-h-[50vh] overflow-y-auto">
               {pickResults == null ? (
                 <div className="flex items-center gap-2 text-sm text-muted-foreground p-4">
-                  <Loader2 className="w-4 h-4 animate-spin" /> Searching…
+                  <Loader2 className="w-4 h-4 animate-spin" /> <Trans>Searching…</Trans>
                 </div>
               ) : pickResults.length === 0 ? (
-                <p className="text-sm text-muted-foreground p-4">No results — try a different query.</p>
+                <p className="text-sm text-muted-foreground p-4"><Trans>No results — try a different query.</Trans></p>
               ) : (
                 <ul className="divide-y divide-border">
                   {pickResults.map(c => (
@@ -541,8 +549,8 @@ export function HardcoverPage() {
                         <span className="min-w-0">
                           <span className="block text-sm text-foreground truncate">{c.title}</span>
                           <span className="block text-xs text-muted-foreground truncate">
-                            {c.authors.join(', ') || 'unknown author'}
-                            {c.users_count > 0 && ` · ${c.users_count} reader${c.users_count === 1 ? '' : 's'}`}
+                            {c.authors.join(', ') || t`unknown author`}
+                            {c.users_count > 0 && ' · ' + plural(c.users_count, { one: '# reader', other: '# readers' })}
                           </span>
                         </span>
                       </button>

--- a/frontend/src/pages/HighlightsPage.tsx
+++ b/frontend/src/pages/HighlightsPage.tsx
@@ -8,6 +8,8 @@ import {
 import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
 import { cn } from '@/lib/utils'
+import { Trans } from '@lingui/react/macro'
+import { t, plural } from '@lingui/core/macro'
 import { AppShell } from '@/components/AppShell'
 
 interface Highlight {
@@ -69,7 +71,7 @@ function groupToMarkdown(g: BookGroup): string {
   for (const h of g.items) {
     if (h.chapter) lines.push(`*${h.chapter}*`)
     if (h.highlighted_text) lines.push(`> ${h.highlighted_text}`)
-    if (h.note) lines.push('', `Note: ${h.note}`)
+    if (h.note) { const note = h.note; lines.push('', t`Note: ${note}`) }
     lines.push('')
   }
   return lines.join('\n').trimEnd()
@@ -101,12 +103,12 @@ function shortDate(dt: string | null): string | null {
 function fullInfo(h: Highlight): string {
   const parts: string[] = []
   const d = parseKo(h.datetime)
-  if (d) parts.push(`Highlighted ${d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })}`)
+  if (d) { const when = d.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' }); parts.push(t`Highlighted ${when}`) }
   if (h.chapter) parts.push(h.chapter)
-  if (h.color) parts.push(`${h.color} highlight`)
+  if (h.color) { const color = h.color; parts.push(t`${color} highlight`) }
   if (h.synced_at) {
     const s = new Date(h.synced_at)
-    if (!isNaN(s.getTime())) parts.push(`Synced to Tome ${s.toLocaleDateString(undefined, { dateStyle: 'medium' })}`)
+    if (!isNaN(s.getTime())) { const when = s.toLocaleDateString(undefined, { dateStyle: 'medium' }); parts.push(t`Synced to Tome ${when}`) }
   }
   return parts.join('  ·  ')
 }
@@ -157,29 +159,29 @@ function HighlightCard({ h, q, showDot, onDelete, onEdited }: { h: Highlight; q:
                 onClick={() => onDelete(h)}
                 className="font-medium text-destructive hover:underline"
               >
-                Delete
+                <Trans>Delete</Trans>
               </button>
               <button
                 onClick={() => setConfirming(false)}
                 className="text-muted-foreground hover:text-foreground"
               >
-                Cancel
+                <Trans>Cancel</Trans>
               </button>
             </span>
           ) : (
             <>
               <button
                 onClick={() => { setDraft(h.note ?? ''); setEditing(e => !e) }}
-                title={h.note ? 'Edit note' : 'Add a note'}
-                aria-label={h.note ? 'Edit note' : 'Add a note'}
+                title={h.note ? t`Edit note` : t`Add a note`}
+                aria-label={h.note ? t`Edit note` : t`Add a note`}
                 className="p-1 -m-1 rounded text-muted-foreground/50 hover:text-foreground transition-all opacity-60 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
               >
                 <Pencil className="w-3.5 h-3.5" />
               </button>
               <button
                 onClick={() => setConfirming(true)}
-                title="Delete this highlight"
-                aria-label="Delete this highlight"
+                title={t`Delete this highlight`}
+                aria-label={t`Delete this highlight`}
                 className="p-1 -m-1 rounded text-muted-foreground/50 hover:text-destructive transition-all opacity-60 sm:opacity-0 sm:group-hover:opacity-100 focus:opacity-100"
               >
                 <Trash2 className="w-3.5 h-3.5" />
@@ -200,14 +202,14 @@ function HighlightCard({ h, q, showDot, onDelete, onEdited }: { h: Highlight; q:
             onChange={e => setDraft(e.target.value)}
             autoFocus
             rows={2}
-            placeholder="Your note — syncs back to KOReader on the next sync"
+            placeholder={t`Your note — syncs back to KOReader on the next sync`}
             className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
           />
           <span className="flex items-center gap-2 text-xs">
             <button onClick={saveNote} disabled={saving} className="font-medium text-primary hover:underline disabled:opacity-50">
-              {saving ? 'Saving…' : 'Save note'}
+              {saving ? t`Saving…` : t`Save note`}
             </button>
-            <button onClick={() => setEditing(false)} className="text-muted-foreground hover:text-foreground">Cancel</button>
+            <button onClick={() => setEditing(false)} className="text-muted-foreground hover:text-foreground"><Trans>Cancel</Trans></button>
           </span>
         </div>
       ) : h.note ? (
@@ -257,7 +259,7 @@ export function HighlightsPage() {
     setError(null)
     api.get<HighlightsResponse>(`/annotations?${buildParams(0).toString()}`, ctrl.signal)
       .then(d => { setItems(d.items); setTotal(d.total); setBooks(d.books) })
-      .catch(e => { if (e.name !== 'AbortError') setError(e.message ?? 'Failed to load') })
+      .catch(e => { if (e.name !== 'AbortError') setError(e.message ?? t`Failed to load`) })
       .finally(() => setLoading(false))
     return () => ctrl.abort()
   }, [buildParams])
@@ -269,7 +271,7 @@ export function HighlightsPage() {
       setItems(prev => [...prev, ...d.items])
       setTotal(d.total)
     } catch (e) {
-      toast.error((e as Error).message ?? 'Failed to load more')
+      toast.error((e as Error).message ?? t`Failed to load more`)
     } finally {
       setLoadingMore(false)
     }
@@ -316,9 +318,9 @@ export function HighlightsPage() {
       const d = await fetchAllMatching()
       const md = groupByBook(d.items).map(groupToMarkdown).join('\n\n')
       await navigator.clipboard.writeText(md)
-      toast.success(`Copied ${d.items.length} highlights as Markdown`)
+      { const n = d.items.length; toast.success(t`Copied ${n} highlights as Markdown`) }
     } catch (e) {
-      toast.error((e as Error).message ?? 'Export failed')
+      toast.error((e as Error).message ?? t`Export failed`)
     }
   }
 
@@ -335,20 +337,20 @@ export function HighlightsPage() {
       a.click()
       a.remove()
       URL.revokeObjectURL(url)
-      toast.success(`Downloaded ${d.items.length} highlights`)
+      { const n = d.items.length; toast.success(t`Downloaded ${n} highlights`) }
     } catch (e) {
-      toast.error((e as Error).message ?? 'Export failed')
+      toast.error((e as Error).message ?? t`Export failed`)
     }
   }
 
   async function copyGroup(g: BookGroup) {
     await navigator.clipboard.writeText(groupToMarkdown(g))
-    toast.success(`Copied ${g.items.length} from “${g.title}”`)
+    { const n = g.items.length; const title = g.title; toast.success(t`Copied ${n} from “${title}”`) }
   }
 
   function noteEdited(h: Highlight, note: string | null) {
     setItems(prev => prev.map(x => (x.id === h.id ? { ...x, note } : x)))
-    toast.success(note ? 'Note saved — syncs to your devices' : 'Note removed')
+    toast.success(note ? t`Note saved — syncs to your devices` : t`Note removed`)
   }
 
   async function deleteHighlight(h: Highlight) {
@@ -372,9 +374,9 @@ export function HighlightsPage() {
             .catch(() => {})
         }
       }
-      toast.success('Highlight deleted')
+      toast.success(t`Highlight deleted`)
     } catch (e) {
-      toast.error((e as Error).message ?? 'Failed to delete highlight')
+      toast.error((e as Error).message ?? t`Failed to delete highlight`)
     }
   }
 
@@ -415,29 +417,29 @@ export function HighlightsPage() {
         <div className="flex items-center gap-1.5">
           <button
             onClick={copyAll}
-            title="Copy all as Markdown"
+            title={t`Copy all as Markdown`}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border hover:bg-muted transition-all"
           >
             <Copy className="w-3.5 h-3.5" />
-            <span className="hidden sm:inline">Copy</span>
+            <span className="hidden sm:inline"><Trans>Copy</Trans></span>
           </button>
           <button
             onClick={downloadAll}
-            title="Download as Markdown file"
+            title={t`Download as Markdown file`}
             className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium border border-border hover:bg-muted transition-all"
           >
             <Download className="w-3.5 h-3.5" />
-            <span className="hidden sm:inline">Export</span>
+            <span className="hidden sm:inline"><Trans>Export</Trans></span>
           </button>
         </div>
       ) : undefined}
     >
       <div className="max-w-3xl mx-auto px-4 py-6 space-y-5">
         <div className="flex items-baseline justify-between gap-3">
-          <h1 className="font-display text-xl text-foreground">Highlights</h1>
+          <h1 className="font-display text-xl text-foreground"><Trans>Highlights</Trans></h1>
           {total > 0 && (
             <span className="text-xs text-muted-foreground/60">
-              {total} from {books} book{books === 1 ? '' : 's'}
+              {plural(books, { one: `${total} from # book`, other: `${total} from # books` })}
             </span>
           )}
         </div>
@@ -451,7 +453,7 @@ export function HighlightsPage() {
               ref={searchRef}
               value={search}
               onChange={e => setSearch(e.target.value)}
-              placeholder="Search your highlights…"
+              placeholder={t`Search your highlights…`}
               className="w-full pl-9 pr-9 py-2 rounded-lg bg-muted/50 border border-border text-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
             />
             {search && (
@@ -465,7 +467,7 @@ export function HighlightsPage() {
           </div>
           <button
             onClick={() => setOnThisDay(v => !v)}
-            title="Highlights you made on this day in past years"
+            title={t`Highlights you made on this day in past years`}
             className={cn(
               'flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium border transition-all whitespace-nowrap',
               onThisDay
@@ -474,11 +476,11 @@ export function HighlightsPage() {
             )}
           >
             <CalendarHeart className="w-3.5 h-3.5" />
-            On this day
+            <Trans>On this day</Trans>
           </button>
           <button
             onClick={() => setOnlyNotes(v => !v)}
-            title="Only highlights that carry one of your notes"
+            title={t`Only highlights that carry one of your notes`}
             className={cn(
               'flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium border transition-all whitespace-nowrap',
               onlyNotes
@@ -487,16 +489,16 @@ export function HighlightsPage() {
             )}
           >
             <StickyNote className="w-3.5 h-3.5" />
-            <span className="hidden sm:inline">Only notes</span>
+            <span className="hidden sm:inline"><Trans>Only notes</Trans></span>
           </button>
           {groups.length > 0 && !searching && (
             <button
               onClick={toggleAll}
-              title={allCollapsed ? 'Expand all' : 'Collapse all'}
+              title={allCollapsed ? t`Expand all` : t`Collapse all`}
               className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-medium border border-border text-muted-foreground hover:bg-muted transition-all whitespace-nowrap"
             >
               {allCollapsed ? <ChevronsUpDown className="w-3.5 h-3.5" /> : <ChevronsDownUp className="w-3.5 h-3.5" />}
-              {allCollapsed ? 'Expand' : 'Collapse'}
+              {allCollapsed ? t`Expand` : t`Collapse`}
             </button>
           )}
         </div>
@@ -514,16 +516,16 @@ export function HighlightsPage() {
             <Quote className="w-8 h-8 opacity-40" />
             {neverSynced ? (
               <>
-                <p className="text-sm font-medium text-foreground">No highlights yet</p>
+                <p className="text-sm font-medium text-foreground"><Trans>No highlights yet</Trans></p>
                 <p className="text-xs max-w-xs leading-relaxed">
-                  Highlights and notes you make in KOReader sync here automatically.
+                  <Trans>Highlights and notes you make in KOReader sync here automatically.
                   Highlight a passage on your device, then sync — it’ll show up in this
-                  commonplace book.
+                  commonplace book.</Trans>
                 </p>
               </>
             ) : (
               <p className="text-sm">
-                {onThisDay ? 'Nothing highlighted on this day — yet.' : 'No highlights match your search.'}
+                {onThisDay ? t`Nothing highlighted on this day — yet.` : t`No highlights match your search.`}
               </p>
             )}
           </div>
@@ -593,7 +595,7 @@ export function HighlightsPage() {
                   className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium border border-border hover:bg-muted transition-all disabled:opacity-60"
                 >
                   {loadingMore ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
-                  Load more ({total - items.length} left)
+                  {(() => { const left = total - items.length; return t`Load more (${left} left)` })()}
                 </button>
               </div>
             )}

--- a/frontend/src/pages/HighlightsPage.tsx
+++ b/frontend/src/pages/HighlightsPage.tsx
@@ -569,7 +569,7 @@ export function HighlightsPage() {
                     </button>
                     <button
                       onClick={() => copyGroup(g)}
-                      title="Copy this book’s highlights as Markdown"
+                      title={t`Copy this book’s highlights as Markdown`}
                       className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
                     >
                       <Copy className="w-3.5 h-3.5" />

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -5,20 +5,24 @@ import { useAuth } from '@/contexts/AuthContext'
 import { ThemePill } from '@/components/ThemeToggle'
 import { BookAnimation } from '@/components/BookAnimation'
 import { cn } from '@/lib/utils'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 
 const API_BASE = '/api'
 
 // Human-readable messages for the ?sso_error= codes the OIDC callback bounces back.
-const SSO_ERRORS: Record<string, string> = {
-  misconfigured: 'SSO is misconfigured on the server (redirect URL). Contact your admin.',
-  disabled: 'SSO is not enabled.',
-  exchange: 'SSO sign-in could not be completed. Please try again.',
-  claims: 'SSO sign-in failed: no identity information was returned.',
-  not_allowed: 'Your account is not permitted to sign in to Tome.',
-  no_account: 'No Tome account is linked to this identity, and self-signup is disabled.',
-  inactive: 'Your Tome account is disabled.',
-  oidc_error: 'SSO sign-in failed. Please try again.',
-  callback: 'SSO sign-in did not complete. Please try again.',
+const SSO_ERRORS: Record<string, MessageDescriptor> = {
+  misconfigured: msg`SSO is misconfigured on the server (redirect URL). Contact your admin.`,
+  disabled: msg`SSO is not enabled.`,
+  exchange: msg`SSO sign-in could not be completed. Please try again.`,
+  claims: msg`SSO sign-in failed: no identity information was returned.`,
+  not_allowed: msg`Your account is not permitted to sign in to Tome.`,
+  no_account: msg`No Tome account is linked to this identity, and self-signup is disabled.`,
+  inactive: msg`Your Tome account is disabled.`,
+  oidc_error: msg`SSO sign-in failed. Please try again.`,
+  callback: msg`SSO sign-in did not complete. Please try again.`,
 }
 
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
@@ -31,6 +35,7 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 }
 
 export function LoginPage() {
+  const { t } = useLingui()
   const { user, login, refreshUser } = useAuth()
   const navigate = useNavigate()
   const [username, setUsername] = useState('')
@@ -49,7 +54,7 @@ export function LoginPage() {
     // Surface an error bounced back from the OIDC callback (?sso_error=…)
     const reason = new URLSearchParams(window.location.search).get('sso_error')
     if (reason) {
-      setError(SSO_ERRORS[reason] ?? 'SSO sign-in failed. Please try again.')
+      setError(SSO_ERRORS[reason] ? i18n._(SSO_ERRORS[reason]) : t`SSO sign-in failed. Please try again.`)
       // Clean the query string so a refresh doesn't re-show it
       window.history.replaceState({}, '', window.location.pathname)
     }
@@ -72,7 +77,7 @@ export function LoginPage() {
       await login(username, password)
       navigate('/')
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Login failed')
+      setError(err instanceof Error ? err.message : t`Login failed`)
     } finally {
       setLoading(false)
     }
@@ -106,7 +111,7 @@ export function LoginPage() {
         if (secs <= 0) {
           if (timerRef.current) clearInterval(timerRef.current)
           if (pollRef.current) clearInterval(pollRef.current)
-          setQcError('Code expired. Try again.')
+          setQcError(t`Code expired. Try again.`)
         }
       }
       updateTimer()
@@ -135,12 +140,12 @@ export function LoginPage() {
           if (e.status === 410) {
             if (pollRef.current) clearInterval(pollRef.current)
             if (timerRef.current) clearInterval(timerRef.current)
-            setQcError('Code expired. Try again.')
+            setQcError(t`Code expired. Try again.`)
           }
         }
       }, 2000)
     } catch {
-      setQcError('Failed to generate code. Try again.')
+      setQcError(t`Failed to generate code. Try again.`)
       setQcLoading(false)
       setQcMode(false)
     } finally {
@@ -165,6 +170,7 @@ export function LoginPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4 safe-top">
+      {/* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS */}
       <style>{`
         @keyframes fade-in-up {
           from { opacity: 0; transform: translateY(12px); }
@@ -190,15 +196,15 @@ export function LoginPage() {
             <div className="space-y-5">
               <div className="flex items-center justify-between">
                 <div>
-                  <h2 className="text-lg font-medium text-foreground">Quick Connect</h2>
+                  <h2 className="text-lg font-medium text-foreground"><Trans>Quick Connect</Trans></h2>
                   <p className="text-sm text-muted-foreground mt-0.5">
-                    Authorize this code from another device
+                    <Trans>Authorize this code from another device</Trans>
                   </p>
                 </div>
                 <button
                   onClick={stopQc}
                   className="p-1.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                  title="Cancel"
+                  title={t`Cancel`}
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -214,7 +220,7 @@ export function LoginPage() {
                     onClick={() => { setQcError(null); setQcMode(false) }}
                     className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg border border-border text-sm font-medium text-foreground hover:bg-muted transition-all"
                   >
-                    Try again
+                    <Trans>Try again</Trans>
                   </button>
                 </div>
               ) : qcLoading ? (
@@ -229,18 +235,18 @@ export function LoginPage() {
                     </div>
                     <div className="flex items-center gap-1.5 text-xs text-muted-foreground mt-1">
                       <Clock className="w-3 h-3" />
-                      <span>Expires in {fmtTime(qcSecondsLeft)}</span>
+                      {(() => { const timeLeft = fmtTime(qcSecondsLeft); return <span><Trans>Expires in {timeLeft}</Trans></span> })()}
                     </div>
                   </div>
 
                   <div className="rounded-lg bg-muted/60 border border-border px-4 py-3 text-xs text-muted-foreground space-y-1">
-                    <p className="font-medium text-foreground text-sm">How to authorize</p>
-                    <p>On a device where you're already signed in, go to <span className="font-medium text-foreground">Settings &rarr; Security &rarr; Quick Connect</span> and enter this code.</p>
+                    <p className="font-medium text-foreground text-sm"><Trans>How to authorize</Trans></p>
+                    <p><Trans>On a device where you're already signed in, go to <span className="font-medium text-foreground">Settings &rarr; Security &rarr; Quick Connect</span> and enter this code.</Trans></p>
                   </div>
 
                   <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
                     <div className="w-3.5 h-3.5 border-2 border-primary/50 border-t-primary rounded-full animate-spin" />
-                    Waiting for authorization…
+                    <Trans>Waiting for authorization…</Trans>
                   </div>
                 </div>
               ) : null}
@@ -248,13 +254,13 @@ export function LoginPage() {
           ) : (
             /* Normal login view */
             <>
-              <h2 className="text-lg font-medium text-foreground mb-1">Welcome back</h2>
-              <p className="text-sm text-muted-foreground mb-6">Sign in to your library</p>
+              <h2 className="text-lg font-medium text-foreground mb-1"><Trans>Welcome back</Trans></h2>
+              <p className="text-sm text-muted-foreground mb-6"><Trans>Sign in to your library</Trans></p>
 
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="space-y-1.5">
                   <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    Username or email
+                    <Trans>Username or email</Trans>
                   </label>
                   <input
                     type="text"
@@ -275,7 +281,7 @@ export function LoginPage() {
 
                 <div className="space-y-1.5">
                   <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                    Password
+                    <Trans>Password</Trans>
                   </label>
                   <div className="relative">
                     <input
@@ -327,7 +333,7 @@ export function LoginPage() {
                   ) : (
                     <>
                       <LogIn className="w-4 h-4" />
-                      Sign in
+                      <Trans>Sign in</Trans>
                     </>
                   )}
                 </button>
@@ -359,7 +365,7 @@ export function LoginPage() {
                   )}
                 >
                   <Smartphone className="w-4 h-4" />
-                  Quick Connect
+                  <Trans>Quick Connect</Trans>
                 </button>
               </div>
             </>
@@ -367,7 +373,7 @@ export function LoginPage() {
         </div>
 
         <p className="text-center text-xs text-muted-foreground mt-6">
-          Tome · Your personal library
+          <Trans>Tome · Your personal library</Trans>
         </p>
       </div>
     </div>

--- a/frontend/src/pages/OidcCallbackPage.tsx
+++ b/frontend/src/pages/OidcCallbackPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '@/contexts/AuthContext'
+import { Trans } from '@lingui/react/macro'
 
 /**
  * Lands the OIDC redirect. The backend appends the freshly minted Tome JWT to
@@ -35,7 +36,7 @@ export function OidcCallbackPage() {
     <div className="min-h-screen flex items-center justify-center bg-background text-muted-foreground">
       <div className="flex items-center gap-3 text-sm">
         <div className="w-4 h-4 border-2 border-primary border-t-transparent rounded-full animate-spin" />
-        Signing you in…
+        <Trans>Signing you in…</Trans>
       </div>
     </div>
   )

--- a/frontend/src/pages/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage.tsx
@@ -1,4 +1,8 @@
 import { useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle } from 'react'
+import { Trans } from '@lingui/react/macro'
+import { t, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 import { useParams, useNavigate } from 'react-router-dom'
 import {
   ArrowLeft, BookOpen, Settings, Rows4,
@@ -52,19 +56,22 @@ const HIGHLIGHT_COLORS = ['yellow', 'green', 'blue', 'purple', 'red'] as const
 
 // ── Theme / font definitions ──────────────────────────────────────────────────
 
-const THEMES: Record<ReaderTheme, { bg: string; text: string; label: string }> = {
-  light: { bg: '#ffffff', text: '#1a1a1a', label: 'Light' },
-  sepia: { bg: '#f7f3e9', text: '#5c4a32', label: 'Sepia' },
-  dark:  { bg: '#1c1c1e', text: '#e5e5e7', label: 'Dark' },
+const THEMES: Record<ReaderTheme, { bg: string; text: string; label: MessageDescriptor }> = {
+  light: { bg: '#ffffff', text: '#1a1a1a', label: msg`Light` },
+  sepia: { bg: '#f7f3e9', text: '#5c4a32', label: msg`Sepia` },
+  dark:  { bg: '#1c1c1e', text: '#e5e5e7', label: msg`Dark` },
 }
 
-const FONT_FAMILIES: Record<FontFamily, { css: string; label: string }> = {
-  default: { css: 'inherit', label: 'Default' },
-  serif:   { css: '"Georgia", "Times New Roman", serif', label: 'Serif' },
-  sans:    { css: '"Inter", "Helvetica Neue", sans-serif', label: 'Sans' },
+/* eslint-disable lingui/no-unlocalized-strings -- CSS font stacks */
+const FONT_FAMILIES: Record<FontFamily, { css: string; label: MessageDescriptor }> = {
+  default: { css: 'inherit', label: msg`Default` },
+  serif:   { css: '"Georgia", "Times New Roman", serif', label: msg`Serif` },
+  sans:    { css: '"Inter", "Helvetica Neue", sans-serif', label: msg`Sans` },
 }
+/* eslint-enable lingui/no-unlocalized-strings */
 
 // Build CSS string to inject into epub renderer
+/* eslint-disable lingui/no-unlocalized-strings -- CSS template, not user-facing text */
 function buildReaderCSS(theme: ReaderTheme, fontSize: number, fontFamily: FontFamily): string {
   const t = THEMES[theme]
   const ff = FONT_FAMILIES[fontFamily].css
@@ -82,6 +89,7 @@ function buildReaderCSS(theme: ReaderTheme, fontSize: number, fontFamily: FontFa
     a { color: ${theme === 'dark' ? '#60a5fa' : '#2563eb'} !important; }
   `
 }
+/* eslint-enable lingui/no-unlocalized-strings */
 
 // ── Streaming Comic Reader ────────────────────────────────────────────────────
 
@@ -276,7 +284,7 @@ function StreamingComicReader({
         <img
           key={currentPage}
           src={pageUrl(currentPage)}
-          alt={`Page ${currentPage + 1}`}
+          alt={(() => { const n = currentPage + 1; return t`Page ${n}` })()}
           style={spread ? { maxHeight: '100%', maxWidth: hasSecondPage ? '50%' : '100%', objectFit: 'contain' } : imgStyle}
           onLoad={() => setImageLoaded(true)}
           onError={() => setImageLoaded(true)}
@@ -286,7 +294,7 @@ function StreamingComicReader({
           <img
             key={currentPage + 1}
             src={pageUrl(currentPage + 1)}
-            alt={`Page ${currentPage + 2}`}
+            alt={(() => { const n = currentPage + 2; return t`Page ${n}` })()}
             style={{ maxHeight: '100%', maxWidth: '50%', objectFit: 'contain' }}
             draggable={false}
           />
@@ -351,7 +359,7 @@ function WebtoonReader({ bookId, totalPages, theme, onProgress, onReadComplete }
           <img
             key={i}
             src={`/api/books/${bookId}/pages/${i}?token=${encodeURIComponent(webtoonToken)}`}
-            alt={`Page ${i + 1}`}
+            alt={(() => { const n = i + 1; return t`Page ${n}` })()}
             className="w-full max-w-2xl"
             loading={i < 3 ? 'eager' : 'lazy'}
             draggable={false}
@@ -443,7 +451,7 @@ const PdfReader = forwardRef<PdfReaderHandle, PdfReaderProps>(function PdfReader
       setNumPages(doc.numPages)
       onDocLoaded(doc.numPages)
     }).catch((e) => {
-      if (!cancelled) onError(`Failed to load PDF: ${(e as Error).message}`)
+      if (!cancelled) { const msg2 = (e as Error).message; onError(t`Failed to load PDF: ${msg2}`) }
     })
     return () => {
       cancelled = true
@@ -534,7 +542,7 @@ const PdfReader = forwardRef<PdfReaderHandle, PdfReaderProps>(function PdfReader
           clearPage(i)
         }
       }
-    }, { root, rootMargin: '1200px 0px' })
+    }, { root, rootMargin: '1200px 0px' }) // eslint-disable-line lingui/no-unlocalized-strings -- CSS margin
     observerRef.current = obs
     pageWrapRefs.current.forEach((el) => { if (el) obs.observe(el) })
     return () => { obs.disconnect(); observerRef.current = null }
@@ -608,11 +616,13 @@ const PdfReader = forwardRef<PdfReaderHandle, PdfReaderProps>(function PdfReader
 
   const isDark = theme === 'dark'
   // Make the white page legible against the chosen background.
+  /* eslint-disable lingui/no-unlocalized-strings -- CSS filters */
   const canvasFilter = theme === 'dark'
     ? 'invert(1) hue-rotate(180deg)'
     : theme === 'sepia'
       ? 'sepia(0.45) brightness(0.97)'
       : 'none'
+  /* eslint-enable lingui/no-unlocalized-strings */
 
   return (
     <div
@@ -878,7 +888,7 @@ export default function ReaderPage() {
         bookData = await api.get<Book>(`/books/${bookId}`)
         setBook(bookData)
       } catch {
-        setLoadError('Book not found.')
+        setLoadError(t`Book not found.`)
         setLoading(false)
         return
       }
@@ -919,7 +929,7 @@ export default function ReaderPage() {
           setComicCurrentPage(savedPage)
           setProgress(comicPctFor(savedPage, pagesData.total))
         } catch (e: unknown) {
-          setLoadError(`Failed to load comic pages: ${(e as Error).message}`)
+          { const msg2 = (e as Error).message; setLoadError(t`Failed to load comic pages: ${msg2}`) }
           setLoading(false)
           return
         }
@@ -946,7 +956,7 @@ export default function ReaderPage() {
       }
 
       if (!hasEpub) {
-        setLoadError('No readable file found for this book.')
+        setLoadError(t`No readable file found for this book.`)
         setLoading(false)
         return
       }
@@ -986,7 +996,7 @@ export default function ReaderPage() {
         const blob = await resp.blob()
         epubFile = new File([blob], 'book.epub', { type: 'application/epub+zip' })
       } catch (e: unknown) {
-        setLoadError(`Failed to load EPUB: ${(e as Error).message}`)
+        { const msg2 = (e as Error).message; setLoadError(t`Failed to load EPUB: ${msg2}`) }
         setLoading(false)
         return
       }
@@ -1075,7 +1085,7 @@ export default function ReaderPage() {
       try {
         await view.open(epubFile)
       } catch (e: unknown) {
-        setLoadError(`EPUB failed to open: ${(e as Error).message}`)
+        { const msg2 = (e as Error).message; setLoadError(t`EPUB failed to open: ${msg2}`) }
         setLoading(false)
         return
       }
@@ -1322,7 +1332,7 @@ export default function ReaderPage() {
       <div className="flex flex-col items-center justify-center h-screen gap-4 text-muted-foreground">
         <BookOpen className="w-12 h-12 opacity-30" />
         <p className="text-sm">{loadError}</p>
-        <button onClick={() => navigate(-1)} className="text-sm text-primary hover:underline">Go back</button>
+        <button onClick={() => navigate(-1)} className="text-sm text-primary hover:underline"><Trans>Go back</Trans></button>
       </div>
     )
   }
@@ -1473,7 +1483,7 @@ export default function ReaderPage() {
               style={{ background: themeColors.bg, borderColor: isDarkTheme ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}
             >
               <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: isDarkTheme ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}>
-                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: themeColors.text, opacity: 0.5 }}>Settings</span>
+                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: themeColors.text, opacity: 0.5 }}><Trans>Settings</Trans></span>
                 <button onClick={() => setShowSettings(false)} style={{ color: themeColors.text, opacity: 0.5 }}>
                   <X className="w-4 h-4" />
                 </button>
@@ -1496,7 +1506,7 @@ export default function ReaderPage() {
                           borderColor: THEMES[t].text + '33',
                         }}
                       >
-                        {THEMES[t].label}
+                        {i18n._(THEMES[t].label)}
                       </button>
                     ))}
                   </div>
@@ -1680,7 +1690,7 @@ export default function ReaderPage() {
               style={{ background: themeColors.bg, borderColor: isDarkTheme ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}
             >
               <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: isDarkTheme ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}>
-                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: themeColors.text, opacity: 0.5 }}>Settings</span>
+                <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: themeColors.text, opacity: 0.5 }}><Trans>Settings</Trans></span>
                 <button onClick={() => setShowSettings(false)} style={{ color: themeColors.text, opacity: 0.5 }}>
                   <X className="w-4 h-4" />
                 </button>
@@ -1703,7 +1713,7 @@ export default function ReaderPage() {
                           borderColor: THEMES[t].text + '33',
                         }}
                       >
-                        {THEMES[t].label}
+                        {i18n._(THEMES[t].label)}
                       </button>
                     ))}
                   </div>
@@ -1803,13 +1813,13 @@ export default function ReaderPage() {
             style={{ background: themeColors.bg, borderColor: isDarkTheme ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}
           >
             <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: isDarkTheme ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}>
-              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: themeColors.text, opacity: 0.5 }}>Contents</span>
+              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: themeColors.text, opacity: 0.5 }}><Trans>Contents</Trans></span>
               <button onClick={() => setShowToc(false)} style={{ color: themeColors.text, opacity: 0.5 }}>
                 <X className="w-4 h-4" />
               </button>
             </div>
             {toc.length === 0 && (
-              <p className="px-4 py-6 text-xs" style={{ color: themeColors.text, opacity: 0.4 }}>No table of contents available.</p>
+              <p className="px-4 py-6 text-xs" style={{ color: themeColors.text, opacity: 0.4 }}><Trans>No table of contents available.</Trans></p>
             )}
             {toc.map((item, i) => (
               <button
@@ -1847,13 +1857,13 @@ export default function ReaderPage() {
                 borderColor: isDarkTheme ? 'rgba(255,255,255,0.15)' : 'rgba(0,0,0,0.12)',
               }}
             >
-              <span className="text-xs font-medium mr-1" style={{ opacity: 0.55 }}>Highlight</span>
+              <span className="text-xs font-medium mr-1" style={{ opacity: 0.55 }}><Trans>Highlight</Trans></span>
               {HIGHLIGHT_COLORS.map(c => (
                 <button
                   key={c}
                   onClick={() => createHighlight(c)}
                   disabled={savingAnnotation}
-                  aria-label={`Highlight in ${c}`}
+                  aria-label={t`Highlight in ${c}`}
                   className="w-6 h-6 rounded-full transition-transform hover:scale-110 disabled:opacity-50"
                   style={{
                     background: fillForColor(c).replace(/[\d.]+\)$/, '0.9)'),
@@ -1887,7 +1897,7 @@ export default function ReaderPage() {
                       <span className="shrink-0">· {activeHighlight.datetime.slice(0, 10)}</span>
                     )}
                   </div>
-                  <button onClick={() => { setActiveHighlight(null); setNoteDraft(null) }} style={{ opacity: 0.5 }} aria-label="Close">
+                  <button onClick={() => { setActiveHighlight(null); setNoteDraft(null) }} style={{ opacity: 0.5 }} aria-label={t`Close`}>
                     <X className="w-4 h-4" />
                   </button>
                 </div>
@@ -1906,13 +1916,13 @@ export default function ReaderPage() {
                       onChange={e => setNoteDraft(e.target.value)}
                       rows={3}
                       autoFocus
-                      placeholder="Add a note…"
+                      placeholder={t`Add a note…`}
                       className="w-full rounded-lg border bg-transparent p-2 text-sm focus:outline-none"
                       style={{ borderColor: isDarkTheme ? 'rgba(255,255,255,0.2)' : 'rgba(0,0,0,0.15)', color: themeColors.text }}
                     />
                     <div className="mt-1.5 flex gap-3 text-xs font-medium">
-                      <button onClick={saveNote} className="hover:underline">Save</button>
-                      <button onClick={() => setNoteDraft(null)} style={{ opacity: 0.6 }} className="hover:underline">Cancel</button>
+                      <button onClick={saveNote} className="hover:underline"><Trans>Save</Trans></button>
+                      <button onClick={() => setNoteDraft(null)} style={{ opacity: 0.6 }} className="hover:underline"><Trans>Cancel</Trans></button>
                     </div>
                   </div>
                 ) : activeHighlight.note ? (
@@ -1924,8 +1934,8 @@ export default function ReaderPage() {
                 <div className="mt-2.5 flex items-center justify-between">
                   <p className="text-[11px]" style={{ opacity: 0.4 }}>
                     {isWebAnnotation(activeHighlight)
-                      ? 'Made on the web — syncs to KOReader'
-                      : 'Synced from KOReader'}
+                      ? t`Made on the web — syncs to KOReader`
+                      : t`Synced from KOReader`}
                   </p>
                   {noteDraft == null && (
                     <div className="flex items-center gap-3 text-xs">
@@ -1935,7 +1945,7 @@ export default function ReaderPage() {
                         style={{ opacity: 0.7 }}
                       >
                         <StickyNote className="w-3.5 h-3.5" />
-                        {activeHighlight.note ? 'Edit note' : 'Add note'}
+                        {activeHighlight.note ? t`Edit note` : t`Add note`}
                       </button>
                       <button
                         onClick={deleteHighlight}
@@ -1943,7 +1953,7 @@ export default function ReaderPage() {
                         style={{ opacity: 0.7 }}
                       >
                         <Trash2 className="w-3.5 h-3.5" />
-                        Delete
+                        <Trans>Delete</Trans>
                       </button>
                     </div>
                   )}
@@ -1960,7 +1970,7 @@ export default function ReaderPage() {
             style={{ background: themeColors.bg, borderColor: isDarkTheme ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}
           >
             <div className="flex items-center justify-between px-4 py-3 border-b" style={{ borderColor: isDarkTheme ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.1)' }}>
-              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: themeColors.text, opacity: 0.5 }}>Settings</span>
+              <span className="text-xs font-semibold uppercase tracking-wider" style={{ color: themeColors.text, opacity: 0.5 }}><Trans>Settings</Trans></span>
               <button onClick={() => setShowSettings(false)} style={{ color: themeColors.text, opacity: 0.5 }}>
                 <X className="w-4 h-4" />
               </button>
@@ -1969,7 +1979,7 @@ export default function ReaderPage() {
             <div className="p-4 flex flex-col gap-6">
               {/* Font size */}
               <div>
-                <p className="text-xs font-medium mb-3" style={{ color: themeColors.text, opacity: 0.5 }}>FONT SIZE</p>
+                <p className="text-xs font-medium mb-3" style={{ color: themeColors.text, opacity: 0.5 }}><Trans>FONT SIZE</Trans></p>
                 <div className="flex items-center gap-3">
                   <button
                     onClick={() => changeFontSize(-10)}
@@ -2008,7 +2018,7 @@ export default function ReaderPage() {
                         fontFamily: FONT_FAMILIES[f].css,
                       }}
                     >
-                      {FONT_FAMILIES[f].label}
+                      {i18n._(FONT_FAMILIES[f].label)}
                     </button>
                   ))}
                 </div>
@@ -2032,7 +2042,7 @@ export default function ReaderPage() {
                         borderColor: THEMES[t].text + '33',
                       }}
                     >
-                      {THEMES[t].label}
+                      {i18n._(THEMES[t].label)}
                     </button>
                   ))}
                 </div>
@@ -2054,8 +2064,8 @@ export default function ReaderPage() {
         <span className="flex-1 text-xs truncate text-center" style={{ color: themeColors.text, opacity: 0.5 }}>
           {chapterLabel}
           {chapterMinsLeft != null && chapterMinsLeft >= 0.5 && (
-            <span title={pacingRef.current?.wpm ? 'Based on your measured reading pace' : 'Based on a default pace (no reading history yet)'}>
-              {chapterLabel ? ' · ' : ''}~{Math.max(1, Math.round(chapterMinsLeft))} min left
+            <span title={pacingRef.current?.wpm ? t`Based on your measured reading pace` : t`Based on a default pace (no reading history yet)`}>
+              {chapterLabel ? ' · ' : ''}{(() => { const m = Math.max(1, Math.round(chapterMinsLeft)); return t`~${m} min left` })()}
             </span>
           )}
         </span>

--- a/frontend/src/pages/ReaderPage.tsx
+++ b/frontend/src/pages/ReaderPage.tsx
@@ -1375,7 +1375,7 @@ export default function ReaderPage() {
                 ? (isDarkTheme ? 'bg-white/20' : 'bg-black/15')
                 : (isDarkTheme ? 'hover:bg-white/10 text-white/50' : 'hover:bg-black/10 text-black/40')
             )}
-            title="Toggle RTL (manga) mode"
+            title={t`Toggle RTL (manga) mode`}
             style={{ color: themeColors.text }}
           >
             RTL
@@ -1385,7 +1385,7 @@ export default function ReaderPage() {
           <button
             onClick={() => setFitMode((m) => m === 'width' ? 'height' : 'width')}
             className={cn('p-1.5 rounded-lg transition-colors', isDarkTheme ? 'hover:bg-white/10 text-white/70' : 'hover:bg-black/10 text-black/60')}
-            title={fitMode === 'width' ? 'Switch to fit height' : 'Switch to fit width'}
+            title={fitMode === 'width' ? t`Switch to fit height` : t`Switch to fit width`}
             style={{ color: themeColors.text }}
           >
             {fitMode === 'width' ? <RotateCcw className="w-4 h-4" /> : <AlignJustify className="w-4 h-4" />}
@@ -1398,7 +1398,7 @@ export default function ReaderPage() {
               className={cn('p-1.5 rounded-lg transition-colors', isDarkTheme ? 'hover:bg-white/10 text-white/70' : 'hover:bg-black/10 text-black/60',
                 spread && (isDarkTheme ? 'bg-white/15' : 'bg-black/10')
               )}
-              title={spread ? 'Single page (S)' : 'Two-page spread (S)'}
+              title={spread ? t`Single page (S)` : t`Two-page spread (S)`}
               style={{ color: themeColors.text }}
             >
               {spread ? <Square className="w-4 h-4" /> : <Columns2 className="w-4 h-4" />}
@@ -1412,7 +1412,7 @@ export default function ReaderPage() {
               className={cn('p-1.5 rounded-lg transition-colors', isDarkTheme ? 'hover:bg-white/10 text-white/70' : 'hover:bg-black/10 text-black/60',
                 showThumbnails && (isDarkTheme ? 'bg-white/15' : 'bg-black/10')
               )}
-              title="Page thumbnails (T)"
+              title={t`Page thumbnails (T)`}
               style={{ color: themeColors.text }}
             >
               <GalleryHorizontalEnd className="w-4 h-4" />
@@ -1423,7 +1423,7 @@ export default function ReaderPage() {
           <button
             onClick={() => setComicMode((m) => m === 'page' ? 'webtoon' : 'page')}
             className={cn('p-1.5 rounded-lg transition-colors', isDarkTheme ? 'hover:bg-white/10 text-white/70' : 'hover:bg-black/10 text-black/60')}
-            title={comicMode === 'page' ? 'Switch to webtoon (scroll) mode' : 'Switch to page mode'}
+            title={comicMode === 'page' ? t`Switch to webtoon (scroll) mode` : t`Switch to page mode`}
             style={{ color: themeColors.text }}
           >
             {comicMode === 'page' ? <Rows4 className="w-4 h-4" /> : <BookOpen className="w-4 h-4" />}
@@ -1437,7 +1437,7 @@ export default function ReaderPage() {
               isDarkTheme ? 'hover:bg-white/10' : 'hover:bg-black/10',
               showSettings && (isDarkTheme ? 'bg-white/15' : 'bg-black/10')
             )}
-            title="Reader settings"
+            title={t`Reader settings`}
             style={{ color: themeColors.text }}
           >
             <Settings className="w-4 h-4" />
@@ -1615,7 +1615,7 @@ export default function ReaderPage() {
           <button
             onClick={() => setPdfFitMode((m) => (m === 'width' ? 'height' : 'width'))}
             className={cn('p-1.5 rounded-lg transition-colors', isDarkTheme ? 'hover:bg-white/10 text-white/70' : 'hover:bg-black/10 text-black/60')}
-            title={pdfFitMode === 'width' ? 'Fit page height (W)' : 'Fit page width (W)'}
+            title={pdfFitMode === 'width' ? t`Fit page height (W)` : t`Fit page width (W)`}
             style={{ color: themeColors.text }}
           >
             {pdfFitMode === 'width' ? <StretchVertical className="w-4 h-4" /> : <StretchHorizontal className="w-4 h-4" />}
@@ -1626,7 +1626,7 @@ export default function ReaderPage() {
             <button
               onClick={zoomOut}
               className={cn('p-1.5 rounded-lg transition-colors', isDarkTheme ? 'hover:bg-white/10 text-white/70' : 'hover:bg-black/10 text-black/60')}
-              title="Zoom out (-)"
+              title={t`Zoom out (-)`}
               style={{ color: themeColors.text }}
             >
               <Minus className="w-4 h-4" />
@@ -1637,7 +1637,7 @@ export default function ReaderPage() {
             <button
               onClick={zoomIn}
               className={cn('p-1.5 rounded-lg transition-colors', isDarkTheme ? 'hover:bg-white/10 text-white/70' : 'hover:bg-black/10 text-black/60')}
-              title="Zoom in (+)"
+              title={t`Zoom in (+)`}
               style={{ color: themeColors.text }}
             >
               <Plus className="w-4 h-4" />
@@ -1652,7 +1652,7 @@ export default function ReaderPage() {
               isDarkTheme ? 'hover:bg-white/10' : 'hover:bg-black/10',
               showSettings && (isDarkTheme ? 'bg-white/15' : 'bg-black/10')
             )}
-            title="Reader settings"
+            title={t`Reader settings`}
             style={{ color: themeColors.text }}
           >
             <Settings className="w-4 h-4" />
@@ -1788,7 +1788,7 @@ export default function ReaderPage() {
         <button
           onClick={() => { setShowToc((o) => !o); setShowSettings(false) }}
           className={cn('p-1.5 rounded-lg transition-colors', isDarkTheme ? 'hover:bg-white/10' : 'hover:bg-black/10', showToc && (isDarkTheme ? 'bg-white/15' : 'bg-black/10'))}
-          title="Table of contents"
+          title={t`Table of contents`}
           style={{ color: themeColors.text }}
         >
           <AlignJustify className="w-4 h-4" />
@@ -1796,7 +1796,7 @@ export default function ReaderPage() {
         <button
           onClick={() => { setShowSettings((o) => !o); setShowToc(false) }}
           className={cn('p-1.5 rounded-lg transition-colors', isDarkTheme ? 'hover:bg-white/10' : 'hover:bg-black/10', showSettings && (isDarkTheme ? 'bg-white/15' : 'bg-black/10'))}
-          title="Reader settings"
+          title={t`Reader settings`}
           style={{ color: themeColors.text }}
         >
           <Settings className="w-4 h-4" />

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -622,7 +622,7 @@ export function SettingsPage() {
                   className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40 sm:mt-5 shrink-0"
                 >
                   {profileSaving && <RefreshCw className="w-3.5 h-3.5 animate-spin" />}
-                  {profileSaving ? t`Saving...` : t`Save changes`}
+                  {profileSaving ? t`Saving…` : t`Save changes`}
                 </button>
               </form>
               {profileError && <p className="text-xs text-destructive mt-2">{profileError}</p>}
@@ -664,7 +664,7 @@ export function SettingsPage() {
                     className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40"
                   >
                     {pwSaving && <RefreshCw className="w-3.5 h-3.5 animate-spin" />}
-                    {pwSaving ? t`Saving...` : t`Update password`}
+                    {pwSaving ? t`Saving…` : t`Update password`}
                   </button>
                 </div>
               </form>
@@ -1111,7 +1111,7 @@ export function SettingsPage() {
                   className="flex items-center gap-1.5 h-9 px-3 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40 shrink-0"
                 >
                   {kosyncSaving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-                  {kosyncSaving ? t`Saving...` : kosyncStatus?.linked ? t`Update` : t`Register`}
+                  {kosyncSaving ? t`Saving…` : kosyncStatus?.linked ? t`Update` : t`Register`}
                 </button>
               </form>
               {kosyncError && <p className="text-xs text-destructive">{kosyncError}</p>}
@@ -1153,7 +1153,7 @@ export function SettingsPage() {
                   ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
                   : <Download className="w-3.5 h-3.5" />
                 }
-                {pluginDownloading ? t`Preparing...` : t`Download plugin ZIP`}
+                {pluginDownloading ? t`Preparing…` : t`Download plugin ZIP`}
               </button>
 
               <SetupGuide />
@@ -1466,7 +1466,7 @@ export function SettingsPage() {
               {apiTokensLoading ? (
                 <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
                   <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                  <Trans>Loading...</Trans>
+                  <Trans>Loading…</Trans>
                 </div>
               ) : apiTokens.length === 0 ? (
                 <p className="text-xs text-muted-foreground py-2">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -23,6 +23,8 @@ import {
 } from '@/lib/theme'
 import { useAuth } from '@/contexts/AuthContext'
 import { Trans, useLingui } from '@lingui/react/macro'
+import { t, msg } from '@lingui/core/macro'
+import type { MessageDescriptor } from '@lingui/core'
 import { LOCALES, getActiveLocale, setLocale } from '@/lib/i18n'
 
 interface ApiKey {
@@ -71,15 +73,15 @@ export function SettingsPage() {
     api.get<{ enabled: boolean }>('/auth/oidc/config').then(r => setSsoEnabled(r.enabled)).catch(() => {})
     const p = new URLSearchParams(window.location.search)
     if (p.get('sso_linked')) {
-      setSsoMsg({ ok: true, text: 'SSO sign-in linked to your account.' })
+      setSsoMsg({ ok: true, text: t`SSO sign-in linked to your account.` })
       refreshUser()
       window.history.replaceState({}, '', window.location.pathname)
     }
     const err = p.get('sso_link_error')
     if (err) {
       setSsoMsg({ ok: false, text: err === 'already_linked'
-        ? 'That SSO identity is already linked to another account.'
-        : 'Could not link SSO. Please try again.' })
+        ? t`That SSO identity is already linked to another account.`
+        : t`Could not link SSO. Please try again.` })
       window.history.replaceState({}, '', window.location.pathname)
     }
   }, [])
@@ -90,7 +92,7 @@ export function SettingsPage() {
       const r = await api.post<{ login_url: string }>('/auth/oidc/link/start', {})
       window.location.href = r.login_url
     } catch {
-      setSsoMsg({ ok: false, text: 'Could not start SSO linking.' })
+      setSsoMsg({ ok: false, text: t`Could not start SSO linking.` })
       setLinkingSso(false)
     }
   }
@@ -120,7 +122,7 @@ export function SettingsPage() {
       setProfileSuccess(true)
       setTimeout(() => setProfileSuccess(false), 3000)
     } catch (err) {
-      setProfileError(err instanceof Error ? err.message : 'Failed to save')
+      setProfileError(err instanceof Error ? err.message : t`Failed to save`)
     } finally {
       setProfileSaving(false)
     }
@@ -139,8 +141,8 @@ export function SettingsPage() {
     e.preventDefault()
     setPwError(null)
     setPwSuccess(false)
-    if (newPassword !== confirmPassword) { setPwError('Passwords do not match'); return }
-    if (newPassword.length < 8) { setPwError('Password must be at least 8 characters'); return }
+    if (newPassword !== confirmPassword) { setPwError(t`Passwords do not match`); return }
+    if (newPassword.length < 8) { setPwError(t`Password must be at least 8 characters`); return }
     setPwSaving(true)
     try {
       await api.put('/auth/me/password', { current_password: currentPassword, new_password: newPassword })
@@ -148,7 +150,7 @@ export function SettingsPage() {
       setTimeout(() => setPwSuccess(false), 4000)
       setCurrentPassword(''); setNewPassword(''); setConfirmPassword('')
     } catch (err: unknown) {
-      setPwError(err instanceof Error ? err.message : 'Failed to change password')
+      setPwError(err instanceof Error ? err.message : t`Failed to change password`)
     } finally {
       setPwSaving(false)
     }
@@ -165,7 +167,7 @@ export function SettingsPage() {
     setQcError(null)
     setQcSuccess(false)
     const code = qcCode.trim().toUpperCase()
-    if (code.length !== 6) { setQcError('Code must be 6 characters'); return }
+    if (code.length !== 6) { setQcError(t`Code must be 6 characters`); return }
     setQcAuthorizing(true)
     try {
       await api.post('/auth/quick-connect/authorize', { code })
@@ -173,10 +175,10 @@ export function SettingsPage() {
       setQcCode('')
       setTimeout(() => setQcSuccess(false), 5000)
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Failed to authorize'
-      if (msg.includes('not found') || msg.includes('Not Found')) setQcError('Code not found. Check the code and try again.')
-      else if (msg.includes('expired')) setQcError('Code has expired. Ask the other device to generate a new one.')
-      else if (msg.includes('already authorized')) setQcError('Code was already authorized.')
+      const msg = err instanceof Error ? err.message : t`Failed to authorize`
+      if (msg.includes('not found') || msg.includes('Not Found')) setQcError(t`Code not found. Check the code and try again.`)
+      else if (msg.includes('expired')) setQcError(t`Code has expired. Ask the other device to generate a new one.`)
+      else if (msg.includes('already authorized')) setQcError(t`Code was already authorized.`)
       else setQcError(msg)
     } finally {
       setQcAuthorizing(false)
@@ -184,7 +186,7 @@ export function SettingsPage() {
   }
 
   // ── Language ──────────────────────────────────────────────────────────────
-  const { t } = useLingui()
+  const { t, i18n } = useLingui()
   const [activeLocale, setActiveLocale] = useState<string>(getActiveLocale)
 
   async function handleLocaleSelect(code: string) {
@@ -221,9 +223,9 @@ export function SettingsPage() {
 
   function handleAddCustomTheme() {
     setCustomError(null)
-    if (!customName.trim()) { setCustomError('Theme name is required'); return }
+    if (!customName.trim()) { setCustomError(t`Theme name is required`); return }
     const vars = parseThemeColors(customColors)
-    if (!vars) { setCustomError('Must be exactly 10 comma-separated hex values (e.g. #1E1E2E)'); return }
+    if (!vars) { setCustomError(t`Must be exactly 10 comma-separated hex values (e.g. #1E1E2E)`); return }
     const id = `custom-${Date.now()}`
     const theme: CustomTheme = { id, label: customName.trim(), dark: customDark, colors: customColors }
     saveCustomTheme(theme)
@@ -265,7 +267,7 @@ export function SettingsPage() {
       const updated = await api.get<KOSyncStatus>('/auth/me/kosync')
       setKosyncStatus(updated)
     } catch (err) {
-      setKosyncError(err instanceof Error ? err.message : 'Failed to register')
+      setKosyncError(err instanceof Error ? err.message : t`Failed to register`)
     } finally {
       setKosyncSaving(false)
     }
@@ -415,7 +417,7 @@ export function SettingsPage() {
       setNewDeviceName('')
       setNewDeviceEmail('')
     } catch (err) {
-      setDeviceError(err instanceof Error ? err.message : 'Failed to add device')
+      setDeviceError(err instanceof Error ? err.message : t`Failed to add device`)
     } finally {
       setDeviceAdding(false)
     }
@@ -466,14 +468,14 @@ export function SettingsPage() {
       const updated = await listTokens(apiTokensAllUsers)
       setApiTokens(updated)
     } catch (err) {
-      setTokenCreateError(err instanceof Error ? err.message : 'Failed to create token')
+      setTokenCreateError(err instanceof Error ? err.message : t`Failed to create token`)
     } finally {
       setTokenCreating(false)
     }
   }
 
   async function handleRevokeApiToken(id: number) {
-    if (!confirm('Revoke this token? Any scripts or tools using it will stop working immediately.')) return
+    if (!confirm(t`Revoke this token? Any scripts or tools using it will stop working immediately.`)) return
     setTokenRevoking(id)
     try {
       await revokeToken(id)
@@ -573,10 +575,10 @@ export function SettingsPage() {
               className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors"
             >
               <ArrowLeft className="w-4 h-4" />
-              Library
+              <Trans>Library</Trans>
             </Link>
             <span className="text-border select-none">/</span>
-            <span className="text-sm font-medium text-foreground">Settings</span>
+            <span className="text-sm font-medium text-foreground"><Trans>Settings</Trans></span>
           </div>
           <ThemeToggle />
         </div>
@@ -586,7 +588,7 @@ export function SettingsPage() {
 
         {/* ── Account & Security ────────────────────────────────────────── */}
         <section>
-          <SectionHeader title="Account & Security" />
+          <SectionHeader title={t`Account & Security`} />
           <div className="mt-4 rounded-xl border border-border bg-card divide-y divide-border overflow-hidden">
 
             {/* Profile */}
@@ -594,7 +596,7 @@ export function SettingsPage() {
               <form onSubmit={handleProfileSubmit} className="flex flex-col sm:flex-row gap-3 items-start">
                 <div className="flex-1 w-full grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
-                    <label className="block text-xs font-medium text-muted-foreground mb-1">Username</label>
+                    <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Username</Trans></label>
                     <input
                       type="text"
                       value={profileUsername}
@@ -604,7 +606,7 @@ export function SettingsPage() {
                     />
                   </div>
                   <div>
-                    <label className="block text-xs font-medium text-muted-foreground mb-1">Email</label>
+                    <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Email</Trans></label>
                     <input
                       type="email"
                       value={profileEmail}
@@ -620,41 +622,41 @@ export function SettingsPage() {
                   className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40 sm:mt-5 shrink-0"
                 >
                   {profileSaving && <RefreshCw className="w-3.5 h-3.5 animate-spin" />}
-                  {profileSaving ? 'Saving...' : 'Save changes'}
+                  {profileSaving ? t`Saving...` : t`Save changes`}
                 </button>
               </form>
               {profileError && <p className="text-xs text-destructive mt-2">{profileError}</p>}
-              {profileSuccess && <p className="text-xs text-success mt-2">Profile updated</p>}
+              {profileSuccess && <p className="text-xs text-success mt-2"><Trans>Profile updated</Trans></p>}
             </div>
 
             {/* Password */}
             <div className="p-5">
-              <p className="text-sm font-medium text-foreground mb-3">Change Password</p>
+              <p className="text-sm font-medium text-foreground mb-3"><Trans>Change Password</Trans></p>
               {user?.auth_source === 'oidc' ? (
                 <p className="text-sm text-muted-foreground max-w-sm">
-                  You're signed in via SSO. Manage your credentials at your identity
-                  provider — there's no Tome password to change.
+                  <Trans>You're signed in via SSO. Manage your credentials at your identity
+                  provider — there's no Tome password to change.</Trans>
                 </p>
               ) : (
               <form onSubmit={handlePasswordSubmit} className="space-y-3 max-w-sm">
                 <PasswordField
-                  label="Current password"
+                  label={t`Current password`}
                   value={currentPassword}
                   onChange={setCurrentPassword}
                   show={showPasswords}
                   onToggleShow={() => setShowPasswords(v => !v)}
                   showToggle
                 />
-                <PasswordField label="New password" value={newPassword} onChange={setNewPassword} show={showPasswords} />
+                <PasswordField label={t`New password`} value={newPassword} onChange={setNewPassword} show={showPasswords} />
                 <PasswordField
-                  label="Confirm new password"
+                  label={t`Confirm new password`}
                   value={confirmPassword}
                   onChange={setConfirmPassword}
                   show={showPasswords}
                   error={!!(pwError && confirmPassword && newPassword !== confirmPassword)}
                 />
                 {pwError && <p className="text-xs text-destructive pt-0.5">{pwError}</p>}
-                {pwSuccess && <p className="text-xs text-success pt-0.5">Password updated successfully</p>}
+                {pwSuccess && <p className="text-xs text-success pt-0.5"><Trans>Password updated successfully</Trans></p>}
                 <div className="pt-1">
                   <button
                     type="submit"
@@ -662,7 +664,7 @@ export function SettingsPage() {
                     className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40"
                   >
                     {pwSaving && <RefreshCw className="w-3.5 h-3.5 animate-spin" />}
-                    {pwSaving ? 'Saving...' : 'Update password'}
+                    {pwSaving ? t`Saving...` : t`Update password`}
                   </button>
                 </div>
               </form>
@@ -672,7 +674,7 @@ export function SettingsPage() {
             {/* SSO linking */}
             {ssoEnabled && (
               <div className="p-5">
-                <p className="text-sm font-medium text-foreground mb-3">Single Sign-On</p>
+                <p className="text-sm font-medium text-foreground mb-3"><Trans>Single Sign-On</Trans></p>
                 {ssoMsg && (
                   <div className={cn(
                     'flex items-center gap-2 text-sm p-3 rounded-lg mb-3 border',
@@ -687,13 +689,14 @@ export function SettingsPage() {
                 {user?.oidc_linked ? (
                   <p className="flex items-center gap-2 text-sm text-muted-foreground">
                     <Check className="w-4 h-4 text-success" />
-                    Your account is linked to SSO — you can sign in with your identity provider.
+                    <Trans>Your account is linked to SSO — you can sign in with your identity provider.</Trans>
                   </p>
                 ) : (
                   <div className="space-y-3 max-w-sm">
                     <p className="text-sm text-muted-foreground">
-                      Link your identity provider to this account so you can sign in with SSO.
-                      Your existing login{user?.auth_source === 'oidc' ? '' : ' and password'} keep working.
+                      {user?.auth_source === 'oidc'
+                        ? <Trans>Link your identity provider to this account so you can sign in with SSO. Your existing login keeps working.</Trans>
+                        : <Trans>Link your identity provider to this account so you can sign in with SSO. Your existing login and password keep working.</Trans>}
                     </p>
                     <button
                       onClick={handleLinkSso}
@@ -701,7 +704,7 @@ export function SettingsPage() {
                       className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium border border-border text-foreground hover:bg-muted transition-all disabled:opacity-40"
                     >
                       {linkingSso ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Key className="w-3.5 h-3.5" />}
-                      Link SSO
+                      <Trans>Link SSO</Trans>
                     </button>
                   </div>
                 )}
@@ -715,15 +718,15 @@ export function SettingsPage() {
                   <Smartphone className="w-3.5 h-3.5 text-primary" />
                 </div>
                 <div>
-                  <p className="text-sm font-medium text-foreground">Quick Connect</p>
+                  <p className="text-sm font-medium text-foreground"><Trans>Quick Connect</Trans></p>
                   <p className="text-xs text-muted-foreground mt-0.5">
-                    Sign in on a new device without entering your password. On the new device, tap "Quick Connect" on the login screen to get a 6-character code, then enter it here.
+                    <Trans>Sign in on a new device without entering your password. On the new device, tap "Quick Connect" on the login screen to get a 6-character code, then enter it here.</Trans>
                   </p>
                 </div>
               </div>
               <form onSubmit={handleQcAuthorize} className="flex items-end gap-2 max-w-xs">
                 <div className="flex-1">
-                  <label className="block text-xs font-medium text-muted-foreground mb-1">Code from new device</label>
+                  <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Code from new device</Trans></label>
                   <input
                     type="text"
                     value={qcCode}
@@ -740,14 +743,14 @@ export function SettingsPage() {
                   className="flex items-center gap-1.5 h-9 px-3 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40 shrink-0"
                 >
                   {qcAuthorizing && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-                  {qcAuthorizing ? 'Authorizing...' : 'Authorize'}
+                  {qcAuthorizing ? t`Authorizing...` : t`Authorize`}
                 </button>
               </form>
               {qcError && <p className="text-xs text-destructive mt-2">{qcError}</p>}
               {qcSuccess && (
                 <div className="flex items-center gap-1.5 text-xs text-success mt-2">
                   <CheckCircle className="w-3.5 h-3.5" />
-                  Device authorized — the new device is now signed in.
+                  <Trans>Device authorized — the new device is now signed in.</Trans>
                 </div>
               )}
             </div>
@@ -757,10 +760,10 @@ export function SettingsPage() {
 
         {/* ── Appearance ───────────────────────────────────────────────── */}
         <section>
-          <SectionHeader title="Appearance" />
+          <SectionHeader title={t`Appearance`} />
 
           {/* Built-in themes — neutral core + warm pair */}
-          {([['Core', 'core'], ['Warm', 'warm']] as const).map(([groupLabel, group]) => (
+          {([[t`Core`, 'core'], [t`Warm`, 'warm']] as const).map(([groupLabel, group]) => (
             <div key={group} className="mt-4">
               <p className="text-xs text-muted-foreground mb-1.5">{groupLabel}</p>
               <div className="grid grid-cols-3 sm:grid-cols-4 gap-2">
@@ -849,7 +852,7 @@ export function SettingsPage() {
             >
               <span className="flex items-center gap-2 font-medium">
                 <Plus className="w-3.5 h-3.5" />
-                Add custom theme
+                <Trans>Add custom theme</Trans>
               </span>
               {customFormOpen ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
             </button>
@@ -858,12 +861,12 @@ export function SettingsPage() {
               <div className="border-t border-border p-4 space-y-4">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
-                    <label className="block text-xs font-medium text-muted-foreground mb-1">Theme name</label>
+                    <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Theme name</Trans></label>
                     <input
                       type="text"
                       value={customName}
                       onChange={e => setCustomName(e.target.value)}
-                      placeholder="My Theme"
+                      placeholder={t`My Theme`}
                       className="w-full text-sm bg-muted rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-ring"
                     />
                   </div>
@@ -875,15 +878,15 @@ export function SettingsPage() {
                         onChange={e => setCustomDark(e.target.checked)}
                         className="w-4 h-4 rounded accent-primary"
                       />
-                      Dark theme
-                      <span className="text-xs text-muted-foreground">(enables dark: variants)</span>
+                      <Trans>Dark theme</Trans>
+                      <span className="text-xs text-muted-foreground"><Trans>(enables dark: variants)</Trans></span>
                     </label>
                   </div>
                 </div>
 
                 <div>
                   <label className="block text-xs font-medium text-muted-foreground mb-1">
-                    Colors <span className="font-normal">(10 hex values, comma-separated)</span>
+                    <Trans>Colors <span className="font-normal">(10 hex values, comma-separated)</span></Trans>
                   </label>
                   <input
                     type="text"
@@ -894,14 +897,14 @@ export function SettingsPage() {
                     spellCheck={false}
                   />
                   <p className="text-[10px] text-muted-foreground mt-1">
-                    Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive
+                    <Trans>Order: background, foreground, card, primary, primary-foreground, muted, muted-foreground, accent, border, destructive</Trans>
                   </p>
                 </div>
 
                 {/* Live preview */}
                 {parsedPreview && (
                   <div className="flex items-center gap-3">
-                    <span className="text-xs text-muted-foreground shrink-0">Preview:</span>
+                    <span className="text-xs text-muted-foreground shrink-0"><Trans>Preview:</Trans></span>
                     <div
                       className="flex items-center gap-1.5 rounded-lg px-3 py-2 border"
                       style={{
@@ -912,7 +915,7 @@ export function SettingsPage() {
                       <div className="w-6 h-6 rounded" style={{ background: parsedPreview['--card'] }} />
                       <div className="w-4 h-4 rounded-full" style={{ background: parsedPreview['--primary'] }} />
                       <span className="text-xs font-medium" style={{ color: parsedPreview['--foreground'] }}>
-                        {customName || 'Preview'}
+                        {customName || t`Preview`}
                       </span>
                     </div>
                   </div>
@@ -925,7 +928,7 @@ export function SettingsPage() {
                   className="flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
                 >
                   <Plus className="w-3.5 h-3.5" />
-                  Add Theme
+                  <Trans>Add Theme</Trans>
                 </button>
               </div>
             )}
@@ -967,6 +970,7 @@ export function SettingsPage() {
 
         {/* ── KOReader ─────────────────────────────────────────────────── */}
         <section>
+          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product name */}
           <SectionHeader title="KOReader" />
           <div className="mt-4 rounded-xl border border-border bg-card overflow-hidden divide-y divide-border">
 
@@ -974,36 +978,36 @@ export function SettingsPage() {
             <div className="p-6 space-y-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-0.5">OPDS Catalog</p>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-0.5"><Trans>OPDS Catalog</Trans></p>
                   <p className="text-xs text-muted-foreground">
-                    Browse and download your library from KOReader or any OPDS client.
+                    <Trans>Browse and download your library from KOReader or any OPDS client.</Trans>
                   </p>
                 </div>
                 <a href={docsLink(DOCS.opds)} target="_blank" rel="noopener noreferrer" className="shrink-0 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors">
-                  Learn more <ExternalLink className="w-3 h-3" />
+                  <Trans>Learn more</Trans> <ExternalLink className="w-3 h-3" />
                 </a>
               </div>
               <ConnectBlock rows={[
-                { label: 'URL', value: opdsUrl, copy: true },
-                { label: 'Username', value: user?.username ?? '—', copy: true },
-                { label: 'Password', value: 'your Tome password' },
+                { label: t`URL`, value: opdsUrl, copy: true },
+                { label: t`Username`, value: user?.username ?? '—', copy: true },
+                { label: t`Password`, value: t`your Tome password` },
               ]} />
               <p className="text-xs text-muted-foreground">
-                In KOReader: Search &rarr; OPDS catalog &rarr; add catalog with the URL above.
+                <Trans>In KOReader: Search &rarr; OPDS catalog &rarr; add catalog with the URL above.</Trans>
               </p>
 
               {/* OPDS PINs — nested under OPDS */}
               <div className="space-y-2 pt-1">
                 <div className="flex items-center justify-between">
                   <p className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
-                    <Key className="w-3 h-3" /> App-specific PINs
+                    <Key className="w-3 h-3" /> <Trans>App-specific PINs</Trans>
                   </p>
                   <div className="flex items-center gap-2">
                     <input
                       type="text"
                       value={pinLabel}
                       onChange={e => setPinLabel(e.target.value)}
-                      placeholder="Label (e.g. KOReader)"
+                      placeholder={t`Label (e.g. KOReader)`}
                       className="h-7 rounded-md border border-border bg-background px-2 text-xs focus:outline-none focus:ring-1 focus:ring-ring w-36"
                     />
                     <button
@@ -1012,17 +1016,17 @@ export function SettingsPage() {
                       className="flex items-center gap-1 text-xs text-primary hover:opacity-80 transition-opacity disabled:opacity-50"
                     >
                       {pinCreating ? <Loader2 className="w-3 h-3 animate-spin" /> : <Plus className="w-3 h-3" />}
-                      Generate PIN
+                      <Trans>Generate PIN</Trans>
                     </button>
                   </div>
                 </div>
                 <p className="text-xs text-muted-foreground">
-                  Short app-specific passwords for OPDS — easier to type on an e-reader than your full password.
+                  <Trans>Short app-specific passwords for OPDS — easier to type on an e-reader than your full password.</Trans>
                 </p>
 
                 {newPinResult && (
                   <div className="rounded-lg bg-success/10 border border-success/20 p-3 space-y-1">
-                    <p className="text-xs text-success font-medium">PIN created — copy it now, it won't be shown again.</p>
+                    <p className="text-xs text-success font-medium"><Trans>PIN created — copy it now, it won't be shown again.</Trans></p>
                     <div className="flex items-center gap-2">
                       <code className="text-xs font-mono text-foreground break-all flex-1">{newPinResult}</code>
                       <button
@@ -1032,7 +1036,7 @@ export function SettingsPage() {
                         <Copy className="w-3 h-3" />
                       </button>
                     </div>
-                    <p className="text-xs text-muted-foreground">Use this as the OPDS password in KOReader (username stays the same).</p>
+                    <p className="text-xs text-muted-foreground"><Trans>Use this as the OPDS password in KOReader (username stays the same).</Trans></p>
                   </div>
                 )}
 
@@ -1043,13 +1047,13 @@ export function SettingsPage() {
                         <span className="font-mono text-muted-foreground w-14 shrink-0">{p.pin_preview}</span>
                         <span className="text-foreground flex-1 truncate">{p.label}</span>
                         <span className="text-muted-foreground hidden sm:block shrink-0">
-                          {p.last_used_at ? `used ${new Date(p.last_used_at).toLocaleDateString()}` : 'never used'}
+                          {(() => { const d = new Date(p.last_used_at ?? 0).toLocaleDateString(i18n.locale); return p.last_used_at ? t`used ${d}` : t`never used` })()}
                         </span>
                         <button
                           onClick={() => handleRevokePin(p.id)}
                           disabled={pinRevoking === p.id}
                           className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
-                          title="Revoke"
+                          title={t`Revoke`}
                         >
                           {pinRevoking === p.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
                         </button>
@@ -1057,7 +1061,7 @@ export function SettingsPage() {
                     ))}
                   </div>
                 ) : (
-                  <p className="text-xs text-muted-foreground">No PINs yet. Generate one to use with OPDS clients.</p>
+                  <p className="text-xs text-muted-foreground"><Trans>No PINs yet. Generate one to use with OPDS clients.</Trans></p>
                 )}
               </div>
             </div>
@@ -1066,16 +1070,16 @@ export function SettingsPage() {
             <div className="p-6 space-y-4">
               <div className="flex items-start justify-between gap-4">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-0.5">Progress Sync</p>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-0.5"><Trans>Progress Sync</Trans></p>
                   <p className="text-xs text-muted-foreground">
-                    Sync reading position between KOReader and Tome.
+                    <Trans>Sync reading position between KOReader and Tome.</Trans>
                   </p>
                 </div>
                 {kosyncStatus?.linked && (
                   <span className="flex items-center gap-1 text-xs text-success shrink-0 mt-0.5">
-                    <Check className="w-3 h-3" /> Linked
+                    <Check className="w-3 h-3" /> <Trans>Linked</Trans>
                     {kosyncStatus.synced_documents != null && (
-                      <span className="text-muted-foreground ml-1">· {kosyncStatus.synced_documents} docs</span>
+                      <span className="text-muted-foreground ml-1">{(() => { const n = kosyncStatus.synced_documents; return t`· ${n} docs` })()}</span>
                     )}
                   </span>
                 )}
@@ -1083,7 +1087,7 @@ export function SettingsPage() {
 
               {kosyncStatus?.last_sync && (
                 <p className="text-xs text-muted-foreground">
-                  Last sync: {new Date(kosyncStatus.last_sync * 1000).toLocaleString()}
+                  {(() => { const d = new Date(kosyncStatus.last_sync * 1000).toLocaleString(i18n.locale); return t`Last sync: ${d}` })()}
                   {kosyncStatus.last_device && ` · ${kosyncStatus.last_device}`}
                 </p>
               )}
@@ -1091,7 +1095,7 @@ export function SettingsPage() {
               <form onSubmit={handleKosyncRegister} className="flex items-end gap-2 max-w-xs">
                 <div className="flex-1">
                   <label className="block text-xs font-medium text-muted-foreground mb-1">
-                    {kosyncStatus?.linked ? 'Update sync password' : 'Set sync password'}
+                    {kosyncStatus?.linked ? t`Update sync password` : t`Set sync password`}
                   </label>
                   <input
                     type="password"
@@ -1107,19 +1111,19 @@ export function SettingsPage() {
                   className="flex items-center gap-1.5 h-9 px-3 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40 shrink-0"
                 >
                   {kosyncSaving && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-                  {kosyncSaving ? 'Saving...' : kosyncStatus?.linked ? 'Update' : 'Register'}
+                  {kosyncSaving ? t`Saving...` : kosyncStatus?.linked ? t`Update` : t`Register`}
                 </button>
               </form>
               {kosyncError && <p className="text-xs text-destructive">{kosyncError}</p>}
-              {kosyncSuccess && <p className="text-xs text-success">KOSync registered successfully</p>}
+              {kosyncSuccess && <p className="text-xs text-success"><Trans>KOSync registered successfully</Trans></p>}
 
               <ConnectBlock rows={[
-                { label: 'URL', value: kosyncUrl, copy: true },
-                { label: 'Username', value: user?.username ?? '—', copy: true },
-                { label: 'Password', value: 'the sync password set above' },
+                { label: t`URL`, value: kosyncUrl, copy: true },
+                { label: t`Username`, value: user?.username ?? '—', copy: true },
+                { label: t`Password`, value: t`the sync password set above` },
               ]} />
               <p className="text-xs text-muted-foreground">
-                In KOReader: Tools &rarr; Progress sync &rarr; Custom sync server.
+                <Trans>In KOReader: Tools &rarr; Progress sync &rarr; Custom sync server.</Trans>
               </p>
             </div>
 
@@ -1127,14 +1131,14 @@ export function SettingsPage() {
             <div className="p-6 space-y-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
-                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-0.5">TomeSync Plugin</p>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground mb-0.5"><Trans>TomeSync Plugin</Trans></p>
                   <p className="text-xs text-muted-foreground">
-                    Native KOReader plugin — tracks reading sessions and syncs by book ID. More reliable than KOSync.
+                    <Trans>Native KOReader plugin — tracks reading sessions and syncs by book ID. More reliable than KOSync.</Trans>
                   </p>
                 </div>
                 <div className="flex items-center gap-3 shrink-0">
                   <a href={docsLink(DOCS.koreader)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors">
-                    Learn more <ExternalLink className="w-3 h-3" />
+                    <Trans>Learn more</Trans> <ExternalLink className="w-3 h-3" />
                   </a>
                   <PluginVersion />
                 </div>
@@ -1149,7 +1153,7 @@ export function SettingsPage() {
                   ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
                   : <Download className="w-3.5 h-3.5" />
                 }
-                {pluginDownloading ? 'Preparing...' : 'Download plugin ZIP'}
+                {pluginDownloading ? t`Preparing...` : t`Download plugin ZIP`}
               </button>
 
               <SetupGuide />
@@ -1158,7 +1162,7 @@ export function SettingsPage() {
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <p className="text-xs font-medium text-muted-foreground flex items-center gap-1.5">
-                    <Key className="w-3 h-3" /> API Keys
+                    <Key className="w-3 h-3" /> <Trans>API Keys</Trans>
                   </p>
                   <button
                     onClick={handleCreateKey}
@@ -1166,13 +1170,13 @@ export function SettingsPage() {
                     className="flex items-center gap-1 text-xs text-primary hover:opacity-80 transition-opacity disabled:opacity-50"
                   >
                     {keyCreating ? <Loader2 className="w-3 h-3 animate-spin" /> : <Plus className="w-3 h-3" />}
-                    New key
+                    <Trans>New key</Trans>
                   </button>
                 </div>
 
                 {newKeyResult && (
                   <div className="rounded-lg bg-success/10 border border-success/20 p-3 space-y-1">
-                    <p className="text-xs text-success font-medium">Key created — copy it now, it won't be shown again.</p>
+                    <p className="text-xs text-success font-medium"><Trans>Key created — copy it now, it won't be shown again.</Trans></p>
                     <div className="flex items-center gap-2">
                       <code className="text-xs font-mono text-foreground break-all flex-1">{newKeyResult}</code>
                       <button onClick={() => navigator.clipboard.writeText(newKeyResult)}
@@ -1189,13 +1193,13 @@ export function SettingsPage() {
                       <div key={k.id} className="flex items-center gap-3 px-3 py-2">
                         <span className="font-mono text-muted-foreground flex-1">{k.key_preview}</span>
                         <span className="text-muted-foreground hidden sm:block">
-                          {k.last_used_at ? `used ${new Date(k.last_used_at).toLocaleDateString()}` : 'never used'}
+                          {(() => { const d = new Date(k.last_used_at ?? 0).toLocaleDateString(i18n.locale); return k.last_used_at ? t`used ${d}` : t`never used` })()}
                         </span>
                         <button
                           onClick={() => handleRevokeKey(k.id)}
                           disabled={keyRevoking === k.id}
                           className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
-                          title="Revoke"
+                          title={t`Revoke`}
                         >
                           {keyRevoking === k.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
                         </button>
@@ -1203,7 +1207,7 @@ export function SettingsPage() {
                     ))}
                   </div>
                 ) : (
-                  <p className="text-xs text-muted-foreground">No API keys. Download the plugin to auto-create one.</p>
+                  <p className="text-xs text-muted-foreground"><Trans>No API keys. Download the plugin to auto-create one.</Trans></p>
                 )}
               </div>
             </div>
@@ -1213,7 +1217,7 @@ export function SettingsPage() {
 
         {/* ── Send to Device ──────────────────────────────────────────── */}
         <section>
-          <SectionHeader title="Send to Device" />
+          <SectionHeader title={t`Send to Device`} />
           <div className="mt-4 rounded-xl border border-border bg-card overflow-hidden">
             <div className="p-5 space-y-4">
               <div className="flex items-start justify-between gap-3">
@@ -1222,14 +1226,14 @@ export function SettingsPage() {
                     <Send className="w-3.5 h-3.5 text-primary" />
                   </div>
                   <div>
-                    <p className="text-sm font-medium text-foreground">E-Reader Devices</p>
+                    <p className="text-sm font-medium text-foreground"><Trans>E-Reader Devices</Trans></p>
                     <p className="text-xs text-muted-foreground mt-0.5">
-                      Add your e-reader or personal email. Books are sent as attachments — works with Kindle, Kobo, or any email address.
+                      <Trans>Add your e-reader or personal email. Books are sent as attachments — works with Kindle, Kobo, or any email address.</Trans>
                     </p>
                   </div>
                 </div>
                 <a href={docsLink(DOCS.sendToDevice)} target="_blank" rel="noopener noreferrer" className="shrink-0 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors">
-                  Learn more <ExternalLink className="w-3 h-3" />
+                  <Trans>Learn more</Trans> <ExternalLink className="w-3 h-3" />
                 </a>
               </div>
 
@@ -1237,37 +1241,41 @@ export function SettingsPage() {
                 <div className="space-y-3">
                   <div className="flex items-center gap-2 rounded-lg bg-warning/10 border border-warning/20 px-3 py-2">
                     <AlertTriangle className="w-3.5 h-3.5 text-warning dark:text-warning shrink-0" />
-                    <p className="text-xs text-warning font-medium">Email delivery is not set up yet.</p>
+                    <p className="text-xs text-warning font-medium"><Trans>Email delivery is not set up yet.</Trans></p>
                   </div>
                   <div className="rounded-lg border border-border overflow-hidden text-xs">
                     <button
                       onClick={() => setSetupGuideOpen(v => !v)}
                       className="w-full flex items-center justify-between px-3 py-2.5 text-left hover:bg-accent/50 transition-colors"
                     >
-                      <span className="font-medium text-foreground">How to set it up</span>
+                      <span className="font-medium text-foreground"><Trans>How to set it up</Trans></span>
                       {setupGuideOpen ? <ChevronUp className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" />}
                     </button>
                     {setupGuideOpen && (
                       <div className="border-t border-border px-3 py-3 space-y-3 text-xs text-muted-foreground">
-                        <p>Your server admin needs to set SMTP environment variables:</p>
+                        <p><Trans>Your server admin needs to set SMTP environment variables:</Trans></p>
                         <div className="space-y-2">
+                          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product name */}
                           <p className="font-medium text-foreground">Gmail</p>
+                          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- env config example */}
                           <code className="block bg-muted rounded px-2 py-1.5 text-[11px] font-mono whitespace-pre-wrap">TOME_SMTP_HOST=smtp.gmail.com{'\n'}TOME_SMTP_PORT=587{'\n'}TOME_SMTP_USER=you@gmail.com{'\n'}TOME_SMTP_PASSWORD=your-app-password</code>
-                          <p>Use a <a href="https://myaccount.google.com/apppasswords" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Google App Password</a>, not your regular password.</p>
+                          <p><Trans>Use a <a href="https://myaccount.google.com/apppasswords" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Google App Password</a>, not your regular password.</Trans></p>
                         </div>
                         <div className="space-y-2">
+                          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product name */}
                           <p className="font-medium text-foreground">Fastmail</p>
+                          {/* eslint-disable-next-line lingui/no-unlocalized-strings -- env config example */}
                           <code className="block bg-muted rounded px-2 py-1.5 text-[11px] font-mono whitespace-pre-wrap">TOME_SMTP_HOST=smtp.fastmail.com{'\n'}TOME_SMTP_PORT=587{'\n'}TOME_SMTP_USER=you@fastmail.com{'\n'}TOME_SMTP_PASSWORD=your-app-password</code>
                         </div>
                         <div className="space-y-2">
-                          <p className="font-medium text-foreground">Other providers</p>
-                          <p>Set <code className="text-foreground">TOME_SMTP_HOST</code>, <code className="text-foreground">TOME_SMTP_PORT</code>, <code className="text-foreground">TOME_SMTP_USER</code>, and <code className="text-foreground">TOME_SMTP_PASSWORD</code>.</p>
+                          <p className="font-medium text-foreground"><Trans>Other providers</Trans></p>
+                          <p><Trans>Set <code className="text-foreground">TOME_SMTP_HOST</code>, <code className="text-foreground">TOME_SMTP_PORT</code>, <code className="text-foreground">TOME_SMTP_USER</code>, and <code className="text-foreground">TOME_SMTP_PASSWORD</code>.</Trans></p>
                         </div>
                         <div className="rounded-lg bg-muted/60 border border-border p-2.5">
-                          <p className="font-medium text-foreground mb-1">Kindle users</p>
-                          <p>Add your SMTP sender address to Amazon's <a href="https://www.amazon.com/hz/mycd/myx#/home/settings/payment" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Approved Personal Document E-mail List</a>, or emails will be silently dropped.</p>
+                          <p className="font-medium text-foreground mb-1"><Trans>Kindle users</Trans></p>
+                          <p><Trans>Add your SMTP sender address to Amazon's <a href="https://www.amazon.com/hz/mycd/myx#/home/settings/payment" target="_blank" rel="noopener noreferrer" className="text-primary hover:underline">Approved Personal Document E-mail List</a>, or emails will be silently dropped.</Trans></p>
                         </div>
-                        <p className="text-muted-foreground/70">Ask your server admin if you don't manage the Tome installation yourself.</p>
+                        <p className="text-muted-foreground/70"><Trans>Ask your server admin if you don't manage the Tome installation yourself.</Trans></p>
                       </div>
                     )}
                   </div>
@@ -1277,17 +1285,17 @@ export function SettingsPage() {
                   {/* Add device form */}
                   <form onSubmit={handleAddDevice} className="flex items-end gap-2">
                     <div className="flex-1">
-                      <label className="block text-xs font-medium text-muted-foreground mb-1">Device name</label>
+                      <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Device name</Trans></label>
                       <input
                         type="text"
                         value={newDeviceName}
                         onChange={e => setNewDeviceName(e.target.value)}
-                        placeholder="My Kindle"
+                        placeholder={t`My Kindle`}
                         className="w-full h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                       />
                     </div>
                     <div className="flex-1">
-                      <label className="block text-xs font-medium text-muted-foreground mb-1">Email address</label>
+                      <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Email address</Trans></label>
                       <input
                         type="email"
                         value={newDeviceEmail}
@@ -1302,7 +1310,7 @@ export function SettingsPage() {
                       className="flex items-center gap-1.5 h-9 px-3 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40 shrink-0"
                     >
                       {deviceAdding ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Plus className="w-3.5 h-3.5" />}
-                      Add
+                      <Trans>Add</Trans>
                     </button>
                   </form>
                   {deviceError && <p className="text-xs text-destructive">{deviceError}</p>}
@@ -1319,7 +1327,7 @@ export function SettingsPage() {
                             onClick={() => handleDeleteDevice(d.id)}
                             disabled={deviceDeleting === d.id}
                             className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
-                            title="Remove device"
+                            title={t`Remove device`}
                           >
                             {deviceDeleting === d.id ? <Loader2 className="w-3 h-3 animate-spin" /> : <Trash2 className="w-3 h-3" />}
                           </button>
@@ -1327,7 +1335,7 @@ export function SettingsPage() {
                       ))}
                     </div>
                   ) : (
-                    <p className="text-xs text-muted-foreground">No devices yet. Add one to start sending books.</p>
+                    <p className="text-xs text-muted-foreground"><Trans>No devices yet. Add one to start sending books.</Trans></p>
                   )}
                 </div>
               ) : null}
@@ -1338,6 +1346,7 @@ export function SettingsPage() {
         {/* ── Hardcover ────────────────────────────────────────────────── */}
         {hardcoverAvailable && (
           <section>
+            {/* eslint-disable-next-line lingui/no-unlocalized-strings -- product name */}
             <SectionHeader title="Hardcover" />
             <HardcoverSync onAvailable={setHardcoverAvailable} />
           </section>
@@ -1345,15 +1354,15 @@ export function SettingsPage() {
 
         {/* ── API Tokens ───────────────────────────────────────────────── */}
         <section>
-          <SectionHeader title="API Tokens" />
+          <SectionHeader title={t`API Tokens`} />
           <div className="mt-4 rounded-xl border border-border bg-card overflow-hidden">
             <div className="p-5 space-y-4">
               <div className="flex items-start justify-between gap-3">
                 <div>
                   <p className="text-xs text-muted-foreground">
-                    Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation.{' '}
+                    <Trans>Long-lived tokens for scripts and tools (e.g. Scribe). Each token is shown once on creation.</Trans>{' '}
                     <a href={docsLink(DOCS.apiTokens)} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-0.5 text-foreground/80 hover:text-primary transition-colors">
-                      Learn more <ExternalLink className="w-3 h-3" />
+                      <Trans>Learn more</Trans> <ExternalLink className="w-3 h-3" />
                     </a>
                   </p>
                 </div>
@@ -1366,7 +1375,7 @@ export function SettingsPage() {
                         onChange={e => setApiTokensAllUsers(e.target.checked)}
                         className="w-3.5 h-3.5 rounded accent-primary"
                       />
-                      All users
+                      <Trans>All users</Trans>
                     </label>
                   )}
                   <button
@@ -1374,7 +1383,7 @@ export function SettingsPage() {
                     className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
                   >
                     <Plus className="w-3 h-3" />
-                    New Token
+                    <Trans>New Token</Trans>
                   </button>
                 </div>
               </div>
@@ -1383,25 +1392,25 @@ export function SettingsPage() {
               {tokenFormOpen && (
                 <form onSubmit={handleCreateToken} className="flex items-end gap-2 rounded-lg bg-muted/50 border border-border p-3">
                   <div className="flex-1">
-                    <label className="block text-xs font-medium text-muted-foreground mb-1">Token name</label>
+                    <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Token name</Trans></label>
                     <input
                       type="text"
                       value={tokenNewName}
                       onChange={e => { setTokenNewName(e.target.value); setTokenCreateError(null) }}
-                      placeholder="e.g. scribe-laptop"
+                      placeholder={t`e.g. scribe-laptop`}
                       autoFocus
                       className="w-full h-9 rounded-md border border-border bg-background px-3 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                     />
                   </div>
                   <div className="shrink-0">
-                    <label className="block text-xs font-medium text-muted-foreground mb-1">Scope</label>
+                    <label className="block text-xs font-medium text-muted-foreground mb-1"><Trans>Scope</Trans></label>
                     <select
                       value={tokenNewScope}
                       onChange={e => setTokenNewScope(e.target.value as 'full' | 'readonly')}
                       className="h-9 rounded-md border border-border bg-background px-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
                     >
-                      <option value="full">Full access</option>
-                      <option value="readonly">Read-only</option>
+                      <option value="full">{t`Full access`}</option>
+                      <option value="readonly">{t`Read-only`}</option>
                     </select>
                   </div>
                   <button
@@ -1410,14 +1419,14 @@ export function SettingsPage() {
                     className="flex items-center gap-1.5 h-9 px-3 rounded-md text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all disabled:opacity-40 shrink-0"
                   >
                     {tokenCreating && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
-                    {tokenCreating ? 'Creating...' : 'Create'}
+                    {tokenCreating ? t`Creating...` : t`Create`}
                   </button>
                   <button
                     type="button"
                     onClick={() => { setTokenFormOpen(false); setTokenNewName(''); setTokenCreateError(null) }}
                     className="flex items-center h-9 px-3 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors shrink-0"
                   >
-                    Cancel
+                    <Trans>Cancel</Trans>
                   </button>
                 </form>
               )}
@@ -1429,7 +1438,7 @@ export function SettingsPage() {
                   <div className="flex items-start gap-2">
                     <AlertTriangle className="w-4 h-4 text-warning dark:text-warning shrink-0 mt-0.5" />
                     <p className="text-xs font-medium text-warning">
-                      This is the only time you will see this token. Store it somewhere safe — it cannot be recovered.
+                      <Trans>This is the only time you will see this token. Store it somewhere safe — it cannot be recovered.</Trans>
                     </p>
                   </div>
                   <div className="flex items-center gap-2 rounded-md bg-background border border-border px-3 py-2">
@@ -1439,7 +1448,7 @@ export function SettingsPage() {
                     <button
                       onClick={handleCopyToken}
                       className="p-1.5 rounded hover:bg-accent transition-colors text-muted-foreground hover:text-foreground shrink-0"
-                      title="Copy token"
+                      title={t`Copy token`}
                     >
                       {tokenCopied ? <Check className="w-3.5 h-3.5 text-success" /> : <Copy className="w-3.5 h-3.5" />}
                     </button>
@@ -1448,7 +1457,7 @@ export function SettingsPage() {
                     onClick={() => { setTokenRevealPlaintext(null); setTokenCopied(false) }}
                     className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
                   >
-                    Done
+                    <Trans>Done</Trans>
                   </button>
                 </div>
               )}
@@ -1457,11 +1466,11 @@ export function SettingsPage() {
               {apiTokensLoading ? (
                 <div className="flex items-center gap-2 text-xs text-muted-foreground py-2">
                   <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                  Loading...
+                  <Trans>Loading...</Trans>
                 </div>
               ) : apiTokens.length === 0 ? (
                 <p className="text-xs text-muted-foreground py-2">
-                  No API tokens yet. Create one to use Scribe or scripts against Tome.
+                  <Trans>No API tokens yet. Create one to use Scribe or scripts against Tome.</Trans>
                 </p>
               ) : (
                 <div className="rounded-lg border border-border overflow-hidden text-xs divide-y divide-border">
@@ -1470,11 +1479,11 @@ export function SettingsPage() {
                     'hidden sm:grid px-3 py-2 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground bg-muted/40',
                     apiTokensAllUsers && user?.is_admin ? 'grid-cols-[1fr_7rem_7rem_6rem_3rem_2rem]' : 'grid-cols-[1fr_7rem_7rem_6rem_2rem]'
                   )}>
-                    <span>Name</span>
-                    <span>Prefix</span>
-                    <span>Last used</span>
-                    <span>Created</span>
-                    {apiTokensAllUsers && user?.is_admin && <span>Owner</span>}
+                    <span><Trans>Name</Trans></span>
+                    <span><Trans>Prefix</Trans></span>
+                    <span><Trans>Last used</Trans></span>
+                    <span><Trans>Created</Trans></span>
+                    {apiTokensAllUsers && user?.is_admin && <span><Trans>Owner</Trans></span>}
                     <span />
                   </div>
                   {apiTokens.map(tok => {
@@ -1492,12 +1501,12 @@ export function SettingsPage() {
                           {tok.name}
                           {(tok.scope ?? 'full') === 'readonly' && (
                             <span className="shrink-0 px-1 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide bg-info/10 text-info border border-info/20">
-                              Read-only
+                              <Trans>Read-only</Trans>
                             </span>
                           )}
                           {isRevoked && (
                             <span className="shrink-0 px-1 py-0.5 rounded text-[9px] font-semibold uppercase tracking-wide bg-muted text-muted-foreground border border-border">
-                              Revoked
+                              <Trans>Revoked</Trans>
                             </span>
                           )}
                         </span>
@@ -1505,10 +1514,10 @@ export function SettingsPage() {
                           tome_{tok.prefix}…
                         </span>
                         <span className="text-muted-foreground hidden sm:block shrink-0">
-                          {tok.last_used_at ? relativeTime(tok.last_used_at) : 'Never'}
+                          {tok.last_used_at ? relativeTime(tok.last_used_at) : t`Never`}
                         </span>
                         <span className="text-muted-foreground hidden sm:block shrink-0">
-                          {new Date(tok.created_at).toLocaleDateString()}
+                          {new Date(tok.created_at).toLocaleDateString(i18n.locale)}
                         </span>
                         {apiTokensAllUsers && user?.is_admin && (
                           <span className="text-muted-foreground hidden sm:block shrink-0 truncate">
@@ -1521,7 +1530,7 @@ export function SettingsPage() {
                               onClick={() => handleRevokeApiToken(tok.id)}
                               disabled={tokenRevoking === tok.id}
                               className="p-1 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive transition-colors"
-                              title="Revoke token"
+                              title={t`Revoke token`}
                             >
                               {tokenRevoking === tok.id
                                 ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -1542,27 +1551,27 @@ export function SettingsPage() {
         {/* ── Export ───────────────────────────────────────────────────── */}
         {/* ── Outbound notifications ────────────────────────────────────── */}
         <section>
-          <SectionHeader title="Notifications" subtle />
+          <SectionHeader title={t`Notifications`} subtle />
           <NotificationChannels />
         </section>
 
         {/* ── Share links overview ──────────────────────────────────────── */}
         <section>
-          <SectionHeader title="Share links" subtle />
+          <SectionHeader title={t`Share links`} subtle />
           <ShareLinksOverview />
         </section>
 
         {/* ── Reading-history import ────────────────────────────────────── */}
         <section>
-          <SectionHeader title="Import reading history" subtle />
+          <SectionHeader title={t`Import reading history`} subtle />
           <ReadingImport />
         </section>
 
         <section>
-          <SectionHeader title="Export" subtle />
+          <SectionHeader title={t`Export`} subtle />
           <div className="mt-3 rounded-xl border border-border/60 bg-card/50 p-5">
             <p className="text-xs text-muted-foreground mb-4">
-              Download your entire library catalog — all titles, authors, series, tags and formats.
+              <Trans>Download your entire library catalog — all titles, authors, series, tags and formats.</Trans>
             </p>
             <div className="flex flex-wrap gap-2">
               <ExportButton format="json" label="JSON" exporting={exporting} onExport={handleExport} />
@@ -1573,13 +1582,13 @@ export function SettingsPage() {
 
         {/* ── Personal backup ─────────────────────────────────────────── */}
         <section>
-          <SectionHeader title="Backup" subtle />
+          <SectionHeader title={t`Backup`} subtle />
           <div className="mt-3 rounded-xl border border-border/60 bg-card/50 p-5">
             <p className="text-xs text-muted-foreground mb-4">
-              Download a JSON snapshot of <strong>your personal data</strong>: reading status,
+              <Trans>Download a JSON snapshot of <strong>your personal data</strong>: reading status,
               every reading session, sync positions, shelves, and your local preferences.
               Book files themselves are not included — Tome only references them on disk.
-              API tokens and KOReader keys are also excluded so the file isn't a credential.
+              API tokens and KOReader keys are also excluded so the file isn't a credential.</Trans>
             </p>
             <button
               onClick={handleBackup}
@@ -1587,14 +1596,14 @@ export function SettingsPage() {
               className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs font-medium border border-border bg-card hover:bg-muted disabled:opacity-60 disabled:cursor-not-allowed transition-all touch-feedback"
             >
               {backingUp ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Download className="w-3.5 h-3.5" />}
-              {backingUp ? 'Preparing…' : 'Download my data'}
+              {backingUp ? t`Preparing…` : t`Download my data`}
             </button>
           </div>
         </section>
 
         {/* ── About ────────────────────────────────────────────────────── */}
         <section>
-          <SectionHeader title="About" subtle />
+          <SectionHeader title={t`About`} subtle />
           <div className="mt-3 rounded-xl border border-border/60 bg-card/50 p-5">
             <div className="flex flex-wrap items-center gap-3">
               <div className="flex items-center gap-2.5">
@@ -1613,7 +1622,7 @@ export function SettingsPage() {
                     className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-semibold text-primary-foreground transition-all hover:bg-primary/90"
                   >
                     <ArrowUpCircle className="w-3.5 h-3.5" />
-                    Update to v{updateInfo.latest}
+                    {(() => { const v = updateInfo.latest; return t`Update to v${v}` })()}
                   </a>
                 )}
                 <a
@@ -1629,8 +1638,8 @@ export function SettingsPage() {
             </div>
             {updateInfo && (
               <p className="mt-3 text-xs text-muted-foreground">
-                A newer release is available — the link opens the release notes.
-                Update by pulling the new image and restarting the container.
+                <Trans>A newer release is available — the link opens the release notes.
+                Update by pulling the new image and restarting the container.</Trans>
               </p>
             )}
           </div>
@@ -1646,13 +1655,13 @@ export function SettingsPage() {
 function relativeTime(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
   const seconds = Math.floor(diff / 1000)
-  if (seconds < 60) return 'Just now'
+  if (seconds < 60) return t`Just now`
   const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes}m ago`
+  if (minutes < 60) return t`${minutes}m ago`
   const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
+  if (hours < 24) return t`${hours}h ago`
   const days = Math.floor(hours / 24)
-  if (days < 30) return `${days}d ago`
+  if (days < 30) return t`${days}d ago`
   return new Date(iso).toLocaleDateString()
 }
 
@@ -1745,6 +1754,7 @@ function PluginVersion() {
   const [label, setLabel] = useState<string | null>(null)
   useEffect(() => {
     api.get<{ version: string; build?: number; semver?: string }>('/plugin/version')
+      // eslint-disable-next-line lingui/no-unlocalized-strings -- version identifier
       .then(r => setLabel(r.semver ? `v${r.semver} (build ${r.build ?? r.version})` : `v${r.version}`))
       .catch(() => {})
   }, [])
@@ -1756,35 +1766,37 @@ function PluginVersion() {
   )
 }
 
-const SETUP_STEPS: { title: string; body: string; mono?: string }[] = [
+const SETUP_STEPS: { title: MessageDescriptor; body: MessageDescriptor; mono?: string }[] = [
   {
-    title: 'Download the plugin',
-    body: 'Click "Download plugin ZIP" above. An API key is automatically created and baked into the plugin — no manual configuration needed.',
+    title: msg`Download the plugin`,
+    body: msg`Click "Download plugin ZIP" above. An API key is automatically created and baked into the plugin — no manual configuration needed.`,
   },
   {
-    title: 'Copy to KOReader',
-    body: "Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install.",
+    title: msg`Copy to KOReader`,
+    body: msg`Unzip the file and copy via SSH (or USB). Remove the old plugin first to ensure a clean install.`,
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- shell command
     mono: 'ssh root@<kindle-ip> "rm -rf /mnt/us/koreader/plugins/tomesync.koplugin" && scp -r tomesync.koplugin root@<kindle-ip>:/mnt/us/koreader/plugins/',
   },
   {
-    title: 'Restart KOReader',
-    body: 'In KOReader: Settings > Device > Restart KOReader. The plugin loads automatically.',
+    title: msg`Restart KOReader`,
+    body: msg`In KOReader: Settings > Device > Restart KOReader. The plugin loads automatically.`,
   },
   {
-    title: 'Open a book downloaded via OPDS',
-    body: 'Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately.',
+    title: msg`Open a book downloaded via OPDS`,
+    body: msg`Books downloaded through the OPDS catalog are automatically mapped to their Tome book ID. Open one and TomeSync will start tracking your session immediately.`,
   },
   {
-    title: "Verify it's working",
-    body: 'In KOReader: main menu -> TomeSync -> "Test connection" to confirm the plugin can reach your Tome server.',
+    title: msg`Verify it's working`,
+    body: msg`In KOReader: main menu -> TomeSync -> "Test connection" to confirm the plugin can reach your Tome server.`,
   },
   {
-    title: 'Note on KOSync coexistence',
-    body: 'TomeSync and KOSync can both be active. TomeSync tracks full reading sessions; KOSync only stores your last position.',
+    title: msg`Note on KOSync coexistence`,
+    body: msg`TomeSync and KOSync can both be active. TomeSync tracks full reading sessions; KOSync only stores your last position.`,
   },
 ]
 
 function SetupGuide() {
+  const { i18n } = useLingui()
   const [open, setOpen] = useState(false)
 
   return (
@@ -1793,7 +1805,7 @@ function SetupGuide() {
         onClick={() => setOpen(v => !v)}
         className="w-full flex items-center justify-between px-3 py-2.5 text-left hover:bg-accent/50 transition-colors"
       >
-        <span className="font-medium text-foreground">Setup instructions</span>
+        <span className="font-medium text-foreground"><Trans>Setup instructions</Trans></span>
         <span className="text-muted-foreground text-[10px]">{open ? '▲' : '▼'}</span>
       </button>
       {open && (
@@ -1804,8 +1816,8 @@ function SetupGuide() {
                 {i + 1}
               </span>
               <div className="space-y-1">
-                <p className="font-medium text-foreground">{step.title}</p>
-                <p className="text-muted-foreground leading-relaxed">{step.body}</p>
+                <p className="font-medium text-foreground">{i18n._(step.title)}</p>
+                <p className="text-muted-foreground leading-relaxed">{i18n._(step.body)}</p>
                 {step.mono && (
                   <p className="font-mono text-muted-foreground/70">{step.mono}</p>
                 )}
@@ -1824,6 +1836,7 @@ function ExportButton({ format, label, exporting, onExport }: {
   exporting: 'json' | 'csv' | null
   onExport: (f: 'json' | 'csv') => void
 }) {
+  const { t } = useLingui()
   const busy = exporting === format
   return (
     <button
@@ -1835,7 +1848,7 @@ function ExportButton({ format, label, exporting, onExport }: {
         ? <RefreshCw className="w-3 h-3 animate-spin" />
         : <Download className="w-3 h-3 text-muted-foreground" />
       }
-      {busy ? 'Exporting...' : `Export ${label}`}
+      {busy ? t`Exporting...` : t`Export ${label}`}
     </button>
   )
 }

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -834,7 +834,7 @@ export function SettingsPage() {
                     <button
                       onClick={() => handleDeleteCustomTheme(theme.id)}
                       className="absolute -top-1.5 -right-1.5 w-4 h-4 rounded-full bg-destructive text-white flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity shadow-sm"
-                      title="Delete theme"
+                      title={t`Delete theme`}
                     >
                       <X className="w-2.5 h-2.5" />
                     </button>
@@ -1699,7 +1699,7 @@ function ConnectBlock({ rows }: { rows: { label: string; value: string; copy?: b
             <button
               onClick={() => copyValue(value)}
               className="p-1 rounded hover:bg-accent transition-colors text-muted-foreground hover:text-foreground shrink-0"
-              title="Copy"
+              title={t`Copy`}
             >
               {copied === value ? <Check className="w-3 h-3 text-success" /> : <Copy className="w-3 h-3" />}
             </button>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -22,6 +22,8 @@ import {
   type CustomTheme, loadCustomThemes, saveCustomTheme, deleteCustomTheme, parseThemeColors,
 } from '@/lib/theme'
 import { useAuth } from '@/contexts/AuthContext'
+import { Trans, useLingui } from '@lingui/react/macro'
+import { LOCALES, getActiveLocale, setLocale } from '@/lib/i18n'
 
 interface ApiKey {
   id: number
@@ -179,6 +181,15 @@ export function SettingsPage() {
     } finally {
       setQcAuthorizing(false)
     }
+  }
+
+  // ── Language ──────────────────────────────────────────────────────────────
+  const { t } = useLingui()
+  const [activeLocale, setActiveLocale] = useState<string>(getActiveLocale)
+
+  async function handleLocaleSelect(code: string) {
+    await setLocale(code)
+    setActiveLocale(code)
   }
 
   // ── Theme ─────────────────────────────────────────────────────────────────
@@ -918,6 +929,24 @@ export function SettingsPage() {
                 </button>
               </div>
             )}
+          </div>
+
+          {/* Language — catalogs are community-maintained, see docs/translating.md */}
+          <div className="mt-6">
+            <p className="text-xs text-muted-foreground mb-1.5"><Trans>Language</Trans></p>
+            <select
+              value={activeLocale}
+              onChange={e => handleLocaleSelect(e.target.value)}
+              aria-label={t`Language`}
+              className="h-9 rounded-md border border-border bg-background px-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
+            >
+              {LOCALES.map(l => (
+                <option key={l.code} value={l.code}>{l.label}</option>
+              ))}
+            </select>
+            <p className="text-xs text-muted-foreground mt-1.5">
+              <Trans>Translations are community-maintained. Anything not yet translated is shown in English.</Trans>
+            </p>
           </div>
         </section>
 

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -931,23 +931,38 @@ export function SettingsPage() {
             )}
           </div>
 
-          {/* Language — catalogs are community-maintained, see docs/translating.md */}
-          <div className="mt-6">
-            <p className="text-xs text-muted-foreground mb-1.5"><Trans>Language</Trans></p>
-            <select
-              value={activeLocale}
-              onChange={e => handleLocaleSelect(e.target.value)}
-              aria-label={t`Language`}
-              className="h-9 rounded-md border border-border bg-background px-2 text-sm focus:outline-none focus:ring-1 focus:ring-ring"
-            >
-              {LOCALES.map(l => (
-                <option key={l.code} value={l.code}>{l.label}</option>
-              ))}
-            </select>
-            <p className="text-xs text-muted-foreground mt-1.5">
-              <Trans>Translations are community-maintained. Anything not yet translated is shown in English.</Trans>
-            </p>
+        </section>
+
+        {/* ── Language ─────────────────────────────────────────────────── */}
+        {/* Pills work up to roughly a dozen locales; if the list outgrows a
+            row or two, swap back to a (styled) select. Labels are the
+            language's own name and stay untranslated on purpose. */}
+        <section>
+          <SectionHeader title={t`Language`} />
+          <div className="mt-4 flex flex-wrap gap-2">
+            {LOCALES.map(l => {
+              const active = activeLocale === l.code
+              return (
+                <button
+                  key={l.code}
+                  onClick={() => handleLocaleSelect(l.code)}
+                  lang={l.code}
+                  className={cn(
+                    'flex items-center gap-2 px-4 py-2 rounded-lg border text-sm transition-all',
+                    active
+                      ? 'border-primary bg-primary/10 text-primary font-medium'
+                      : 'border-border text-muted-foreground hover:text-foreground hover:border-primary/40 hover:bg-muted/50'
+                  )}
+                >
+                  {l.label}
+                  {active && <Check className="w-3.5 h-3.5" />}
+                </button>
+              )
+            })}
           </div>
+          <p className="text-xs text-muted-foreground mt-3">
+            <Trans>Translations are community-maintained. Anything not yet translated is shown in English.</Trans>
+          </p>
         </section>
 
         {/* ── KOReader ─────────────────────────────────────────────────── */}

--- a/frontend/src/pages/SetupPage.tsx
+++ b/frontend/src/pages/SetupPage.tsx
@@ -6,8 +6,10 @@ import { ThemeToggle } from '@/components/ThemeToggle'
 import { TomeMark } from '@/components/TomeMark'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { Trans, useLingui } from '@lingui/react/macro'
 
 export function SetupPage() {
+  const { t } = useLingui()
   const { user, login } = useAuth()
   const navigate = useNavigate()
   const [form, setForm] = useState({ username: '', email: '', password: '', confirm: '' })
@@ -27,8 +29,8 @@ export function SetupPage() {
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
-    if (!passwordsMatch) { setError('Passwords do not match'); return }
-    if (!passwordStrong) { setError('Password must be at least 8 characters'); return }
+    if (!passwordsMatch) { setError(t`Passwords do not match`); return }
+    if (!passwordStrong) { setError(t`Password must be at least 8 characters`); return }
 
     setLoading(true)
     setError(null)
@@ -41,7 +43,7 @@ export function SetupPage() {
       await login(form.username, form.password)
       navigate('/')
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Setup failed')
+      setError(err instanceof Error ? err.message : t`Setup failed`)
     } finally {
       setLoading(false)
     }
@@ -49,6 +51,7 @@ export function SetupPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4 safe-top">
+      {/* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS */}
       <style>{`
         @keyframes fade-in-up {
           from { opacity: 0; transform: translateY(12px); }
@@ -82,32 +85,32 @@ export function SetupPage() {
             <div className="w-5 h-5 rounded-full bg-primary flex items-center justify-center">
               <span className="text-[10px] font-semibold text-primary-foreground">1</span>
             </div>
-            <span className="text-xs font-medium text-foreground">Create admin account</span>
+            <span className="text-xs font-medium text-foreground"><Trans>Create admin account</Trans></span>
           </div>
           <div className="w-8 h-px bg-border mx-1" />
           <div className="flex items-center gap-1.5 opacity-40">
             <div className="w-5 h-5 rounded-full border border-border flex items-center justify-center">
               <span className="text-[10px] text-muted-foreground">2</span>
             </div>
-            <span className="text-xs text-muted-foreground">Your library</span>
+            <span className="text-xs text-muted-foreground"><Trans>Your library</Trans></span>
           </div>
         </div>
 
         {/* Card — fade in on mount */}
         <div className="bg-card border border-border rounded-2xl p-6 shadow-lg shadow-black/5 animate-fade-in-up">
-          <h2 className="text-lg font-medium text-foreground mb-1">Welcome to Tome</h2>
-          <p className="text-sm text-muted-foreground mb-6">Create your admin account to get started</p>
+          <h2 className="text-lg font-medium text-foreground mb-1"><Trans>Welcome to Tome</Trans></h2>
+          <p className="text-sm text-muted-foreground mb-6"><Trans>Create your admin account to get started</Trans></p>
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                Username
+                <Trans>Username</Trans>
               </label>
               <input
                 type="text"
                 value={form.username}
                 onChange={e => set('username', e.target.value)}
-                placeholder="librarian"
+                placeholder={t`librarian`}
                 required
                 autoComplete="username"
                 className="w-full px-3 py-2.5 rounded-lg text-sm bg-background border border-input text-foreground placeholder:text-muted-foreground/50 focus:outline-none focus:ring-2 focus:ring-ring focus:border-transparent focus:scale-[1.01] transition-all duration-200"
@@ -116,7 +119,7 @@ export function SetupPage() {
 
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                Email
+                <Trans>Email</Trans>
               </label>
               <input
                 type="email"
@@ -131,7 +134,7 @@ export function SetupPage() {
 
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                Password
+                <Trans>Password</Trans>
               </label>
               <div className="relative">
                 <input
@@ -154,14 +157,14 @@ export function SetupPage() {
               {form.password.length > 0 && (
                 <p className={cn('text-xs flex items-center gap-1', passwordStrong ? 'text-success' : 'text-muted-foreground')}>
                   {passwordStrong ? <CheckCircle2 className="w-3 h-3" /> : <AlertCircle className="w-3 h-3" />}
-                  {passwordStrong ? 'Strong enough' : 'Minimum 8 characters'}
+                  {passwordStrong ? t`Strong enough` : t`Minimum 8 characters`}
                 </p>
               )}
             </div>
 
             <div className="space-y-1.5">
               <label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                Confirm password
+                <Trans>Confirm password</Trans>
               </label>
               <input
                 type={showPassword ? 'text' : 'password'}
@@ -203,7 +206,7 @@ export function SetupPage() {
               ) : (
                 <>
                   <UserPlus className="w-4 h-4" />
-                  Create admin account
+                  <Trans>Create admin account</Trans>
                 </>
               )}
             </button>
@@ -214,22 +217,22 @@ export function SetupPage() {
         <div className="mt-5 flex items-center justify-center gap-6">
           <div className="flex flex-col items-center gap-1.5">
             <BookOpen className="w-3.5 h-3.5 text-muted-foreground/60" />
-            <span className="text-xs text-muted-foreground/60">Your Library</span>
+            <span className="text-xs text-muted-foreground/60"><Trans>Your Library</Trans></span>
           </div>
           <div className="w-px h-6 bg-border/60" />
           <div className="flex flex-col items-center gap-1.5">
             <Smartphone className="w-3.5 h-3.5 text-muted-foreground/60" />
-            <span className="text-xs text-muted-foreground/60">KOReader Sync</span>
+            <span className="text-xs text-muted-foreground/60"><Trans>KOReader Sync</Trans></span>
           </div>
           <div className="w-px h-6 bg-border/60" />
           <div className="flex flex-col items-center gap-1.5">
             <BarChart3 className="w-3.5 h-3.5 text-muted-foreground/60" />
-            <span className="text-xs text-muted-foreground/60">Reading Stats</span>
+            <span className="text-xs text-muted-foreground/60"><Trans>Reading Stats</Trans></span>
           </div>
         </div>
 
         <p className="text-center text-xs text-muted-foreground mt-4">
-          Tome · Your personal library
+          <Trans>Tome · Your personal library</Trans>
         </p>
       </div>
     </div>

--- a/frontend/src/pages/SharePage.tsx
+++ b/frontend/src/pages/SharePage.tsx
@@ -7,6 +7,10 @@ import { useParams } from 'react-router-dom'
 import { BookOpen, ChevronDown, Quote, Star, StickyNote } from 'lucide-react'
 import { TomeMark } from '@/components/TomeMark'
 import { cn } from '@/lib/utils'
+import { Trans, Plural } from '@lingui/react/macro'
+import { t, plural, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 import { applyTheme, getStoredTheme } from '@/lib/theme'
 
 interface SharedHighlight {
@@ -81,8 +85,8 @@ function groupByArc(books: SharedBook[], arcs: SharedArc[]): { arc: SharedArc | 
 function fmtDuration(seconds: number): string {
   const h = Math.floor(seconds / 3600)
   const m = Math.round((seconds % 3600) / 60)
-  if (h === 0) return `${m}m`
-  return m === 0 ? `${h}h` : `${h}h ${m}m`
+  if (h === 0) return t`${m}m`
+  return m === 0 ? t`${h}h` : t`${h}h ${m}m`
 }
 
 function fmtDay(iso: string): string {
@@ -91,7 +95,12 @@ function fmtDay(iso: string): string {
   })
 }
 
+const SERIES_STATUS_WORDS: Record<string, MessageDescriptor> = {
+  ongoing: msg`ongoing`, finished: msg`finished`, hiatus: msg`hiatus`,
+}
+
 const DAY_MS = 86400000
+// eslint-disable-next-line lingui/no-unlocalized-strings -- ISO suffix
 const dayNum = (d: string) => Math.floor(Date.parse(`${d}T00:00:00Z`) / DAY_MS)
 
 /** The owner's reading of this book as a day-intensity strip — the same
@@ -167,15 +176,14 @@ function SharedBookCard({ b, defaultOpen = false }: { b: SharedBook; defaultOpen
           {b.rating != null && <div className="mt-1.5"><Rating value={b.rating} /></div>}
           {b.stats && (
             <p className="mt-1.5 text-xs text-muted-foreground">
-              {b.stats.status === 'read' ? 'Read' : b.stats.status === 'reading' ? 'Reading' : null}
+              {b.stats.status === 'read' ? t`Read` : b.stats.status === 'reading' ? t`Reading` : null}
               {b.stats.total_seconds > 0 && (
                 <>
                   {b.stats.status ? ' · ' : ''}
-                  {fmtDuration(b.stats.total_seconds)} over {b.stats.reading_days}{' '}
-                  {b.stats.reading_days === 1 ? 'day' : 'days'}
+                  {(() => { const dur = fmtDuration(b.stats.total_seconds); return plural(b.stats.reading_days, { one: `${dur} over # day`, other: `${dur} over # days` }) })()}
                 </>
               )}
-              {b.stats.finished_on ? ` · finished ${fmtDay(b.stats.finished_on)}` : ''}
+              {(() => { const d = b.stats.finished_on ? fmtDay(b.stats.finished_on) : ''; return b.stats.finished_on ? t` · finished ${d}` : '' })()}
             </p>
           )}
           {b.tags.length > 0 && (
@@ -193,7 +201,7 @@ function SharedBookCard({ b, defaultOpen = false }: { b: SharedBook; defaultOpen
               className="mt-2 flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
             >
               <ChevronDown className={cn('h-3.5 w-3.5 transition-transform', open && 'rotate-180')} />
-              {open ? 'Less' : b.highlights.length > 0 ? `Description & ${b.highlights.length} highlight${b.highlights.length !== 1 ? 's' : ''}` : 'Description'}
+              {open ? t`Less` : b.highlights.length > 0 ? plural(b.highlights.length, { one: 'Description & # highlight', other: 'Description & # highlights' }) : t`Description`}
             </button>
           )}
         </div>
@@ -240,6 +248,7 @@ export function SharePage() {
     // Belt-and-braces with the server's X-Robots-Tag.
     const meta = document.createElement('meta')
     meta.name = 'robots'
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- robots directive
     meta.content = 'noindex, nofollow'
     document.head.appendChild(meta)
     return () => { document.head.removeChild(meta) }
@@ -249,11 +258,11 @@ export function SharePage() {
     // Plain fetch on purpose: no auth token attached, no 401 redirect logic.
     fetch(`/api/share/${token}`)
       .then(async r => {
-        if (!r.ok) throw new Error((await r.json()).detail || 'Not found')
+        if (!r.ok) throw new Error((await r.json()).detail || t`Not found`)
         return r.json()
       })
       .then(setData)
-      .catch(e => setError(e instanceof Error ? e.message : 'Not found'))
+      .catch(e => setError(e instanceof Error ? e.message : t`Not found`))
   }, [token])
 
   if (error) {
@@ -267,7 +276,7 @@ export function SharePage() {
   if (!data) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background">
-        <p className="animate-pulse text-sm text-muted-foreground">Loading…</p>
+        <p className="animate-pulse text-sm text-muted-foreground"><Trans>Loading…</Trans></p>
       </div>
     )
   }
@@ -279,10 +288,10 @@ export function SharePage() {
           <Quote className="h-4 w-4 text-primary" />
           <h1 className="font-display text-lg text-foreground">{data.title}</h1>
           <span className="text-xs text-muted-foreground">
-            · a shared {data.kind}
-            {data.kind !== 'book' ? ` · ${data.totals.books} book${data.totals.books !== 1 ? 's' : ''}` : ''}
-            {data.totals.read > 0 && data.kind !== 'book' ? ` · ${data.totals.read} read` : ''}
-            {data.totals.total_seconds > 0 ? ` · ${fmtDuration(data.totals.total_seconds)} read time` : ''}
+            {data.kind === 'book' ? t`· a shared book` : data.kind === 'series' ? t`· a shared series` : t`· a shared shelf`}
+            {data.kind !== 'book' ? ' · ' + plural(data.totals.books, { one: '# book', other: '# books' }) : ''}
+            {(() => { const n = data.totals.read; return n > 0 && data.kind !== 'book' ? t` · ${n} read` : '' })()}
+            {(() => { const dur = fmtDuration(data.totals.total_seconds); return data.totals.total_seconds > 0 ? t` · ${dur} read time` : '' })()}
           </span>
         </div>
       </header>
@@ -293,7 +302,7 @@ export function SharePage() {
               <h2 className="font-display text-xl text-foreground">{data.title}</h2>
               {data.series.status && (
                 <span className="rounded-full border border-border bg-muted px-2 py-0.5 text-[11px] capitalize text-muted-foreground">
-                  {data.series.status}
+                  {SERIES_STATUS_WORDS[data.series.status] ? i18n._(SERIES_STATUS_WORDS[data.series.status]) : data.series.status}
                 </span>
               )}
             </div>
@@ -304,11 +313,13 @@ export function SharePage() {
               <div className="mt-1.5"><Rating value={data.series.rating} /></div>
             )}
             <p className="mt-3 flex items-center justify-between text-[11px] text-muted-foreground">
+              {(() => { const readN = data.totals.read; const unreadN = data.totals.books - data.totals.read; return (
               <span>
-                {data.totals.read} read · {data.totals.books - data.totals.read} unread
-                {data.totals.total_seconds > 0 ? ` · ${fmtDuration(data.totals.total_seconds)}` : ''}
+                <Trans>{readN} read · {unreadN} unread</Trans>
+                {(() => { const dur = fmtDuration(data.totals.total_seconds); return data.totals.total_seconds > 0 ? ` · ${dur}` : '' })()}
               </span>
-              <span>{data.totals.books} volumes</span>
+              ) })()}
+              <span><Plural value={data.totals.books} one="# volume" other="# volumes" /></span>
             </p>
             <div className="mt-1 h-2 overflow-hidden rounded-full bg-muted">
               <div
@@ -322,19 +333,22 @@ export function SharePage() {
           </section>
         )}
         {data.books.length === 0 ? (
-          <p className="py-12 text-center text-sm text-muted-foreground">Nothing here yet.</p>
+          <p className="py-12 text-center text-sm text-muted-foreground"><Trans>Nothing here yet.</Trans></p>
         ) : data.kind === 'series' && data.series && data.series.arcs.length > 0 ? (
           groupByArc(data.books, data.series.arcs).map((g, gi) => (
             <section key={gi} className="mb-6">
               <div className="mb-2 flex items-baseline gap-2 border-b border-border/60 pb-1.5">
                 <h3 className="font-display text-sm text-foreground">
-                  {g.arc ? g.arc.name : 'Other volumes'}
+                  {g.arc ? g.arc.name : t`Other volumes`}
                 </h3>
-                {g.arc && (
-                  <span className="text-[11px] text-muted-foreground">
-                    Vol. {g.arc.start_index}–{g.arc.end_index}
-                  </span>
-                )}
+                {g.arc && (() => {
+                  const a = g.arc.start_index, b = g.arc.end_index
+                  return (
+                    <span className="text-[11px] text-muted-foreground">
+                      <Trans>Vol. {a}–{b}</Trans>
+                    </span>
+                  )
+                })()}
               </div>
               {g.arc?.description && (
                 <p className="mb-3 text-xs leading-relaxed text-muted-foreground">{g.arc.description}</p>
@@ -353,7 +367,7 @@ export function SharePage() {
         )}
         <footer className="flex items-center justify-center gap-1.5 pb-4 pt-10 text-xs text-muted-foreground/60">
           <TomeMark className="h-3.5 w-3.5" strokeWidth={7} />
-          Shared from a self-hosted Tome library
+          <Trans>Shared from a self-hosted Tome library</Trans>
         </footer>
       </main>
     </div>

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -1258,7 +1258,7 @@ function TileShell({
         <h3 className="min-w-0 truncate font-display text-xs font-medium text-muted-foreground">{def.titleFor?.(config) ?? i18n._(def.title)}</h3>
         {def.infoHint && <def.infoHint />}
         {def.fixedWindow && (
-          <span title="This tile uses a fixed window and ignores the range picker" className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
+          <span title={t`This tile uses a fixed window and ignores the range picker`} className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
             {i18n._(def.fixedWindow)}
           </span>
         )}

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -12,6 +12,10 @@ import { toPng } from 'html-to-image'
 import { Plus, RotateCcw, X, BarChart3, HelpCircle, Sparkles, SlidersHorizontal, Pencil, Check, GripVertical, Calendar, ChevronLeft, ChevronRight, Clock, Activity, BookCheck, Flame, FileText, Target, Gauge, Search, Copy, Loader2, CloudOff, Download, Upload, ImageDown, Star, TrendingUp, ScatterChart as ScatterIcon, Trophy, Globe, Library as LibraryIcon, Clock3, Infinity as InfinityIcon, Type, Ruler, Repeat, type LucideIcon } from 'lucide-react'
 import { cn, formatDate, formatDuration } from '@/lib/utils'
 import { api } from '@/lib/api'
+import { Trans } from '@lingui/react/macro'
+import { t, msg } from '@lingui/core/macro'
+import { i18n } from '@lingui/core'
+import type { MessageDescriptor } from '@lingui/core'
 import { BookAnimation } from '@/components/BookAnimation'
 import { DOCS, docsLink } from '@/lib/docs'
 import { type StatsResponse, type CompletionEstimate } from '@/components/stats/shared'
@@ -103,11 +107,11 @@ type WidgetCtx = {
 
 type WidgetDef = {
   id: string
-  title: string
+  title: MessageDescriptor
   icon?: LucideIcon
   size: { w: number; h: number; minW: number; minH: number }
   chartTypes?: ChartKind[]
-  metrics?: { id: string; label: string }[]
+  metrics?: { id: string; label: MessageDescriptor }[]
   /** Config picks a series (options come from the user's series_completion). */
   seriesPicker?: boolean
   /** Config picks a backlog scope (status / library / shelf). */
@@ -117,7 +121,7 @@ type WidgetDef = {
   titleFor?: (config: TileConfig) => string
   /** Set when the widget ignores the page range picker (e.g. "12 mo") — rendered
       as a small chip so the fixed window is visible, not a surprise. */
-  fixedWindow?: string
+  fixedWindow?: MessageDescriptor
   /** Optional info popover rendered beside the tile title (an InfoHint-style
       component) — for tiles whose rows carry labels that need explaining. */
   infoHint?: React.ComponentType
@@ -134,14 +138,14 @@ const newId = (prefix: string) => `${prefix}--${Date.now().toString(36)}${(_uid+
 
 // Metrics the Custom Stat tile can show — all derived from the /stats payload.
 const METRICS = [
-  { id: 'avg-session', label: 'Avg Session' },
-  { id: 'time-per-day', label: 'Time / Day' },
-  { id: 'pages-per-day', label: 'Pages / Day' },
-  { id: 'pages-per-hour', label: 'Pages / Hour' },
-  { id: 'best-day', label: 'Best Day' },
-  { id: 'longest-session', label: 'Longest Session' },
-  { id: 'books-started', label: 'Books Started' },
-  { id: 'longest-streak', label: 'Longest Streak' },
+  { id: 'avg-session', label: msg`Avg Session` },
+  { id: 'time-per-day', label: msg`Time / Day` },
+  { id: 'pages-per-day', label: msg`Pages / Day` },
+  { id: 'pages-per-hour', label: msg`Pages / Hour` },
+  { id: 'best-day', label: msg`Best Day` },
+  { id: 'longest-session', label: msg`Longest Session` },
+  { id: 'books-started', label: msg`Books Started` },
+  { id: 'longest-streak', label: msg`Longest Streak` },
 ]
 
 function metricValue(stats: StatsResponse, id: string): { value: string; sub?: string } {
@@ -149,19 +153,19 @@ function metricValue(stats: StatsResponse, id: string): { value: string; sub?: s
   const secs = stats.headline.total_reading_seconds
   switch (id) {
     case 'time-per-day':
-      return { value: formatDuration(Math.round(secs / days)), sub: `over ${days} days` }
+      return { value: formatDuration(Math.round(secs / days)), sub: t`over ${days} days` }
     case 'pages-per-day':
-      return { value: String(Math.round(stats.headline.pages_turned / days)), sub: `over ${days} days` }
+      return { value: String(Math.round(stats.headline.pages_turned / days)), sub: t`over ${days} days` }
     case 'pages-per-hour':
-      return { value: secs > 0 ? String(Math.round(stats.headline.pages_turned / (secs / 3600))) : '0', sub: 'average pace' }
+      return { value: secs > 0 ? String(Math.round(stats.headline.pages_turned / (secs / 3600))) : '0', sub: t`average pace` }
     case 'best-day': {
       const best = stats.daily.reduce((a, b) => (b.seconds > a.seconds ? b : a), { date: '', seconds: 0, sessions: 0, pages: 0 })
-      return best.seconds > 0 ? { value: formatDuration(best.seconds), sub: formatDate(best.date) } : { value: '0m', sub: 'no reading yet' }
+      return best.seconds > 0 ? { value: formatDuration(best.seconds), sub: formatDate(best.date) } : { value: '0m', sub: t`no reading yet` }
     }
     case 'longest-session': {
       let top: StatsResponse['session_timeline'][number] | null = null
       for (const s of stats.session_timeline) if (!top || s.duration_seconds > top.duration_seconds) top = s
-      return top ? { value: formatDuration(top.duration_seconds), sub: top.title } : { value: '0m', sub: 'no sessions yet' }
+      return top ? { value: formatDuration(top.duration_seconds), sub: top.title } : { value: '0m', sub: t`no sessions yet` }
     }
     case 'books-started':
       return { value: String(stats.completion_rate.started), sub: `${stats.completion_rate.finished} finished` }
@@ -188,56 +192,56 @@ const WIDGETS: WidgetDef[] = [
   // Headline figures — one tile each (separately movable / removable).
   {
     id: 'stat-time',
-    title: 'Reading Time',
+    title: msg`Reading Time`,
     icon: Clock,
     size: STAT_SIZE,
     render: ({ stats }) => (
-      <HeadlineStatBody value={formatDuration(stats.headline.total_reading_seconds)} sub={`avg ${formatDuration(stats.headline.avg_session_seconds)}`} />
+      <HeadlineStatBody value={formatDuration(stats.headline.total_reading_seconds)} sub={(() => { const avg = formatDuration(stats.headline.avg_session_seconds); return t`avg ${avg}` })()} />
     ),
   },
   {
     id: 'stat-sessions',
-    title: 'Sessions',
+    title: msg`Sessions`,
     icon: Activity,
     size: STAT_SIZE,
     render: ({ stats }) => <HeadlineStatBody value={String(stats.headline.total_sessions)} />,
   },
   {
     id: 'stat-finished',
-    title: 'Finished',
+    title: msg`Finished`,
     icon: BookCheck,
     size: STAT_SIZE,
     render: ({ stats }) => <HeadlineStatBody value={String(stats.headline.books_finished)} />,
   },
   {
     id: 'stat-streak',
-    title: 'Streak',
+    title: msg`Streak`,
     icon: Flame,
     size: STAT_SIZE,
-    render: ({ stats }) => <HeadlineStatBody value={`${stats.headline.current_streak_days}d`} sub={`Longest: ${stats.headline.longest_streak_days}d`} />,
+    render: ({ stats }) => <HeadlineStatBody value={`${stats.headline.current_streak_days}d`} sub={(() => { const d = stats.headline.longest_streak_days; return t`Longest: ${d}d` })()} />,
   },
   {
     id: 'stat-pages',
-    title: 'Pages Turned',
+    title: msg`Pages Turned`,
     icon: FileText,
     size: STAT_SIZE,
     render: ({ stats }) => <HeadlineStatBody value={stats.headline.pages_turned.toLocaleString()} />,
   },
   {
     id: 'stat-completion',
-    title: 'Completion',
+    title: msg`Completion`,
     icon: Target,
     size: STAT_SIZE,
-    render: ({ stats }) => <HeadlineStatBody value={`${stats.completion_rate.pct}%`} sub={`${stats.completion_rate.finished} of ${stats.completion_rate.started} started`} />,
+    render: ({ stats }) => <HeadlineStatBody value={`${stats.completion_rate.pct}%`} sub={(() => { const fin = stats.completion_rate.finished, st = stats.completion_rate.started; return t`${fin} of ${st} started` })()} />,
   },
   {
     id: 'stat-metric',
-    title: 'Custom Stat',
+    title: msg`Custom Stat`,
     icon: Gauge,
     size: STAT_SIZE,
     metrics: METRICS,
     defaultConfig: { chartType: 'bar', days: 0, metric: 'avg-session' },
-    titleFor: (cfg) => METRICS.find((m) => m.id === cfg.metric)?.label ?? 'Custom Stat',
+    titleFor: (cfg) => { const hit = METRICS.find((m) => m.id === cfg.metric); return hit ? i18n._(hit.label) : t`Custom Stat` },
     render: ({ stats }, cfg) => {
       const v = metricValue(stats, cfg.metric ?? 'avg-session')
       return <HeadlineStatBody value={v.value} sub={v.sub} />
@@ -245,7 +249,7 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'goal',
-    title: 'Reading Goals',
+    title: msg`Reading Goals`,
     icon: Target,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     autoH: true,
@@ -253,7 +257,7 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'currently-reading',
-    title: 'Currently Reading',
+    title: msg`Currently Reading`,
     size: { w: 6, h: 2, minW: 3, minH: 1 },
     autoH: true,
     defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
@@ -261,7 +265,7 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'daily',
-    title: 'Reading Time per Day',
+    title: msg`Reading Time per Day`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     chartTypes: ['bar', 'line', 'area'],
     defaultConfig: { chartType: 'bar', days: 0 },
@@ -269,13 +273,13 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'top-books',
-    title: 'Top Books by Reading Time',
+    title: msg`Top Books by Reading Time`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <TopBooksByTime topBooks={stats.top_books} />,
   },
   {
     id: 'books-finished',
-    title: 'Books Finished',
+    title: msg`Books Finished`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     chartTypes: ['area', 'line', 'bar'],
     defaultConfig: { chartType: 'area', days: 0 },
@@ -283,14 +287,14 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'activity-365',
-    title: 'Reading Activity — Last 365 Days',
+    title: msg`Reading Activity — Last 365 Days`,
     size: { w: 12, h: 2, minW: 4, minH: 2 },
-    fixedWindow: '365 d',
+    fixedWindow: msg`365 d`,
     render: ({ stats }) => <ReadingActivity365 heatmap={stats.heatmap_daily} />,
   },
   {
     id: 'session-log',
-    title: 'Recent Sessions',
+    title: msg`Recent Sessions`,
     size: { w: 12, h: 6, minW: 5, minH: 2 },
     autoH: true,
     infoHint: SessionLogHint,
@@ -298,77 +302,77 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'recently-finished',
-    title: 'Recently Finished',
+    title: msg`Recently Finished`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     autoH: true,
     render: ({ stats }) => <RecentlyFinished booksFinished={stats.books_finished} />,
   },
   {
     id: 'streak-calendar',
-    title: 'This Month',
+    title: msg`This Month`,
     size: { w: 3, h: 2, minW: 2, minH: 2 },
-    fixedWindow: 'current',
+    fixedWindow: msg`current`,
     render: ({ stats }) => <StreakCalendar heatmap={stats.heatmap_daily} />,
   },
   {
     id: 'dow-bar',
-    title: 'Reading by Weekday',
+    title: msg`Reading by Weekday`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <DayOfWeekBar data={stats.hour_dow_heatmap} />,
   },
   {
     id: 'time-of-day',
-    title: 'Time of Day Split',
+    title: msg`Time of Day Split`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <TimeOfDaySplit data={stats.hour_dow_heatmap} />,
   },
   {
     id: 'time-by-format',
-    title: 'Time by Format',
+    title: msg`Time by Format`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <TimeByFormat data={stats.pace_by_format} />,
   },
   // Habits tab
   {
     id: 'hour-dow',
-    title: 'Reading Intensity by Hour and Day',
+    title: msg`Reading Intensity by Hour and Day`,
     size: { w: 12, h: 2, minW: 5, minH: 2 },
     render: ({ stats }) => <HourDowCard data={stats.hour_dow_heatmap} />,
   },
   {
     id: 'session-timeline',
-    title: 'Session Timeline',
+    title: msg`Session Timeline`,
     size: { w: 6, h: 3, minW: 4, minH: 2 },
     render: ({ stats }) => <SessionTimeline sessions={stats.session_timeline} />,
   },
   {
     id: 'reading-timeline',
-    title: 'Reading Timeline',
+    title: msg`Reading Timeline`,
     size: { w: 12, h: 7, minW: 6, minH: 3 },
-    fixedWindow: 'lifetime',
+    fixedWindow: msg`lifetime`,
     render: () => <TimelineRibbon />,
   },
   {
     id: 'reading-pace',
-    title: 'Reading Pace',
+    title: msg`Reading Pace`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <ReadingPaceChart pace={stats.reading_pace} />,
   },
   {
     id: 'pace-by-format',
-    title: 'Pace by Format',
+    title: msg`Pace by Format`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <PaceByFormat data={stats.pace_by_format} />,
   },
   {
     id: 'speed-trend',
-    title: 'Reading Speed Trend',
+    title: msg`Reading Speed Trend`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <ReadingSpeedTrend pace={stats.reading_pace} />,
   },
   {
     id: 'estimates',
-    title: 'Completion Estimates',
+    title: msg`Completion Estimates`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     autoH: true,
     defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
@@ -376,25 +380,25 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'reading-dna',
-    title: 'Reading DNA',
+    title: msg`Reading DNA`,
     size: { w: 4, h: 3, minW: 3, minH: 2 },
     render: ({ stats }) =>
       stats.reading_dna?.ready
         ? <ReadingDNABody dna={stats.reading_dna} />
-        : <p className="text-sm text-muted-foreground">Not enough reading history yet.</p>,
+        : <p className="text-sm text-muted-foreground"><Trans>Not enough reading history yet.</Trans></p>,
   },
   {
     id: 'period-comparison',
-    title: 'Period Comparison',
+    title: msg`Period Comparison`,
     size: { w: 6, h: 1, minW: 3, minH: 1 },
     render: ({ stats }) =>
-      stats.period_comparison ? <PeriodComparison comparison={stats.period_comparison} /> : <p className="text-sm text-muted-foreground">No comparison data.</p>,
+      stats.period_comparison ? <PeriodComparison comparison={stats.period_comparison} /> : <p className="text-sm text-muted-foreground"><Trans>No comparison data.</Trans></p>,
   },
   {
     id: 'monthly-comparison',
-    title: 'Reading Hours & Books Finished — Last 12 Months',
+    title: msg`Reading Hours & Books Finished — Last 12 Months`,
     size: { w: 12, h: 2, minW: 4, minH: 2 },
-    fixedWindow: '12 mo',
+    fixedWindow: msg`12 mo`,
     chartTypes: ['bar', 'line', 'area'],
     defaultConfig: { chartType: 'bar', days: 0 },
     render: ({ stats }, cfg) => <MonthlyComparison monthly={stats.monthly_comparison} chartType={cfg.chartType} />,
@@ -402,13 +406,13 @@ const WIDGETS: WidgetDef[] = [
   // Library tab
   {
     id: 'year-in-review',
-    title: 'Year in Review',
+    title: msg`Year in Review`,
     size: { w: 6, h: 2, minW: 4, minH: 1 },
     render: ({ stats }) => <YearInReview summary={stats.year_summary} />,
   },
   {
     id: 'series-completion',
-    title: 'Series Completion',
+    title: msg`Series Completion`,
     size: { w: 6, h: 3, minW: 3, minH: 2 },
     autoH: true,
     defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
@@ -426,184 +430,184 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'author-affinity',
-    title: 'Top Authors by Reading Time',
+    title: msg`Top Authors by Reading Time`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <AuthorAffinity data={stats.author_affinity} />,
   },
   {
     id: 'completion-by-type',
-    title: 'Finish Rate per Book Category',
+    title: msg`Finish Rate per Book Category`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <CompletionByType data={stats.completion_by_type} />,
   },
   {
     id: 'category-breakdown',
-    title: 'Category Breakdown',
+    title: msg`Category Breakdown`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
     render: ({ stats }) => <CategoryBreakdown data={stats.by_category} />,
   },
   {
     id: 'genre-over-time',
-    title: 'Reading by Category — Last 12 Months',
+    title: msg`Reading by Category — Last 12 Months`,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
-    fixedWindow: '12 mo',
+    fixedWindow: msg`12 mo`,
     chartTypes: ['area', 'bar'],
     defaultConfig: { chartType: 'area', days: 0 },
     render: ({ stats }, cfg) => <GenreOverTime data={stats.genre_over_time} chartType={cfg.chartType === 'bar' ? 'bar' : 'area'} />,
   },
   {
     id: 'library-growth',
-    title: 'Cumulative Books Added — Last 24 Months',
+    title: msg`Cumulative Books Added — Last 24 Months`,
     size: { w: 12, h: 2, minW: 4, minH: 2 },
-    fixedWindow: '24 mo',
+    fixedWindow: msg`24 mo`,
     chartTypes: ['area', 'bar'],
     defaultConfig: { chartType: 'area', days: 0 },
     render: ({ stats }, cfg) => <LibraryGrowthChart data={stats.library_growth} height="100%" chartType={cfg.chartType === 'bar' ? 'bar' : 'area'} />,
   },
   {
     id: 'per-book-table',
-    title: 'All Books by Reading Time',
+    title: msg`All Books by Reading Time`,
     size: { w: 12, h: 3, minW: 5, minH: 2 },
     autoH: true,
     render: ({ stats }) => <PerBookTimeTable data={stats.per_book_time} />,
   },
   {
     id: 'series-spotlight',
-    title: 'Series Spotlight',
+    title: msg`Series Spotlight`,
     size: { w: 3, h: 2, minW: 2, minH: 2 },
     seriesPicker: true,
-    titleFor: (cfg) => cfg.series ?? 'Series Spotlight',
+    titleFor: (cfg) => cfg.series ?? t`Series Spotlight`,
     render: ({ stats }, cfg) => <SeriesSpotlight data={stats.series_completion} series={cfg.series} />,
   },
   // Taste tab — ratings (all-time, ignore the date range)
   {
     id: 'rating-distribution',
-    title: 'Rating Distribution',
+    title: msg`Rating Distribution`,
     icon: Star,
     size: { w: 4, h: 2, minW: 3, minH: 2 },
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <RatingDistribution data={stats.ratings.distribution} />,
   },
   {
     id: 'taste-by-genre',
-    title: 'Taste by Genre',
+    title: msg`Taste by Genre`,
     icon: Sparkles,
     size: { w: 4, h: 2, minW: 3, minH: 2 },
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <TasteByGenre data={stats.ratings.by_category} />,
   },
   {
     id: 'top-rated',
-    title: 'Highest & Lowest Rated',
+    title: msg`Highest & Lowest Rated`,
     icon: Star,
     size: { w: 4, h: 3, minW: 3, minH: 2 },
     autoH: true,
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <TopRatedBooks books={stats.ratings.books} />,
   },
   {
     id: 'rating-vs-time',
-    title: 'Rating vs Time Spent',
+    title: msg`Rating vs Time Spent`,
     icon: ScatterIcon,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <RatingVsTime books={stats.ratings.books} />,
   },
   {
     id: 'best-rated-series',
-    title: 'Best-Rated Series',
+    title: msg`Best-Rated Series`,
     icon: Star,
     size: { w: 4, h: 3, minW: 3, minH: 2 },
     autoH: true,
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <BestRatedSeries series={stats.ratings.series} />,
   },
   {
     id: 'rating-trend',
-    title: 'Rating Trend',
+    title: msg`Rating Trend`,
     icon: TrendingUp,
     size: { w: 6, h: 2, minW: 3, minH: 2 },
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <RatingTrend trend={stats.ratings.trend} />,
   },
   // Batch-2 insights
   {
     id: 'lifetime-totals',
-    title: 'Lifetime Totals',
+    title: msg`Lifetime Totals`,
     icon: InfinityIcon,
     size: { w: 6, h: 2, minW: 4, minH: 1 },
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <LifetimeTotals data={stats.lifetime} />,
   },
   {
     id: 'personal-records',
-    title: 'Personal Records',
+    title: msg`Personal Records`,
     icon: Trophy,
     size: { w: 4, h: 3, minW: 3, minH: 2 },
     autoH: true,
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <PersonalRecords data={stats.records} />,
   },
   {
     id: 'library-completion',
-    title: 'Library Completion',
+    title: msg`Library Completion`,
     icon: LibraryIcon,
     size: { w: 4, h: 3, minW: 3, minH: 2 },
     autoH: true,
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <LibraryCompletion data={stats.tbr} />,
   },
   {
     id: 'reading-clock',
-    title: 'Reading Clock',
+    title: msg`Reading Clock`,
     icon: Clock3,
     size: { w: 4, h: 3, minW: 3, minH: 2 },
     render: ({ stats }) => <ReadingClock data={stats.hour_dow_heatmap} />,
   },
   {
     id: 'reading-by-language',
-    title: 'Reading by Language',
+    title: msg`Reading by Language`,
     icon: Globe,
     size: { w: 4, h: 2, minW: 3, minH: 2 },
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <ReadingByLanguage data={stats.language} />,
   },
   // Phase 4 — word-count powered (all-time)
   {
     id: 'words-read',
-    title: 'Words Read',
+    title: msg`Words Read`,
     icon: Type,
     size: { w: 6, h: 2, minW: 3, minH: 1 },
     autoH: true,
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
     render: ({ stats }) => <WordsRead data={stats.words} />,
   },
   {
     id: 'true-wpm',
-    title: 'Reading Speed',
+    title: msg`Reading Speed`,
     icon: Gauge,
     size: { w: 6, h: 3, minW: 3, minH: 2 },
     autoH: true,
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
     render: ({ stats }) => <TrueWpm data={stats.wpm} />,
   },
   {
     id: 'book-length',
-    title: 'Book Length',
+    title: msg`Book Length`,
     icon: Ruler,
     size: { w: 6, h: 3, minW: 3, minH: 2 },
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     render: ({ stats }) => <BookLength data={stats.book_lengths} />,
   },
   {
     id: 'rereads',
-    title: 'Re-reads',
+    title: msg`Re-reads`,
     icon: Repeat,
     size: { w: 4, h: 3, minW: 3, minH: 2 },
     autoH: true,
-    fixedWindow: 'all',
+    fixedWindow: msg`all`,
     defaultConfig: { chartType: 'bar', days: 0, autoFit: true },
     render: ({ stats }) => <ReReads data={stats.rereads} />,
   },
@@ -611,60 +615,60 @@ const WIDGETS: WidgetDef[] = [
 
 const defById = (id: string) => WIDGETS.find((w) => w.id === id.replace(/--[a-z0-9]+$/, ''))!
 
-const WIDGET_DESC: Record<string, string> = {
-  'stat-time': 'Total time read + avg session',
-  'stat-sessions': 'Number of reading sessions',
-  'stat-finished': 'Books completed',
-  'stat-streak': 'Current & longest daily streak',
-  'stat-pages': 'Total pages turned',
-  'stat-completion': 'Started vs finished ratio',
-  'currently-reading': 'Books in progress, with covers',
-  daily: 'Minutes read per day',
-  'top-books': 'Most-read books by time',
-  'books-finished': 'Cumulative finishes over time',
-  'activity-365': 'A year of reading, heatmap',
-  'session-log': 'Every session — paginated, deletable',
-  'stat-metric': 'Pick your own metric — avg session, pages/day, best day…',
-  goal: 'All your reading goals — rings fill as you read, managed in place',
-  'recently-finished': 'Latest finishes, newest first',
-  'streak-calendar': 'This month, read days filled',
-  'dow-bar': 'Which weekday you read most',
-  'time-of-day': 'Morning vs evening reader?',
-  'time-by-format': 'EPUB vs CBZ time split',
-  'series-spotlight': 'One series front and center — you pick which',
-  'hour-dow': 'When you read — hour × weekday',
-  'session-timeline': 'Daily sessions on a 24h track',
-  'reading-timeline': 'Your reading life — every book a bar in time',
-  'reading-pace': 'Pages per minute over time',
-  'pace-by-format': 'Speed by book format',
-  'speed-trend': 'Are you getting faster?',
-  estimates: 'Time left on books in progress',
-  'period-comparison': 'This period vs the last',
-  'monthly-comparison': 'Hours & finishes, last 12 months',
-  'year-in-review': 'Your year, at a glance (1y/All)',
-  'series-completion': 'How far through each series',
-  'backlog-estimate': 'How long your unread pile would take',
-  'author-affinity': 'Most-read authors',
-  'completion-by-type': 'Finish rate by book type',
-  'category-breakdown': 'Time split across categories',
-  'genre-over-time': 'Category mix over the year',
-  'library-growth': 'Library size over time',
-  'per-book-table': 'Sortable table of every book',
-  'rating-distribution': 'How you spread your 1–5 stars',
-  'taste-by-genre': 'Average rating per book type',
-  'rating-vs-time': 'Do you rate books you spend longer on higher?',
-  'rating-trend': 'Your ratings over time',
-  'top-rated': 'Your highest & lowest rated books',
-  'best-rated-series': 'Series ranked by your rating',
-  'lifetime-totals': 'All-time hours, pages, books, streak',
-  'personal-records': 'Longest session, biggest day, most pages',
-  'library-completion': 'How much of what you own you’ve read',
-  'reading-clock': 'A 24-hour radial of when you read',
-  'reading-by-language': 'Reading time split by language',
-  'words-read': 'Lifetime words read, by year',
-  'true-wpm': 'Your real reading speed — words ÷ time',
-  'book-length': 'How long the books you finish are',
-  'rereads': 'Books whose pages you revisit',
+const WIDGET_DESC: Record<string, MessageDescriptor> = {
+  'stat-time': msg`Total time read + avg session`,
+  'stat-sessions': msg`Number of reading sessions`,
+  'stat-finished': msg`Books completed`,
+  'stat-streak': msg`Current & longest daily streak`,
+  'stat-pages': msg`Total pages turned`,
+  'stat-completion': msg`Started vs finished ratio`,
+  'currently-reading': msg`Books in progress, with covers`,
+  daily: msg`Minutes read per day`,
+  'top-books': msg`Most-read books by time`,
+  'books-finished': msg`Cumulative finishes over time`,
+  'activity-365': msg`A year of reading, heatmap`,
+  'session-log': msg`Every session — paginated, deletable`,
+  'stat-metric': msg`Pick your own metric — avg session, pages/day, best day…`,
+  goal: msg`All your reading goals — rings fill as you read, managed in place`,
+  'recently-finished': msg`Latest finishes, newest first`,
+  'streak-calendar': msg`This month, read days filled`,
+  'dow-bar': msg`Which weekday you read most`,
+  'time-of-day': msg`Morning vs evening reader?`,
+  'time-by-format': msg`EPUB vs CBZ time split`,
+  'series-spotlight': msg`One series front and center — you pick which`,
+  'hour-dow': msg`When you read — hour × weekday`,
+  'session-timeline': msg`Daily sessions on a 24h track`,
+  'reading-timeline': msg`Your reading life — every book a bar in time`,
+  'reading-pace': msg`Pages per minute over time`,
+  'pace-by-format': msg`Speed by book format`,
+  'speed-trend': msg`Are you getting faster?`,
+  estimates: msg`Time left on books in progress`,
+  'period-comparison': msg`This period vs the last`,
+  'monthly-comparison': msg`Hours & finishes, last 12 months`,
+  'year-in-review': msg`Your year, at a glance (1y/All)`,
+  'series-completion': msg`How far through each series`,
+  'backlog-estimate': msg`How long your unread pile would take`,
+  'author-affinity': msg`Most-read authors`,
+  'completion-by-type': msg`Finish rate by book type`,
+  'category-breakdown': msg`Time split across categories`,
+  'genre-over-time': msg`Category mix over the year`,
+  'library-growth': msg`Library size over time`,
+  'per-book-table': msg`Sortable table of every book`,
+  'rating-distribution': msg`How you spread your 1–5 stars`,
+  'taste-by-genre': msg`Average rating per book type`,
+  'rating-vs-time': msg`Do you rate books you spend longer on higher?`,
+  'rating-trend': msg`Your ratings over time`,
+  'top-rated': msg`Your highest & lowest rated books`,
+  'best-rated-series': msg`Series ranked by your rating`,
+  'lifetime-totals': msg`All-time hours, pages, books, streak`,
+  'personal-records': msg`Longest session, biggest day, most pages`,
+  'library-completion': msg`How much of what you own you’ve read`,
+  'reading-clock': msg`A 24-hour radial of when you read`,
+  'reading-by-language': msg`Reading time split by language`,
+  'words-read': msg`Lifetime words read, by year`,
+  'true-wpm': msg`Your real reading speed — words ÷ time`,
+  'book-length': msg`How long the books you finish are`,
+  'rereads': msg`Books whose pages you revisit`,
 }
 
 // Widgets that are a number/short text — render their preview at natural size (no scale).
@@ -678,21 +682,21 @@ const SCROLL_IDS = new Set([
   'goal',
 ])
 
-const GALLERY_GROUPS: { label: string; ids: string[] }[] = [
+const GALLERY_GROUPS: { label: MessageDescriptor; ids: string[] }[] = [
   {
-    label: 'Overview',
+    label: msg`Overview`,
     ids: ['stat-time', 'stat-sessions', 'stat-finished', 'stat-streak', 'stat-pages', 'stat-completion', 'stat-metric', 'goal', 'currently-reading', 'recently-finished', 'streak-calendar', 'daily', 'top-books', 'books-finished', 'activity-365', 'lifetime-totals', 'words-read', 'session-log'],
   },
   {
-    label: 'Habits',
+    label: msg`Habits`,
     ids: ['hour-dow', 'reading-clock', 'reading-dna', 'reading-timeline', 'session-timeline', 'reading-pace', 'pace-by-format', 'true-wpm', 'dow-bar', 'time-of-day', 'time-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'],
   },
   {
-    label: 'Library',
+    label: msg`Library`,
     ids: ['year-in-review', 'library-completion', 'series-completion', 'series-spotlight', 'backlog-estimate', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'reading-by-language', 'library-growth', 'personal-records', 'book-length', 'rereads', 'per-book-table'],
   },
   {
-    label: 'Taste',
+    label: msg`Taste`,
     ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'],
   },
 ]
@@ -756,23 +760,25 @@ const INITIAL_POS: Record<string, { x: number; y: number; w: number; h: number }
 // Each tab is its own board (own tiles + layout), independently customizable.
 type TabState = { id: string; label: string; tiles: Tile[]; layout: Layout }
 
-const TAB_DEFS: { id: string; label: string; ids: string[] }[] = [
-  { id: 'overview', label: 'Overview', ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log'] },
-  { id: 'habits', label: 'Habits', ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
-  { id: 'library', label: 'Library', ids: ['year-in-review', 'series-completion', 'backlog-estimate', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
-  { id: 'taste', label: 'Taste', ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'] },
-  { id: 'timeline', label: 'Timeline', ids: ['reading-timeline'] },
+const TAB_DEFS: { id: string; label: MessageDescriptor; ids: string[] }[] = [
+  { id: 'overview', label: msg`Overview`, ids: [...STAT_IDS, 'currently-reading', 'daily', 'top-books', 'books-finished', 'activity-365', 'session-log'] },
+  { id: 'habits', label: msg`Habits`, ids: ['hour-dow', 'session-timeline', 'reading-pace', 'pace-by-format', 'speed-trend', 'estimates', 'period-comparison', 'monthly-comparison'] },
+  { id: 'library', label: msg`Library`, ids: ['year-in-review', 'series-completion', 'backlog-estimate', 'author-affinity', 'completion-by-type', 'category-breakdown', 'genre-over-time', 'library-growth', 'per-book-table'] },
+  { id: 'taste', label: msg`Taste`, ids: ['rating-distribution', 'taste-by-genre', 'rating-vs-time', 'rating-trend', 'top-rated', 'best-rated-series'] },
+  { id: 'timeline', label: msg`Timeline`, ids: ['reading-timeline'] },
   // Phase 4 word-count tiles (words-read / true-wpm / book-length) are gallery-only
   // — addable from "Add tile" but on no default board, matching the batch-2 convention.
 ]
 
-function buildTab(def: { id: string; label: string; ids: string[] }): TabState {
-  if (def.ids.length === 0) return { id: def.id, label: def.label, tiles: [], layout: [] }
+function buildTab(def: { id: string; label: MessageDescriptor; ids: string[] }): TabState {
+  // Board names are plain persisted strings — resolve the default label with the
+  // locale active at creation time.
+  if (def.ids.length === 0) return { id: def.id, label: i18n._(def.label), tiles: [], layout: [] }
   // re-base y so each tab's board starts at the top
   const minY = Math.min(...def.ids.map((id) => INITIAL_POS[id].y))
   return {
     id: def.id,
-    label: def.label,
+    label: i18n._(def.label),
     tiles: def.ids.map((id) => ({ id, defId: id, config: defById(id).defaultConfig ?? DEFAULT_CFG })),
     layout: def.ids.map((id) => {
       const p = INITIAL_POS[id]
@@ -803,18 +809,18 @@ const withMissingDefaultTabs = (tabs: TabState[]): TabState[] => {
 }
 
 const RANGES = [
-  { days: 7, label: '7d' },
-  { days: 30, label: '30d' },
-  { days: 90, label: '90d' },
-  { days: 365, label: '1y' },
-  { days: 0, label: 'All' },
+  { days: 7, label: msg`7d` },
+  { days: 30, label: msg`30d` },
+  { days: 90, label: msg`90d` },
+  { days: 365, label: msg`1y` },
+  { days: 0, label: msg`All` },
 ]
 // Per-tile timeframe options. 0 = follow the page's range picker.
 const TIMEFRAMES = [
-  { days: 0, label: 'Range' },
-  { days: 7, label: '7d' },
-  { days: 14, label: '14d' },
-  { days: 30, label: '30d' },
+  { days: 0, label: msg`Range` },
+  { days: 7, label: msg`7d` },
+  { days: 14, label: msg`14d` },
+  { days: 30, label: msg`30d` },
 ]
 
 // ── Config popover ────────────────────────────────────────────────────────────
@@ -890,7 +896,7 @@ function ConfigPopover({
         )}
         {def.seriesPicker && (
           <>
-            <p className="mb-1.5 font-medium text-muted-foreground">Series</p>
+            <p className="mb-1.5 font-medium text-muted-foreground"><Trans>Series</Trans></p>
             {seriesOptions && seriesOptions.length > 0 ? (
               <select
                 value={config.series ?? seriesOptions[0]}
@@ -904,13 +910,13 @@ function ConfigPopover({
                 ))}
               </select>
             ) : (
-              <p className="text-muted-foreground/70">No series with reading progress yet.</p>
+              <p className="text-muted-foreground/70"><Trans>No series with reading progress yet.</Trans></p>
             )}
           </>
         )}
         {def.metrics && (
           <>
-            <p className="mb-1.5 font-medium text-muted-foreground">Metric</p>
+            <p className="mb-1.5 font-medium text-muted-foreground"><Trans>Metric</Trans></p>
             <div className="grid grid-cols-2 gap-1">
               {def.metrics.map((m) => (
                 <button
@@ -922,7 +928,7 @@ function ConfigPopover({
                     config.metric === m.id ? 'border-primary bg-primary/10 text-primary' : 'border-border text-muted-foreground hover:text-foreground',
                   )}
                 >
-                  {m.label}
+                  {i18n._(m.label)}
                 </button>
               ))}
             </div>
@@ -930,7 +936,7 @@ function ConfigPopover({
         )}
         {def.chartTypes && (
           <>
-            <p className="mb-1.5 font-medium text-muted-foreground">Chart type</p>
+            <p className="mb-1.5 font-medium text-muted-foreground"><Trans>Chart type</Trans></p>
             <div className="mb-3 flex rounded-md border border-border p-0.5">
               {def.chartTypes.map((ct) => (
                 <button
@@ -946,7 +952,7 @@ function ConfigPopover({
                 </button>
               ))}
             </div>
-            <p className="mb-1.5 font-medium text-muted-foreground">Timeframe</p>
+            <p className="mb-1.5 font-medium text-muted-foreground"><Trans>Timeframe</Trans></p>
             <div className="flex gap-1">
               {TIMEFRAMES.map((t) => (
                 <button
@@ -958,22 +964,22 @@ function ConfigPopover({
                     config.days === t.days ? 'border-primary bg-primary/10 text-primary' : 'border-border text-muted-foreground hover:text-foreground',
                   )}
                 >
-                  {t.label}
+                  {i18n._(t.label)}
                 </button>
               ))}
             </div>
-            <p className="mt-2 text-[10px] leading-snug text-muted-foreground/70">Range follows the page's range picker; days show the newest slice of it.</p>
+            <p className="mt-2 text-[10px] leading-snug text-muted-foreground/70"><Trans>Range follows the page's range picker; days show the newest slice of it.</Trans></p>
           </>
         )}
         {def.autoH && (
           <div className={cn((def.chartTypes || def.metrics || def.seriesPicker || def.scopePicker) && 'mt-3 border-t border-border pt-3')}>
             <div className="flex items-center justify-between gap-2">
-              <span className="font-medium text-muted-foreground">Auto-fit height</span>
+              <span className="font-medium text-muted-foreground"><Trans>Auto-fit height</Trans></span>
               <button
                 type="button"
                 role="switch"
                 aria-checked={!!config.autoFit}
-                aria-label="Auto-fit height"
+                aria-label={t`Auto-fit height`}
                 onClick={() => onChange({ autoFit: !config.autoFit })}
                 className={cn(
                   'relative h-4 w-7 shrink-0 rounded-full transition-colors',
@@ -989,7 +995,7 @@ function ConfigPopover({
               </button>
             </div>
             <p className="mt-1 text-[10px] leading-snug text-muted-foreground/70">
-              Shrink/grow this tile to fit its content. Off: set the height yourself (content scrolls).
+              <Trans>Shrink/grow this tile to fit its content. Off: set the height yourself (content scrolls).</Trans>
             </p>
           </div>
         )}
@@ -1018,7 +1024,7 @@ function AddWidgetModal({
     if (boardFilter === 'off' && present.has(id)) return false
     if (!needle) return true
     const w = defById(id)
-    return w.title.toLowerCase().includes(needle) || (WIDGET_DESC[id] ?? '').toLowerCase().includes(needle)
+    return i18n._(w.title).toLowerCase().includes(needle) || (WIDGET_DESC[id] ? i18n._(WIDGET_DESC[id]) : '').toLowerCase().includes(needle)
   }
   const groups = GALLERY_GROUPS.map((g) => ({ ...g, ids: g.ids.filter(matches) })).filter((g) => g.ids.length > 0)
 
@@ -1028,10 +1034,10 @@ function AddWidgetModal({
       <div className="relative z-10 w-full max-w-3xl max-h-[85vh] overflow-y-auto rounded-2xl border border-border bg-card p-5 shadow-xl shadow-accent-soft">
         <div className="mb-3 flex items-start justify-between">
           <div>
-            <h2 className="text-base font-semibold">Add a widget</h2>
-            <p className="text-xs text-muted-foreground">Removed a tile? Add it back — or add another copy.</p>
+            <h2 className="text-base font-semibold"><Trans>Add a widget</Trans></h2>
+            <p className="text-xs text-muted-foreground"><Trans>Removed a tile? Add it back — or add another copy.</Trans></p>
           </div>
-          <button type="button" onClick={onClose} aria-label="Close" className="rounded-md p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground">
+          <button type="button" onClick={onClose} aria-label={t`Close`} className="rounded-md p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground">
             <X className="h-4 w-4" />
           </button>
         </div>
@@ -1043,13 +1049,13 @@ function AddWidgetModal({
               autoFocus
               value={q}
               onChange={(e) => setQ(e.target.value)}
-              placeholder="Search widgets…"
+              placeholder={t`Search widgets…`}
               className="w-full rounded-lg border border-border bg-background py-1.5 pl-8 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:border-primary focus:outline-none"
             />
           </div>
           {/* quick filter: every widget vs only those already on / not yet on this board */}
           <div className="flex shrink-0 items-center gap-0.5 rounded-lg bg-muted p-0.5 text-xs">
-            {([['all', 'All'], ['on', 'On board'], ['off', 'Not on board']] as const).map(([id, label]) => (
+            {([['all', t`All`], ['on', t`On board`], ['off', t`Not on board`]] as const).map(([id, label]) => (
               <button
                 key={id}
                 type="button"
@@ -1066,13 +1072,13 @@ function AddWidgetModal({
         </div>
 
         {groups.length === 0 && (
-          <p className="py-10 text-center text-sm text-muted-foreground">{needle ? `No widgets match “${q}”.` : boardFilter === 'on' ? 'No widgets on this board yet.' : 'Every widget is already on this board.'}</p>
+          <p className="py-10 text-center text-sm text-muted-foreground">{needle ? t`No widgets match “${q}”.` : boardFilter === 'on' ? t`No widgets on this board yet.` : t`Every widget is already on this board.`}</p>
         )}
 
         <div className="flex flex-col gap-5">
           {groups.map((group) => (
-            <div key={group.label}>
-              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{group.label}</h3>
+            <div key={group.ids[0]}>
+              <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">{i18n._(group.label)}</h3>
               <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
                 {group.ids.map((id) => {
                   const w = defById(id)
@@ -1081,7 +1087,7 @@ function AddWidgetModal({
                       key={id}
                       type="button"
                       onClick={() => onAdd(id)}
-                      title={WIDGET_DESC[id]}
+                      title={WIDGET_DESC[id] ? i18n._(WIDGET_DESC[id]) : undefined}
                       className="group/card flex flex-col gap-1.5 rounded-lg border border-border bg-background p-2 text-left transition hover:border-primary/50 hover:bg-muted"
                     >
                       {/* live mini-preview. Number/text widgets render at natural size so
@@ -1097,9 +1103,9 @@ function AddWidgetModal({
                         )}
                       </div>
                       <div className="flex items-center gap-1.5 px-0.5">
-                        <span className="truncate text-xs font-medium text-foreground">{w.title}</span>
+                        <span className="truncate text-xs font-medium text-foreground">{i18n._(w.title)}</span>
                         {present.has(id) && (
-                          <span className="ml-auto shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[9px] text-muted-foreground">on board</span>
+                          <span className="ml-auto shrink-0 rounded-full bg-muted px-1.5 py-0.5 text-[9px] text-muted-foreground"><Trans>on board</Trans></span>
                         )}
                       </div>
                     </button>
@@ -1199,6 +1205,7 @@ function TileShell({
     const x = (e.clientX - r.left) / r.width
     const y = (e.clientY - r.top) / r.height
     setGlare({ x: x * 100, y: y * 100 })
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS transform
     tiltRef.current.style.transform = `rotateY(${(x * 2 - 1) * 5}deg) rotateX(${(y * 2 - 1) * -5}deg) translateY(-5px)`
   }
   function onLeave() {
@@ -1246,16 +1253,16 @@ function TileShell({
         {/* truncate, don't wrap — a wrapped title pushes the body out of 1-row tiles.
             12px + a 12px icon keeps long labels ("Reading Time") on one line in a
             narrow ~126px stat tile instead of clipping to "Reading Ti…". */}
-        <h3 className="min-w-0 truncate font-display text-xs font-medium text-muted-foreground">{def.titleFor?.(config) ?? def.title}</h3>
+        <h3 className="min-w-0 truncate font-display text-xs font-medium text-muted-foreground">{def.titleFor?.(config) ?? i18n._(def.title)}</h3>
         {def.infoHint && <def.infoHint />}
         {def.fixedWindow && (
           <span title="This tile uses a fixed window and ignores the range picker" className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
-            {def.fixedWindow}
+            {i18n._(def.fixedWindow)}
           </span>
         )}
         {editMode && def.autoH && config.autoFit && (
-          <span title="Height auto-fits the content — only width is resizable" className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
-            Auto
+          <span title={t`Height auto-fits the content — only width is resizable`} className="shrink-0 rounded bg-muted px-1 py-px text-[9px] font-medium text-muted-foreground">
+            <Trans>Auto</Trans>
           </span>
         )}
         {editMode && (
@@ -1269,7 +1276,7 @@ function TileShell({
                   'no-drag -my-1 rounded-md p-1 transition hover:bg-muted hover:text-foreground',
                   cfgOpen ? 'bg-muted text-foreground' : 'text-muted-foreground',
                 )}
-                aria-label="Configure"
+                aria-label={t`Configure`}
               >
                 <SlidersHorizontal className="h-3.5 w-3.5" />
               </button>
@@ -1280,8 +1287,8 @@ function TileShell({
                 onPointerDown={(e) => e.stopPropagation()}
                 onClick={onDuplicate}
                 className="no-drag -my-1 rounded-md p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground"
-                aria-label={`Duplicate ${def.title}`}
-                title="Duplicate tile"
+                aria-label={(() => { const title = i18n._(def.title); return t`Duplicate ${title}` })()}
+                title={t`Duplicate tile`}
               >
                 <Copy className="h-3.5 w-3.5" />
               </button>
@@ -1291,7 +1298,7 @@ function TileShell({
               onPointerDown={(e) => e.stopPropagation()}
               onClick={onRemove}
               className="no-drag -my-1 rounded-md p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground"
-              aria-label={`Remove ${def.title}`}
+              aria-label={(() => { const title = i18n._(def.title); return t`Remove ${title}` })()}
             >
               <X className="h-3.5 w-3.5" />
             </button>
@@ -1537,10 +1544,12 @@ type CustomRange = { start: string; end: string }
 type PadWidth = 'none' | 'bit' | 'lot'
 const PAD_X: Record<PadWidth, string> = {
   none: 'px-4',
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- Tailwind classes
   bit: 'px-4 sm:px-[7%]',
+  // eslint-disable-next-line lingui/no-unlocalized-strings -- Tailwind classes
   lot: 'px-4 sm:px-[16%]',
 }
-const PAD_LABEL: Record<PadWidth, string> = { none: 'None', bit: 'A bit', lot: 'A lot' }
+const PAD_LABEL: Record<PadWidth, MessageDescriptor> = { none: msg`None`, bit: msg`A bit`, lot: msg`A lot` }
 
 // A tab whose only tile is the Reading Timeline renders full-bleed in view mode:
 // no card, no grid, edge-to-edge and viewport-tall. Edit mode falls back to the
@@ -1580,6 +1589,7 @@ function sanitizePersisted(p: Persisted): Persisted | null {
     const ids = new Set(tiles.map((x) => x.id))
     return {
       id: String(t.id),
+      // eslint-disable-next-line lingui/no-unlocalized-strings -- fallback board name kept stable in storage
       label: String(t.label ?? 'Board'),
       tiles: tiles.map((x) => ({ ...x, config: { ...DEFAULT_CFG, ...(x.config ?? {}) } })),
       layout: (t.layout ?? []).filter((l) => ids.has(l.i)),
@@ -1622,16 +1632,16 @@ function RangeCalendar({ from, to, onPick }: { from: string; to: string; onPick:
   return (
     <div>
       <div className="mb-2 flex items-center justify-between">
-        <button type="button" onClick={() => setView(new Date(y, m - 1, 1))} className="rounded-md p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground" aria-label="Previous month">
+        <button type="button" onClick={() => setView(new Date(y, m - 1, 1))} className="rounded-md p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground" aria-label={t`Previous month`}>
           <ChevronLeft className="h-4 w-4" />
         </button>
         <span className="text-xs font-semibold text-foreground">{monthLabel}</span>
-        <button type="button" onClick={() => setView(new Date(y, m + 1, 1))} className="rounded-md p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground" aria-label="Next month">
+        <button type="button" onClick={() => setView(new Date(y, m + 1, 1))} className="rounded-md p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground" aria-label={t`Next month`}>
           <ChevronRight className="h-4 w-4" />
         </button>
       </div>
       <div className="grid grid-cols-7 gap-0.5">
-        {['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'].map((w) => (
+        {[t`Mo`, t`Tu`, t`We`, t`Th`, t`Fr`, t`Sa`, t`Su`].map((w) => (
           <div key={w} className="py-1 text-center text-[10px] font-medium text-muted-foreground">{w}</div>
         ))}
         {cells.map((d, i) => {
@@ -1702,7 +1712,7 @@ function RangeControl({
             !custom && days === r.days ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
           )}
         >
-          {r.label}
+          {i18n._(r.label)}
         </button>
       ))}
       <button
@@ -1714,7 +1724,7 @@ function RangeControl({
         )}
       >
         <Calendar className="h-3.5 w-3.5" />
-        {custom ? `${fmtDay(custom.start)} – ${fmtDay(custom.end)}` : 'Custom'}
+        {custom ? `${fmtDay(custom.start)} – ${fmtDay(custom.end)}` : t`Custom`}
       </button>
 
       {open && (
@@ -1724,7 +1734,7 @@ function RangeControl({
             <RangeCalendar from={from} to={to} onPick={pick} />
             <div className="mt-2 flex items-center justify-between border-t border-border pt-2 text-xs">
               <span className="text-muted-foreground">
-                {from ? (to ? `${fmtDay(from)} – ${fmtDay(to)}` : `${fmtDay(from)} – …`) : 'Pick a start & end'}
+                {from ? (to ? `${fmtDay(from)} – ${fmtDay(to)}` : `${fmtDay(from)} – …`) : t`Pick a start & end`}
               </span>
               <div className="flex items-center gap-1.5">
                 {custom && (
@@ -1736,7 +1746,7 @@ function RangeControl({
                     }}
                     className="rounded-md px-2 py-1 text-muted-foreground transition hover:text-foreground"
                   >
-                    Clear
+                    <Trans>Clear</Trans>
                   </button>
                 )}
                 <button
@@ -1748,7 +1758,7 @@ function RangeControl({
                   }}
                   className="rounded-md bg-primary px-3 py-1 font-medium text-primary-foreground transition hover:bg-primary/90 disabled:opacity-40"
                 >
-                  Apply
+                  <Trans>Apply</Trans>
                 </button>
               </div>
             </div>
@@ -1807,6 +1817,11 @@ export function StatsPage() {
   const active = tabs.find((t) => t.id === activeTabId) ?? tabs[0]
   // View-mode-only: a board holding nothing but the timeline escapes the grid.
   const soloTimeline = !editMode && active.tiles.length === 1 && active.tiles[0].defId === 'reading-timeline'
+  // Hoisted: inside tabs.map the param `t` shadows Lingui's t.
+  const renameBoardLabel = (name: string) => t`Rename ${name}`
+  const deleteBoardLabel = (name: string) => t`Delete ${name}`
+  const renameBoardTitle = t`Rename board`
+  const deleteBoardTitle = t`Delete board`
   // genuinely no reading history (not just a quiet range): full onboarding state
   const neverRead = !!stats && stats.headline.total_sessions === 0 && stats.heatmap_daily.every((d) => d.seconds === 0)
 
@@ -1936,7 +1951,7 @@ export function StatsPage() {
       updateActive((t) => ({ ...t, tiles: t.tiles.filter((x) => x.id !== id), layout: t.layout.filter((it) => it.i !== id) }))
       if (tile && lay) {
         const def = defById(tile.defId)
-        pushUndo(`Removed “${def.titleFor?.(tile.config) ?? def.title}”`, () => {
+        pushUndo((() => { const title = def.titleFor?.(tile.config) ?? i18n._(def.title); return t`Removed “${title}”` })(), () => {
           setTabs((prev) => prev.map((t) => (t.id === tabId ? { ...t, tiles: [...t.tiles, tile], layout: [...t.layout, lay] } : t)))
         })
       }
@@ -2014,9 +2029,9 @@ export function StatsPage() {
           const tiles = (p.tiles as Tile[]).filter((x) => WIDGETS.some((w) => w.id === x.defId)).map((x) => ({ ...x, config: { ...DEFAULT_CFG, ...(x.config ?? {}) } }))
           const ids = new Set(tiles.map((x) => x.id))
           const layout = (p.layout as Layout).filter((l) => ids.has(l.i))
-          addTabWith(String(p.label ?? 'Imported board'), tiles, layout)
+          addTabWith(String(p.label ?? t`Imported board`), tiles, layout)
         } catch {
-          pushUndo('That file is not a Tome board export.', () => {})
+          pushUndo(t`That file is not a Tome board export.`, () => {})
         }
       })
     },
@@ -2046,7 +2061,7 @@ export function StatsPage() {
       const remaining = tabs.filter((t) => t.id !== id)
       setTabs(remaining)
       setActiveTabId((cur) => (cur === id ? (remaining[Math.max(0, idx - 1)] ?? remaining[0]).id : cur))
-      pushUndo(`Deleted board “${removed.label}”`, () => {
+      pushUndo((() => { const name = removed.label; return t`Deleted board “${name}”` })(), () => {
         setTabs((prev) => {
           const next = [...prev]
           next.splice(Math.min(idx, next.length), 0, removed)
@@ -2075,6 +2090,7 @@ export function StatsPage() {
 
   return (
     <AppShell>
+      {/* eslint-disable-next-line lingui/no-unlocalized-strings -- CSS */}
       <style>{`
         .react-grid-item.react-grid-placeholder {
           background: var(--primary, #6366f1) !important;
@@ -2105,12 +2121,12 @@ export function StatsPage() {
         {/* min-h + wrap: on phones the range pills don't fit beside the title row,
             so they wrap to a second line instead of overflowing the viewport */}
         <div className={cn('flex min-h-14 flex-wrap items-center gap-x-3 py-1.5 px-4')}>
-          <h1 className="font-display text-xl text-foreground">Reading Stats</h1>
+          <h1 className="font-display text-xl text-foreground"><Trans>Reading Stats</Trans></h1>
           <a
             href={docsLink(DOCS.stats)}
             target="_blank"
             rel="noopener noreferrer"
-            title="What do these mean? — read the stats docs"
+            title={t`What do these mean? — read the stats docs`}
             className="rounded-md p-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
           >
             <HelpCircle className="h-3.5 w-3.5" />
@@ -2181,8 +2197,8 @@ export function StatsPage() {
                     <button
                       type="button"
                       onClick={() => setRenamingId(t.id)}
-                      aria-label={`Rename ${t.label}`}
-                      title="Rename board"
+                      aria-label={renameBoardLabel(t.label)}
+                      title={renameBoardTitle}
                       className={cn('rounded p-0.5 text-muted-foreground transition hover:text-foreground', tabs.length > 1 ? '' : 'mr-1.5')}
                     >
                       <Pencil className="h-3 w-3" />
@@ -2191,8 +2207,8 @@ export function StatsPage() {
                       <button
                         type="button"
                         onClick={() => deleteTab(t.id)}
-                        aria-label={`Delete ${t.label}`}
-                        title="Delete board"
+                        aria-label={deleteBoardLabel(t.label)}
+                        title={deleteBoardTitle}
                         className="mr-1.5 rounded p-0.5 text-muted-foreground transition hover:text-foreground"
                       >
                         <X className="h-3 w-3" />
@@ -2208,8 +2224,8 @@ export function StatsPage() {
                 <button
                   type="button"
                   onClick={() => setTabMenuOpen((o) => !o)}
-                  aria-label="Add board"
-                  title="Add board"
+                  aria-label={t`Add board`}
+                  title={t`Add board`}
                   className={cn(
                     'flex items-center rounded-md px-2 py-1.5 transition hover:bg-muted/50 hover:text-foreground',
                     tabMenuOpen ? 'bg-muted/50 text-foreground' : 'text-muted-foreground',
@@ -2223,38 +2239,38 @@ export function StatsPage() {
                     <div className="absolute left-0 top-full z-50 mt-1.5 w-48 rounded-lg border border-border bg-card p-1 text-xs shadow-xl">
                       <button
                         type="button"
-                        onClick={() => addTabWith('New board', [], [], true)}
+                        onClick={() => addTabWith(t`New board`, [], [], true)}
                         className="w-full rounded-md px-2 py-1.5 text-left text-foreground transition hover:bg-muted"
                       >
-                        Empty board
+                        <Trans>Empty board</Trans>
                       </button>
                       <button
                         type="button"
-                        onClick={() => addTabWith(`${active.label} copy`, active.tiles.map((x) => ({ ...x, config: { ...x.config } })), active.layout.map((l) => ({ ...l })))}
+                        onClick={() => { const name = active.label; addTabWith(t`${name} copy`, active.tiles.map((x) => ({ ...x, config: { ...x.config } })), active.layout.map((l) => ({ ...l }))) }}
                         className="w-full truncate rounded-md px-2 py-1.5 text-left text-foreground transition hover:bg-muted"
                       >
-                        Duplicate “{active.label}”
+                        {(() => { const name = active.label; return <Trans>Duplicate “{name}”</Trans> })()}
                       </button>
                       <button
                         type="button"
                         onClick={() => importInputRef.current?.click()}
                         className="flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-foreground transition hover:bg-muted"
                       >
-                        <Upload className="h-3 w-3 text-muted-foreground" /> Import board…
+                        <Upload className="h-3 w-3 text-muted-foreground" /> <Trans>Import board…</Trans>
                       </button>
                       <div className="my-1 border-t border-border" />
-                      <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">Start from default</p>
+                      <p className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground"><Trans>Start from default</Trans></p>
                       {TAB_DEFS.map((d) => (
                         <button
                           key={d.id}
                           type="button"
                           onClick={() => {
                             const b = buildTab(d)
-                            addTabWith(d.label, b.tiles, b.layout)
+                            addTabWith(i18n._(d.label), b.tiles, b.layout)
                           }}
                           className="w-full rounded-md px-2 py-1.5 text-left text-foreground transition hover:bg-muted"
                         >
-                          {d.label}
+                          {i18n._(d.label)}
                         </button>
                       ))}
                     </div>
@@ -2282,13 +2298,13 @@ export function StatsPage() {
                   className={cn('flex items-center gap-1 text-[10px]', saveState === 'error' ? 'text-red-500' : 'text-muted-foreground')}
                 >
                   {saveState === 'saving' ? <Loader2 className="h-3 w-3 animate-spin" /> : saveState === 'saved' ? <Check className="h-3 w-3" /> : <CloudOff className="h-3 w-3" />}
-                  {saveState === 'saving' ? 'Saving' : saveState === 'saved' ? 'Saved' : 'Save failed'}
+                  {saveState === 'saving' ? t`Saving` : saveState === 'saved' ? t`Saved` : t`Save failed`}
                 </span>
               )}
               {editMode && (
                 <>
                   <div className="flex items-center gap-0.5 rounded-lg bg-muted p-0.5 text-xs">
-                    <span className="px-1.5 text-muted-foreground">Padding</span>
+                    <span className="px-1.5 text-muted-foreground"><Trans>Padding</Trans></span>
                     {(['none', 'bit', 'lot'] as const).map((w) => (
                       <button
                         key={w}
@@ -2299,18 +2315,18 @@ export function StatsPage() {
                           pad === w ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground',
                         )}
                       >
-                        {PAD_LABEL[w]}
+                        {i18n._(PAD_LABEL[w])}
                       </button>
                     ))}
                   </div>
                   <button type="button" onClick={() => setAddOpen(true)} className="flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1 text-xs font-medium text-foreground transition hover:bg-muted">
-                    <Plus className="h-3.5 w-3.5" /> Add tile
+                    <Plus className="h-3.5 w-3.5" /> <Trans>Add tile</Trans>
                   </button>
                   <button type="button" onClick={reset} className="flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground transition hover:bg-muted">
-                    <RotateCcw className="h-3.5 w-3.5" /> Reset
+                    <RotateCcw className="h-3.5 w-3.5" /> <Trans>Reset</Trans>
                   </button>
-                  <button type="button" onClick={exportBoard} title="Export this board as a JSON file (share or back up)" className="flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground transition hover:bg-muted">
-                    <Download className="h-3.5 w-3.5" /> Export
+                  <button type="button" onClick={exportBoard} title={t`Export this board as a JSON file (share or back up)`} className="flex items-center gap-1 rounded-md border border-border bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground transition hover:bg-muted">
+                    <Download className="h-3.5 w-3.5" /> <Trans>Export</Trans>
                   </button>
                 </>
               )}
@@ -2318,8 +2334,8 @@ export function StatsPage() {
                 type="button"
                 onClick={exportImage}
                 disabled={shotBusy}
-                title="Save this board as an image"
-                aria-label="Save board as image"
+                title={t`Save this board as an image`}
+                aria-label={t`Save board as image`}
                 className="flex items-center rounded-md border border-border bg-card p-1.5 text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:opacity-50"
               >
                 {shotBusy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <ImageDown className="h-3.5 w-3.5" />}
@@ -2338,7 +2354,7 @@ export function StatsPage() {
                 )}
               >
                 {editMode ? <Check className="h-3.5 w-3.5" /> : <Pencil className="h-3.5 w-3.5" />}
-                {editMode ? 'Done' : 'Edit'}
+                {editMode ? t`Done` : t`Edit`}
               </button>
             </div>
           </div>
@@ -2353,7 +2369,7 @@ export function StatsPage() {
         <div className="mb-4 flex items-center gap-2 rounded-lg border border-primary/30 bg-primary/5 px-3 py-2 text-xs">
           <Sparkles className="h-3.5 w-3.5 shrink-0 text-primary" />
           <span className="text-foreground">
-            This page is yours — every tile can be moved, resized, swapped or removed, per board. Hit{' '}
+            <Trans>This page is yours — every tile can be moved, resized, swapped or removed, per board. Hit{' '}
             <button
               type="button"
               onClick={() => {
@@ -2364,9 +2380,9 @@ export function StatsPage() {
             >
               Edit
             </button>{' '}
-            to start. Reset always brings the defaults back.
+            to start. Reset always brings the defaults back.</Trans>
           </span>
-          <button type="button" onClick={dismissHint} aria-label="Dismiss" className="ml-auto rounded p-0.5 text-muted-foreground transition hover:text-foreground">
+          <button type="button" onClick={dismissHint} aria-label={t`Dismiss`} className="ml-auto rounded p-0.5 text-muted-foreground transition hover:text-foreground">
             <X className="h-3.5 w-3.5" />
           </button>
         </div>
@@ -2377,7 +2393,7 @@ export function StatsPage() {
       {stats && !neverRead && stats.headline.total_sessions === 0 && (
         <div className="mb-4 flex items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
           <BarChart3 className="h-3.5 w-3.5 shrink-0 opacity-60" />
-          No reading sessions in this range — session-based tiles will be empty.
+          <Trans>No reading sessions in this range — session-based tiles will be empty.</Trans>
         </div>
       )}
 
@@ -2388,22 +2404,22 @@ export function StatsPage() {
       ) : neverRead ? (
         <div className="flex flex-col items-center justify-center gap-4 py-32 text-muted-foreground">
           <BarChart3 className="h-16 w-16 opacity-20" />
-          <p className="text-sm font-medium text-foreground">No reading data yet</p>
+          <p className="text-sm font-medium text-foreground"><Trans>No reading data yet</Trans></p>
           <p className="max-w-xs text-center text-xs">
-            Reading stats appear once sessions arrive — synced from the TomeSync
+            <Trans>Reading stats appear once sessions arrive — synced from the TomeSync
             KOReader plugin, logged by hand on a book page, or imported from a
-            KOReader statistics file.
+            KOReader statistics file.</Trans>
           </p>
           <Link to="/settings" className="text-xs text-primary hover:underline">
-            Download the plugin from Settings
+            <Trans>Download the plugin from Settings</Trans>
           </Link>
         </div>
       ) : stats ? (
         active.tiles.length === 0 ? (
           <div className="flex flex-col items-center gap-2 py-24 text-muted-foreground">
             <Plus className="h-10 w-10 opacity-20" />
-            <p className="text-sm">This board is empty.</p>
-            <p className="text-xs">{editMode ? 'Use “Add tile” to build your ' + active.label + ' board.' : 'Hit Edit, then Add tile.'}</p>
+            <p className="text-sm"><Trans>This board is empty.</Trans></p>
+            <p className="text-xs">{editMode ? (() => { const name = active.label; return t`Use “Add tile” to build your ${name} board.` })() : t`Hit Edit, then Add tile.`}</p>
           </div>
         ) : soloTimeline ? (
           <FullBleedTimeline />
@@ -2413,7 +2429,7 @@ export function StatsPage() {
           </div>
         )
       ) : (
-        <p className="py-32 text-center text-sm text-muted-foreground">Couldn’t load stats.</p>
+        <p className="py-32 text-center text-sm text-muted-foreground"><Trans>Couldn’t load stats.</Trans></p>
       )}
       </div>
 
@@ -2433,9 +2449,9 @@ export function StatsPage() {
             }}
             className="font-medium text-primary transition hover:underline"
           >
-            Undo
+            <Trans>Undo</Trans>
           </button>
-          <button type="button" onClick={() => setUndo(null)} aria-label="Dismiss" className="rounded p-0.5 text-muted-foreground transition hover:text-foreground">
+          <button type="button" onClick={() => setUndo(null)} aria-label={t`Dismiss`} className="rounded p-0.5 text-muted-foreground transition hover:text-foreground">
             <X className="h-3.5 w-3.5" />
           </button>
         </div>

--- a/frontend/src/pages/StatsPage.tsx
+++ b/frontend/src/pages/StatsPage.tsx
@@ -420,12 +420,13 @@ const WIDGETS: WidgetDef[] = [
   },
   {
     id: 'backlog-estimate',
-    title: 'Backlog',
+    title: msg`Backlog`,
     size: { w: 12, h: 2, minW: 4, minH: 2 },
     autoH: true,
     scopePicker: true,
+    // eslint-disable-next-line lingui/no-unlocalized-strings -- persisted default; UI shows the live scope label
     defaultConfig: { chartType: 'bar', days: 0, scope: DEFAULT_BACKLOG_SCOPE, scopeLabel: 'Want to Read', autoFit: true },
-    titleFor: (cfg) => `Backlog · ${cfg.scopeLabel ?? 'Want to Read'}`,
+    titleFor: (cfg) => { const scope = cfg.scopeLabel ?? t`Want to Read`; return t`Backlog · ${scope}` },
     render: (_ctx, cfg) => <BacklogEstimate scope={cfg.scope} />,
   },
   {
@@ -869,7 +870,7 @@ function ConfigPopover({
       >
         {def.scopePicker && (
           <>
-            <p className="mb-1.5 font-medium text-muted-foreground">Scope</p>
+            <p className="mb-1.5 font-medium text-muted-foreground"><Trans>Scope</Trans></p>
             {scopes ? (
               <select
                 value={config.scope ?? DEFAULT_BACKLOG_SCOPE}
@@ -880,17 +881,18 @@ function ConfigPopover({
                 className="w-full rounded-md border border-border bg-background px-1.5 py-1 text-xs text-foreground focus:border-primary focus:outline-none"
               >
                 {scopes.filter((s) => !s.group).map((s) => <option key={s.id} value={s.id}>{s.label}</option>)}
+                {/* eslint-disable-next-line lingui/no-unlocalized-strings -- API group keys */}
                 {(['Libraries', 'Shelves'] as const).map((g) => {
                   const items = scopes.filter((s) => s.group === g)
                   return items.length > 0 ? (
-                    <optgroup key={g} label={g}>
+                    <optgroup key={g} label={g === 'Libraries' ? t`Libraries` : t`Shelves`}>
                       {items.map((s) => <option key={s.id} value={s.id}>{s.label}</option>)}
                     </optgroup>
                   ) : null
                 })}
               </select>
             ) : (
-              <p className="text-muted-foreground/70">Loading…</p>
+              <p className="text-muted-foreground/70"><Trans>Loading…</Trans></p>
             )}
           </>
         )}

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable lingui/no-unlocalized-strings -- DEAD CODE: /users redirects to /admin
+   (AdminPage's UsersTab replaced this page). Not translated; candidate for deletion. */
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import {

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -338,7 +338,7 @@ export function WishlistPage() {
                         onClick={() => handleDelete(w)}
                         disabled={deleting === w.id}
                         className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors shrink-0 disabled:opacity-40"
-                        title="Remove wish"
+                        title={t`Remove wish`}
                         aria-label={t`Remove wish`}
                       >
                         {deleting === w.id

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -14,6 +14,8 @@ import { WishlistModal } from '@/components/WishlistModal'
 import { SeriesCoverageStrip } from '@/components/SeriesCoverageStrip'
 import { docsLink, DOCS } from '@/lib/docs'
 import { cn } from '@/lib/utils'
+import { Trans, Plural } from '@lingui/react/macro'
+import { t } from '@lingui/core/macro'
 
 function WishCover({ coverUrl }: { coverUrl: string | null }) {
   return (
@@ -35,12 +37,12 @@ function WishCover({ coverUrl }: { coverUrl: string | null }) {
 function ageLabel(iso: string): string {
   const diff = Date.now() - new Date(iso).getTime()
   const days = Math.floor(diff / 86_400_000)
-  if (days === 0) return 'Today'
-  if (days === 1) return 'Yesterday'
-  if (days < 30) return `${days}d ago`
+  if (days === 0) return t`Today`
+  if (days === 1) return t`Yesterday`
+  if (days < 30) return t`${days}d ago`
   const months = Math.floor(days / 30)
-  if (months < 12) return `${months}mo ago`
-  return `${Math.floor(months / 12)}y ago`
+  if (months < 12) return t`${months}mo ago`
+  { const years = Math.floor(months / 12); return t`${years}y ago` }
 }
 
 // ── Following (release detection) ─────────────────────────────────────────────
@@ -104,18 +106,18 @@ function FollowingSection() {
   return (
     <div>
       <div className="flex items-center justify-between mb-1">
-        <h2 className="text-sm font-semibold text-foreground">Following</h2>
-        <span className="text-xs text-muted-foreground">{follows.length} series</span>
+        <h2 className="text-sm font-semibold text-foreground"><Trans>Following</Trans></h2>
+        <span className="text-xs text-muted-foreground"><Plural value={follows.length} one="# series" other="# series" /></span>
       </div>
       <p className="text-xs text-muted-foreground mb-3">
-        Get notified when a new volume of a followed series is released.
+        <Trans>Get notified when a new volume of a followed series is released.</Trans>
       </p>
 
       <div className="relative mb-3">
         <input
           value={q}
           onChange={e => setQ(e.target.value)}
-          placeholder="Follow a series — search Hardcover…"
+          placeholder={t`Follow a series — search Hardcover…`}
           className="w-full h-9 px-3 rounded-lg bg-muted border border-border text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
         />
         {searching && <Loader2 className="absolute right-3 top-2.5 w-4 h-4 animate-spin text-muted-foreground" />}
@@ -134,7 +136,7 @@ function FollowingSection() {
                 <span className="min-w-0 flex-1">
                   <span className="block text-sm text-foreground truncate">{r.name}</span>
                   <span className="block text-xs text-muted-foreground truncate">
-                    {r.author ?? 'Unknown author'}{r.total ? ` · ${r.total} volumes` : ''}
+                    {r.author ?? t`Unknown author`}{(() => { const n = r.total; return n ? t` · ${n} volumes` : '' })()}
                   </span>
                 </span>
                 <Plus className="w-4 h-4 text-muted-foreground shrink-0" />
@@ -154,14 +156,14 @@ function FollowingSection() {
               <div className="min-w-0 flex-1">
                 <p className="text-sm font-medium text-foreground truncate">{f.name}</p>
                 <p className="text-xs text-muted-foreground truncate">
-                  {f.latest_known_index != null && <>Latest: vol {fmtVol(f.latest_known_index)}</>}
-                  {f.owned_max_index != null && <> · you have vol {fmtVol(f.owned_max_index)}</>}
+                  {f.latest_known_index != null && (() => { const v = fmtVol(f.latest_known_index); return <Trans>Latest: vol {v}</Trans> })()}
+                  {f.owned_max_index != null && (() => { const v = fmtVol(f.owned_max_index); return <Trans> · you have vol {v}</Trans> })()}
                 </p>
               </div>
               <button
                 onClick={() => unfollow(f.id)}
-                title="Unfollow"
-                aria-label={`Unfollow ${f.name}`}
+                title={t`Unfollow`}
+                aria-label={(() => { const name = f.name; return t`Unfollow ${name}` })()}
                 className="p-1.5 rounded text-muted-foreground/60 hover:text-destructive transition-colors"
               >
                 <Trash2 className="w-4 h-4" />
@@ -193,7 +195,7 @@ export function WishlistPage() {
       const all = await listWishes()
       setWishes(all)
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load wishlist')
+      setError(e instanceof Error ? e.message : t`Failed to load wishlist`)
     } finally {
       setLoading(false)
     }
@@ -213,9 +215,9 @@ export function WishlistPage() {
     try {
       await deleteWish(wish.id)
       setWishes(prev => prev.filter(w => w.id !== wish.id))
-      toast.success('Wish removed')
+      toast.success(t`Wish removed`)
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : 'Failed to remove wish')
+      toast.error(e instanceof Error ? e.message : t`Failed to remove wish`)
     } finally {
       setDeleting(null)
     }
@@ -229,8 +231,8 @@ export function WishlistPage() {
       <AppShell>
         <div className="flex flex-col items-center justify-center gap-3 py-24 text-center">
           <Sparkles className="w-10 h-10 text-muted-foreground" />
-          <p className="text-sm text-muted-foreground">Members can add books to their wishlist.</p>
-          <Link to="/" className="text-sm text-primary hover:underline">Go back</Link>
+          <p className="text-sm text-muted-foreground"><Trans>Members can add books to their wishlist.</Trans></p>
+          <Link to="/" className="text-sm text-primary hover:underline"><Trans>Go back</Trans></Link>
         </div>
       </AppShell>
     )
@@ -244,12 +246,12 @@ export function WishlistPage() {
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
         >
           <Plus className="w-3.5 h-3.5" />
-          <span className="hidden sm:inline">Wish</span>
+          <span className="hidden sm:inline"><Trans>Wish</Trans></span>
         </button>
       }
     >
       <div className="max-w-3xl mx-auto px-4 py-6 space-y-6">
-        <h1 className="font-display text-xl text-foreground">Wishlist</h1>
+        <h1 className="font-display text-xl text-foreground"><Trans>Wishlist</Trans></h1>
         {loading ? (
           <div className="flex justify-center py-16">
             <Loader2 className="w-6 h-6 animate-spin text-muted-foreground" />
@@ -266,7 +268,7 @@ export function WishlistPage() {
               {openWishes.length > 0 && (
                 <div className="flex items-center justify-between mb-3">
                   <h2 className="text-sm font-semibold text-foreground">
-                    Open
+                    <Trans>Open</Trans>
                     <span className="ml-2 text-xs font-normal text-muted-foreground">({openWishes.length})</span>
                   </h2>
                   <a
@@ -275,7 +277,7 @@ export function WishlistPage() {
                     rel="noopener noreferrer"
                     className="shrink-0 inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors"
                   >
-                    Learn more <ExternalLink className="w-3 h-3" />
+                    <Trans>Learn more</Trans> <ExternalLink className="w-3 h-3" />
                   </a>
                 </div>
               )}
@@ -284,16 +286,16 @@ export function WishlistPage() {
                 <div className="flex flex-col items-center gap-4 py-12 text-center">
                   <Sparkles className="w-12 h-12 text-muted-foreground/30" />
                   <div>
-                    <p className="text-sm font-medium text-foreground mb-1">Your wishlist is empty</p>
+                    <p className="text-sm font-medium text-foreground mb-1"><Trans>Your wishlist is empty</Trans></p>
                     <p className="text-xs text-muted-foreground">
-                      Add books you'd like to see in the library.{' '}
+                      <Trans>Add books you'd like to see in the library.</Trans>{' '}
                       <a
                         href={docsLink(DOCS.wishlist)}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="underline underline-offset-2 hover:text-primary transition-colors"
                       >
-                        Learn more
+                        <Trans>Learn more</Trans>
                       </a>
                     </p>
                   </div>
@@ -302,7 +304,7 @@ export function WishlistPage() {
                     className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
                   >
                     <Plus className="w-4 h-4" />
-                    Add a wish
+                    <Trans>Add a wish</Trans>
                   </button>
                 </div>
               ) : (
@@ -321,7 +323,7 @@ export function WishlistPage() {
                         {w.series && w.series_index == null && (
                           <span className="mt-0.5 self-start inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-muted border border-border text-muted-foreground font-medium">
                             <Layers className="w-2.5 h-2.5" />
-                            Whole series
+                            <Trans>Whole series</Trans>
                           </span>
                         )}
                         {w.series && w.series_index == null && w.series_coverage && w.series_coverage.length > 0 && (
@@ -337,7 +339,7 @@ export function WishlistPage() {
                         disabled={deleting === w.id}
                         className="p-1.5 rounded-md text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors shrink-0 disabled:opacity-40"
                         title="Remove wish"
-                        aria-label="Remove wish"
+                        aria-label={t`Remove wish`}
                       >
                         {deleting === w.id
                           ? <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -357,7 +359,7 @@ export function WishlistPage() {
                   className="flex items-center gap-2 text-sm font-semibold text-muted-foreground hover:text-foreground transition-colors mb-3"
                 >
                   {fulfilledOpen ? <ChevronUp className="w-4 h-4" /> : <ChevronDown className="w-4 h-4" />}
-                  Fulfilled
+                  <Trans>Fulfilled</Trans>
                   <span className="text-xs font-normal">({fulfilledWishes.length})</span>
                 </button>
 
@@ -376,14 +378,14 @@ export function WishlistPage() {
                           <p className="text-sm font-medium text-foreground leading-snug line-clamp-2">{w.title}</p>
                           {w.author && <p className="text-xs text-muted-foreground truncate">{w.author}</p>}
                           <span className="mt-1 self-start text-[10px] px-1.5 py-0.5 rounded bg-success/10 text-success border border-success/20 font-medium">
-                            Fulfilled
+                            <Trans>Fulfilled</Trans>
                           </span>
                           {w.fulfilled_book_id && (
                             <Link
                               to={`/books/${w.fulfilled_book_id}`}
                               className="mt-1 text-xs text-primary hover:underline"
                             >
-                              View book
+                              <Trans>View book</Trans>
                             </Link>
                           )}
                         </div>
@@ -404,7 +406,7 @@ export function WishlistPage() {
           onClose={() => setAddOpen(false)}
           onCreated={() => {
             load()
-            toast.success('Wish added')
+            toast.success(t`Wish added`)
           }}
         />
       )}

--- a/frontend/src/po.d.ts
+++ b/frontend/src/po.d.ts
@@ -1,0 +1,6 @@
+// Compiled message catalogs — @lingui/vite-plugin turns a `.po` import into
+// `{ messages }` at build time.
+declare module '*.po' {
+  import type { Messages } from '@lingui/core'
+  export const messages: Messages
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
 import { VitePWA } from 'vite-plugin-pwa'
+import { lingui, linguiTransformerBabelPreset } from '@lingui/vite-plugin'
+import babel from '@rolldown/plugin-babel'
 
 export default defineConfig({
   // Some deps (react-draggable, prop-types — pulled in by react-grid-layout) read
@@ -13,6 +15,12 @@ export default defineConfig({
   },
   plugins: [
     react(),
+    // Lingui: <Trans>, t`` and msg`` macros are compiled away by a Babel plugin.
+    // @vitejs/plugin-react v6 no longer runs Babel itself, so the macro runs via
+    // @rolldown/plugin-babel (the preset scopes it to our sources). lingui() turns
+    // `import ... from './messages.po'` into compiled message catalogs.
+    lingui(),
+    babel({ presets: [linguiTransformerBabelPreset()] }),
     tailwindcss(),
     VitePWA({
       registerType: 'autoUpdate',


### PR DESCRIPTION
Makes the web frontend translatable. Source strings stay inline in English; translations live in gettext `.po` catalogs under `frontend/src/locales/` and are community-maintained (`docs/translating.md`).

## What's in here

- **Lingui 6 scaffold**: `@lingui/react` macros compiled via `@rolldown/plugin-babel` (plugin-react v6 has no Babel option), catalogs compiled at build time by `@lingui/vite-plugin`. Locale plumbing in `src/lib/i18n.ts` — stored preference (`tome_locale`) → browser language → English, activated before first render.
- **Language picker** in Settings → Appearance.
- **Full extraction sweep**: every user-facing string across all pages and components — 1,754 messages. JSX text via `<Trans>`, toasts/attributes/confirms via `t`, plurals via `<Plural>`, module-level label maps as `msg` descriptors resolved at render.
- **Lint enforcement**: `lingui/no-unlocalized-strings` is an *error* — the burn-down went 2,361 → 0, so new bare strings fail lint. Product names (Tome, TomeSync, KOReader, Hardcover, …) are exempt and never translated. Note: the plugin never checks `title=` attributes; those were swept manually and will need manual attention in future PRs.
- **CI freshness check**: `lingui extract` + `git diff --exit-code -- src/locales` fails the build on stale catalogs.
- **zh-CN catalog** scaffolded for the reporter of #183 to fill in. Untranslated strings fall back to English.
- Catalog hygiene: merged near-duplicate msgids (`...` → `…`).

## Scope

The KOReader plugin, website, OPDS feed, and backend error strings stay English-only in v1 by design.

## Verification

- Every sweep area was screenshot-diffed before/after against the showcase instance (two vite roots, same backend, frozen animations, PIL pixel diff) — English rendering is pixel-identical everywhere; the reader (page, TOC drawer, settings panel, error states) verified the same way.
- `npm run build` green, eslint at 0 lingui findings, catalogs fresh.

Closes #183 (translation infrastructure; the zh-CN translation itself lands as follow-up contributions).