### PR TITLE
Add per-user tag exclusion and download limits

### DIFF
--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -2113,6 +2113,9 @@ def download_book(
     if not user_can_see_book(db, current_user, book_file.book):
         raise HTTPException(status_code=404, detail="File not found")
 
+    from backend.services.downloads_quota import enforce_download, record_download
+    enforce_download(db, current_user)
+
     file_path = Path(book_file.file_path)
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="File no longer on disk")
@@ -2120,6 +2123,7 @@ def download_book(
     from backend.services.metadata_embed import get_baked_path
     serve_path = get_baked_path(book_file.book, book_file)
     record_served_artifact(db, book_file.book_id, book_file, serve_path)
+    record_download(db, current_user, book_id)
 
     filename = f"{book_file.book.title}.{book_file.format}"
     audit(db, "books.downloaded", user_id=current_user.id, username=current_user.username,

--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -39,6 +39,9 @@ def bulk_download(
     if not books:
         raise HTTPException(404, "No books found")
 
+    from backend.services.downloads_quota import enforce_download, record_download
+    enforce_download(db, current_user, count=len(books))
+
     from backend.services.metadata_embed import get_baked_path
     from backend.services.ko_hash import record_served_artifact
 
@@ -58,6 +61,7 @@ def bulk_download(
                 serve = get_baked_path(book, f)
                 record_served_artifact(db, book.id, f, serve)
                 zf.write(str(serve), f"{folder}/{raw.name}")
+            record_download(db, current_user, book.id)
 
     buf.seek(0)
     # Parity with the single-download path, which audits each download.

--- a/backend/api/opds.py
+++ b/backend/api/opds.py
@@ -393,10 +393,14 @@ def opds_download(
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="File not found on disk")
 
+    from backend.services.downloads_quota import enforce_download, record_download
+    enforce_download(db, user)
+
     from backend.services.audit import audit
     audit(db, "books.downloaded",
           user_id=user.id, username=user.username,
           resource_type="book", resource_id=book.id, resource_title=book.title)
+    record_download(db, user, book.id)
 
     # Queue this download so the next unknown KOSync progress push auto-links to this book
     try:

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -419,6 +419,9 @@ class PermissionsSchema(BaseModel):
     can_use_kosync: bool = True
     can_share: bool = False
     can_bulk_operations: bool = False
+    # Content restrictions (issue #190)
+    excluded_tags: Optional[str] = None   # comma-separated tag names to hide
+    download_limit: Optional[int] = None  # per-day cap; None = unlimited, 0 = off
 
     model_config = {"from_attributes": True}
 
@@ -667,7 +670,10 @@ def set_permissions(
     if not perms:
         perms = UserPermission(user_id=user.id)
         db.add(perms)
-    for field, val in body.model_dump().items():
+    # Partial update: only the fields actually present in the request are
+    # applied, so a caller can change e.g. just the download limit without
+    # resetting every other permission to its schema default.
+    for field, val in body.model_dump(exclude_unset=True).items():
         setattr(perms, field, val)
     db.commit()
     db.refresh(user)

--- a/backend/core/permissions.py
+++ b/backend/core/permissions.py
@@ -28,6 +28,17 @@ def is_admin(user: User) -> bool:
     return user.is_admin or user.role == "admin"
 
 
+def excluded_tags_for(user) -> list[str]:
+    """Tag names this user must never see (issue #190). Parsed from the
+    comma-separated ``UserPermission.excluded_tags``; empty for admins and users
+    with no restriction set."""
+    perms = getattr(user, "permissions", None)
+    raw = getattr(perms, "excluded_tags", None) if perms else None
+    if not raw:
+        return []
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
 def is_member_or_above(user: User) -> bool:
     return has_role(user, "member")
 
@@ -59,7 +70,7 @@ def book_visibility_filter(db: Session, user: User):
     ]
 
     no_library = ~Book.libraries.any()
-    return or_(
+    visible = or_(
         # Own uploads are always visible to their uploader.
         Book.added_by == user.id,
         # Unfiled books fall back to the shared-collection rule: admin-uploaded
@@ -74,6 +85,15 @@ def book_visibility_filter(db: Session, user: User):
         Book.libraries.any(Library.owner_id == user.id),
         Book.libraries.any(Library.assigned_users.any(_User.id == user.id)),
     )
+
+    # Per-user content restriction (issue #190): hide any book carrying one of
+    # the user's excluded tags. Applied on top of visibility so it also removes
+    # the tag from filter dropdowns and blocks downloads of those books.
+    excluded = excluded_tags_for(user)
+    if excluded:
+        from backend.models.book import BookTag
+        visible = and_(visible, ~Book.tags.any(BookTag.tag.in_(excluded)))
+    return visible
 
 
 def user_can_see_book(db: Session, user: User, book: "Book") -> bool:  # type: ignore[name-defined]

--- a/backend/main.py
+++ b/backend/main.py
@@ -146,6 +146,15 @@ async def lifespan(app: FastAPI):
         if "oidc_issuer" not in user_cols:
             conn.execute(text("ALTER TABLE users ADD COLUMN oidc_issuer VARCHAR(255)"))
             conn.commit()
+        # Per-user content restrictions (issue #190): excluded tags + download cap.
+        # Both nullable → existing accounts stay unrestricted / unlimited.
+        perm_cols = {r[1] for r in conn.execute(text("PRAGMA table_info(user_permissions)")).fetchall()}
+        if perm_cols and "excluded_tags" not in perm_cols:
+            conn.execute(text("ALTER TABLE user_permissions ADD COLUMN excluded_tags TEXT"))
+            conn.commit()
+        if perm_cols and "download_limit" not in perm_cols:
+            conn.execute(text("ALTER TABLE user_permissions ADD COLUMN download_limit INTEGER"))
+            conn.commit()
         # Migrate api_keys.key (plaintext) → key_hash (sha256) + key_prefix (display)
         # so a DB leak doesn't compromise any KOReader plugin install. One-way: existing
         # installed plugins keep working because they send the plaintext, we hash on lookup.

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -12,3 +12,4 @@ from backend.models.notification import Notification  # noqa: F401
 from backend.models.send_queue import SendQueueItem  # noqa: F401
 from backend.models.user_dashboard import UserDashboard  # noqa: F401
 from backend.models.ko_stats import PageStat, StatsImport, KoStatsBookMatch, KoHash  # noqa: F401
+from backend.models.download_event import DownloadEvent  # noqa: F401

--- a/backend/models/download_event.py
+++ b/backend/models/download_event.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.core.database import Base
+
+
+class DownloadEvent(Base):
+    """One row per served download.
+
+    Used to enforce per-user daily download limits
+    (``UserPermission.download_limit``) and to give a lightweight download
+    history. ``book_id`` is intentionally not a foreign key so deleting a book
+    never disturbs the count.
+    """
+
+    __tablename__ = "download_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id"), nullable=False, index=True
+    )
+    book_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False, index=True
+    )

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import List, TYPE_CHECKING
+from typing import List, Optional, TYPE_CHECKING
 from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -95,5 +95,14 @@ class UserPermission(Base):
     can_use_kosync: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     can_share: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     can_bulk_operations: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+
+    # Content restrictions
+    # Comma-separated tag names this user must never see; books carrying any of
+    # them are filtered out of every listing/search/OPDS feed and cannot be
+    # downloaded (e.g. an under-18 account with "성인" excluded).
+    excluded_tags: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    # Per-day download cap: NULL = unlimited, 0 = downloads disabled, N = at most
+    # N downloads per (UTC) day. Enforced across the single/bulk/OPDS endpoints.
+    download_limit: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
 
     user: Mapped["User"] = relationship("User", back_populates="permissions")

--- a/backend/services/downloads_quota.py
+++ b/backend/services/downloads_quota.py
@@ -1,0 +1,64 @@
+"""Per-user download limits (issue #190, feature B).
+
+A single place the single-file, bulk-zip and OPDS download endpoints all call to
+enforce ``UserPermission.can_download`` and ``UserPermission.download_limit``:
+
+  can_download = False  → downloads disabled
+  download_limit = 0    → downloads disabled
+  download_limit = N>0  → at most N downloads per UTC day
+  download_limit = NULL → unlimited (the default)
+
+Admins are always unlimited and their downloads are not counted.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from backend.core.permissions import is_admin
+from backend.models.download_event import DownloadEvent
+
+
+def _limit_and_perms(user):
+    perms = getattr(user, "permissions", None)
+    return perms, (getattr(perms, "download_limit", None) if perms else None)
+
+
+def _day_start() -> datetime:
+    now = datetime.utcnow()
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def used_today(db: Session, user_id: int) -> int:
+    return (
+        db.query(DownloadEvent)
+        .filter(DownloadEvent.user_id == user_id, DownloadEvent.created_at >= _day_start())
+        .count()
+    )
+
+
+def enforce_download(db: Session, user, count: int = 1) -> None:
+    """Raise 403 if `user` may not download `count` more files right now."""
+    if is_admin(user):
+        return
+    perms, limit = _limit_and_perms(user)
+    if perms is not None and perms.can_download is False:
+        raise HTTPException(status_code=403, detail="Downloads are disabled for your account")
+    if limit is None:
+        return
+    if limit <= 0:
+        raise HTTPException(status_code=403, detail="Downloads are disabled for your account")
+    if used_today(db, user.id) + count > limit:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Daily download limit reached ({limit} per day)",
+        )
+
+
+def record_download(db: Session, user, book_id: int | None) -> None:
+    """Log a served download so it counts toward the daily limit. No-op for admins."""
+    if is_admin(user):
+        return
+    db.add(DownloadEvent(user_id=user.id, book_id=book_id, created_at=datetime.utcnow()))

--- a/frontend/src/pages/UsersPage.tsx
+++ b/frontend/src/pages/UsersPage.tsx
@@ -19,6 +19,10 @@ interface UserData {
   is_admin: boolean
   created_at: string
   role: 'admin' | 'member' | 'guest'
+  permissions?: {
+    excluded_tags: string | null
+    download_limit: number | null
+  } | null
 }
 
 interface UserModalProps {
@@ -146,6 +150,69 @@ function UserModal({ user, onClose, onSaved }: UserModalProps) {
             </button>
           </div>
         </form>
+      </div>
+    </div>
+  )
+}
+
+// Per-user content restrictions (issue #190): hidden tags + daily download cap.
+function RestrictionEditor({ user, onSaved }: { user: UserData; onSaved: (u: UserData) => void }) {
+  const [tags, setTags] = useState(user.permissions?.excluded_tags ?? '')
+  const [limit, setLimit] = useState<string>(
+    user.permissions?.download_limit == null ? '' : String(user.permissions.download_limit),
+  )
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  async function save() {
+    setSaving(true)
+    setSaved(false)
+    try {
+      const trimmed = limit.trim()
+      const updated = await api.put<UserData>(`/users/${user.id}/permissions`, {
+        excluded_tags: tags.trim() || null,
+        download_limit: trimmed === '' ? null : Math.max(0, parseInt(trimmed, 10) || 0),
+      })
+      onSaved(updated)
+      setSaved(true)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mt-3 pt-3 border-t border-border flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">
+          Hidden tags — books carrying any of these tags are hidden from this user (comma-separated)
+        </label>
+        <input
+          value={tags}
+          onChange={(e) => { setTags(e.target.value); setSaved(false) }}
+          placeholder="e.g. 성인, mature"
+          className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm"
+        />
+      </div>
+      <div className="flex items-center gap-2 flex-wrap">
+        <label className="text-xs text-muted-foreground shrink-0">Downloads per day</label>
+        <input
+          value={limit}
+          onChange={(e) => { setLimit(e.target.value); setSaved(false) }}
+          inputMode="numeric"
+          placeholder="unlimited"
+          className="w-28 rounded-lg border border-border bg-background px-3 py-1.5 text-sm"
+        />
+        <span className="text-xs text-muted-foreground">blank = unlimited, 0 = disabled</span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={save}
+          disabled={saving}
+          className="rounded-lg bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium disabled:opacity-50"
+        >
+          {saving ? 'Saving…' : 'Save restrictions'}
+        </button>
+        {saved && <span className="text-xs text-green-600">Saved</span>}
       </div>
     </div>
   )
@@ -365,6 +432,12 @@ export function UsersPage() {
                       </div>
                       {permSaving === u.id && <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />}
                     </div>
+                    {u.role !== 'admin' && (
+                      <RestrictionEditor
+                        user={u}
+                        onSaved={(s) => setUsers((prev) => prev.map((x) => (x.id === s.id ? { ...x, ...s } : x)))}
+                      />
+                    )}
                   </div>
                 )}
               </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ def _init_test_db():
     import backend.models.notification  # noqa: F401
     import backend.models.send_queue  # noqa: F401
     import backend.models.ko_stats  # noqa: F401
+    import backend.models.download_event  # noqa: F401
 
     Base.metadata.create_all(bind=test_engine)
 

--- a/tests/test_content_restrictions.py
+++ b/tests/test_content_restrictions.py
@@ -1,0 +1,108 @@
+"""Per-user content restrictions: excluded tags + download limits (GH #190).
+
+Feature A: a non-admin user with an excluded tag must never see (or download)
+books carrying that tag. Feature B: a per-user daily download cap — disabled,
+N-per-day, or unlimited — enforced across the download endpoints; admins are
+always unlimited.
+"""
+import pytest
+from fastapi import HTTPException
+
+from backend.core.permissions import book_visibility_filter, excluded_tags_for
+from backend.core.security import hash_password
+from backend.models.book import Book
+from backend.models.user import User, UserPermission
+from backend.services.downloads_quota import enforce_download, record_download, used_today
+
+_n = 0
+
+
+def _make_user(db, *, excluded_tags=None, download_limit=None, can_download=True):
+    global _n
+    _n += 1
+    u = User(
+        username=f"restricted{_n}",
+        email=f"restricted{_n}@example.com",
+        hashed_password=hash_password("password123"),
+        is_active=True,
+        is_admin=False,
+        role="member",
+        must_change_password=False,
+    )
+    db.add(u)
+    db.flush()
+    db.add(UserPermission(
+        user_id=u.id,
+        can_download=can_download,
+        excluded_tags=excluded_tags,
+        download_limit=download_limit,
+    ))
+    db.flush()
+    db.refresh(u)
+    return u
+
+
+def test_excluded_tags_parsing(db):
+    u = _make_user(db, excluded_tags=" 성인 , 19 ,")
+    assert excluded_tags_for(u) == ["성인", "19"]
+    assert excluded_tags_for(_make_user(db)) == []
+
+
+def test_visibility_filter_hides_excluded_tag(db, make_book):
+    clean = make_book(title="Clean Book", tags=["general"])
+    adult = make_book(title="Adult Book", tags=["성인"])
+    u = _make_user(db, excluded_tags="성인")
+
+    ids = {b.id for b in db.query(Book).filter(book_visibility_filter(db, u)).all()}
+    assert clean.id in ids
+    assert adult.id not in ids
+
+
+def test_admin_sees_excluded_tag(db, make_book, admin_user):
+    """The filter early-returns True for admins, so restrictions never apply."""
+    adult = make_book(title="Adult Book", tags=["성인"])
+    admin, _ = admin_user
+    # admin visibility filter is `True` → the row is returned
+    ids = {b.id for b in db.query(Book).filter(book_visibility_filter(db, admin)).all()}
+    assert adult.id in ids
+
+
+def test_download_disabled_by_flag(db):
+    with pytest.raises(HTTPException) as exc:
+        enforce_download(db, _make_user(db, can_download=False))
+    assert exc.value.status_code == 403
+
+
+def test_download_disabled_by_zero_limit(db):
+    with pytest.raises(HTTPException) as exc:
+        enforce_download(db, _make_user(db, download_limit=0))
+    assert exc.value.status_code == 403
+
+
+def test_daily_download_limit(db):
+    u = _make_user(db, download_limit=2)
+    enforce_download(db, u)                 # 0 used → ok
+    record_download(db, u, 1)
+    record_download(db, u, 2)
+    db.flush()
+    assert used_today(db, u.id) == 2
+    with pytest.raises(HTTPException) as exc:
+        enforce_download(db, u)             # would be the 3rd
+    assert exc.value.status_code == 403
+
+
+def test_bulk_count_respects_remaining_quota(db):
+    u = _make_user(db, download_limit=3)
+    record_download(db, u, 1)
+    db.flush()
+    enforce_download(db, u, count=2)        # 1 used + 2 = 3 ≤ 3 → ok
+    with pytest.raises(HTTPException):
+        enforce_download(db, u, count=3)    # 1 + 3 = 4 > 3
+
+
+def test_admin_is_unlimited_and_uncounted(db, admin_user):
+    admin, _ = admin_user
+    enforce_download(db, admin, count=10_000)   # no raise
+    record_download(db, admin, 1)               # no-op for admins
+    db.flush()
+    assert used_today(db, admin.id) == 0


### PR DESCRIPTION
Implements #190.

Two admin-configurable, per-user content restrictions.

## A. Excluded tags
`UserPermission.excluded_tags` (comma-separated tag names) is folded into the
single `book_visibility_filter`, so a book carrying an excluded tag disappears
from every listing, search, filter dropdown and OPDS feed for that user, and
can't be downloaded — e.g. an under-18 account with `성인` excluded. Admins are
never filtered.

## B. Download limits
`UserPermission.download_limit` (`NULL` = unlimited, `0` = disabled, `N` = at
most N per UTC day) and the existing (previously unenforced) `can_download` flag
are now enforced across the single, bulk-zip and OPDS download endpoints, backed
by a new `download_events` counter table. Admins are unlimited and uncounted.

## Implementation notes
- Additive startup migration adds the two columns (matching the existing
  `main.py` pattern); `create_all` builds `download_events`.
- `set_permissions` now applies a **partial** update (`exclude_unset`) so a
  caller can change one field without resetting the rest.
- Admin UI: a restrictions editor in the expanded user row on the Users page
  (hidden tags + downloads/day).

## Test plan
`tests/test_content_restrictions.py` (8 tests) covers tag-exclusion visibility,
the download disable / daily-quota / bulk-count paths, and admin bypass. Backend
import + OPDS/visibility suites are green; the frontend typechecks in the build.
Verified end-to-end on a test deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
