### PR TITLE
release: v2.4.0 "Gloss"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to Tome are documented here. Format loosely follows
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-09-03
+
 ### Changed
 - Smoother interface motion throughout the web app. Dialogs now animate
   out as well as in, the notification dropdown pops from its corner, and
@@ -23,6 +25,10 @@ All notable changes to Tome are documented here. Format loosely follows
   alongside the offset and the server buckets each timestamp against the
   timezone's real transition history. Clients that only send an offset
   (KOReader plugin, external API users) keep the previous behaviour.
+- OPDS search returns results again. The OpenSearch description pointed
+  readers at the descriptor URL instead of the results feed, so a search from
+  an OPDS client got the description document back and showed nothing. Thanks
+  @ziozzang. (#193)
 
 ### Added
 - Per-user content restrictions, set by an admin in Admin → Users. Hidden

--- a/README.md
+++ b/README.md
@@ -166,6 +166,17 @@ Requirements: Python 3.12+, Node.js 18+
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for project conventions and PR guidelines.
 
+## Translating
+
+The web UI is translatable. English is the source and lives in the code;
+every other language is a community-maintained catalog under
+`frontend/src/locales/<code>/messages.po`, editable with any text editor or
+[Poedit](https://poedit.net/). Anything not yet translated falls back to
+English, so partial catalogs are fine to ship. To improve a language, fill in
+the empty `msgstr` entries and open a pull request; to add one, see
+[docs/translating.md](docs/translating.md) for the two-line setup. The
+KOReader plugin and this website stay English for now.
+
 ## Documentation
 
 - [Reader](docs/reader.md) -- EPUB, comic/manga reader, keyboard shortcuts, ComicInfo.xml
@@ -174,6 +185,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for project conventions and PR guidelines
 - [Scribe](docs/scribe.md) -- Claude Code Skill for batch ingest, metadata refresh, and series audits
 - [Import Script](docs/import.md) -- bulk importing an existing collection from filenames
 - [Features](docs/features.md) -- Quick Connect, OPDS PINs, permissions, themes, API tokens, and more
+- [Translating](docs/translating.md) -- improving or adding a UI language
 
 ## Acknowledgements
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -68,6 +68,10 @@ Tome ships with three built-in themes:
 
 Switch themes in **Settings > Appearance**. The theme is stored per-browser, so different devices can use different themes.
 
+### Interface Language
+
+The web UI is translatable. Choose a language in **Settings > Appearance > Language**; on first visit Tome follows the browser language when a catalog exists for it. Translations are community-maintained `.po` files and anything untranslated falls back to English -- see [translating.md](translating.md) to improve or add one. The KOReader plugin, OPDS and the website stay English.
+
 ### Custom Themes
 
 You can create a fully custom theme by pasting 10 comma-separated hex color values in **Settings > Appearance > Custom Theme**. The 10 values map to the theme's color palette in order. Custom themes are stored per-browser alongside your theme preference.
@@ -148,6 +152,15 @@ Click any book's cover to open the cover picker. Search Google Books and OpenLib
 
 Admins have an additional uploader dropdown filter on the dashboard to view books by a specific user.
 
+### Content Restrictions
+
+Admins can narrow an individual account further under **Admin > Users**:
+
+- **Hidden tags** -- a comma-separated list. Books carrying any of these tags (matched case-insensitively) are invisible to that user everywhere: browsing, search, filters, OPDS and the KOReader plugin, including the user's own uploads. Untagged books are not affected, so tag first, then hide.
+- **Downloads per day** -- a cap on files fetched per UTC day, enforced on every download path (single file, bulk ZIP, OPDS, TomeSync). Blank means unlimited, `0` disables downloads.
+
+Admin accounts are never restricted.
+
 ---
 
 ## Filtering
@@ -205,3 +218,4 @@ How your collection grows and what you finish:
 - **Completion by type** — finish rates per book type
 - **Per-book time table** — total time, sessions, and pages turned for every book
 - **Library growth** — books added over time
+- **Backlog** -- how long your unstarted books would take at your own pace (hours from word count x your reading speed, days from your recent minutes per day), scoped to Want to Read, all unread, a library, or a shelf. The same estimate shows as "Est. read time" on the book page and "left in this series" on the series page

--- a/docs/reader.md
+++ b/docs/reader.md
@@ -11,6 +11,7 @@ Tome has a built-in reader that handles EPUBs, manga/comics (CBZ/CBR), and PDFs 
 - Adjustable font size and font family (serif, sans-serif, monospace)
 - Reading position saved automatically via EPUB CFI -- reopen a book and you're right where you left off
 - Progress percentage tracked and visible on the dashboard
+- Tap zones -- on touch screens, choose in the reader settings whether tapping the right side (Default) or the left side (Swapped) turns to the next page, or turn taps off and swipe only. Shared with the comic reader, stored per browser
 
 ---
 
@@ -19,6 +20,7 @@ Tome has a built-in reader that handles EPUBs, manga/comics (CBZ/CBR), and PDFs 
 Pages are streamed individually from the server -- no need to download the entire archive before reading.
 
 - **Page navigation** -- click/tap left or right half of the screen, use arrow keys, or swipe on mobile
+- **Tap zones** -- Default (tap right for next), Swapped (tap left for next, for one-handed reading), or Off (swipe only). Set in the reader settings panel; RTL volumes keep advancing in their reading direction
 - **Two-page spread** -- auto-enabled on wide screens, toggle with `S` key. Pages display side-by-side like an open book
 - **RTL (right-to-left)** -- auto-enabled for manga book types. Page order and navigation direction flip so manga reads correctly. Toggle with `R` key
 - **Fit modes** -- fit-to-width or fit-to-height, toggle with `W` key

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tome"
-version = "2.3.0"
+version = "2.4.0"
 description = "Self-hosted ebook library"
 requires-python = ">=3.12"
 dependencies = [

--- a/website/src/pages/docs/koreader.astro
+++ b/website/src/pages/docs/koreader.astro
@@ -3,7 +3,6 @@ import DocsLayout from '../../layouts/DocsLayout.astro'
 import SectionHero from '../../components/SectionHero.astro'
 import DocsMeta from '../../components/DocsMeta.astro'
 import Callout from '../../components/Callout.astro'
-import UnreleasedNote from '../../components/UnreleasedNote.astro'
 import Steps from '../../components/Steps.astro'
 import Kbd from '../../components/Kbd.astro'
 import { Tabs } from '../../components/Tabs'
@@ -271,7 +270,6 @@ const deviceSnippet  = '# Mount the device, then copy:\nunzip tomesync.koplugin.
   </Callout>
 
   <h2 id="changing-servers">Changing servers &amp; switching accounts</h2>
-  <UnreleasedNote />
   <p>
     The downloaded plugin comes pre-configured, but the configuration isn't locked in. From
     plugin build 41, the connection can be changed on the device under

--- a/website/src/pages/docs/reader.astro
+++ b/website/src/pages/docs/reader.astro
@@ -64,6 +64,25 @@ import { withBase } from '../../lib/path'
     </tbody>
   </table>
 
+  <h3 id="tap-zones">Tap zones</h3>
+  <p>
+    On a touch screen, tapping the reading surface turns the page. Which side does what is a
+    setting in the reader's settings panel (<Kbd>s</Kbd>), shared by the EPUB and comic readers
+    and remembered per browser:
+  </p>
+  <ul>
+    <li><strong>Default</strong> — tap right for the next page, left for the previous one.</li>
+    <li><strong>Swapped</strong> — tap left for next. For reading one-handed with the device in
+      your left hand, thumb over the near edge.</li>
+    <li><strong>Off</strong> — taps never turn pages; swipe instead. Useful when you keep
+      turning pages by accident while zooming or scrolling.</li>
+  </ul>
+  <p>
+    Right-to-left comics keep advancing in their reading direction whatever the setting says,
+    swipes and arrow keys are unaffected, and while zoomed into a comic page taps pan rather
+    than turn.
+  </p>
+
   <h2>Highlights &amp; notes</h2>
   <p>
     Your KOReader highlights are painted right in the text, in their KOReader colours. Each
@@ -123,6 +142,7 @@ import { withBase } from '../../lib/path'
   <Callout variant="tip" title="Mobile gestures work too">
     Tap left/right thirds of the screen to turn pages, tap centre for the controls overlay.
     Pinch-zoom is supported in page mode.
+    Which side means "next" is the <a href="#tap-zones">tap zones</a> setting above.
   </Callout>
 
   <h2>PDF</h2>

--- a/website/src/pages/docs/stats.astro
+++ b/website/src/pages/docs/stats.astro
@@ -328,6 +328,32 @@ import { withBase } from '../../lib/path'
     acquisition sprees you'd otherwise forget about.
   </p>
 
+  <h3>Backlog</h3>
+  <p>
+    How long the pile would take at your own pace. The tile sums an estimate for every book you
+    haven't started in its scope and shows the total in hours and in days, with a per-type
+    breakdown underneath. The scope is picked in the tile's edit-mode settings: your
+    <strong>Want to Read</strong> queue (the default), everything unread, a library, or a shelf.
+  </p>
+  <ul>
+    <li><strong>Hours</strong> come from the book's word count at your measured words per minute.
+      Books without a word count — CBZ and PDF — fall back to your average time per finished
+      book of that type. A book Tome can't place either way is counted as "not estimated yet"
+      rather than guessed.</li>
+    <li><strong>Days</strong> come from your minutes per day over the last 30 days, or the last
+      90 when the past month was quiet. No recent reading, no day figure.</li>
+  </ul>
+  <p>
+    The same estimate appears in two other places: the book page shows an <strong>Est. read
+    time</strong> cell in Details (hover it to see which pace was used), and the series page puts
+    "left in this series" over the unstarted volumes.
+  </p>
+
+  <Callout variant="info" title="It needs a couple of finished books first">
+    The pace is measured, not assumed. Until you have finished a few word-counted books of a type
+    the tile asks you to, instead of inventing a number.
+  </Callout>
+
   <h2>Timeline board</h2>
   <p>
     Your reading life as a Gantt chart. One lane per series (standalones get their own),

--- a/website/src/pages/docs/themes.astro
+++ b/website/src/pages/docs/themes.astro
@@ -78,6 +78,24 @@ const palettes = [
     ))}
   </details>
 
+  <h2>Language</h2>
+  <p>
+    The web UI is translatable. Pick a language under <strong>Settings → Appearance →
+    Language</strong>; on a first visit Tome uses your browser's language when a catalog for it
+    exists, and English otherwise. The choice is stored per browser, like the theme.
+  </p>
+  <p>
+    English is the source and always complete. Every other language is a community-maintained
+    catalog, and anything not yet translated falls back to English, so a partly translated
+    language is still usable. Simplified Chinese ships as a starting point. The KOReader plugin,
+    the OPDS feed and this website stay English for now.
+  </p>
+  <p>
+    Want your language in the picker, or the existing one finished? It's a single
+    <code>.po</code> file and a pull request — see
+    <a href="https://github.com/bndct-devops/tome/blob/main/docs/translating.md">docs/translating.md</a>.
+  </p>
+
   <h2>Keyboard shortcuts</h2>
   <p>
     Press <code>?</code> anywhere to open the keyboard shortcuts modal. Here's the full list:

--- a/website/src/pages/docs/users-and-roles.astro
+++ b/website/src/pages/docs/users-and-roles.astro
@@ -3,6 +3,7 @@ import DocsLayout from '../../layouts/DocsLayout.astro'
 import SectionHero from '../../components/SectionHero.astro'
 import DocsMeta from '../../components/DocsMeta.astro'
 import Callout from '../../components/Callout.astro'
+import { withBase } from '../../lib/path'
 import Steps from '../../components/Steps.astro'
 import { ThemedShot } from '../../components/ThemedShot'
 import { RolesVisibilityDemo } from '../../components/mockups/RolesVisibilityDemo'
@@ -85,6 +86,36 @@ const visibilitySvg = fs.readFileSync(path.resolve(process.cwd(), 'public/diagra
     The dashboard has a "My books / Shared library" toggle for members so they can flip between
     "only books I uploaded" and "everything I have access to."
   </p>
+
+  <h2>Content restrictions</h2>
+  <p>
+    Library membership decides <em>which</em> books an account can reach. Two per-account
+    restrictions, set by an admin under <strong>Admin → Users</strong>, narrow that further.
+    They are meant for the shared-instance case: a child's account, a guest you'd rather
+    not hand the whole shelf to, an account that is really a KOReader on the family Wi-Fi.
+  </p>
+  <ul>
+    <li><strong>Hidden tags.</strong> A comma-separated list of tags. A book carrying any of them
+      is invisible to that account everywhere — browsing, search, filters and facets, the series
+      view, OPDS and the KOReader plugin — and is invisible even if the account uploaded it. Tags
+      match case-insensitively, so <code>Adult</code> and <code>adult</code> are the same
+      restriction. A hidden book answers 404 to that account, exactly like a book that isn't
+      there.</li>
+    <li><strong>Downloads per day.</strong> A cap on how many files the account can fetch per UTC
+      day, enforced on every download path: single file, bulk ZIP, OPDS and TomeSync. Blank means
+      unlimited, <code>0</code> disables downloads entirely. Only files actually served count, and
+      the day boundary is UTC because OPDS apps and e-readers send no timezone.</li>
+  </ul>
+  <p>
+    Admin accounts are never restricted, and reading in the browser is not a download. Both
+    restrictions live on the account, not on the books, so nothing changes for anyone else.
+  </p>
+
+  <Callout variant="tip" title="Hidden tags only hide what is tagged">
+    The gate is the tag, so an untagged book passes. Tag the books you want to keep out of reach
+    first — bulk metadata edit on a filtered selection, or <a href={withBase("/docs/scribe")}>Scribe</a>,
+    both do it in one go — and then hide the tag.
+  </Callout>
 
   <h2>Libraries</h2>
   <p>


### PR DESCRIPTION
Release prep for v2.4.0 "Gloss".

- Roll `CHANGELOG.md` and bump `pyproject.toml` to 2.4.0
- Add the missing changelog entry for the OPDS search fix (#193)
- Document tap zones, per-user content restrictions, backlog estimates and the language picker on the website and in `docs/`
- README: Translating section
- Drop the unreleased banner from the plugin docs (build 41 ships in this release)

Verified: full backend suite (1165 passed), website build, and a prod-shaped check of DST bucketing and content restrictions against a snapshot of the production database.