### PR TITLE
feat(ui): unified interface motion — animated modal exits, grid enter/exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+### Changed
+- Smoother interface motion throughout the web app. Dialogs now animate
+  out as well as in, the notification dropdown pops from its corner, and
+  books gliding to their new grid positions on filter or size changes now
+  also fade in and out as they enter and leave the results. Honours the
+  system "reduce motion" preference.
+
 ### Added
 - Per-user content restrictions, set by an admin in Admin → Users. Hidden
   tags make books carrying any of the listed tags (matched

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "clsx": "^2.1.1",
         "html-to-image": "^1.11.13",
         "lucide-react": "^1.7.0",
+        "motion": "^13.1.1",
         "pdfjs-dist": "^6.2.108",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -5633,6 +5634,29 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-13.1.1.tgz",
+      "integrity": "sha512-B/xn2TPS4f61cEBLFjiYlQFnBZUW1YVj/LM+C+N4OP8Rs95VLEI2ot/RlfBg111la/EiyECFaJJi/A3FWA8MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^13.1.1",
+        "motion-utils": "^13.0.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
@@ -7244,6 +7268,43 @@
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
       "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/motion": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-13.1.1.tgz",
+      "integrity": "sha512-WNZoK6xiF+kkTqkZ5K7FDDh6A8BG4i5Hc7KXtW8gtTxkpJFds+hIOrDaQGKjQj/AE/i4hJqAaUHEqp/Qo02y6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^13.1.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-13.1.1.tgz",
+      "integrity": "sha512-XSf8VYWSB6G/0IY3rWVbyLcxWXtAVHkN1PQE2agTaCv3u8RGvbwu56TyyR/MNzBqqNavEBTZzErcxI1TxBrjcA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^13.0.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-13.0.0.tgz",
+      "integrity": "sha512-7DnN7TmbLcYXcG4RVadXIihWlyuM9afoUww8Y5Agg431kGKiuL2/OMyP4mJ5wLz+pvN3t5ySClLOaVXJ+wekRQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8931,8 +8992,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "clsx": "^2.1.1",
     "html-to-image": "^1.11.13",
     "lucide-react": "^1.7.0",
+    "motion": "^13.1.1",
     "pdfjs-dist": "^6.2.108",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate, useLocation } from 'react-route
 import { Keyboard } from 'lucide-react'
 import { AuthProvider, useAuth } from '@/contexts/AuthContext'
 import { ToastProvider } from '@/contexts/ToastContext'
+import { MotionProvider } from '@/lib/motion'
 import { ProtectedRoute } from '@/components/ProtectedRoute'
 import { ImpersonationBanner } from '@/components/ImpersonationBanner'
 import { ForcePasswordChange } from '@/components/ForcePasswordChange'
