### PR TITLE
fix(stats): DST-correct reading-day bucketing via DayCtx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ All notable changes to Tome are documented here. Format loosely follows
   also fade in and out as they enter and leave the results. Honours the
   system "reduce motion" preference.
 
+### Fixed
+- Reading streaks (and every day-bucketed stat) now handle daylight-saving
+  time correctly. Day bucketing used the browser's current UTC offset for
+  all of history, so a session started between 3 and 4 AM local time in the
+  opposite DST regime landed on the wrong day - a single winter bedtime
+  read could silently cut a months-long streak, and the streak number
+  changed at each clock change. The web app now sends its IANA timezone
+  alongside the offset and the server buckets each timestamp against the
+  timezone's real transition history. Clients that only send an offset
+  (KOReader plugin, external API users) keep the previous behaviour.
+
 ### Added
 - Per-user content restrictions, set by an admin in Admin → Users. Hidden
   tags make books carrying any of the listed tags (matched

--- a/backend/api/books.py
+++ b/backend/api/books.py
@@ -1289,7 +1289,7 @@ def get_reader_pacing(
     has such history (the reader falls back to a default pace)."""
     from backend.models.book import BookChapter
     from backend.services import reconciled_reading as rr
-    from backend.services.reading_day import date_modifier
+    from backend.services.reading_day import DayCtx
 
     book = _visible_book_or_404(db, current_user, book_id)
     chapters = (
@@ -1301,7 +1301,7 @@ def get_reader_pacing(
 
     wpm = None
     covered = rr.covered_book_ids(db, current_user.id)
-    secs_by_book = rr.book_seconds(db, current_user.id, date_modifier(0), covered, None, None)
+    secs_by_book = rr.book_seconds(db, current_user.id, DayCtx(0), covered, None, None)
     rows = (
         db.query(Book.id, Book.word_count)
         .join(UserBookStatus, UserBookStatus.book_id == Book.id)
@@ -1337,6 +1337,7 @@ def get_reader_pacing(
 def get_book_estimate(
     book_id: int,
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    tz: Optional[str] = Query(None, description="IANA timezone name for DST-correct day bucketing"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
@@ -1346,7 +1347,7 @@ def get_book_estimate(
     from backend.services import backlog_estimate as be
 
     book = _visible_book_or_404(db, current_user, book_id)
-    pace = be.compute_pace(db, current_user.id, tz_offset)
+    pace = be.compute_pace(db, current_user.id, tz_offset, tz)
     return be.estimate_book(book, pace)
 
 
@@ -1468,6 +1469,7 @@ def restore_position(
 def get_book_reading_stats(
     book_id: int,
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    tz: Optional[str] = Query(None, description="IANA timezone name for DST-correct day bucketing"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -1489,14 +1491,14 @@ def get_book_reading_stats(
     if not user_can_see_book(db, current_user, book):
         raise HTTPException(status_code=404, detail="Book not found")
 
-    own = compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset)
+    own = compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset, tz_name=tz)
     aggregate = (
         compute_book_aggregate_stats(db, book_id=book_id)
         if _is_admin(current_user)
         else None
     )
     # Per-page intensity from imported KOReader page-stats (None if web-only reading)
-    intensity = compute_book_page_intensity(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset)
+    intensity = compute_book_page_intensity(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset, tz_name=tz)
     # Time per TOC chapter (None without a chapter map or page-stats)
     chapters = compute_book_chapter_times(db, user_id=current_user.id, book_id=book_id)
 
@@ -1515,6 +1517,7 @@ def add_manual_reading_session(
     book_id: int,
     payload: ManualSessionIn,
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    tz: Optional[str] = Query(None, description="IANA timezone name for DST-correct day bucketing"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
@@ -1598,7 +1601,7 @@ def add_manual_reading_session(
         )
 
     db.commit()
-    return {"own": compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset)}
+    return {"own": compute_book_reading_stats(db, user_id=current_user.id, book_id=book_id, tz_offset=tz_offset, tz_name=tz)}
 
 
 @router.delete("/{book_id}/imported-history")

--- a/backend/api/home.py
+++ b/backend/api/home.py
@@ -166,6 +166,7 @@ def get_focus(
 @router.get("/stats")
 def get_home_stats(
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    tz: str | None = Query(None, description="IANA timezone name for DST-correct day bucketing"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
@@ -200,7 +201,7 @@ def get_home_stats(
 
     # Reconciled so the home streak matches the stats page: imported KOReader
     # page-stat days count alongside live sessions (no-op without imported stats).
-    current_streak_days, _ = reconciled_user_streaks(db, current_user.id, tz_offset)
+    current_streak_days, _ = reconciled_user_streaks(db, current_user.id, tz_offset, tz_name=tz)
 
     return {
         "current_streak_days": current_streak_days,
@@ -213,13 +214,14 @@ def get_home_stats(
 @router.get("/reading-dna")
 def get_home_reading_dna(
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    tz: str | None = Query(None, description="IANA timezone name for DST-correct day bucketing"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
     """Reading-personality summary for the Home rail (see services.reading_dna)."""
     from backend.services.reading_dna import compute_reading_dna
 
-    return compute_reading_dna(db, current_user, tz_offset)
+    return compute_reading_dna(db, current_user, tz_offset, tz)
 
 
 @router.get("/activity")

--- a/backend/api/share.py
+++ b/backend/api/share.py
@@ -392,7 +392,7 @@ def _serialize_books(db: Session, owner: User, books: list) -> list[dict]:
     content, and it is what makes a share worth looking at. Still zero routes
     to files."""
     from backend.services import reconciled_reading as rr
-    from backend.services.reading_day import date_modifier
+    from backend.services.reading_day import DayCtx
 
     book_ids = [b.id for b in books]
     status_rows = {
@@ -407,7 +407,7 @@ def _serialize_books(db: Session, owner: User, books: list) -> list[dict]:
     # Reconciled per-day reading (UTC day-bucketing — the owner's exact tz is
     # unknown server-side and a public page doesn't need it to the hour).
     covered = rr.covered_book_ids(db, owner.id)
-    day_secs = rr.book_day_seconds(db, owner.id, date_modifier(0), covered)
+    day_secs = rr.book_day_seconds(db, owner.id, DayCtx(0), covered)
     activity: dict[int, list[dict]] = {}
     for (bid, day), secs in sorted(day_secs.items(), key=lambda kv: (kv[0][0], kv[0][1] or "")):
         if bid in (set(book_ids)) and secs > 0 and day is not None:

--- a/backend/api/stats.py
+++ b/backend/api/stats.py
@@ -20,7 +20,7 @@ from backend.models.user_book_status import UserBookStatus
 from backend.models.user_series_rating import UserSeriesRating
 from backend.models.library import BookType
 from backend.services.streaks import reconciled_user_streaks
-from backend.services.reading_day import ROLLOVER_HOURS, date_modifier, effective_today, epoch_day
+from backend.services.reading_day import ROLLOVER_HOURS, DayCtx
 from backend.services import reconciled_reading as rr
 from backend.services.audit import audit
 from backend.services.session_hygiene import is_suspect, median_secs_per_page, suggested_seconds
@@ -64,10 +64,17 @@ def get_stats(
     start: Optional[str] = Query(None, description="Custom range start (YYYY-MM-DD, local). Overrides `days`."),
     end: Optional[str] = Query(None, description="Custom range end (YYYY-MM-DD, local, inclusive)."),
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    tz: Optional[str] = Query(None, description="IANA timezone name for DST-correct day bucketing"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
     now = datetime.utcnow()
+    # Day-identity bucketing goes through the canonical DayCtx (local day + 4h
+    # rollover, DST-correct per row when the client sends its IANA timezone —
+    # see backend/services/reading_day.py) so daily charts, the heatmap and
+    # re-read detection agree with the streak. Hour-of-day display picks the
+    # no-rollover variant inside rr.hour_dow.
+    day_ctx = DayCtx(tz_offset, tz)
 
     # Range resolution: an explicit `start` switches to a custom date range and
     # overrides `days`. Dates are local; convert to UTC for filtering (UTC = local +
@@ -106,17 +113,7 @@ def get_stats(
     # Inclusive fill window for the daily chart. "Today" is the user's current
     # reading day (4h rollover), which at 00:00–04:00 local is still yesterday.
     fill_start = fill_start_local or (cutoff or (now - timedelta(days=365))).date()
-    fill_end = fill_end_local or effective_today(tz_offset)
-
-    # Convert JS getTimezoneOffset (minutes, negative = east of UTC) to SQLite modifier
-    # e.g. CEST = UTC+2 → JS returns -120 → we need '+2 hours'
-    offset_hours = -(tz_offset // 60)
-    tz_modifier = f"{offset_hours:+d} hours"
-    # Day-identity bucketing goes through the canonical reading-day modifier
-    # (local day + 4h rollover — see backend/services/reading_day.py) so daily
-    # charts, the heatmap and re-read detection agree with the streak. The plain
-    # tz_modifier stays ONLY for hour-of-day display (hour × weekday heatmap).
-    day_modifier = date_modifier(tz_offset)
+    fill_end = fill_end_local or day_ctx.today()
 
     # Base query filtered to this user (still used by session-level tiles: pace, timeline,
     # pace-by-format — page-stats have no natural "sessions" so those stay session-sourced).
@@ -131,7 +128,7 @@ def get_stats(
     covered = rr.covered_book_ids(db, current_user.id)
 
     total_seconds, total_sessions, pages_turned = rr.totals(
-        db, current_user.id, day_modifier, covered, cutoff, range_end
+        db, current_user.id, day_ctx, covered, cutoff, range_end
     )
 
     avg_session = int(total_seconds / total_sessions) if total_sessions > 0 else 0
@@ -149,20 +146,20 @@ def get_stats(
 
     # Streaks (all time, local-day with 4h rollover). Reconciled: page-stat days count too.
     current_streak, longest_streak = reconciled_user_streaks(
-        db, current_user.id, tz_offset, covered
+        db, current_user.id, tz_offset, covered, tz_name=tz
     )
 
     # Daily aggregation (for selected range) — reconciled (page-stats win per book).
     daily = _fill_daily_map(
-        rr.daily_map(db, current_user.id, day_modifier, covered, cutoff, range_end),
+        rr.daily_map(db, current_user.id, day_ctx, covered, cutoff, range_end),
         fill_start, fill_end,
     )
 
     # Heatmap daily — always last 365 days — reconciled.
     heatmap_cutoff = now - timedelta(days=365)
     heatmap_daily = _fill_daily_map(
-        rr.daily_map(db, current_user.id, day_modifier, covered, heatmap_cutoff, None),
-        heatmap_cutoff.date(), effective_today(tz_offset),
+        rr.daily_map(db, current_user.id, day_ctx, covered, heatmap_cutoff, None),
+        heatmap_cutoff.date(), day_ctx.today(),
     )
 
     # Books finished list (for chart)
@@ -184,7 +181,7 @@ def get_stats(
 
     # Reconciled per-book reading time for the window (page-stats win per book), reused by
     # top-books, category, per-book table, and author-affinity below.
-    win_book = rr.book_seconds(db, current_user.id, day_modifier, covered, cutoff, range_end)
+    win_book = rr.book_seconds(db, current_user.id, day_ctx, covered, cutoff, range_end)
     book_meta: dict[int, tuple] = {}
     if win_book:
         for bid, title, author, cover, label in (
@@ -321,7 +318,7 @@ def get_stats(
         def _tl_iso(epoch: int) -> str:
             return datetime.fromtimestamp(epoch, timezone.utc).replace(tzinfo=None).isoformat() + "Z"
 
-        clusters = rr._cluster_rows(db, current_user.id, day_modifier, cutoff, range_end)
+        clusters = rr._cluster_rows(db, current_user.id, day_ctx, cutoff, range_end)
         clusters.sort(key=lambda c: -int(c.start))
         clusters = clusters[:50]
         cl_titles = dict(
@@ -353,7 +350,7 @@ def get_stats(
         duration = (range_end or now) - cutoff
         prev_start = start_date - duration
         prev_seconds = rr.totals(
-            db, current_user.id, day_modifier, covered, prev_start, start_date
+            db, current_user.id, day_ctx, covered, prev_start, start_date
         )[0]
         pct_change: Optional[float] = 0.0
         if prev_seconds > 0:
@@ -430,7 +427,7 @@ def get_stats(
 
     # ── Monthly comparison (last 12 months) ── reconciled ──────────────────
     month_cutoff = now - timedelta(days=365)
-    _mm = rr.monthly_map(db, current_user.id, day_modifier, covered, month_cutoff)
+    _mm = rr.monthly_map(db, current_user.id, day_ctx, covered, month_cutoff)
     month_session_map: dict[str, dict] = {
         m: {"seconds": v[0], "sessions": v[1]} for m, v in _mm.items()
     }
@@ -438,7 +435,7 @@ def get_stats(
     # Books finished per month
     month_finished_rows = (
         db.query(
-            func.strftime('%Y-%m', UserBookStatus.updated_at, day_modifier).label("month"),
+            func.strftime('%Y-%m', day_ctx.dt_shifted(UserBookStatus.updated_at)).label("month"),
             func.count(UserBookStatus.id).label("cnt"),
         )
         .filter(
@@ -446,7 +443,7 @@ def get_stats(
             UserBookStatus.status == "read",
             UserBookStatus.updated_at >= month_cutoff,
         )
-        .group_by(func.strftime('%Y-%m', UserBookStatus.updated_at, day_modifier))
+        .group_by(func.strftime('%Y-%m', day_ctx.dt_shifted(UserBookStatus.updated_at)))
         .all()
     )
     month_finished_map = {r.month: int(r.cnt) for r in month_finished_rows}
@@ -469,7 +466,7 @@ def get_stats(
 
     # ── Genre over time (last 12 months, stacked) ── reconciled ───────────
     # Reconciled per-(book, month) seconds, rolled up to book-type per month.
-    _bm = rr.book_month_seconds(db, current_user.id, day_modifier, covered, month_cutoff)
+    _bm = rr.book_month_seconds(db, current_user.id, day_ctx, covered, month_cutoff)
     _genre_ids = {bid for (bid, _m) in _bm.keys()}
     _genre_cat: dict[int, str] = {}
     if _genre_ids:
@@ -498,7 +495,7 @@ def get_stats(
         genre_over_time.append(entry)
 
     # ── Hour × day-of-week heatmap (168 cells) ── reconciled ─────────────────
-    hour_dow_map = rr.hour_dow(db, current_user.id, tz_modifier, covered, cutoff, range_end)
+    hour_dow_map = rr.hour_dow(db, current_user.id, day_ctx, covered, cutoff, range_end)
     hour_dow_heatmap = [
         {
             "dow": d,
@@ -689,7 +686,7 @@ def get_stats(
 
     # ── Ratings / taste (all-time, independent of the date window) ─────────────
     # Your taste isn't a 30-day thing, so these ignore cutoff/range entirely.
-    book_seconds_all = rr.book_seconds(db, current_user.id, day_modifier, covered, None, None)
+    book_seconds_all = rr.book_seconds(db, current_user.id, day_ctx, covered, None, None)
     rated_rows = (
         db.query(
             Book.id, Book.title, Book.author, Book.cover_path,
@@ -772,8 +769,8 @@ def get_stats(
     }
 
     # ── Lifetime / records / TBR / language (all-time, ignore the date range) ──
-    lt_secs, lt_sessions, lt_pages = rr.totals(db, current_user.id, day_modifier, covered, None, None)
-    all_daily = rr.daily_map(db, current_user.id, day_modifier, covered, None, None)
+    lt_secs, lt_sessions, lt_pages = rr.totals(db, current_user.id, day_ctx, covered, None, None)
+    all_daily = rr.daily_map(db, current_user.id, day_ctx, covered, None, None)
     lifetime = {
         "seconds": lt_secs,
         "sessions": lt_sessions,
@@ -958,7 +955,7 @@ def get_stats(
     # A page read on 2+ distinct reading days is a re-read. We rank books by how
     # many of their pages got revisited. Pure page-stats, no plugin work.
     from backend.models.ko_stats import PageStat as _PageStat
-    _day = epoch_day(_PageStat.start_time, tz_offset)
+    _day = day_ctx.epoch_day(_PageStat.start_time)
     _reread_pages_sq = (
         db.query(
             _PageStat.book_id.label("book_id"),
@@ -1011,7 +1008,7 @@ def get_stats(
 
     # ── Reading DNA — fixed trailing window, independent of the range selector ──
     from backend.services.reading_dna import compute_reading_dna
-    reading_dna = compute_reading_dna(db, current_user, tz_offset)
+    reading_dna = compute_reading_dna(db, current_user, tz_offset, tz)
 
     return {
         "range_days": effective_days,
@@ -1128,6 +1125,7 @@ def _backlog_books(db: Session, current_user: User, scope: str) -> list[Book]:
 def get_backlog_estimate(
     scope: str = Query("want", description="want | unread | library:<id> | shelf:<id>"),
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    tz: Optional[str] = Query(None, description="IANA timezone name for DST-correct day bucketing"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
@@ -1135,7 +1133,7 @@ def get_backlog_estimate(
     from backend.services import backlog_estimate as be
 
     books = _backlog_books(db, current_user, scope)
-    return {"scope": scope, **be.summarise(db, books, be.compute_pace(db, current_user.id, tz_offset))}
+    return {"scope": scope, **be.summarise(db, books, be.compute_pace(db, current_user.id, tz_offset, tz))}
 
 
 @router.get("/stats/backlog-scopes")
@@ -1159,6 +1157,7 @@ def get_backlog_scopes(
 @router.get("/stats/completion-estimates")
 def get_completion_estimates(
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    tz: Optional[str] = Query(None, description="IANA timezone name for DST-correct day bucketing"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> list:
@@ -1222,7 +1221,7 @@ def get_completion_estimates(
             db.query(
                 func.count(func.distinct(case((PageStat.start_time >= window_epoch, PageStat.page)))),
                 func.count(func.distinct(case((PageStat.start_time >= window_epoch,
-                                               epoch_day(PageStat.start_time, tz_offset))))),
+                                               DayCtx(tz_offset, tz).epoch_day(PageStat.start_time))))),
                 # Furthest position as a per-row page/total fraction — a page
                 # number only means anything against its own row's pagination.
                 func.max(PageStat.page * 1.0 / PageStat.total_pages),
@@ -1302,16 +1301,17 @@ def get_completion_estimates(
 @router.get("/stats/timeline")
 def get_reading_timeline(
     tz_offset: int = Query(0, description="Client timezone offset in minutes (JS getTimezoneOffset)"),
+    tz: Optional[str] = Query(None, description="IANA timezone name for DST-correct day bucketing"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ) -> dict:
     """Lifetime reading timeline: every book with recorded reading and its active
     days, reconciled across live sessions and imported KOReader page-stats.
     Day bucketing is the canonical reading day (4h rollover)."""
-    tzm = date_modifier(tz_offset)
+    day_ctx = DayCtx(tz_offset, tz)
     covered = rr.covered_book_ids(db, current_user.id)
-    day_secs = rr.book_day_seconds(db, current_user.id, tzm, covered)
-    today = effective_today(tz_offset).isoformat()
+    day_secs = rr.book_day_seconds(db, current_user.id, day_ctx, covered)
+    today = day_ctx.today().isoformat()
     if not day_secs:
         return {"books": [], "today": today}
 
@@ -1368,6 +1368,7 @@ def list_sessions(
     book_id: Optional[int] = Query(None),
     sort: str = Query("recent", pattern="^(recent|longest)$"),
     tz_offset: int = Query(0),
+    tz: Optional[str] = Query(None),
     day: Optional[str] = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"),
     db: Session = Depends(get_db),
     current_user: User = Depends(get_current_user),
@@ -1408,7 +1409,7 @@ def list_sessions(
         base = base.filter(ReadingSession.book_id == book_id)
     if day is not None:
         base = base.filter(
-            func.date(ReadingSession.started_at, date_modifier(tz_offset)) == day
+            DayCtx(tz_offset, tz).dt_day(ReadingSession.started_at) == day
         )
     total_sessions = base.count()
     order = (
@@ -1446,7 +1447,7 @@ def list_sessions(
         # seconds in the totals and draw Activity bars, so they must be listed
         # even though session COUNTS everywhere else keep the noise floor.
         clusters = rr._cluster_rows(
-            db, current_user.id, date_modifier(tz_offset), None, None,
+            db, current_user.id, DayCtx(tz_offset, tz), None, None,
             book_id=book_id, min_secs=0,
         )
         if day is not None:

--- a/backend/services/backlog_estimate.py
+++ b/backend/services/backlog_estimate.py
@@ -32,7 +32,7 @@ from backend.models.book import Book
 from backend.models.library import BookType
 from backend.models.user_book_status import UserBookStatus
 from backend.services import reconciled_reading as rr
-from backend.services.reading_day import date_modifier
+from backend.services.reading_day import DayCtx
 
 DEFAULT_WPM = 250
 WPM_MIN_SECONDS = 300
@@ -59,8 +59,8 @@ class Pace:
         }
 
 
-def compute_pace(db: Session, user_id: int, tz_offset: int = 0) -> Pace:
-    tzm = date_modifier(tz_offset)
+def compute_pace(db: Session, user_id: int, tz_offset: int = 0, tz_name: str | None = None) -> Pace:
+    tzm = DayCtx(tz_offset, tz_name)
     covered = rr.covered_book_ids(db, user_id)
 
     # All-time reconciled seconds per book — feeds both wpm and type averages.

--- a/backend/services/reading_day.py
+++ b/backend/services/reading_day.py
@@ -44,3 +44,169 @@ def epoch_day_int(epoch_seconds: int, tz_offset_minutes: int) -> int:
 def effective_today(tz_offset_minutes: int, rollover_hours: int = ROLLOVER_HOURS) -> date:
     """The user's current reading day — what walking back a streak starts from."""
     return (datetime.utcnow() + timedelta(hours=effective_hours(tz_offset_minutes, rollover_hours))).date()
+
+
+# ── DST-aware bucketing (DayCtx) ─────────────────────────────────────────────
+#
+# The plain-offset helpers above apply the client's *current* UTC offset to all
+# of history, so in a DST timezone every session started between 3 and 4 AM
+# local time in the opposite DST regime lands one day late (a 03:39 CET
+# January read bucketed with the August CEST offset falls after the rollover
+# boundary → wrong day, broken streak). DayCtx fixes that: given an IANA
+# timezone name it emits per-row SQL CASE expressions over the zone's real
+# transition instants, and does proper zoneinfo math on the Python side. With
+# no (or an unknown) timezone name it reproduces the fixed-offset behaviour
+# exactly, so older clients (plugin, OPDS, external API users) are unchanged.
+
+from dataclasses import dataclass
+from functools import lru_cache
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from sqlalchemy import case, literal
+
+_TRANSITIONS_START_YEAR = 2000
+
+
+def _offset_minutes_at(dt_utc: datetime, tz: ZoneInfo) -> int:
+    off = dt_utc.astimezone(tz).utcoffset()
+    return int(off.total_seconds() // 60) if off is not None else 0
+
+
+@lru_cache(maxsize=16)
+def _transitions(tz_name: str, end_year: int) -> tuple[tuple[int, int], ...]:
+    """UTC-offset timeline for a zone: ((epoch_instant, offset_minutes), …),
+    first entry anchored at _TRANSITIONS_START_YEAR. Probed at 12h steps and
+    refined to the minute — exact for every real-world transition rule.
+    Cache key includes end_year so the table refreshes at the year rollover."""
+    tz = ZoneInfo(tz_name)
+    from datetime import timezone as _tz
+    t = datetime(_TRANSITIONS_START_YEAR, 1, 1, tzinfo=_tz.utc)
+    end = datetime(end_year, 12, 31, tzinfo=_tz.utc)
+    cur = _offset_minutes_at(t, tz)
+    out = [(int(t.timestamp()), cur)]
+    step = timedelta(hours=12)
+    while t < end:
+        nxt = t + step
+        o = _offset_minutes_at(nxt, tz)
+        if o != cur:
+            lo, hi = t, nxt
+            while hi - lo > timedelta(minutes=1):
+                mid = lo + (hi - lo) / 2
+                mid = mid.replace(second=0, microsecond=0)
+                if mid <= lo:
+                    break
+                if _offset_minutes_at(mid, tz) == cur:
+                    lo = mid
+                else:
+                    hi = mid
+            out.append((int(hi.timestamp()), o))
+            cur = o
+        t = nxt
+    return tuple(out)
+
+
+def _valid_tz(name: str | None) -> str | None:
+    if not name:
+        return None
+    try:
+        ZoneInfo(name)
+    except (ZoneInfoNotFoundError, ValueError):
+        return None
+    return name
+
+
+@dataclass(frozen=True)
+class DayCtx:
+    """Per-request bucketing context: the client's current offset (fallback,
+    JS getTimezoneOffset semantics) plus an optional IANA timezone name that
+    unlocks DST-correct per-row bucketing. Build one at the endpoint and pass
+    it down — every day/hour/month bucket in a request must come from the same
+    ctx or buckets drift apart."""
+
+    tz_offset_minutes: int = 0
+    tz_name: str | None = None
+    rollover_hours: int = ROLLOVER_HOURS
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "tz_name", _valid_tz(self.tz_name))
+
+    # ── internals ────────────────────────────────────────────────────────────
+
+    def _zone(self) -> ZoneInfo:
+        return ZoneInfo(self.tz_name)  # type: ignore[arg-type]  (guarded by caller)
+
+    def _trans(self) -> tuple[tuple[int, int], ...]:
+        return _transitions(self.tz_name, datetime.utcnow().year + 2)
+
+    def _case_modifier(self, boundary_exprs, shift_minutes: int):
+        """SQL CASE picking the right '±N minutes' modifier per row.
+        boundary_exprs: fn(epoch_instant) -> comparison expression."""
+        trans = self._trans()
+        whens = [
+            (boundary_exprs(instant), literal(f"{off - shift_minutes:+d} minutes"))
+            for instant, off in reversed(trans[1:])
+        ]
+        first_off = trans[0][1]
+        return case(*whens, else_=literal(f"{first_off - shift_minutes:+d} minutes"))
+
+    def _fixed_modifier(self, rollover_hours: int) -> str:
+        return date_modifier(self.tz_offset_minutes, rollover_hours)
+
+    @staticmethod
+    def _dt_boundary(instant: int) -> str:
+        return datetime.utcfromtimestamp(instant).strftime("%Y-%m-%d %H:%M:%S")
+
+    # ── SQL expressions: reading day (local day with rollover) ───────────────
+
+    def dt_day(self, column):
+        """Reading day for a naive-UTC DateTime column → 'YYYY-MM-DD'."""
+        if self.tz_name is None:
+            return func.date(column, self._fixed_modifier(self.rollover_hours))
+        mod = self._case_modifier(lambda i: column >= self._dt_boundary(i),
+                                  self.rollover_hours * 60)
+        return func.date(column, mod)
+
+    def epoch_day(self, column):
+        """Reading day for an epoch-seconds column → 'YYYY-MM-DD'."""
+        if self.tz_name is None:
+            return func.date(column, "unixepoch", self._fixed_modifier(self.rollover_hours))
+        mod = self._case_modifier(lambda i: column >= i, self.rollover_hours * 60)
+        return func.date(column, "unixepoch", mod)
+
+    # ── SQL expressions: shifted local datetime ──────────────────────────────
+    # With rollover (day-consistent months etc.) and without (hour-of-day
+    # display, where a 1 AM session must read as hour 1).
+
+    def dt_shifted(self, column, *, rollover: bool = True):
+        shift = self.rollover_hours * 60 if rollover else 0
+        if self.tz_name is None:
+            return func.datetime(column, self._fixed_modifier(self.rollover_hours if rollover else 0))
+        return func.datetime(column, self._case_modifier(
+            lambda i: column >= self._dt_boundary(i), shift))
+
+    def epoch_shifted(self, column, *, rollover: bool = True):
+        shift = self.rollover_hours * 60 if rollover else 0
+        if self.tz_name is None:
+            return func.datetime(column, "unixepoch",
+                                 self._fixed_modifier(self.rollover_hours if rollover else 0))
+        return func.datetime(column, "unixepoch", self._case_modifier(
+            lambda i: column >= i, shift))
+
+    # ── Python side ──────────────────────────────────────────────────────────
+
+    def py_day(self, epoch_seconds: int) -> date:
+        """Reading day of an epoch timestamp."""
+        if self.tz_name is None:
+            eff = effective_hours(self.tz_offset_minutes, self.rollover_hours)
+            return (datetime.utcfromtimestamp(epoch_seconds) + timedelta(hours=eff)).date()
+        from datetime import timezone as _tz
+        local = datetime.fromtimestamp(epoch_seconds, _tz.utc).astimezone(self._zone())
+        return (local - timedelta(hours=self.rollover_hours)).date()
+
+    def today(self) -> date:
+        """The user's current reading day."""
+        if self.tz_name is None:
+            return effective_today(self.tz_offset_minutes, self.rollover_hours)
+        from datetime import timezone as _tz
+        now_local = datetime.now(_tz.utc).astimezone(self._zone())
+        return (now_local - timedelta(hours=self.rollover_hours)).date()

--- a/backend/services/reading_dna.py
+++ b/backend/services/reading_dna.py
@@ -24,7 +24,7 @@ from backend.models.book import Book
 from backend.models.user import User
 from backend.models.user_book_status import UserBookStatus
 from backend.services import reconciled_reading as rr
-from backend.services.reading_day import date_modifier, effective_today
+from backend.services.reading_day import DayCtx
 
 # Per-axis vocabulary, tone-checked. Tuple is (low-pole word, high-pole word).
 _NOUN = {
@@ -75,19 +75,18 @@ def _lerp_score(v: float, lo: float, hi: float) -> float:
     return _clamp((v - lo) / (hi - lo) * 100.0)
 
 
-def compute_reading_dna(db: Session, user: User, tz_offset: int) -> dict:
+def compute_reading_dna(db: Session, user: User, tz_offset: int, tz_name: str | None = None) -> dict:
     now = datetime.utcnow()
-    # Plain local offset — used ONLY for the hour-of-day trait, where 1am must
-    # read as hour 1. Day-identity buckets use the reading-day modifier below.
-    offset_hours = -(tz_offset // 60)
-    tzm = f"{offset_hours:+d} hours"
-    day_mod = date_modifier(tz_offset)
+    # One DayCtx for everything: day-identity buckets use the reading-day
+    # variant; rr.hour_dow internally picks the plain-local (no rollover)
+    # variant so 1am reads as hour 1.
+    day_mod = DayCtx(tz_offset, tz_name)
     covered = rr.covered_book_ids(db, user.id)
 
     traits: dict[str, float] = {}
 
     # ── Time (early bird ↔ night owl) — trailing 365d hour distribution ──────────
-    hour_dow = rr.hour_dow(db, user.id, tzm, covered, now - timedelta(days=365), None)
+    hour_dow = rr.hour_dow(db, user.id, day_mod, covered, now - timedelta(days=365), None)
     hour_secs: dict[int, int] = {}
     for (_d, h), (secs, _sess) in hour_dow.items():
         hour_secs[h] = hour_secs.get(h, 0) + secs
@@ -104,7 +103,7 @@ def compute_reading_dna(db: Session, user: User, tz_offset: int) -> dict:
     # two active days, and the user's own "today" — not the UTC date.
     adays = rr.active_days(db, user.id, day_mod, covered)
     if adays:
-        today = effective_today(tz_offset)
+        today = day_mod.today()
         window = 120
         first = min(adays)
         span = min(window, (today - first).days + 1)

--- a/backend/services/reading_stats.py
+++ b/backend/services/reading_stats.py
@@ -17,7 +17,7 @@ from sqlalchemy.orm import Session
 from backend.models.book import Book
 from backend.models.tome_sync import ReadingSession
 from backend.models.user_book_status import UserBookStatus
-from backend.services.reading_day import date_modifier, effective_today, epoch_day, epoch_day_int
+from backend.services.reading_day import DayCtx
 
 
 class _SrcRow(NamedTuple):
@@ -62,6 +62,7 @@ def compute_book_reading_stats(
     user_id: int,
     book_id: int,
     tz_offset: int = 0,
+    tz_name: str | None = None,
 ) -> dict:
     """Return reading statistics for one user on one book.
 
@@ -125,15 +126,16 @@ def compute_book_reading_stats(
     progress: Optional[float] = status_row.progress_pct if status_row else None
 
     # ── Session timeline — reading-day buckets ────────────────────────────────
-    day_mod = date_modifier(tz_offset)
+    day_ctx = DayCtx(tz_offset, tz_name)
+    rs_day = day_ctx.dt_day(ReadingSession.started_at)
     timeline_rows = (
         base.with_entities(
-            func.date(ReadingSession.started_at, day_mod).label("date"),
+            rs_day.label("date"),
             func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
             func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages"),
         )
-        .group_by(func.date(ReadingSession.started_at, day_mod))
-        .order_by(func.date(ReadingSession.started_at, day_mod))
+        .group_by(rs_day)
+        .order_by(rs_day)
         .all()
     )
     session_timeline = [
@@ -196,7 +198,7 @@ def compute_book_reading_stats(
         # Daily buckets from page-stats, by reading day (local + 4h rollover).
         day_rows = (
             db.query(
-                epoch_day(PageStat.start_time, tz_offset).label("day"),
+                day_ctx.epoch_day(PageStat.start_time).label("day"),
                 func.coalesce(func.sum(PageStat.duration_seconds), 0).label("seconds"),
                 func.count(func.distinct(PageStat.page)).label("pages"),
             )
@@ -225,7 +227,7 @@ def compute_book_reading_stats(
         if add_count:
             add_rows = (
                 additive.with_entities(
-                    func.date(ReadingSession.started_at, day_mod).label("date"),
+                    day_ctx.dt_day(ReadingSession.started_at).label("date"),
                     func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("seconds"),
                     func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages"),
                 )
@@ -245,7 +247,7 @@ def compute_book_reading_stats(
         # always equals the rows the dropdown can show (plus additive
         # web/manual sessions, which keep their own counts).
         sessions = len(
-            _cluster_rows(db, user_id, day_mod, None, None, book_id=book_id)
+            _cluster_rows(db, user_id, day_ctx, None, None, book_id=book_id)
         ) + add_count
         avg_session_seconds = round(total_seconds / sessions) if sessions else 0
 
@@ -280,10 +282,10 @@ def compute_book_reading_stats(
     prog_base = base.filter(counted_clause()) if ps_seconds > 0 else base
     prog_rows = (
         prog_base.with_entities(
-            func.date(ReadingSession.started_at, day_mod).label("date"),
+            day_ctx.dt_day(ReadingSession.started_at).label("date"),
             func.max(ReadingSession.progress_end).label("p"),
         )
-        .group_by(func.date(ReadingSession.started_at, day_mod))
+        .group_by(day_ctx.dt_day(ReadingSession.started_at))
         .all()
     )
     for r in prog_rows:
@@ -308,7 +310,7 @@ def compute_book_reading_stats(
             db.query(
                 func.coalesce(PageStat.device, "koreader").label("device"),
                 func.coalesce(func.sum(PageStat.duration_seconds), 0).label("seconds"),
-                func.count(func.distinct(epoch_day(PageStat.start_time, tz_offset))).label("units"),
+                func.count(func.distinct(day_ctx.epoch_day(PageStat.start_time))).label("units"),
             )
             .filter(PageStat.user_id == user_id, PageStat.book_id == book_id)
             .group_by("device")
@@ -344,7 +346,7 @@ def compute_book_reading_stats(
 
     # ── Reading momentum: last 7 days vs the 7 before ─────────────────────────
     # "Today" is the user's current reading day, matching the timeline buckets.
-    today = effective_today(tz_offset)
+    today = day_ctx.today()
     recent_seconds = prior_seconds = 0
     for row in session_timeline:
         try:
@@ -533,6 +535,7 @@ def compute_book_page_intensity(
     book_id: int,
     bins: int = 50,
     tz_offset: int = 0,
+    tz_name: str | None = None,
 ) -> Optional[dict]:
     """Per-page reading intensity for one book, from imported KOReader page-stats.
 
@@ -567,6 +570,7 @@ def compute_book_page_intensity(
 
     curve = [0] * bins
     bin_days: dict[int, set] = defaultdict(set)
+    day_ctx = DayCtx(tz_offset, tz_name)
     total_seconds = 0
     # "Latest" pagination = the most recent row's total_pages. NOT max():
     # reopening a finished 250-page book once at a 1571-page pagination must
@@ -589,7 +593,7 @@ def compute_book_page_intensity(
             latest_start = int(start_time or 0)
             latest_total_pages = int(total_pages)
         # reading-day bucket (page revisited on a different day ⇒ a re-read)
-        bin_days[b].add(epoch_day_int(int(start_time), tz_offset) if start_time else 0)
+        bin_days[b].add(day_ctx.py_day(int(start_time)).toordinal() if start_time else 0)
 
     # Coverage as a fraction-space interval union — pagination-robust — then
     # expressed against the latest pagination for the "X of Y pages" line.

--- a/backend/services/reconciled_reading.py
+++ b/backend/services/reconciled_reading.py
@@ -32,6 +32,7 @@ than MIN_SESSION_SECONDS are noise (a page flip while shelving) and aren't count
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Optional
 
 from sqlalchemy import Integer, and_, exists, func, or_
@@ -39,6 +40,7 @@ from sqlalchemy.orm import Session
 
 from backend.models.ko_stats import PageStat
 from backend.models.tome_sync import ReadingSession
+from backend.services.reading_day import DayCtx
 
 # ReadingSession.device values that can never be described by imported KOReader
 # page-stats. Everything else (device names, NULL legacy rows) is device-origin.
@@ -126,12 +128,12 @@ def _rs_filtered(db: Session, user_id: int, covered: list[int],
     return q
 
 
-def _ps_day(tzm: str):
-    return func.date(PageStat.start_time, "unixepoch", tzm)
+def _ps_day(day: DayCtx):
+    return day.epoch_day(PageStat.start_time)
 
 
-def _ps_local(tzm: str):
-    return func.datetime(PageStat.start_time, "unixepoch", tzm)
+def _ps_local(day: DayCtx, *, rollover: bool):
+    return day.epoch_shifted(PageStat.start_time, rollover=rollover)
 
 
 # A new session starts when the gap between consecutive page rows of the same
@@ -142,7 +144,7 @@ SESSION_GAP_SECONDS = 1800
 MIN_SESSION_SECONDS = 10
 
 
-def _cluster_rows(db, user_id: int, tzm: str,
+def _cluster_rows(db, user_id: int, day: DayCtx,
                   cutoff: Optional[datetime], range_end: Optional[datetime],
                   book_id: Optional[int] = None,
                   min_secs: int = MIN_SESSION_SECONDS):
@@ -167,7 +169,7 @@ def _cluster_rows(db, user_id: int, tzm: str,
     """
     from sqlalchemy import text
 
-    where, params = ["user_id = :uid"], {"uid": user_id, "tzm": tzm,
+    where, params = ["user_id = :uid"], {"uid": user_id,
                                          "gap": SESSION_GAP_SECONDS,
                                          "min_secs": min_secs}
     ce, ee = _epoch(cutoff), _epoch(range_end)
@@ -193,7 +195,6 @@ def _cluster_rows(db, user_id: int, tzm: str,
             FROM ordered
         )
         SELECT book_id,
-               date(MIN(start_time), 'unixepoch', :tzm) AS day,
                MIN(start_time) AS start,
                MAX(start_time) AS last_start,
                SUM(duration_seconds) AS secs,
@@ -203,12 +204,22 @@ def _cluster_rows(db, user_id: int, tzm: str,
         GROUP BY book_id, cluster_id
         HAVING SUM(duration_seconds) >= :min_secs
     """)
-    return db.execute(sql, params).all()
+    # The day label is computed Python-side so it is DST-correct per cluster
+    # (a SQL bind can only carry one fixed offset for all rows).
+    return [
+        SimpleNamespace(
+            book_id=r.book_id,
+            day=day.py_day(int(r.start)).isoformat(),
+            start=r.start, last_start=r.last_start,
+            secs=r.secs, pages=r.pages, device=r.device,
+        )
+        for r in db.execute(sql, params).all()
+    ]
 
 
 # ── Totals ────────────────────────────────────────────────────────────────────
 
-def totals(db, user_id, tzm, covered, cutoff, range_end) -> tuple[int, int, int]:
+def totals(db, user_id, day, covered, cutoff, range_end) -> tuple[int, int, int]:
     """(seconds, sessions, pages) reconciled over the window."""
     rs = _rs_filtered(db, user_id, covered, cutoff, range_end).with_entities(
         func.coalesce(func.sum(ReadingSession.duration_seconds), 0),
@@ -224,18 +235,18 @@ def totals(db, user_id, tzm, covered, cutoff, range_end) -> tuple[int, int, int]
         secs += int(ps[0] or 0)
         pages += int(ps[1] or 0)
         # real sessions: gap-clustered, not one-per-(book, day)
-        sessions += len(_cluster_rows(db, user_id, tzm, cutoff, range_end))
+        sessions += len(_cluster_rows(db, user_id, day, cutoff, range_end))
     return secs, sessions, pages
 
 
 # ── Daily (per local-day) ───────────────────────────────────────────────────────
 
-def daily_map(db, user_id, tzm, covered, start_dt, end_dt) -> dict[str, tuple[int, int, int]]:
+def daily_map(db, user_id, day, covered, start_dt, end_dt) -> dict[str, tuple[int, int, int]]:
     """day_str -> (seconds, sessions, pages). Caller fills the gaps."""
     rows = (
         _rs_filtered(db, user_id, covered, start_dt, end_dt)
         .with_entities(
-            func.date(ReadingSession.started_at, tzm).label("day"),
+            day.dt_day(ReadingSession.started_at).label("day"),
             func.coalesce(func.sum(ReadingSession.duration_seconds), 0).label("secs"),
             func.count(ReadingSession.id).label("sessions"),
             func.coalesce(func.sum(ReadingSession.pages_turned), 0).label("pages"),
@@ -250,7 +261,7 @@ def daily_map(db, user_id, tzm, covered, start_dt, end_dt) -> dict[str, tuple[in
         day_groups = (
             _ps_filtered(db, user_id, start_dt, end_dt)
             .with_entities(
-                _ps_day(tzm).label("day"),
+                _ps_day(day).label("day"),
                 func.sum(PageStat.duration_seconds).label("secs"),
                 func.count(PageStat.id).label("pages"),
             )
@@ -259,7 +270,7 @@ def daily_map(db, user_id, tzm, covered, start_dt, end_dt) -> dict[str, tuple[in
         for g in day_groups:
             e = out.setdefault(g.day, [0, 0, 0])
             e[0] += int(g.secs or 0); e[2] += int(g.pages or 0)
-        for c in _cluster_rows(db, user_id, tzm, start_dt, end_dt):
+        for c in _cluster_rows(db, user_id, day, start_dt, end_dt):
             e = out.setdefault(c.day, [0, 0, 0])
             e[1] += 1
     return {d: (v[0], v[1], v[2]) for d, v in out.items()}
@@ -267,7 +278,7 @@ def daily_map(db, user_id, tzm, covered, start_dt, end_dt) -> dict[str, tuple[in
 
 # ── Per-book ────────────────────────────────────────────────────────────────────
 
-def book_seconds(db, user_id, tzm, covered, cutoff, range_end) -> dict[int, tuple[int, int, int]]:
+def book_seconds(db, user_id, day, covered, cutoff, range_end) -> dict[int, tuple[int, int, int]]:
     """book_id -> (seconds, sessions, pages) reconciled over the window."""
     rows = (
         _rs_filtered(db, user_id, covered, cutoff, range_end)
@@ -294,15 +305,15 @@ def book_seconds(db, user_id, tzm, covered, cutoff, range_end) -> dict[int, tupl
         for r in rows2:
             e = out.setdefault(r.book_id, [0, 0, 0])
             e[0] += int(r.secs or 0); e[2] += int(r.pages or 0)
-        for c in _cluster_rows(db, user_id, tzm, cutoff, range_end):
+        for c in _cluster_rows(db, user_id, day, cutoff, range_end):
             e = out.setdefault(c.book_id, [0, 0, 0])
             e[1] += 1
     return {b: (v[0], v[1], v[2]) for b, v in out.items()}
 
 
-def book_month_seconds(db, user_id, tzm, covered, start_dt) -> dict[tuple[int, str], int]:
+def book_month_seconds(db, user_id, day, covered, start_dt) -> dict[tuple[int, str], int]:
     """(book_id, 'YYYY-MM') -> seconds. For the genre-over-time stack."""
-    rs_month = func.strftime("%Y-%m", func.datetime(ReadingSession.started_at, tzm))
+    rs_month = func.strftime("%Y-%m", day.dt_shifted(ReadingSession.started_at))
     rows = (
         _rs_filtered(db, user_id, covered, start_dt, None)
         .filter(ReadingSession.book_id.isnot(None))
@@ -312,7 +323,7 @@ def book_month_seconds(db, user_id, tzm, covered, start_dt) -> dict[tuple[int, s
     )
     out: dict[tuple[int, str], int] = {(r.book_id, r.m): int(r.secs or 0) for r in rows}
     if covered:
-        ps_month = func.strftime("%Y-%m", _ps_local(tzm))
+        ps_month = func.strftime("%Y-%m", _ps_local(day, rollover=True))
         rows2 = (
             _ps_filtered(db, user_id, start_dt, None)
             .with_entities(PageStat.book_id, ps_month.label("m"),
@@ -324,9 +335,9 @@ def book_month_seconds(db, user_id, tzm, covered, start_dt) -> dict[tuple[int, s
     return out
 
 
-def book_day_seconds(db, user_id, tzm, covered) -> dict[tuple[int, str], int]:
+def book_day_seconds(db, user_id, day, covered) -> dict[tuple[int, str], int]:
     """(book_id, 'YYYY-MM-DD') -> seconds, all time. For the reading timeline."""
-    rs_day = func.date(ReadingSession.started_at, tzm)
+    rs_day = day.dt_day(ReadingSession.started_at)
     rows = (
         _rs_filtered(db, user_id, covered, None, None)
         .filter(ReadingSession.book_id.isnot(None))
@@ -338,7 +349,7 @@ def book_day_seconds(db, user_id, tzm, covered) -> dict[tuple[int, str], int]:
     if covered:
         rows2 = (
             _ps_filtered(db, user_id, None, None)
-            .with_entities(PageStat.book_id, _ps_day(tzm).label("d"),
+            .with_entities(PageStat.book_id, _ps_day(day).label("d"),
                            func.coalesce(func.sum(PageStat.duration_seconds), 0).label("secs"))
             .group_by(PageStat.book_id, "d").all()
         )
@@ -349,9 +360,9 @@ def book_day_seconds(db, user_id, tzm, covered) -> dict[tuple[int, str], int]:
 
 # ── Hour × day-of-week ──────────────────────────────────────────────────────────
 
-def hour_dow(db, user_id, tzm, covered, cutoff, range_end) -> dict[tuple[int, int], tuple[int, int]]:
+def hour_dow(db, user_id, day, covered, cutoff, range_end) -> dict[tuple[int, int], tuple[int, int]]:
     """(dow, hour) -> (seconds, sessions)."""
-    rs_local = func.datetime(ReadingSession.started_at, tzm)
+    rs_local = day.dt_shifted(ReadingSession.started_at, rollover=False)
     rows = (
         _rs_filtered(db, user_id, covered, cutoff, range_end)
         .with_entities(
@@ -367,8 +378,8 @@ def hour_dow(db, user_id, tzm, covered, cutoff, range_end) -> dict[tuple[int, in
         rows2 = (
             _ps_filtered(db, user_id, cutoff, range_end)
             .with_entities(
-                func.cast(func.strftime("%w", _ps_local(tzm)), Integer).label("dow"),
-                func.cast(func.strftime("%H", _ps_local(tzm)), Integer).label("hour"),
+                func.cast(func.strftime("%w", _ps_local(day, rollover=False)), Integer).label("dow"),
+                func.cast(func.strftime("%H", _ps_local(day, rollover=False)), Integer).label("hour"),
                 func.coalesce(func.sum(PageStat.duration_seconds), 0).label("secs"),
                 func.count(func.distinct(PageStat.book_id)).label("sessions"),
             )
@@ -382,9 +393,9 @@ def hour_dow(db, user_id, tzm, covered, cutoff, range_end) -> dict[tuple[int, in
 
 # ── Monthly (per 'YYYY-MM') ─────────────────────────────────────────────────────
 
-def monthly_map(db, user_id, tzm, covered, start_dt) -> dict[str, tuple[int, int]]:
+def monthly_map(db, user_id, day, covered, start_dt) -> dict[str, tuple[int, int]]:
     """'YYYY-MM' -> (seconds, sessions)."""
-    rs_month = func.strftime("%Y-%m", func.datetime(ReadingSession.started_at, tzm))
+    rs_month = func.strftime("%Y-%m", day.dt_shifted(ReadingSession.started_at))
     rows = (
         _rs_filtered(db, user_id, covered, start_dt, None)
         .with_entities(rs_month.label("m"),
@@ -396,7 +407,7 @@ def monthly_map(db, user_id, tzm, covered, start_dt) -> dict[str, tuple[int, int
     if covered:
         day_groups = (
             _ps_filtered(db, user_id, start_dt, None)
-            .with_entities(PageStat.book_id, _ps_day(tzm).label("day"),
+            .with_entities(PageStat.book_id, _ps_day(day).label("day"),
                            func.sum(PageStat.duration_seconds).label("secs"))
             .group_by(PageStat.book_id, "day").all()
         )
@@ -409,7 +420,7 @@ def monthly_map(db, user_id, tzm, covered, start_dt) -> dict[str, tuple[int, int
 
 # ── Reconciled active-day set (for streaks) ─────────────────────────────────────
 
-def active_days(db, user_id, tzm, covered) -> set:
+def active_days(db, user_id, day, covered) -> set:
     from datetime import date as _date
     # A day is "active" if the user read at all that day — page-stat OR session,
     # covered book or not. We deliberately do NOT exclude covered-book sessions
@@ -421,14 +432,14 @@ def active_days(db, user_id, tzm, covered) -> set:
     rs_days = {
         r[0] for r in
         _rs_filtered(db, user_id, [], None, None)
-        .with_entities(func.date(ReadingSession.started_at, tzm)).distinct().all()
+        .with_entities(day.dt_day(ReadingSession.started_at)).distinct().all()
         if r[0]
     }
     if covered:
         rs_days |= {
             r[0] for r in
             _ps_filtered(db, user_id, None, None)
-            .with_entities(_ps_day(tzm)).distinct().all()
+            .with_entities(_ps_day(day)).distinct().all()
             if r[0]
         }
     return {_date.fromisoformat(d) for d in rs_days}

--- a/backend/services/streaks.py
+++ b/backend/services/streaks.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 
 from backend.models.tome_sync import ReadingSession
 # Re-exported for existing importers; the canonical home is reading_day.
-from backend.services.reading_day import ROLLOVER_HOURS, date_modifier, effective_today  # noqa: F401
+from backend.services.reading_day import ROLLOVER_HOURS, DayCtx, date_modifier, effective_today  # noqa: F401
 
 
 def streaks_from_dates(day_set: set[date], today: date) -> tuple[int, int]:
@@ -43,17 +43,18 @@ def compute_user_streaks(
     db: Session,
     user_id: int,
     tz_offset_minutes: int,
+    tz_name: str | None = None,
 ) -> tuple[int, int]:
     """Return (current_streak, longest_streak) for a user, in their local day with 4h rollover."""
-    modifier = date_modifier(tz_offset_minutes)
+    day = DayCtx(tz_offset_minutes, tz_name)
     rows = (
-        db.query(func.date(ReadingSession.started_at, modifier).label("d"))
+        db.query(day.dt_day(ReadingSession.started_at).label("d"))
         .filter(ReadingSession.user_id == user_id)
         .distinct()
         .all()
     )
     day_set = {date.fromisoformat(r.d) for r in rows if r.d}
-    return streaks_from_dates(day_set, effective_today(tz_offset_minutes))
+    return streaks_from_dates(day_set, day.today())
 
 
 def reconciled_user_streaks(
@@ -61,6 +62,7 @@ def reconciled_user_streaks(
     user_id: int,
     tz_offset_minutes: int,
     covered: list[int] | None = None,
+    tz_name: str | None = None,
 ) -> tuple[int, int]:
     """Return (current, longest) streaks counting reconciled reading.
 
@@ -76,6 +78,7 @@ def reconciled_user_streaks(
     if covered is None:
         covered = rr.covered_book_ids(db, user_id)
     if not covered:
-        return compute_user_streaks(db, user_id, tz_offset_minutes)
-    day_set = rr.active_days(db, user_id, date_modifier(tz_offset_minutes), covered)
-    return streaks_from_dates(day_set, effective_today(tz_offset_minutes))
+        return compute_user_streaks(db, user_id, tz_offset_minutes, tz_name)
+    day = DayCtx(tz_offset_minutes, tz_name)
+    day_set = rr.active_days(db, user_id, day, covered)
+    return streaks_from_dates(day_set, day.today())

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,22 @@
 const API_BASE = "/api"
 
+// Wherever a request sends the legacy tz_offset (a single fixed offset), pair
+// it with the IANA timezone name so the backend can bucket reading days
+// DST-correctly per timestamp instead of applying today's offset to all of
+// history (a January 03:39 CET read otherwise lands on the wrong day when
+// queried in summer, breaking streaks).
+function withTz(path: string): string {
+  if (!path.includes("tz_offset=") || /[?&]tz=/.test(path)) return path
+  try {
+    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    return zone ? `${path}&tz=${encodeURIComponent(zone)}` : path
+  } catch {
+    return path
+  }
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  path = withTz(path)
   const token = localStorage.getItem("tome_token")
   const headers: HeadersInit = {
     "Content-Type": "application/json",

--- a/tests/test_reading_day.py
+++ b/tests/test_reading_day.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from backend.models.ko_stats import PageStat
 from backend.models.tome_sync import ReadingSession
 from backend.services.reading_day import (
+    DayCtx,
     date_modifier,
     effective_today,
     epoch_day_int,
@@ -142,5 +143,5 @@ def test_dna_rhythm_counts_midnight_read_as_one_active_day(db, admin_user, make_
     db.flush()
 
     covered = rr.covered_book_ids(db, user.id)
-    days = rr.active_days(db, user.id, date_modifier(CEST), covered)
+    days = rr.active_days(db, user.id, DayCtx(CEST), covered)
     assert len(days) == 20

--- a/tests/test_stats_reconciliation.py
+++ b/tests/test_stats_reconciliation.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 
 from backend.models.tome_sync import ReadingSession
 from backend.models.ko_stats import PageStat
+from backend.services.reading_day import DayCtx
 
 
 def _epoch(y, mo, d, h=12):
@@ -94,7 +95,7 @@ def test_two_sittings_same_day_are_two_sessions(db, admin_user, make_book):
                 [(base, 60), (base + 70, 60), (base + 140, 60),
                  (base + 4 * 3600, 60), (base + 4 * 3600 + 90, 60)])
     covered = covered_book_ids(db, user.id)
-    secs, sessions, pages = totals(db, user.id, "+0 hours", covered, None, None)
+    secs, sessions, pages = totals(db, user.id, DayCtx(0, rollover_hours=0), covered, None, None)
     assert sessions == 2          # the old approximation reported 1
     assert secs == 300 and pages == 5
 
@@ -109,7 +110,7 @@ def test_midnight_crossing_is_one_session_on_start_day(db, admin_user, make_book
     _seed_stats(db, user.id, book.id,
                 [(start + i * 300, 240) for i in range(7)])  # 35 min span
     covered = covered_book_ids(db, user.id)
-    dm = daily_map(db, user.id, "+0 hours", covered, None, None)
+    dm = daily_map(db, user.id, DayCtx(0, rollover_hours=0), covered, None, None)
     total_sessions = sum(v[1] for v in dm.values())
     assert total_sessions == 1                       # old: 2 (one per day touched)
     assert dm["2026-03-10"][1] == 1                  # attributed to the start day
@@ -127,7 +128,7 @@ def test_noise_flip_not_counted_as_session(db, admin_user, make_book):
                 [(base, 3),                    # 3s flip — below MIN_SESSION_SECONDS
                  (base + 7200, 120), (base + 7300, 120)])  # a real sitting later
     covered = covered_book_ids(db, user.id)
-    _, sessions, _ = totals(db, user.id, "+0 hours", covered, None, None)
+    _, sessions, _ = totals(db, user.id, DayCtx(0, rollover_hours=0), covered, None, None)
     assert sessions == 1
 
 
@@ -140,7 +141,7 @@ def test_per_book_session_counts_are_clustered(db, admin_user, make_book):
     _seed_stats(db, user.id, book.id,
                 [(base, 60), (base + 3 * 3600, 60), (base + 30 * 3600, 60)])
     covered = covered_book_ids(db, user.id)
-    bs = book_seconds(db, user.id, "+0 hours", covered, None, None)
+    bs = book_seconds(db, user.id, DayCtx(0, rollover_hours=0), covered, None, None)
     assert bs[book.id][1] == 3
 
 

--- a/tests/test_streak_dst.py
+++ b/tests/test_streak_dst.py
@@ -1,0 +1,132 @@
+"""DST-correct reading-day bucketing (DayCtx).
+
+Regression for the seasonal streak bug: day bucketing applied the client's
+*current* UTC offset (JS getTimezoneOffset) to all of history, so a session
+started between 3 and 4 AM local time in the opposite DST regime landed one
+day late. Real case: a 03:39 CET bedtime read on the night of 2026-01-08→09
+(02:39:54 UTC), bucketed with the August CEST offset (-120), fell on Jan 9 —
+leaving Jan 8 empty and cutting a 260-day streak down to 230.
+
+With an IANA timezone name (`tz` query param, sent by the web app alongside
+`tz_offset`) DayCtx buckets per row using the zone's real transition instants.
+Offset-only clients (plugin, external API users) keep the old fixed-offset
+behaviour bit-for-bit.
+"""
+from datetime import date, datetime, timezone
+
+from backend.models.ko_stats import PageStat
+from backend.models.tome_sync import ReadingSession
+from backend.services import reconciled_reading as rr
+from backend.services.reading_day import DayCtx
+
+# The prod session: 2026-01-09 02:39:54 UTC == 03:39:54 CET — before the 4 AM
+# rollover, so it belongs to Jan 8's reading day.
+PROD_UTC = datetime(2026, 1, 9, 2, 39, 54)
+PROD_EPOCH = int(PROD_UTC.replace(tzinfo=timezone.utc).timestamp())
+SUMMER_OFFSET = -120  # what a Vienna browser sends in August (CEST)
+
+
+def _session(db, user, book, started_at):
+    db.add(ReadingSession(user_id=user.id, book_id=book.id, started_at=started_at,
+                          ended_at=started_at, duration_seconds=600, pages_turned=10))
+
+
+# ── Unit: Python-side bucketing ───────────────────────────────────────────────
+
+def test_py_day_winter_session_with_summer_offset():
+    aware = DayCtx(SUMMER_OFFSET, "Europe/Vienna")
+    legacy = DayCtx(SUMMER_OFFSET)
+    assert aware.py_day(PROD_EPOCH) == date(2026, 1, 8)     # fixed
+    assert legacy.py_day(PROD_EPOCH) == date(2026, 1, 9)    # documented old behaviour
+
+
+def test_unknown_tz_name_falls_back_to_fixed_offset():
+    assert DayCtx(SUMMER_OFFSET, "Not/AZone").tz_name is None
+    assert DayCtx(SUMMER_OFFSET, "Not/AZone").py_day(PROD_EPOCH) == date(2026, 1, 9)
+
+
+def test_summer_session_agrees_in_both_modes():
+    # 03:30 CEST on Jul 14 (01:30 UTC) — same regime as the query offset, so
+    # tz-aware and fixed-offset bucketing must agree: the day before.
+    e = int(datetime(2026, 7, 14, 1, 30, tzinfo=timezone.utc).timestamp())
+    assert DayCtx(SUMMER_OFFSET, "Europe/Vienna").py_day(e) == date(2026, 7, 13)
+    assert DayCtx(SUMMER_OFFSET).py_day(e) == date(2026, 7, 13)
+
+
+# ── SQL: session (datetime column) and page-stat (epoch column) paths ─────────
+
+def test_dt_day_sql_buckets_winter_session_correctly(db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Black Summoner")
+    _session(db, user, book, PROD_UTC)
+    db.flush()
+
+    aware = DayCtx(SUMMER_OFFSET, "Europe/Vienna")
+    legacy = DayCtx(SUMMER_OFFSET)
+    got_aware = db.query(aware.dt_day(ReadingSession.started_at)).scalar()
+    got_legacy = db.query(legacy.dt_day(ReadingSession.started_at)).scalar()
+    assert got_aware == "2026-01-08"
+    assert got_legacy == "2026-01-09"
+
+
+def test_active_days_includes_the_bedtime_read_day(db, admin_user, make_book):
+    """The exact prod shape: normal daytime sessions plus one 03:39 CET
+    bedtime read as the only reading of Jan 8. Tz-aware active_days keeps
+    Jan 8; the fixed-offset set loses it (the streak breaker)."""
+    user, _ = admin_user
+    book = make_book(title="Streak chain")
+    for d in (5, 6, 7):
+        _session(db, user, book, datetime(2026, 1, d, 12, 0, 0))
+    _session(db, user, book, PROD_UTC)                     # Jan 8's only read
+    _session(db, user, book, datetime(2026, 1, 9, 12, 0, 0))
+    db.flush()
+
+    aware_days = rr.active_days(db, user.id, DayCtx(SUMMER_OFFSET, "Europe/Vienna"), [])
+    legacy_days = rr.active_days(db, user.id, DayCtx(SUMMER_OFFSET), [])
+
+    assert date(2026, 1, 8) in aware_days
+    assert {date(2026, 1, d) for d in (5, 6, 7, 8, 9)} <= aware_days
+    assert date(2026, 1, 8) not in legacy_days             # the old gap
+
+
+def test_epoch_day_pagestat_path(db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="Imported history")
+    db.add(PageStat(user_id=user.id, book_id=book.id, page=1, total_pages=100,
+                    start_time=PROD_EPOCH, duration_seconds=300, device="Kindle"))
+    db.flush()
+
+    aware = DayCtx(SUMMER_OFFSET, "Europe/Vienna")
+    assert db.query(aware.epoch_day(PageStat.start_time)).scalar() == "2026-01-08"
+    # covered book → page-stat days join the active-day set
+    days = rr.active_days(db, user.id, aware, [book.id])
+    assert date(2026, 1, 8) in days
+
+
+# ── API: the tz param threads through and the expressions run ─────────────────
+
+def test_stats_endpoints_accept_tz(client, db, admin_user, make_book):
+    user, _ = admin_user
+    book = make_book(title="API smoke")
+    _session(db, user, book, PROD_UTC)
+    db.add(PageStat(user_id=user.id, book_id=book.id, page=1, total_pages=100,
+                    start_time=PROD_EPOCH, duration_seconds=300, device="Kindle"))
+    db.flush()
+
+    for path in (
+        "/api/stats?days=0&tz_offset=-120&tz=Europe/Vienna",
+        "/api/home/stats?tz_offset=-120&tz=Europe/Vienna",
+        "/api/stats/timeline?tz_offset=-120&tz=Europe/Vienna",
+        "/api/stats/sessions?tz_offset=-120&tz=Europe/Vienna",
+        f"/api/books/{book.id}/reading-stats?tz_offset=-120&tz=Europe/Vienna",
+    ):
+        r = client.get(path)
+        assert r.status_code == 200, f"{path}: {r.status_code} {r.text[:200]}"
+
+    # With only the bedtime session in the DB, the timeline must key that
+    # reading to Jan 8 (tz-aware) — and must NOT contain a Jan 9 bucket.
+    daily = client.get(
+        "/api/stats/timeline?tz_offset=-120&tz=Europe/Vienna").json()
+    blob = str(daily)
+    assert "2026-01-08" in blob
+    assert "2026-01-09" not in blob


### PR DESCRIPTION
## Summary

Reading streaks (and every day-bucketed stat) mishandled daylight-saving time: day bucketing applied the browser's *current* `getTimezoneOffset()` as one fixed SQLite modifier across all of history. Any session started between 3 and 4 AM local time in the opposite DST regime landed one day late — a real 03:39 CET bedtime read (02:39 UTC, night of Jan 8→9), queried in August with the CEST offset, bucketed to Jan 9, leaving Jan 8 empty and cutting a 260-day streak to 230. The streak number also changed at each clock change.

**Fix:** `DayCtx` in `backend/services/reading_day.py` — carries the legacy offset plus an optional IANA timezone name. With the name it emits per-row SQL CASE expressions over the zone's real DST transition instants (probed from zoneinfo, cached, exact to the minute) for both datetime and epoch columns, and uses real zoneinfo math Python-side. Without one it reproduces the fixed-offset behaviour bit-for-bit, so offset-only clients (KOReader plugin, external API users) are unchanged.

Per `reading_day.py`'s own invariant (all day buckets must agree), the ctx threads through every consumer: streaks, `reconciled_reading` (incl. the raw-SQL cluster day labels, now computed Python-side), stats/home/books endpoints, reading DNA, backlog pace, per-book reading stats. Endpoints gain an optional `tz` query param; `api.ts` appends the browser's IANA zone wherever `tz_offset` is already sent. Side benefit: the hour×weekday heatmap now shows winter sessions at their true local hour.

## Test plan

- New `tests/test_streak_dst.py` (7 tests): the exact prod session through the Python, SQL-datetime, SQL-epoch, `active_days`, and API paths; unknown-tz fallback; documents that offset-only clients keep the old behaviour.
- Full suite: 1165 passed (three existing tests updated to the `DayCtx` signature, assertions unchanged).
- Frontend build green.
- Dev DB verification: longest streak heals 59 → 89 once winter sessions bucket with the winter offset — same failure mode as prod's 230 vs 260 (loom, which buckets with proper zoneinfo, agrees with the fixed numbers).