### PR TITLE
feat(users): per-user content restrictions - hidden tags + daily download limit (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to Tome are documented here. Format loosely follows
 ## [Unreleased]
 
 ### Added
+- Per-user content restrictions, set by an admin in Admin → Users. Hidden
+  tags make books carrying any of the listed tags (matched
+  case-insensitively) invisible to that user everywhere - browsing, search,
+  filters, OPDS and the KOReader plugin - including the user's own uploads.
+  A downloads-per-day limit caps how many files the account can fetch per
+  UTC day (0 disables downloads entirely, blank means unlimited), enforced
+  on every download path: single file, bulk ZIP, OPDS and TomeSync. Admin
+  accounts are never restricted. (#190)
 - Reader tap zones are now configurable. A "Tap zones" setting in the EPUB
   and comic readers' settings panel offers Default (tap right for next page),
   Swapped (tap left for next - for reading one-handed with the device in the

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -2113,6 +2113,9 @@ def download_book(
     if not user_can_see_book(db, current_user, book_file.book):
         raise HTTPException(status_code=404, detail="File not found")
 
+    from backend.services.download_quota import enforce_download_limit, record_download
+    enforce_download_limit(db, current_user)
+
     file_path = Path(book_file.file_path)
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="File no longer on disk")
@@ -2120,6 +2123,7 @@ def download_book(
     from backend.services.metadata_embed import get_baked_path
     serve_path = get_baked_path(book_file.book, book_file)
     record_served_artifact(db, book_file.book_id, book_file, serve_path)
+    record_download(db, current_user, book_id)
 
     filename = f"{book_file.book.title}.{book_file.format}"
     audit(db, "books.downloaded", user_id=current_user.id, username=current_user.username,

--- a/backend/api/downloads.py
+++ b/backend/api/downloads.py
@@ -40,24 +40,32 @@ def bulk_download(
         raise HTTPException(404, "No books found")
 
     from backend.services.metadata_embed import get_baked_path
+    from backend.services.download_quota import enforce_download_limit, record_download
     from backend.services.ko_hash import record_served_artifact
+
+    # The quota counts files, so enforce against the number of files this zip
+    # will actually contain — before any expensive baking/zipping starts.
+    servable = [
+        (book, f)
+        for book in books
+        for f in book.files
+        if Path(f.file_path).exists()
+    ]
+    enforce_download_limit(db, current_user, count=len(servable))
 
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        for book in books:
+        for book, f in servable:
             author = (book.author or "Unknown Author").replace("/", "-")[:60]
             title = book.title.replace("/", "-")[:80]
             folder = f"{author} - {title}"
-            for f in book.files:
-                raw = Path(f.file_path)
-                if not raw.exists():
-                    continue
-                # Serve a copy with Tome's metadata baked in, like every other
-                # download path (single/OPDS/TomeSync). Falls back to the raw
-                # file if baking fails. Keep the original filename in the zip.
-                serve = get_baked_path(book, f)
-                record_served_artifact(db, book.id, f, serve)
-                zf.write(str(serve), f"{folder}/{raw.name}")
+            # Serve a copy with Tome's metadata baked in, like every other
+            # download path (single/OPDS/TomeSync). Falls back to the raw
+            # file if baking fails. Keep the original filename in the zip.
+            serve = get_baked_path(book, f)
+            record_served_artifact(db, book.id, f, serve)
+            zf.write(str(serve), f"{folder}/{Path(f.file_path).name}")
+            record_download(db, current_user, book.id)
 
     buf.seek(0)
     # Parity with the single-download path, which audits each download.

--- a/backend/api/opds.py
+++ b/backend/api/opds.py
@@ -393,6 +393,10 @@ def opds_download(
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="File not found on disk")
 
+    from backend.services.download_quota import enforce_download_limit, record_download
+    enforce_download_limit(db, user)
+    record_download(db, user, book.id)
+
     from backend.services.audit import audit
     audit(db, "books.downloaded",
           user_id=user.id, username=user.username,

--- a/backend/api/tome_sync.py
+++ b/backend/api/tome_sync.py
@@ -1412,6 +1412,9 @@ def download_book_via_api_key(
     if not user_can_see_book(db, user, book_file.book):
         raise HTTPException(status_code=404, detail="File not found")
 
+    from backend.services.download_quota import enforce_download_limit, record_download
+    enforce_download_limit(db, user)
+
     file_path = Path(book_file.file_path)
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="File no longer on disk")
@@ -1420,6 +1423,7 @@ def download_book_via_api_key(
     from backend.services.ko_hash import record_served_artifact
     serve_path = get_baked_path(book_file.book, book_file)
     record_served_artifact(db, book_file.book_id, book_file, serve_path)
+    record_download(db, user, book_file.book_id)
 
     filename = f"{book_file.book.title}.{book_file.format}"
     return FileResponse(

--- a/backend/api/users.py
+++ b/backend/api/users.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -432,8 +433,22 @@ class UserOut(BaseModel):
     role: str
     created_at: str
     permissions: Optional[PermissionsSchema]
+    # Content restrictions (issue #190)
+    excluded_tags: list[str] = []
+    download_limit: Optional[int] = None
 
     model_config = {"from_attributes": True}
+
+
+def _stored_excluded_tags(user: User) -> list[str]:
+    """The admin-entered tag list as stored (original casing), for display."""
+    if not user.excluded_tags:
+        return []
+    try:
+        raw = json.loads(user.excluded_tags)
+    except (ValueError, TypeError):
+        return []
+    return [t for t in raw if isinstance(t, str)]
 
 
 class UserCreate(BaseModel):
@@ -491,6 +506,8 @@ def list_users(db: Session = Depends(get_db), _: User = Depends(require_admin)):
                 role="admin" if u.is_admin else u.role,
                 created_at=str(u.created_at),
                 permissions=PermissionsSchema.model_validate(perms) if perms else None,
+                excluded_tags=_stored_excluded_tags(u),
+                download_limit=u.download_limit,
             )
         )
     return result
@@ -532,6 +549,8 @@ def create_user(body: UserCreate, db: Session = Depends(get_db), admin: User = D
         role="admin" if user.is_admin else user.role,
         created_at=str(user.created_at),
         permissions=PermissionsSchema.model_validate(user.permissions),
+        excluded_tags=_stored_excluded_tags(user),
+        download_limit=user.download_limit,
     )
 
 
@@ -612,6 +631,8 @@ def update_user(
         role="admin" if user.is_admin else user.role,
         created_at=str(user.created_at),
         permissions=PermissionsSchema.model_validate(user.permissions) if user.permissions else None,
+        excluded_tags=_stored_excluded_tags(user),
+        download_limit=user.download_limit,
     )
 
 
@@ -680,6 +701,62 @@ def set_permissions(
         role="admin" if user.is_admin else user.role,
         created_at=str(user.created_at),
         permissions=PermissionsSchema.model_validate(user.permissions),
+        excluded_tags=_stored_excluded_tags(user),
+        download_limit=user.download_limit,
+    )
+
+
+class RestrictionsIn(BaseModel):
+    """Content restrictions (issue #190). A dedicated endpoint — deliberately
+    not folded into PUT /permissions, whose full-replace contract is left
+    untouched."""
+    excluded_tags: list[str] = []
+    download_limit: Optional[int] = None  # None = unlimited, 0 = disabled, N = files per UTC day
+
+
+@router.put("/users/{user_id}/restrictions", response_model=UserOut)
+def set_restrictions(
+    user_id: int,
+    body: RestrictionsIn,
+    db: Session = Depends(get_db),
+    admin: User = Depends(require_admin),
+):
+    user = db.get(User, user_id)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    if user.is_admin or user.role == "admin":
+        raise HTTPException(status_code=400, detail="Admin accounts cannot be restricted")
+    if body.download_limit is not None and body.download_limit < 0:
+        raise HTTPException(status_code=400, detail="download_limit must be 0 or greater")
+
+    # Normalise: trim, drop empties, dedupe case-insensitively (matching is
+    # case-insensitive too), keep the admin's casing for display.
+    seen: set[str] = set()
+    tags: list[str] = []
+    for t in body.excluded_tags:
+        t = t.strip()
+        if t and t.lower() not in seen:
+            seen.add(t.lower())
+            tags.append(t)
+
+    user.excluded_tags = json.dumps(tags) if tags else None
+    user.download_limit = body.download_limit
+    db.commit()
+    db.refresh(user)
+    audit(db, "users.restrictions_updated", user_id=admin.id, username=admin.username,
+          resource_type="user", resource_id=user.id, resource_title=user.username,
+          details={"excluded_tags": tags, "download_limit": body.download_limit})
+    return UserOut(
+        id=user.id,
+        username=user.username,
+        email=user.email,
+        is_active=user.is_active,
+        is_admin=user.is_admin,
+        role="admin" if user.is_admin else user.role,
+        created_at=str(user.created_at),
+        permissions=PermissionsSchema.model_validate(user.permissions) if user.permissions else None,
+        excluded_tags=_stored_excluded_tags(user),
+        download_limit=user.download_limit,
     )
 
 

--- a/backend/core/permissions.py
+++ b/backend/core/permissions.py
@@ -32,6 +32,20 @@ def is_member_or_above(user: User) -> bool:
     return has_role(user, "member")
 
 
+def excluded_tags_for(user: User) -> list[str]:
+    """Tag names this user must never see (issue #190), lowercased.
+    Stored as a JSON list in ``User.excluded_tags``; empty for admins and
+    for users with no restriction set."""
+    if is_admin(user) or not user.excluded_tags:
+        return []
+    import json
+    try:
+        raw = json.loads(user.excluded_tags)
+    except (ValueError, TypeError):
+        return []
+    return [t.strip().lower() for t in raw if isinstance(t, str) and t.strip()]
+
+
 def book_visibility_filter(db: Session, user: User):
     """Return a SQLAlchemy filter expression restricting Book rows to those
     the user is allowed to see. This is the single source of truth for book
@@ -59,7 +73,7 @@ def book_visibility_filter(db: Session, user: User):
     ]
 
     no_library = ~Book.libraries.any()
-    return or_(
+    visible = or_(
         # Own uploads are always visible to their uploader.
         Book.added_by == user.id,
         # Unfiled books fall back to the shared-collection rule: admin-uploaded
@@ -74,6 +88,18 @@ def book_visibility_filter(db: Session, user: User):
         Book.libraries.any(Library.owner_id == user.id),
         Book.libraries.any(Library.assigned_users.any(_User.id == user.id)),
     )
+
+    # Per-user content restriction (issue #190): a book carrying an excluded
+    # tag is invisible — including the user's own uploads (the restriction is
+    # account-wide by design, e.g. an under-18 account). Matching is
+    # case-insensitive; note SQLite's lower() only folds ASCII, which is fine
+    # for the tag conventions in use (CJK tags have no case).
+    excluded = excluded_tags_for(user)
+    if excluded:
+        from sqlalchemy import func
+        from backend.models.book import BookTag
+        visible = and_(visible, ~Book.tags.any(func.lower(BookTag.tag).in_(excluded)))
+    return visible
 
 
 def user_can_see_book(db: Session, user: User, book: "Book") -> bool:  # type: ignore[name-defined]

--- a/backend/main.py
+++ b/backend/main.py
@@ -146,6 +146,15 @@ async def lifespan(app: FastAPI):
         if "oidc_issuer" not in user_cols:
             conn.execute(text("ALTER TABLE users ADD COLUMN oidc_issuer VARCHAR(255)"))
             conn.commit()
+        # Content restrictions (issue #190). Both nullable, so every existing
+        # account stays unrestricted and unlimited. download_events itself is
+        # created by create_all.
+        if "excluded_tags" not in user_cols:
+            conn.execute(text("ALTER TABLE users ADD COLUMN excluded_tags TEXT"))
+            conn.commit()
+        if "download_limit" not in user_cols:
+            conn.execute(text("ALTER TABLE users ADD COLUMN download_limit INTEGER"))
+            conn.commit()
         # Migrate api_keys.key (plaintext) → key_hash (sha256) + key_prefix (display)
         # so a DB leak doesn't compromise any KOReader plugin install. One-way: existing
         # installed plugins keep working because they send the plaintext, we hash on lookup.

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -12,3 +12,4 @@ from backend.models.notification import Notification  # noqa: F401
 from backend.models.send_queue import SendQueueItem  # noqa: F401
 from backend.models.user_dashboard import UserDashboard  # noqa: F401
 from backend.models.ko_stats import PageStat, StatsImport, KoStatsBookMatch, KoHash  # noqa: F401
+from backend.models.download_event import DownloadEvent  # noqa: F401

--- a/backend/models/download_event.py
+++ b/backend/models/download_event.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.core.database import Base
+
+
+class DownloadEvent(Base):
+    """One row per file served to a non-admin user, across every download
+    path (single / bulk ZIP / OPDS / TomeSync). Counted by
+    backend/services/download_quota.py to enforce ``User.download_limit``.
+    ``book_id`` is deliberately not a foreign key: deleting a book must not
+    delete its rows, or the day's count would go backwards.
+    """
+
+    __tablename__ = "download_events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    book_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, nullable=False, index=True
+    )

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -44,6 +44,16 @@ class User(Base):
     hardcover_linked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     # Linking and syncing are separate opt-ins: a linked user can pause pushes.
     hardcover_sync_enabled: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    # Content restrictions (issue #190), admin-set. Lives on User, not the
+    # deprecated UserPermission table. Admin accounts are never restricted.
+    # excluded_tags: JSON list of tag names — books carrying any of them
+    # (case-insensitive) are invisible to this user (see
+    # backend/core/permissions.py:book_visibility_filter).
+    # download_limit: NULL = unlimited, 0 = downloads disabled, N = at most
+    # N files per UTC day, enforced on every download path (single / bulk /
+    # OPDS / TomeSync) via backend/services/download_quota.py.
+    excluded_tags: Mapped[str | None] = mapped_column(Text, nullable=True)
+    download_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False

--- a/backend/services/download_quota.py
+++ b/backend/services/download_quota.py
@@ -1,0 +1,75 @@
+"""Per-user download limits (issue #190).
+
+``User.download_limit`` semantics:
+
+  NULL  -> unlimited (the default; every pre-existing account)
+  0     -> downloads disabled
+  N > 0 -> at most N files per UTC day
+
+Every download path — single file (``books.py``), bulk ZIP (``downloads.py``),
+OPDS and TomeSync — must call :func:`enforce_download_limit` before serving and
+:func:`record_download` per file served. Admins are never limited and never
+counted. The deprecated ``UserPermission.can_download`` flag is intentionally
+not consulted: it has never been enforced, and starting to would silently lock
+out accounts whose flag was unticked back when the old permissions editor was
+in use.
+
+Days are UTC calendar days (not the stats "reading day"): quota clients
+(OPDS apps, KOReader) send no timezone, so a fixed boundary is the only
+consistent one.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import HTTPException
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from backend.core.permissions import is_admin
+from backend.models.download_event import DownloadEvent
+from backend.models.user import User
+
+
+def _utc_day_start() -> datetime:
+    return datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+
+
+def downloads_used_today(db: Session, user_id: int) -> int:
+    return (
+        db.query(func.count(DownloadEvent.id))
+        .filter(
+            DownloadEvent.user_id == user_id,
+            DownloadEvent.created_at >= _utc_day_start(),
+        )
+        .scalar()
+        or 0
+    )
+
+
+def enforce_download_limit(db: Session, user: User, count: int = 1) -> None:
+    """Raise 403 if serving ``count`` more files would exceed the user's
+    daily limit. Call before doing any expensive work (baking, zipping)."""
+    if is_admin(user):
+        return
+    limit = user.download_limit
+    if limit is None:
+        return
+    if limit <= 0:
+        raise HTTPException(status_code=403, detail="Downloads are disabled for your account")
+    used = downloads_used_today(db, user.id)
+    if used + count > limit:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Daily download limit reached ({used}/{limit} used today)",
+        )
+
+
+def record_download(db: Session, user: User, book_id: int | None) -> None:
+    """Count one served file toward the user's daily limit. No-op for admins
+    and for users with no limit set — an unlimited account writes no rows, so
+    flipping a limit on later starts counting from that moment."""
+    if is_admin(user) or user.download_limit is None:
+        return
+    db.add(DownloadEvent(user_id=user.id, book_id=book_id))
+    db.commit()

--- a/frontend/src/locales/en/messages.po
+++ b/frontend/src/locales/en/messages.po
@@ -1736,6 +1736,10 @@ msgstr "Bindery flow explained — open docs"
 msgid "Black"
 msgstr "Black"
 
+#: src/pages/AdminPage.tsx
+msgid "blank = unlimited, 0 = downloads disabled"
+msgstr "blank = unlimited, 0 = downloads disabled"
+
 #: src/pages/BinderyPage.tsx
 msgid "book"
 msgstr "book"
@@ -2603,6 +2607,10 @@ msgstr "Download backup"
 msgid "Download failed"
 msgstr "Download failed"
 
+#: src/pages/AdminPage.tsx
+msgid "Download limit must be a number of 0 or more"
+msgstr "Download limit must be a number of 0 or more"
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Download Markdown export"
 msgstr "Download Markdown export"
@@ -2634,6 +2642,10 @@ msgstr "Download ZIP"
 #: src/pages/HighlightsPage.tsx
 msgid "Downloaded {n} highlights"
 msgstr "Downloaded {n} highlights"
+
+#: src/pages/AdminPage.tsx
+msgid "Downloads per day"
+msgstr "Downloads per day"
 
 #: src/components/UploadModal.tsx
 msgid "Drop books here or <0>click to browse</0>"
@@ -2686,6 +2698,10 @@ msgstr "e.g. 1"
 #: src/pages/BinderyPage.tsx
 msgid "e.g. 2023"
 msgstr "e.g. 2023"
+
+#: src/pages/AdminPage.tsx
+msgid "e.g. adult, mature"
+msgstr "e.g. adult, mature"
 
 #: src/pages/BinderyPage.tsx
 msgid "e.g. en"
@@ -3065,6 +3081,10 @@ msgstr "Failed to save note"
 msgid "Failed to save rating"
 msgstr "Failed to save rating"
 
+#: src/pages/AdminPage.tsx
+msgid "Failed to save restrictions"
+msgstr "Failed to save restrictions"
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to save review"
 msgstr "Failed to save review"
@@ -3417,6 +3437,10 @@ msgstr "hiatus"
 #: src/components/ManageSeriesModal.tsx
 msgid "Hiatus"
 msgstr "Hiatus"
+
+#: src/pages/AdminPage.tsx
+msgid "Hidden tags — books carrying any of these tags are invisible to this user (comma-separated)"
+msgstr "Hidden tags — books carrying any of these tags are invisible to this user (comma-separated)"
 
 #: src/pages/BookDetailPage.tsx
 msgid "Hide details"
@@ -5766,6 +5790,10 @@ msgstr "Save failed"
 msgid "Save note"
 msgstr "Save note"
 
+#: src/pages/AdminPage.tsx
+msgid "Save restrictions"
+msgstr "Save restrictions"
+
 #: src/components/Sidebar.tsx
 msgid "Save the library first, then reopen it to share with users."
 msgstr "Save the library first, then reopen it to share with users."
@@ -5774,6 +5802,7 @@ msgstr "Save the library first, then reopen it to share with users."
 msgid "Save this board as an image"
 msgstr "Save this board as an image"
 
+#: src/pages/AdminPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Saved"
 msgstr "Saved"
@@ -5787,6 +5816,7 @@ msgstr "Saving"
 #~ msgstr "Saving..."
 
 #: src/components/ForcePasswordChange.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -6998,6 +7028,10 @@ msgstr "Unknown author"
 #: src/pages/BookDetailPage.tsx
 msgid "unknown device"
 msgstr "unknown device"
+
+#: src/pages/AdminPage.tsx
+msgid "unlimited"
+msgstr "unlimited"
 
 #: src/components/HardcoverSync.tsx
 msgid "Unlink"

--- a/frontend/src/locales/zh-CN/messages.po
+++ b/frontend/src/locales/zh-CN/messages.po
@@ -1736,6 +1736,10 @@ msgstr ""
 msgid "Black"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "blank = unlimited, 0 = downloads disabled"
+msgstr ""
+
 #: src/pages/BinderyPage.tsx
 msgid "book"
 msgstr ""
@@ -2603,6 +2607,10 @@ msgstr ""
 msgid "Download failed"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Download limit must be a number of 0 or more"
+msgstr ""
+
 #: src/components/KeyboardShortcutsModal.tsx
 msgid "Download Markdown export"
 msgstr ""
@@ -2633,6 +2641,10 @@ msgstr ""
 
 #: src/pages/HighlightsPage.tsx
 msgid "Downloaded {n} highlights"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Downloads per day"
 msgstr ""
 
 #: src/components/UploadModal.tsx
@@ -2685,6 +2697,10 @@ msgstr ""
 
 #: src/pages/BinderyPage.tsx
 msgid "e.g. 2023"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "e.g. adult, mature"
 msgstr ""
 
 #: src/pages/BinderyPage.tsx
@@ -3065,6 +3081,10 @@ msgstr ""
 msgid "Failed to save rating"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Failed to save restrictions"
+msgstr ""
+
 #: src/pages/BookDetailPage.tsx
 msgid "Failed to save review"
 msgstr ""
@@ -3416,6 +3436,10 @@ msgstr ""
 
 #: src/components/ManageSeriesModal.tsx
 msgid "Hiatus"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "Hidden tags — books carrying any of these tags are invisible to this user (comma-separated)"
 msgstr ""
 
 #: src/pages/BookDetailPage.tsx
@@ -5766,6 +5790,10 @@ msgstr ""
 msgid "Save note"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
+msgid "Save restrictions"
+msgstr ""
+
 #: src/components/Sidebar.tsx
 msgid "Save the library first, then reopen it to share with users."
 msgstr ""
@@ -5774,6 +5802,7 @@ msgstr ""
 msgid "Save this board as an image"
 msgstr ""
 
+#: src/pages/AdminPage.tsx
 #: src/pages/StatsPage.tsx
 msgid "Saved"
 msgstr ""
@@ -5787,6 +5816,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/ForcePasswordChange.tsx
+#: src/pages/AdminPage.tsx
 #: src/pages/BookDetailPage.tsx
 #: src/pages/HighlightsPage.tsx
 #: src/pages/SettingsPage.tsx
@@ -6997,6 +7027,10 @@ msgstr ""
 #: src/components/PositionHistoryModal.tsx
 #: src/pages/BookDetailPage.tsx
 msgid "unknown device"
+msgstr ""
+
+#: src/pages/AdminPage.tsx
+msgid "unlimited"
 msgstr ""
 
 #: src/components/HardcoverSync.tsx

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -42,6 +42,8 @@ interface UserData {
   is_admin: boolean
   created_at: string
   role: 'admin' | 'member' | 'guest'
+  excluded_tags?: string[]
+  download_limit?: number | null
 }
 
 interface AdminStats {
@@ -183,6 +185,80 @@ function UserModal({ user, onClose, onSaved }: {
 }
 
 // ── UsersTab ──────────────────────────────────────────────────────────────
+
+// Content restrictions (issue #190): hidden tags + daily download cap.
+// Rendered in the expanded user row for non-admin accounts only.
+function RestrictionEditor({ user, onSaved }: { user: UserData; onSaved: (u: UserData) => void }) {
+  const { t } = useLingui()
+  const [tags, setTags] = useState((user.excluded_tags ?? []).join(', '))
+  const [limit, setLimit] = useState(user.download_limit == null ? '' : String(user.download_limit))
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function save() {
+    setSaving(true)
+    setSaved(false)
+    setError(null)
+    const trimmedLimit = limit.trim()
+    const parsed = trimmedLimit === '' ? null : parseInt(trimmedLimit, 10)
+    if (parsed !== null && (Number.isNaN(parsed) || parsed < 0)) {
+      setError(t`Download limit must be a number of 0 or more`)
+      setSaving(false)
+      return
+    }
+    try {
+      const updated = await api.put<UserData>(`/users/${user.id}/restrictions`, {
+        excluded_tags: tags.split(',').map(s => s.trim()).filter(Boolean),
+        download_limit: parsed,
+      })
+      onSaved(updated)
+      setSaved(true)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t`Failed to save restrictions`)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="mt-3 pt-3 border-t border-border flex flex-col gap-3">
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-muted-foreground">
+          <Trans>Hidden tags — books carrying any of these tags are invisible to this user (comma-separated)</Trans>
+        </label>
+        <input
+          value={tags}
+          onChange={(e) => { setTags(e.target.value); setSaved(false) }}
+          placeholder={t`e.g. adult, mature`}
+          className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm"
+        />
+      </div>
+      <div className="flex items-center gap-2 flex-wrap">
+        <label className="text-xs text-muted-foreground shrink-0"><Trans>Downloads per day</Trans></label>
+        <input
+          value={limit}
+          onChange={(e) => { setLimit(e.target.value); setSaved(false) }}
+          inputMode="numeric"
+          placeholder={t`unlimited`}
+          className="w-28 rounded-lg border border-border bg-background px-3 py-1.5 text-sm"
+        />
+        <span className="text-xs text-muted-foreground"><Trans>blank = unlimited, 0 = downloads disabled</Trans></span>
+      </div>
+      <div className="flex items-center gap-2">
+        <button
+          onClick={save}
+          disabled={saving}
+          className="rounded-md bg-primary text-primary-foreground px-3 py-1.5 text-xs font-medium hover:bg-primary/90 transition-colors disabled:opacity-50"
+        >
+          {saving ? t`Saving…` : t`Save restrictions`}
+        </button>
+        {saved && <span className="text-xs text-success"><Trans>Saved</Trans></span>}
+        {error && <span className="text-xs text-destructive">{error}</span>}
+      </div>
+    </div>
+  )
+}
 
 function UsersTab() {
   const { t, i18n } = useLingui()
@@ -370,6 +446,12 @@ function UsersTab() {
                     </div>
                     {permSaving === u.id && <Loader2 className="w-3.5 h-3.5 animate-spin text-muted-foreground" />}
                   </div>
+                  {u.role !== 'admin' && (
+                    <RestrictionEditor
+                      user={u}
+                      onSaved={(saved) => setUsers(prev => prev.map(x => x.id === saved.id ? saved : x))}
+                    />
+                  )}
                 </div>
               )}
             </div>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,7 @@ def _init_test_db():
     import backend.models.notification  # noqa: F401
     import backend.models.send_queue  # noqa: F401
     import backend.models.ko_stats  # noqa: F401
+    import backend.models.download_event  # noqa: F401
 
     Base.metadata.create_all(bind=test_engine)
 

--- a/tests/test_user_restrictions.py
+++ b/tests/test_user_restrictions.py
@@ -1,0 +1,298 @@
+"""Per-user content restrictions: excluded tags + download limits (GH #190).
+
+Feature A — excluded tags: a non-admin user with excluded tags must never see
+(or download) a book carrying any of them, case-insensitively, across every
+surface that routes through ``book_visibility_filter`` (books list, single
+book, OPDS). The restriction is account-wide: it hides even the user's own
+uploads.
+
+Feature B — download limits: ``User.download_limit`` (NULL = unlimited,
+0 = disabled, N = files per UTC day) enforced on all four download paths —
+single file, bulk ZIP, OPDS, and TomeSync (the path the rejected external PR
+missed). Admins are never limited and never counted. The deprecated
+``UserPermission.can_download`` flag stays unenforced on purpose.
+"""
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from backend.core.permissions import book_visibility_filter, excluded_tags_for
+from backend.core.security import get_current_user, get_current_user_basic, hash_password
+from backend.models.book import Book
+from backend.models.download_event import DownloadEvent
+from backend.models.user import User
+from backend.services.download_quota import (
+    downloads_used_today,
+    enforce_download_limit,
+    record_download,
+)
+
+_counter = 0
+
+
+def _make_member(db, *, excluded_tags=None, download_limit=None) -> User:
+    global _counter
+    _counter += 1
+    u = User(
+        username=f"member{_counter}",
+        email=f"member{_counter}@example.com",
+        hashed_password=hash_password("password123"),
+        is_active=True,
+        is_admin=False,
+        role="member",
+        must_change_password=False,
+        excluded_tags=json.dumps(excluded_tags) if excluded_tags else None,
+        download_limit=download_limit,
+    )
+    db.add(u)
+    db.flush()
+    return u
+
+
+def _as_user(client, user: User):
+    """Make every JWT- and Basic-authed endpoint act as `user`."""
+    client.app.dependency_overrides[get_current_user] = lambda: user
+    client.app.dependency_overrides[get_current_user_basic] = lambda: user
+
+
+def _as_tomesync_user(client, user: User):
+    from backend.api.tome_sync import _get_api_key_user
+    client.app.dependency_overrides[_get_api_key_user] = lambda: user
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides(client):
+    yield
+    from backend.api.tome_sync import _get_api_key_user
+    client.app.dependency_overrides.pop(get_current_user, None)
+    client.app.dependency_overrides.pop(get_current_user_basic, None)
+    client.app.dependency_overrides.pop(_get_api_key_user, None)
+
+
+# ── Feature A: excluded tags ─────────────────────────────────────────────────
+
+def test_excluded_tags_parsing_and_admin_exemption(db, admin_user):
+    u = _make_member(db, excluded_tags=[" Adult ", "성인", "", "adult"])
+    assert excluded_tags_for(u) == ["adult", "성인", "adult"] or set(excluded_tags_for(u)) == {"adult", "성인"}
+    admin, _ = admin_user
+    admin.excluded_tags = json.dumps(["whatever"])
+    assert excluded_tags_for(admin) == []
+    # Corrupt JSON never breaks the filter
+    u.excluded_tags = "not json"
+    assert excluded_tags_for(u) == []
+
+
+def test_visibility_filter_hides_excluded_tag(db, make_book):
+    clean = make_book(title="Clean Book", tags=["fantasy"])
+    adult = make_book(title="Adult Book", tags=["성인"])
+    u = _make_member(db, excluded_tags=["성인"])
+    ids = {b.id for b in db.query(Book).filter(book_visibility_filter(db, u)).all()}
+    assert clean.id in ids
+    assert adult.id not in ids
+
+
+def test_tag_matching_is_case_insensitive(db, make_book):
+    tagged = make_book(title="Tagged Book", tags=["adult"])
+    u = _make_member(db, excluded_tags=["Adult"])
+    ids = {b.id for b in db.query(Book).filter(book_visibility_filter(db, u)).all()}
+    assert tagged.id not in ids
+
+
+def test_restriction_hides_even_own_upload(db, make_book):
+    u = _make_member(db, excluded_tags=["mature"])
+    own = make_book(title="Own Upload", tags=["mature"])
+    own.added_by = u.id
+    db.flush()
+    ids = {b.id for b in db.query(Book).filter(book_visibility_filter(db, u)).all()}
+    assert own.id not in ids
+
+
+def test_admin_still_sees_excluded_books(db, make_book, admin_user):
+    adult = make_book(title="Adult Book", tags=["성인"])
+    admin, _ = admin_user
+    filt = book_visibility_filter(db, admin)
+    ids = {b.id for b in db.query(Book).filter(filt).all()}
+    assert adult.id in ids
+
+
+def test_books_list_and_single_book_endpoints_hide_excluded(client, db, make_book):
+    make_book(title="Visible Book", tags=["fantasy"])
+    hidden = make_book(title="Hidden Book", tags=["성인"])
+    u = _make_member(db, excluded_tags=["성인"])
+    _as_user(client, u)
+
+    resp = client.get("/api/books")
+    assert resp.status_code == 200
+    data = resp.json()
+    titles = [b["title"] for b in (data["books"] if isinstance(data, dict) else data)]
+    assert "Visible Book" in titles
+    assert "Hidden Book" not in titles
+
+    assert client.get(f"/api/books/{hidden.id}").status_code == 404
+
+
+def test_opds_search_hides_excluded(client, db, make_book):
+    make_book(title="Findable Clean", tags=["fantasy"])
+    make_book(title="Findable Hidden", tags=["성인"])
+    u = _make_member(db, excluded_tags=["성인"])
+    _as_user(client, u)
+
+    resp = client.get("/opds/search/results?q=Findable")
+    assert resp.status_code == 200
+    assert "Findable Clean" in resp.text
+    assert "Findable Hidden" not in resp.text
+
+
+# ── Feature B: download limits (service level) ───────────────────────────────
+
+def test_unlimited_by_default_and_uncounted(db):
+    u = _make_member(db)  # download_limit = None
+    enforce_download_limit(db, u, count=10_000)  # no raise
+    record_download(db, u, 1)  # no-op while unlimited
+    assert downloads_used_today(db, u.id) == 0
+
+
+def test_limit_zero_disables_downloads(db):
+    u = _make_member(db, download_limit=0)
+    with pytest.raises(HTTPException) as exc:
+        enforce_download_limit(db, u)
+    assert exc.value.status_code == 403
+
+
+def test_daily_limit_counts_and_blocks(db):
+    u = _make_member(db, download_limit=2)
+    enforce_download_limit(db, u)
+    record_download(db, u, 1)
+    record_download(db, u, 2)
+    assert downloads_used_today(db, u.id) == 2
+    with pytest.raises(HTTPException) as exc:
+        enforce_download_limit(db, u)  # would be the 3rd today
+    assert exc.value.status_code == 403
+
+
+def test_bulk_count_checked_against_remaining_quota(db):
+    u = _make_member(db, download_limit=3)
+    record_download(db, u, 1)
+    enforce_download_limit(db, u, count=2)  # 1 + 2 = 3 ≤ 3
+    with pytest.raises(HTTPException):
+        enforce_download_limit(db, u, count=3)  # 1 + 3 = 4 > 3
+
+
+def test_admin_never_limited_or_counted(db, admin_user):
+    admin, _ = admin_user
+    admin.download_limit = 0  # even a nonsense value on an admin row is ignored
+    enforce_download_limit(db, admin, count=500)
+    record_download(db, admin, 1)
+    assert downloads_used_today(db, admin.id) == 0
+
+
+# ── Feature B: all four download paths enforce ───────────────────────────────
+
+def test_single_download_endpoint_blocked(client, db, make_book):
+    book = make_book(title="Blocked Single")
+    u = _make_member(db, download_limit=0)
+    _as_user(client, u)
+    resp = client.get(f"/api/books/{book.id}/download/{book.files[0].id}")
+    assert resp.status_code == 403
+    assert "disabled" in resp.json()["detail"]
+
+
+def test_bulk_download_endpoint_blocked(client, db, make_book, tmp_path):
+    p = tmp_path / "bulk.epub"
+    p.write_bytes(b"not a real epub")
+    book = make_book(title="Blocked Bulk", file_path=str(p))
+    u = _make_member(db, download_limit=0)
+    _as_user(client, u)
+    resp = client.post("/api/downloads", json={"book_ids": [book.id]})
+    assert resp.status_code == 403
+
+
+def test_opds_download_endpoint_blocked(client, db, make_book, tmp_path):
+    p = tmp_path / "opds.epub"
+    p.write_bytes(b"not a real epub")
+    book = make_book(title="Blocked OPDS", file_path=str(p))
+    u = _make_member(db, download_limit=0)
+    _as_user(client, u)
+    resp = client.get(f"/opds/download/{book.id}/{book.files[0].id}")
+    assert resp.status_code == 403
+
+
+def test_tomesync_download_endpoint_blocked(client, db, make_book):
+    """The path the rejected external PR (#195) forgot — KOReader plugin
+    downloads must respect the limit too."""
+    book = make_book(title="Blocked TomeSync")
+    u = _make_member(db, download_limit=0)
+    _as_tomesync_user(client, u)
+    resp = client.get(
+        f"/api/tome-sync/download/{book.id}/{book.files[0].id}",
+        headers={"Authorization": "Bearer tome_dummy"},
+    )
+    assert resp.status_code == 403
+
+
+def test_end_to_end_limit_one_then_blocked(client, db, make_book, tmp_path):
+    """A real served file counts, and the next request is refused."""
+    p = tmp_path / "real.epub"
+    p.write_bytes(b"garbage bytes, bake falls back to raw file")
+    book = make_book(title="Countable Book", file_path=str(p))
+    u = _make_member(db, download_limit=1)
+    _as_user(client, u)
+
+    first = client.get(f"/api/books/{book.id}/download/{book.files[0].id}")
+    assert first.status_code == 200
+    assert db.query(DownloadEvent).filter_by(user_id=u.id).count() == 1
+
+    second = client.get(f"/api/books/{book.id}/download/{book.files[0].id}")
+    assert second.status_code == 403
+    assert "limit" in second.json()["detail"].lower()
+
+
+# ── Admin restrictions endpoint ──────────────────────────────────────────────
+
+def test_set_restrictions_persists_and_normalises(client, db):
+    u = _make_member(db)
+    resp = client.put(f"/api/users/{u.id}/restrictions", json={
+        "excluded_tags": ["  Adult ", "adult", "성인", ""],
+        "download_limit": 5,
+    })
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["excluded_tags"] == ["Adult", "성인"]  # trimmed, deduped case-insensitively
+    assert body["download_limit"] == 5
+
+    listed = {x["id"]: x for x in client.get("/api/users").json()}
+    assert listed[u.id]["excluded_tags"] == ["Adult", "성인"]
+    assert listed[u.id]["download_limit"] == 5
+
+
+def test_set_restrictions_clears(client, db):
+    u = _make_member(db, excluded_tags=["성인"], download_limit=3)
+    resp = client.put(f"/api/users/{u.id}/restrictions", json={
+        "excluded_tags": [],
+        "download_limit": None,
+    })
+    assert resp.status_code == 200
+    db.refresh(u)
+    assert u.excluded_tags is None
+    assert u.download_limit is None
+
+
+def test_set_restrictions_rejects_admin_target(client, db, admin_user):
+    admin, _ = admin_user
+    resp = client.put(f"/api/users/{admin.id}/restrictions", json={"excluded_tags": ["x"]})
+    assert resp.status_code == 400
+
+
+def test_set_restrictions_rejects_negative_limit(client, db):
+    u = _make_member(db)
+    resp = client.put(f"/api/users/{u.id}/restrictions", json={"download_limit": -1})
+    assert resp.status_code == 400
+
+
+def test_set_restrictions_requires_admin(client, db):
+    u = _make_member(db)
+    other = _make_member(db)
+    _as_user(client, u)
+    resp = client.put(f"/api/users/{other.id}/restrictions", json={"download_limit": 0})
+    assert resp.status_code == 403


### PR DESCRIPTION
Implements #190.

## What
Admin-set restrictions per non-admin account, edited in **Admin → Users** (expanded row):

**Hidden tags** - books carrying any listed tag are invisible to that user, matched case-insensitively. Folded into `book_visibility_filter` (the single source of truth), so browsing, search, facets, single-book, OPDS and the TomeSync series browser all inherit it with no per-endpoint code. Account-wide by design: it hides the user's own uploads too (the point is e.g. an under-18 account). Admins are never restricted.

**Downloads per day** - `User.download_limit`: blank = unlimited, 0 = downloads disabled, N = at most N files per UTC day. Enforced on **all four** download paths - single file, bulk ZIP, OPDS, and TomeSync - via a single `backend/services/download_quota.py`, counted in a new `download_events` table. Unlimited accounts write no counter rows.

## Design notes (vs the closed #195)
- Restrictions live on `User`, not the deprecated `UserPermission` table.
- The never-enforced `can_download` flag stays unenforced - enforcing it now would silently lock out accounts whose flag was unticked in the pre-roles editor. `limit = 0` is the off switch instead.
- Dedicated `PUT /users/{id}/restrictions` endpoint (admin-only, audited, refuses admin targets, validates the limit) - the `PUT /permissions` full-replace contract is untouched.
- The TomeSync/KOReader download path is covered (the gap in #195).
- Editor sits in the live AdminPage UsersTab (not the dead `UsersPage.tsx`), with Lingui strings and inline error handling.

## Test plan
- 22 new tests in `tests/test_user_restrictions.py`: filter behaviour (case-insensitivity, own-upload hiding, admin exemption, corrupt-JSON safety), quota service semantics, per-endpoint 403s on all four download paths, end-to-end count-then-block, and the restrictions endpoint (normalisation, clearing, admin-target refusal, negative limit, non-admin 403).
- Full backend suite green: 1158 passed. `npm run build` green, catalogs extracted.
- E2E against a throwaway instance driving the real UI with Playwright: editor saves `mature, adult` (and `mature,adult` normalises identically), restricted member's dashboard/detail/download hide the tagged book, download #2 of the day returns 403 with a clear message, admin unaffected.