### PR TITLE
Fix OPDS search: point OpenSearch template at the results endpoint

### DIFF
--- a/backend/api/opds.py
+++ b/backend/api/opds.py
@@ -334,7 +334,7 @@ def opds_search_descriptor(request: Request, user: User = Depends(get_current_us
         f'<InputEncoding>UTF-8</InputEncoding>'
         f'<OutputEncoding>UTF-8</OutputEncoding>'
         f'<Url type="{ACQUISITION_TYPE}"'
-        f'     template="{base}/opds/search?q={{searchTerms}}"/>'
+        f'     template="{base}/opds/search/results?q={{searchTerms}}"/>'
         '</OpenSearchDescription>'
     )
     return Response(content=xml, media_type="application/opensearchdescription+xml")

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -126,3 +126,44 @@ def test_opds_root_endpoint_serves_default_namespace(client):
         assert "ns0:" not in resp.text
     finally:
         client.app.dependency_overrides.pop(get_current_user_basic, None)
+
+
+def test_opds_search_descriptor_targets_results_endpoint(client):
+    """The OpenSearch descriptor's Url template must point at the results feed,
+    not back at the descriptor itself — otherwise a client that follows the
+    template gets opensearchdescription XML instead of an acquisition feed and
+    shows nothing (GH #191)."""
+    import re
+
+    client.app.dependency_overrides[get_current_user_basic] = lambda: _AdminUser()
+    try:
+        resp = client.get("/opds/search")
+        assert resp.status_code == 200
+        assert "opensearchdescription" in resp.headers["content-type"]
+        tmpl = re.search(r'template="([^"]+)"', resp.text).group(1)
+        assert tmpl.endswith("/opds/search/results?q={searchTerms}"), tmpl
+    finally:
+        client.app.dependency_overrides.pop(get_current_user_basic, None)
+
+
+def test_opds_search_via_descriptor_template_returns_results(client, make_book):
+    """End-to-end: resolving the advertised OpenSearch template must yield an
+    acquisition feed containing the match — the exact path an OPDS reader takes
+    when the user searches (GH #191). Fails if the template bounces back to the
+    descriptor."""
+    import re
+
+    make_book(title="Findable Unique Title", author="Searchable Author")
+    client.app.dependency_overrides[get_current_user_basic] = lambda: _AdminUser()
+    try:
+        desc = client.get("/opds/search")
+        tmpl = re.search(r'template="([^"]+)"', desc.text).group(1)
+        url = tmpl.replace("{searchTerms}", "Findable")
+        path = url.split("testserver", 1)[1] if "testserver" in url else url
+
+        resp = client.get(path)
+        assert resp.status_code == 200
+        assert "application/atom+xml" in resp.headers["content-type"]
+        assert "Findable Unique Title" in resp.text
+    finally:
+        client.app.dependency_overrides.pop(get_current_user_basic, None)


### PR DESCRIPTION
Fixes #191.

## Problem
The OpenSearch description served at `/opds/search` advertised
`template="{base}/opds/search?q={searchTerms}"` — which points back at the
descriptor route itself. An OPDS reader that follows the template therefore gets
the OpenSearchDescription XML back instead of an acquisition feed, so search
shows nothing / errors.

## Fix
Point the template at `/opds/search/results`, the route that actually runs the
query. The `q` parameter already matches, so this is a one-line change.

## Test plan
Added two regression tests in `tests/test_opds.py` (both fail before the fix):
- the descriptor's `Url` template targets `/opds/search/results`;
- end-to-end — resolving the advertised template returns an `application/atom+xml`
  acquisition feed containing the match.

`pytest tests/test_opds.py` is green, and the change was verified on a test
deployment with a live OPDS client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