@@ -193,8 +194,10 @@ function App() {
     <BrowserRouter>
       <AuthProvider>
         <ToastProvider>
-          <AppRoutes />
-          <ImpersonationBanner />
+          <MotionProvider>
+            <AppRoutes />
+            <ImpersonationBanner />
+          </MotionProvider>
         </ToastProvider>
       </AuthProvider>
     </BrowserRouter>

--- a/frontend/src/components/BookCard.tsx
+++ b/frontend/src/components/BookCard.tsx
@@ -35,8 +35,6 @@ interface BookCardProps {
   progressPct?: number | null
   rating?: number | null
   index?: number
-  // Set as data-flip-id on the root so a parent grid can FLIP-animate reflows
-  flipId?: string
   // Home rows are usually all one format — the badge is noise there, so those
   // callers turn it off. Library grids keep it (that's where formats differ).
   showFormatBadge?: boolean
@@ -62,7 +60,7 @@ function RatingStars({ rating, size = 11 }: { rating?: number | null; size?: num
 export function BookCard({
   book, view, selected, focused, onSelect,
   onTagClick: _onTagClick, onSeriesClick, onAuthorClick,
-  readingStatus, progressPct, rating, flipId, showFormatBadge = true,
+  readingStatus, progressPct, rating, showFormatBadge = true,
 }: BookCardProps) {
   const { t } = useLingui()
   const navigate = useNavigate()
@@ -231,7 +229,6 @@ export function BookCard({
   return (
     <div
       ref={cardRef as React.RefObject<HTMLDivElement>}
-      data-flip-id={flipId}
       className={cn('group flex flex-col cursor-pointer touch-feedback', onSelect && 'select-none')}
       style={{ perspective: '600px' }}
       onClick={onSelect ? onSelect : () => navigate(`/books/${book.id}`)}

--- a/frontend/src/components/BulkMetadataReviewModal.tsx
+++ b/frontend/src/components/BulkMetadataReviewModal.tsx
@@ -4,6 +4,7 @@ import { t } from '@lingui/core/macro'
 import { AlertCircle, Check, ChevronDown, ChevronUp, Loader2, Search, Sparkles, X } from 'lucide-react'
 import { api } from '@/lib/api'
 import { cn } from '@/lib/utils'
+import { ModalShell } from '@/components/ModalShell'
 import type { MetadataCandidate } from '@/lib/books'
 import { CoverImage } from './CoverImage'
 
@@ -55,6 +56,9 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
 
   useEffect(() => {
     if (open && bookIds.length > 0) {
+      // Reset on open (not close) so content survives the exit animation.
+      setProgress(null)
+      setDoneState(null)
       fetchAll()
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -180,25 +184,16 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
 
   function handleClose() {
     if (applying) return
-    setResults([])
-    setRowState({})
-    setError(null)
-    setProgress(null)
-    setDoneState(null)
     onClose()
   }
-
-  if (!open) return null
 
   const matched = results.filter(r => r.best_match_index !== null).length
   const needsReview = results.filter(r => r.best_match_index === null && r.candidates.length > 0).length
   const noMatch = results.filter(r => r.candidates.length === 0).length
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={handleClose} />
-
-      <div className="relative z-10 bg-background border border-border rounded-2xl shadow-xl shadow-accent-soft w-full max-w-3xl mx-4 max-h-[90vh] flex flex-col">
+    <ModalShell open={open} onClose={handleClose} className="w-full max-w-3xl">
+      <div className="bg-background border border-border rounded-2xl shadow-xl shadow-accent-soft max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border shrink-0">
           <div className="flex items-center gap-2 font-semibold text-sm">
@@ -453,6 +448,6 @@ export function BulkMetadataReviewModal({ bookIds, open, onClose, onApplied, onM
           </div>
         )}
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/frontend/src/components/CoverPickerModal.tsx
+++ b/frontend/src/components/CoverPickerModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { Camera, Check, ImageOff, Loader2, Search, Upload, X } from 'lucide-react'
 import type { BookDetail } from '@/lib/books'
+import { ModalShell } from '@/components/ModalShell'
 import { Trans, Plural } from '@lingui/react/macro'
 import { t } from '@lingui/core/macro'
 
@@ -118,20 +119,14 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
   }
 
   function handleClose() {
-    setCandidates([])
-    setError(null)
-    setCustomUrl('')
-    setQuery('')
+    // State resets on the next open; keeping it here would blank the content
+    // mid-exit-animation.
     onClose()
   }
 
-  if (!open) return null
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={handleClose} />
-
-      <div className="relative z-10 bg-background border border-border rounded-2xl shadow-xl shadow-accent-soft w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto">
+    <ModalShell open={open} onClose={handleClose} className="w-full max-w-2xl">
+      <div className="bg-background border border-border rounded-2xl shadow-xl shadow-accent-soft max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border sticky top-0 bg-background z-10">
           <div className="flex items-center gap-2 font-semibold text-sm">
@@ -289,6 +284,6 @@ export function CoverPickerModal({ book, open, onClose, onApplied }: Props) {
           )}
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/frontend/src/components/EntityModal.tsx
+++ b/frontend/src/components/EntityModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { Loader2 } from 'lucide-react'
 import { IconPicker } from '@/components/Sidebar'
+import { ModalShell } from '@/components/ModalShell'
 import { Trans } from '@lingui/react/macro'
 import { t } from '@lingui/core/macro'
 
@@ -47,11 +48,10 @@ export function EntityModal({ title, initialName = '', initialIcon, defaultIcon 
   }
 
   return (
-    <div
-      className="fixed inset-0 bg-black/40 backdrop-blur-sm z-50 flex items-center justify-center"
-      onMouseDown={e => { if (e.target === e.currentTarget) onClose() }}
-    >
-      <div className="bg-card text-foreground rounded-2xl shadow-xl shadow-accent-soft max-w-sm w-full mx-4 p-6 space-y-4">
+    // Mounted-on-open by callers, so `open` is always true: animated enter,
+    // instant exit (the tree unmounts with the caller's conditional).
+    <ModalShell open onClose={onClose} className="w-full max-w-sm">
+      <div className="bg-card text-foreground rounded-2xl shadow-xl shadow-accent-soft p-6 space-y-4">
         <h2 className="text-base font-semibold">{title}</h2>
 
         <input
@@ -89,6 +89,6 @@ export function EntityModal({ title, initialName = '', initialIcon, defaultIcon 
           </button>
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/frontend/src/components/KeyboardShortcutsModal.tsx
+++ b/frontend/src/components/KeyboardShortcutsModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { Keyboard, X } from 'lucide-react'
+import { ModalShell } from '@/components/ModalShell'
 import { Trans, useLingui } from '@lingui/react/macro'
 import { msg } from '@lingui/core/macro'
 import type { MessageDescriptor } from '@lingui/core'
@@ -96,18 +97,9 @@ export function KeyboardShortcutsModal({ open, onClose }: Props) {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [open, onClose])
 
-  if (!open) return null
-
   return (
-    <>
-      {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm"
-        onClick={onClose}
-      />
-      {/* Panel */}
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
-        <div className="pointer-events-auto w-full max-w-md bg-card border border-border rounded-2xl shadow-2xl overflow-hidden">
+    <ModalShell open={open} onClose={onClose} className="w-full max-w-md">
+      <div className="bg-card border border-border rounded-2xl shadow-2xl overflow-hidden">
           {/* Header */}
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
             <div className="flex items-center gap-2.5">
@@ -147,8 +139,7 @@ export function KeyboardShortcutsModal({ open, onClose }: Props) {
               </div>
             ))}
           </div>
-        </div>
       </div>
-    </>
+    </ModalShell>
   )
 }

--- a/frontend/src/components/ManageSeriesModal.tsx
+++ b/frontend/src/components/ManageSeriesModal.tsx
@@ -5,6 +5,7 @@ import { i18n } from '@lingui/core'
 import type { MessageDescriptor } from '@lingui/core'
 import { X, Plus, Trash2, Loader2, Save } from 'lucide-react'
 import { api } from '@/lib/api'
+import { ModalShell } from '@/components/ModalShell'
 import type { Arc, SeriesMeta, SeriesStatus } from '@/lib/books'
 import { cn } from '@/lib/utils'
 
@@ -164,8 +165,8 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
   const isBusy = statusSaving || arcsSaving
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
-      <div className="w-full max-w-3xl bg-card rounded-2xl border border-border shadow-xl shadow-accent-soft flex flex-col max-h-[90vh] min-h-[420px]">
+    <ModalShell open className="w-full max-w-3xl">
+      <div className="bg-card rounded-2xl border border-border shadow-xl shadow-accent-soft flex flex-col max-h-[90vh] min-h-[420px]">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
           <div>
@@ -360,6 +361,6 @@ export function ManageSeriesModal({ seriesName, volumes, onClose, onSaved }: Pro
           </div>
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/frontend/src/components/MetadataFetchModal.tsx
+++ b/frontend/src/components/MetadataFetchModal.tsx
@@ -5,6 +5,7 @@ import { i18n } from '@lingui/core'
 import type { MessageDescriptor } from '@lingui/core'
 import { Loader2, Sparkles, BookOpen, ExternalLink, Check, X } from 'lucide-react'
 import { BookAnimation } from '@/components/BookAnimation'
+import { ModalShell } from '@/components/ModalShell'
 import type { BookDetail, MetadataCandidate } from '@/lib/books'
 
 const API = import.meta.env.VITE_API_URL ?? ''
@@ -61,10 +62,8 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
 
   useEffect(() => {
     if (open) {
-      setCandidates([])
-      setError(null)
-      setStep('search')
-      setQuery('')
+      // Full reset on open (not close) so content survives the exit animation.
+      reset()
       setTimeout(() => doSearch(''), 50)
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -167,7 +166,6 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
       if (!r.ok) throw new Error(await r.text())
       const updated: BookDetail = await r.json()
       onApplied(updated)
-      reset()
       onClose()
     } catch (e: unknown) {
       setError(e instanceof Error ? e.message : t`Apply failed`)
@@ -177,19 +175,12 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
   }
 
   function handleClose() {
-    reset()
     onClose()
   }
 
-  if (!open) return null
-
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
-      {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={handleClose} />
-
-      {/* Panel */}
-      <div className="relative z-10 bg-background border border-border rounded-2xl shadow-xl shadow-accent-soft w-full max-w-3xl mx-4 max-h-[90vh] overflow-y-auto">
+    <ModalShell open={open} onClose={handleClose} className="w-full max-w-3xl">
+      <div className="bg-background border border-border rounded-2xl shadow-xl shadow-accent-soft max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-border sticky top-0 bg-background z-10">
           <div className="flex items-center gap-2 font-semibold text-sm">
@@ -420,6 +411,6 @@ export function MetadataFetchModal({ book, open, onClose, onApplied }: Props) {
           )}
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/frontend/src/components/ModalShell.tsx
+++ b/frontend/src/components/ModalShell.tsx
@@ -1,0 +1,51 @@
+import { type ReactNode } from 'react'
+import { AnimatePresence, m } from 'motion/react'
+import { cn } from '@/lib/utils'
+
+interface Props {
+  open: boolean
+  /** Backdrop click handler. Omit to make the backdrop inert (confirm-gated flows). */
+  onClose?: () => void
+  /** Sizing/layout for the panel wrapper, e.g. "w-full max-w-md". The visual
+      card (bg, border, rounding) stays in the caller's markup. */
+  className?: string
+  children: ReactNode
+}
+
+/** Shared animated modal scaffold: backdrop fade + panel pop, in and out.
+    Render it unconditionally and drive it via `open` — an early
+    `if (!open) return null` in the caller would skip the exit animation. */
+export function ModalShell({ open, onClose, className, children }: Props) {
+  return (
+    <AnimatePresence>
+      {open && (
+        <m.div
+          key="modal"
+          className="fixed inset-0 z-50"
+          initial="hidden"
+          animate="visible"
+          exit="hidden"
+        >
+          <m.div
+            variants={{ hidden: { opacity: 0 }, visible: { opacity: 1 } }}
+            transition={{ duration: 0.15 }}
+            className="fixed inset-0 bg-black/50 backdrop-blur-sm"
+            onClick={onClose}
+          />
+          <div className="fixed inset-0 flex items-center justify-center p-4 pointer-events-none">
+            <m.div
+              variants={{
+                hidden: { opacity: 0, scale: 0.96, y: 8 },
+                visible: { opacity: 1, scale: 1, y: 0 },
+              }}
+              transition={{ duration: 0.16, ease: [0.2, 0.8, 0.2, 1] }}
+              className={cn('pointer-events-auto', className)}
+            >
+              {children}
+            </m.div>
+          </div>
+        </m.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
+import { AnimatePresence, m } from 'motion/react'
 import { Bell, Check, BookOpen, Target, Timer } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { cn } from '@/lib/utils'
@@ -134,8 +135,15 @@ export function NotificationBell() {
         )}
       </button>
 
+      <AnimatePresence>
       {open && (
-        <div className="absolute right-0 top-full mt-1.5 z-50 w-80 max-h-96 flex flex-col bg-card border border-border rounded-xl shadow-xl shadow-accent-soft overflow-hidden">
+        <m.div
+          initial={{ opacity: 0, scale: 0.95, y: -4 }}
+          animate={{ opacity: 1, scale: 1, y: 0 }}
+          exit={{ opacity: 0, scale: 0.95, y: -4 }}
+          transition={{ duration: 0.14, ease: [0.2, 0.8, 0.2, 1] }}
+          style={{ transformOrigin: 'top right' }}
+          className="absolute right-0 top-full mt-1.5 z-50 w-80 max-h-96 flex flex-col bg-card border border-border rounded-xl shadow-xl shadow-accent-soft overflow-hidden">
           {/* Header */}
           <div className="flex items-center justify-between px-3 py-2.5 border-b border-border shrink-0">
             <span className="text-xs font-semibold text-foreground"><Trans>Notifications</Trans></span>
@@ -195,8 +203,9 @@ export function NotificationBell() {
               ))
             )}
           </div>
-        </div>
+        </m.div>
       )}
+      </AnimatePresence>
     </div>
   )
 }

--- a/frontend/src/components/PositionHistoryModal.tsx
+++ b/frontend/src/components/PositionHistoryModal.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { History, Loader2, RotateCcw, X } from 'lucide-react'
 import { api } from '@/lib/api'
+import { ModalShell } from '@/components/ModalShell'
 import { cn } from '@/lib/utils'
 import { Trans } from '@lingui/react/macro'
 import { t } from '@lingui/core/macro'
@@ -57,10 +58,8 @@ export function PositionHistoryModal({ bookId, onClose, onRestored }: {
   }
 
   return createPortal(
-    <>
-      <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" onClick={onClose} />
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
-        <div className="pointer-events-auto flex max-h-[70vh] w-full max-w-md flex-col rounded-xl border border-border bg-card shadow-xl">
+    <ModalShell open onClose={onClose} className="w-full max-w-md">
+        <div className="flex max-h-[70vh] flex-col rounded-xl border border-border bg-card shadow-xl">
           <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
             <History className="h-4 w-4 text-primary" />
             <h2 className="font-display text-base text-foreground"><Trans>Position history</Trans></h2>
@@ -129,8 +128,7 @@ export function PositionHistoryModal({ bookId, onClose, onRestored }: {
             </p>
           </div>
         </div>
-      </div>
-    </>,
+    </ModalShell>,
     document.body,
   )
 }

--- a/frontend/src/components/SendToDeviceModal.tsx
+++ b/frontend/src/components/SendToDeviceModal.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Send, X, Loader2, AlertTriangle } from 'lucide-react'
 import { BookAnimation } from '@/components/BookAnimation'
+import { ModalShell } from '@/components/ModalShell'
 import { api } from '@/lib/api'
 import { useToast } from '@/contexts/ToastContext'
 import type { BookFile } from '@/lib/books'
@@ -63,8 +64,6 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
     })
   }, [open])
 
-  if (!open) return null
-
   async function handleSend() {
     if (!selectedDevice) return
     setSending(true)
@@ -99,10 +98,8 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
   const selectedFile = singleBook?.files.find(f => f.id === selectedFileId)
 
   return (
-    <>
-      <div className="fixed inset-0 bg-black/50 z-50" onClick={onClose} />
-      <div className="fixed inset-0 flex items-center justify-center z-50 p-4">
-        <div className="bg-card border border-border rounded-2xl shadow-2xl max-w-md w-full max-h-[90vh] overflow-y-auto">
+    <ModalShell open={open} onClose={onClose} className="w-full max-w-md">
+        <div className="bg-card border border-border rounded-2xl shadow-2xl max-h-[90vh] overflow-y-auto">
           {/* Header */}
           <div className="flex items-center justify-between px-5 py-4 border-b border-border">
             <div className="flex items-center gap-2">
@@ -238,7 +235,6 @@ export function SendToDeviceModal({ open, onClose, books }: SendToDeviceModalPro
             )}
           </div>
         </div>
-      </div>
-    </>
+    </ModalShell>
   )
 }

--- a/frontend/src/components/ShareShelfModal.tsx
+++ b/frontend/src/components/ShareShelfModal.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { Check, Copy, Link2, Loader2, Share2, Trash2, X } from 'lucide-react'
 import { api } from '@/lib/api'
+import { ModalShell } from '@/components/ModalShell'
 import { copyToClipboard } from '@/lib/utils'
 import { Trans } from '@lingui/react/macro'
 import { t } from '@lingui/core/macro'
@@ -72,10 +73,8 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
   }
 
   return createPortal(
-    <>
-      <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" onClick={onClose} />
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
-        <div className="pointer-events-auto w-full max-w-md rounded-xl border border-border bg-card shadow-xl">
+    <ModalShell open onClose={onClose} className="w-full max-w-md">
+        <div className="rounded-xl border border-border bg-card shadow-xl">
           <div className="flex items-center gap-2 border-b border-border px-5 py-3.5">
             <Share2 className="h-4 w-4 text-primary" />
             <h2 className="font-display text-base text-foreground"><Trans>Share &quot;{title}&quot;</Trans></h2>
@@ -164,8 +163,7 @@ export function ShareModal({ title, endpoint, noun = 'shelf', onClose }: {
             )}
           </div>
         </div>
-      </div>
-    </>,
+    </ModalShell>,
     document.body,
   )
 }

--- a/frontend/src/components/UploadModal.tsx
+++ b/frontend/src/components/UploadModal.tsx
@@ -3,6 +3,7 @@ import { X, FileText, Layers, Upload, CheckCircle2, AlertCircle, Loader2 } from 
 import { api } from '@/lib/api'
 import { useBookTypes } from '@/lib/bookTypes'
 import { useToast } from '@/contexts/ToastContext'
+import { ModalShell } from '@/components/ModalShell'
 import { cn } from '@/lib/utils'
 import { Trans } from '@lingui/react/macro'
 import { t, plural } from '@lingui/core/macro'
@@ -185,45 +186,25 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
     }
   }
 
-  const [closing, setClosing] = useState(false)
-  const [visible, setVisible] = useState(false)
-
+  // Fresh state on every open; content stays intact during the exit animation.
   useEffect(() => {
     if (isOpen) {
-      setClosing(false)
-      requestAnimationFrame(() => setVisible(true))
+      setItems([])
+      setBulkType('')
+      setSummary(null)
     }
   }, [isOpen])
 
   function handleClose() {
     if (uploading) return
-    setClosing(true)
-    setVisible(false)
-    setTimeout(() => {
-      setClosing(false)
-      setItems([])
-      setBulkType('')
-      setSummary(null)
-      onClose()
-    }, 200)
+    onClose()
   }
-
-  if (!isOpen && !closing) return null
 
   const pendingCount = items.filter(it => it.status === 'pending').length
 
   return (
-    <div
-      className={cn(
-        'fixed inset-0 z-50 flex items-center justify-center p-4 transition-all duration-200',
-        visible ? 'bg-black/40 backdrop-blur-sm' : 'bg-black/0 backdrop-blur-0'
-      )}
-      onMouseDown={e => { if (e.target === e.currentTarget) handleClose() }}
-    >
-      <div className={cn(
-        'bg-card text-foreground rounded-2xl shadow-xl shadow-accent-soft w-full max-w-lg flex flex-col max-h-[90vh] transition-all duration-200',
-        visible ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
-      )}>
+    <ModalShell open={isOpen} onClose={handleClose} className="w-full max-w-lg">
+      <div className="bg-card text-foreground rounded-2xl shadow-xl shadow-accent-soft flex flex-col max-h-[90vh]">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
           <h2 className="text-base font-semibold flex items-center gap-2">
@@ -391,6 +372,6 @@ export function UploadModal({ isOpen, onClose, onDone, onUploaded, onWishMatches
           </div>
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/frontend/src/components/WishlistModal.tsx
+++ b/frontend/src/components/WishlistModal.tsx
@@ -3,6 +3,7 @@ import { Trans } from '@lingui/react/macro'
 import { t } from '@lingui/core/macro'
 import { X, Search, Loader2, BookOpen, Layers, ChevronLeft } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { ModalShell } from '@/components/ModalShell'
 import {
   searchWishCandidates,
   searchWishSeries,
@@ -13,6 +14,7 @@ import {
 } from '@/lib/wishlist'
 
 interface Props {
+  open: boolean
   onClose: () => void
   onCreated: () => void
 }
@@ -31,7 +33,7 @@ function SeriesThumb({ url }: { url: string | null }) {
   )
 }
 
-export function WishlistModal({ onClose, onCreated }: Props) {
+export function WishlistModal({ open, onClose, onCreated }: Props) {
   const [searchMode, setSearchMode] = useState<Mode>('book')
   const [seriesAvailable, setSeriesAvailable] = useState(false)
   const [query, setQuery] = useState('')
@@ -53,26 +55,26 @@ export function WishlistModal({ onClose, onCreated }: Props) {
 
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [visible, setVisible] = useState(false)
 
   const searchRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
-    requestAnimationFrame(() => setVisible(true))
+    if (!open) return
     inputRef.current?.focus()
     // Series search is Hardcover-only — only offer the Series tab when available.
     seriesSearchAvailable().then(r => setSeriesAvailable(!!r.available)).catch(() => {})
-  }, [])
+  }, [open])
 
   useEffect(() => {
+    if (!open) return
     function onKey(e: KeyboardEvent) {
       if (e.key === 'Escape') handleClose()
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [open])
 
   const doSearch = useCallback(async (q: string, mode: Mode) => {
     if (!q.trim()) {
@@ -120,8 +122,7 @@ export function WishlistModal({ onClose, onCreated }: Props) {
   }
 
   function handleClose() {
-    setVisible(false)
-    setTimeout(onClose, 200)
+    onClose()
   }
 
   function deriveSeriesName(c: WishSearchResult): string {
@@ -224,17 +225,8 @@ export function WishlistModal({ onClose, onCreated }: Props) {
   const inSearchState = !manualMode && !selected && !selectedSeries
 
   return (
-    <div
-      className={cn(
-        'fixed inset-0 z-50 flex items-center justify-center p-4 transition-all duration-200',
-        visible ? 'bg-black/40 backdrop-blur-sm' : 'bg-black/0 backdrop-blur-0'
-      )}
-      onMouseDown={e => { if (e.target === e.currentTarget) handleClose() }}
-    >
-      <div className={cn(
-        'bg-card text-foreground rounded-2xl shadow-xl shadow-accent-soft w-full max-w-lg flex flex-col max-h-[85vh] transition-all duration-200',
-        visible ? 'opacity-100 scale-100' : 'opacity-0 scale-95'
-      )}>
+    <ModalShell open={open} onClose={handleClose} className="w-full max-w-lg">
+      <div className="bg-card text-foreground rounded-2xl shadow-xl shadow-accent-soft flex flex-col max-h-[85vh]">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-border shrink-0">
           <h2 className="text-base font-semibold"><Trans>Add to Wishlist</Trans></h2>
@@ -557,6 +549,6 @@ export function WishlistModal({ onClose, onCreated }: Props) {
           </button>
         </div>
       </div>
-    </div>
+    </ModalShell>
   )
 }

--- a/frontend/src/lib/motion-features.ts
+++ b/frontend/src/lib/motion-features.ts
@@ -1,0 +1,3 @@
+// Loaded lazily by MotionProvider so the animation engine (domMax: layout
+// animations + gestures) lands in its own chunk instead of the main bundle.
+export { domMax as default } from 'motion/react'

--- a/frontend/src/lib/motion.tsx
+++ b/frontend/src/lib/motion.tsx
@@ -1,0 +1,15 @@
+import { type ReactNode } from 'react'
+import { LazyMotion, MotionConfig } from 'motion/react'
+
+// Async so the engine is a separate chunk; `strict` makes any accidental
+// `motion.div` (which would statically pull the full engine back into the
+// main bundle) throw in dev — always use `m.div` from 'motion/react'.
+const loadFeatures = () => import('./motion-features').then(mod => mod.default)
+
+export function MotionProvider({ children }: { children: ReactNode }) {
+  return (
+    <LazyMotion features={loadFeatures} strict>
+      <MotionConfig reducedMotion="user">{children}</MotionConfig>
+    </LazyMotion>
+  )
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useLayoutEffect, useRef, useState, useCallback, type ReactNode } from 'react'
+import { useEffect, useRef, useState, useCallback, type ReactNode } from 'react'
+import { AnimatePresence, m } from 'motion/react'
 import { Link, useSearchParams, useNavigate } from 'react-router-dom'
 import {
   BookOpen, X, Home, ChevronRight,
@@ -8,6 +9,7 @@ import {
   Flame, BookCheck, Clock, BookOpenCheck, Play, CheckCheck, Trash2, Settings2, Layers, Star, Quote, Moon, Shuffle, Share2,
 } from 'lucide-react'
 import { AppHeader, HeaderSearch } from '@/components/AppHeader'
+import { ModalShell } from '@/components/ModalShell'
 import { useAuth, isMember, isAdmin } from '@/contexts/AuthContext'
 import { Trans, useLingui, Plural } from '@lingui/react/macro'
 import { t, plural, msg } from '@lingui/core/macro'
@@ -157,8 +159,6 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
   const { t } = useLingui()
   const [deleting, setDeleting] = useState(false)
 
-  if (!open) return null
-
   const selectedBooks = books.filter(b => selectedIds.has(b.id))
 
   async function handleDelete() {
@@ -168,13 +168,8 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
   }
 
   return (
-    <>
-      <div
-        className="fixed inset-0 z-40 bg-black/50"
-        onClick={() => { if (!deleting) onCancel() }}
-      />
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
-        <div className="pointer-events-auto w-full max-w-md bg-card border border-border rounded-2xl shadow-2xl shadow-accent-soft flex flex-col max-h-[80vh]">
+    <ModalShell open={open} onClose={() => { if (!deleting) onCancel() }} className="w-full max-w-md">
+        <div className="bg-card border border-border rounded-2xl shadow-2xl shadow-accent-soft flex flex-col max-h-[80vh]">
           {/* Header */}
           <div className="flex items-center justify-between px-6 pt-6 pb-4 shrink-0">
             <div className="flex items-center gap-2">
@@ -260,8 +255,7 @@ function BulkDeleteModal({ open, books, selectedIds, onCancel, onConfirm }: Bulk
             </button>
           </div>
         </div>
-      </div>
-    </>
+    </ModalShell>
   )
 }
 
@@ -699,48 +693,7 @@ export function DashboardPage() {
   const [books, setBooks] = useState<Book[]>([])
   const { handleToggle } = useShiftSelect(books.map(b => b.id))
 
-  // FLIP-animate the books grid through cover-size reflows: when the column
-  // count changes, cards glide from their old box to the new one instead of
-  // teleporting. Rendered card width is a step function of the slider (1fr
-  // stretching), so easing the size value itself does nothing — the motion
-  // has to come from animating the reflow.
   const booksGridRef = useRef<HTMLDivElement | null>(null)
-  const flipRectsRef = useRef<Map<string, { left: number; top: number; width: number }>>(new Map())
-  useLayoutEffect(() => {
-    const el = booksGridRef.current
-    const prev = flipRectsRef.current
-    const next = new Map<string, { left: number; top: number; width: number }>()
-    if (el) {
-      const moved: HTMLElement[] = []
-      for (const child of Array.from(el.children) as HTMLElement[]) {
-        const id = child.dataset.flipId
-        if (!id) continue
-        // offset* is layout-relative (scroll- and transform-independent)
-        next.set(id, { left: child.offsetLeft, top: child.offsetTop, width: child.offsetWidth })
-        const a = prev.get(id)
-        const b = next.get(id)!
-        if (!a || (a.left === b.left && a.top === b.top && a.width === b.width)) continue
-        const scale = a.width / b.width
-        child.style.transition = 'none'
-        child.style.transformOrigin = 'top left'
-        // eslint-disable-next-line lingui/no-unlocalized-strings -- CSS transform
-        child.style.transform = `translate(${a.left - b.left}px, ${a.top - b.top}px) scale(${scale})`
-        moved.push(child)
-      }
-      if (moved.length > 0) {
-        // One synchronous reflow commits the inverted transforms before they
-        // transition back — a lone rAF can collapse into the same style flush
-        void el.offsetWidth
-        for (const child of moved) {
-          child.style.transition = 'transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1)'
-          child.style.transform = ''
-        }
-      }
-    }
-    flipRectsRef.current = next
-    // books in the deps so positions are (re)captured when the list loads or
-    // changes — without it the post-load baseline is empty and nothing animates
-  }, [gridSize, view, books])
   const [totalCount, setTotalCount] = useState<number | null>(null)
   const [readingStatuses, setReadingStatuses] = useState<Record<number, { status: ReadingStatus; progress_pct: number | null; rating: number | null }>>({})
   const [facets, setFacets] = useState<Facets>({ series: [], authors: [], tags: [], formats: [], languages: [] })
@@ -2339,10 +2292,21 @@ export function DashboardPage() {
             </div>
           ) : (
             <div key={view} ref={booksGridRef} className={cn(gridClass, refreshing && 'opacity-50 transition-opacity duration-150')} style={gridStyle}>
+              {/* POC: Motion layout animations replace the hand-rolled FLIP above —
+                  `layout` covers reflows (grid-size slider, filter survivors gliding)
+                  and AnimatePresence adds enter/exit, which FLIP never had. */}
+              <AnimatePresence mode="popLayout" initial={false}>
               {books.map((book, i) => (
-                groupActive && book.series ? (
+                <m.div
+                  key={`${cardView}-${groupActive && book.series ? 'stack-' : ''}${book.id}`}
+                  layout
+                  initial={{ opacity: 0, scale: 0.92 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  exit={{ opacity: 0, scale: 0.92 }}
+                  transition={{ layout: { duration: 0.24, ease: [0.2, 0.8, 0.2, 1] }, duration: 0.15 }}
+                >
+                {groupActive && book.series ? (
                   <SeriesStackCard
-                    key={`${cardView}-stack-${book.id}`}
                     book={book}
                     count={book.series_count ?? 1}
                     view={cardView}
@@ -2352,8 +2316,6 @@ export function DashboardPage() {
                   />
                 ) : (
                 <BookCard
-                  key={`${cardView}-${book.id}`}
-                  flipId={String(book.id)}
                   book={book}
                   view={cardView}
                   index={i}
@@ -2367,8 +2329,10 @@ export function DashboardPage() {
                   progressPct={readingStatuses[book.id]?.progress_pct}
                   rating={readingStatuses[book.id]?.rating}
                 />
-                )
+                )}
+                </m.div>
               ))}
+              </AnimatePresence>
             </div>
           )}
           {/* Infinite scroll sentinel */}
@@ -2401,14 +2365,8 @@ export function DashboardPage() {
       />
 
       {/* ── Bulk metadata modal ─────────────────────────────────────────────── */}
-      {bulkMetaOpen && (
-        <>
-          <div
-            className="fixed inset-0 z-40 bg-black/50"
-            onClick={() => { if (!bulkMetaSaving) setBulkMetaOpen(false) }}
-          />
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4 pointer-events-none">
-            <div className="pointer-events-auto w-full max-w-md bg-card border border-border rounded-2xl shadow-2xl p-6">
+      <ModalShell open={bulkMetaOpen} onClose={() => { if (!bulkMetaSaving) setBulkMetaOpen(false) }} className="w-full max-w-md">
+            <div className="bg-card border border-border rounded-2xl shadow-2xl p-6">
               <div className="flex items-start justify-between mb-1">
                 <h2 className="text-base font-semibold text-foreground">
                   <Plural value={selected.size} one="Edit Metadata for # Book" other="Edit Metadata for # Books" />
@@ -2518,9 +2476,7 @@ export function DashboardPage() {
                 </button>
               </div>
             </div>
-          </div>
-        </>
-      )}
+      </ModalShell>
     </div>
   )
 }

--- a/frontend/src/pages/WishlistPage.tsx
+++ b/frontend/src/pages/WishlistPage.tsx
@@ -183,6 +183,9 @@ export function WishlistPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [addOpen, setAddOpen] = useState(false)
+  // Bumped on each open so the always-mounted modal remounts with fresh state
+  // (it used to reset by conditional unmount, which killed the exit animation).
+  const [addEpoch, setAddEpoch] = useState(0)
   const [fulfilledOpen, setFulfilledOpen] = useState(true)
   const [deleting, setDeleting] = useState<number | null>(null)
 
@@ -242,7 +245,7 @@ export function WishlistPage() {
     <AppShell
       actions={
         <button
-          onClick={() => setAddOpen(true)}
+          onClick={() => { setAddEpoch(e => e + 1); setAddOpen(true) }}
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
         >
           <Plus className="w-3.5 h-3.5" />
@@ -300,7 +303,7 @@ export function WishlistPage() {
                     </p>
                   </div>
                   <button
-                    onClick={() => setAddOpen(true)}
+                    onClick={() => { setAddEpoch(e => e + 1); setAddOpen(true) }}
                     className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium bg-primary text-primary-foreground hover:opacity-90 transition-all"
                   >
                     <Plus className="w-4 h-4" />
@@ -401,15 +404,15 @@ export function WishlistPage() {
         {!loading && !error && <FollowingSection />}
       </div>
 
-      {addOpen && (
-        <WishlistModal
-          onClose={() => setAddOpen(false)}
-          onCreated={() => {
-            load()
-            toast.success(t`Wish added`)
-          }}
-        />
-      )}
+      <WishlistModal
+        key={addEpoch}
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onCreated={() => {
+          load()
+          toast.success(t`Wish added`)
+        }}
+      />
     </AppShell>
   )
 }


### PR DESCRIPTION
## Summary

Adopts [Motion](https://motion.dev) (MIT) for interface animation, replacing three hand-rolled systems with one.

- **LazyMotion setup**: animation engine loads as a separate 28 kB gzip chunk; main-bundle cost is +16 kB gzip. `MotionConfig reducedMotion="user"` honours the OS reduce-motion preference everywhere.
- **ModalShell**: shared scaffold giving every centered modal a backdrop fade + panel pop, on close as well as open (impossible with plain CSS since React unmounts the node). Converts Upload, Wishlist, CoverPicker, MetadataFetch, BulkMetadataReview, SendToDevice, BulkDelete, inline bulk-edit, KeyboardShortcuts (full enter+exit) and Entity, PositionHistory, ShareShelf, ManageSeries (animated enter). Backdrops standardised.
- **Books grid**: Motion `layout` animations replace the hand-rolled FLIP hook — same glide on filter/size changes, plus enter/exit fades for cards joining/leaving the result set.
- **Notification bell** dropdown pops from its corner.
- Deletes the FLIP hook + `flipId` plumbing and the `closing`/`visible` state machines; modals reset state on open (not close) so content survives the exit animation.

Mobile sidebar drawer intentionally untouched (already animates both ways via CSS). CommandPalette / ForcePasswordChange / WhatsNewPanel / MetadataManager left as-is.

## Test plan
- `npm run build` green; eslint clean on touched files (remaining errors pre-existing on main)
- Manually verified on dev: modal open/close cycles keep content through the exit, Wishlist modal state is fresh per open, grid glides + fades on filter/slider, reduce-motion snaps everything instant